### PR TITLE
adding 'all' meta-package

### DIFF
--- a/instrumentors/opentelemetry-auto-instrumentation-all/README.rst
+++ b/instrumentors/opentelemetry-auto-instrumentation-all/README.rst
@@ -1,0 +1,22 @@
+OpenTelemetry Auto-instrumentation All Package 
+==============================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-auto-instrumentation-all.svg
+   :target: https://pypi.org/project/opentelemetry-auto-instrumentation-all/
+
+This package installs all auto-instrumented packages for user convenience
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-auto-instrumentation-all
+
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentors/opentelemetry-auto-instrumentation-all/setup.cfg
+++ b/instrumentors/opentelemetry-auto-instrumentation-all/setup.cfg
@@ -1,0 +1,51 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-auto-instrumentation-all
+description = Meta package to install all auto-instrumentation for OpenTelemetry
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-auto-instr-python/instrumentors/sqlalchemy
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.4
+packages=find_namespace:
+install_requires =
+    opentelemetry-auto-instrumentation
+    opentelemetry-ext-flask
+    opentelemetry-ext-http-requests
+    opentelemetry-sdk
+
+[options.extras_require]
+test =
+    sqlalchemy
+
+[options.packages.find]
+where = src

--- a/instrumentors/opentelemetry-auto-instrumentation-all/setup.py
+++ b/instrumentors/opentelemetry-auto-instrumentation-all/setup.py
@@ -1,0 +1,27 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(BASE_DIR, "version.py")
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"],
+)
+

--- a/instrumentors/opentelemetry-auto-instrumentation-all/version.py
+++ b/instrumentors/opentelemetry-auto-instrumentation-all/version.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.7.dev0"
+


### PR DESCRIPTION
As a convenience to users, adding a package that would install all the contrib packages, as well as the opentelemetry-auto-instrumentation & opentelemetry-sdk.