### PR TITLE
moving pymongo code into contrib repo

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -15,4 +15,4 @@ multi_line_output=3
 skip=target
 skip_glob=**/gen/*,.venv*/*,venv*/*,reference*/*
 known_first_party=opentelemetry
-known_third_party=psutil,pytest
+known_third_party=mysql,psutil,psycopg2,pymongo,pytest

--- a/instrumentation/opentelemetry-instrumentation-docker-tests/tests/check_availability.py
+++ b/instrumentation/opentelemetry-instrumentation-docker-tests/tests/check_availability.py
@@ -1,0 +1,108 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import time
+
+import mysql.connector
+import psycopg2
+import pymongo
+
+MONGODB_COLLECTION_NAME = "test"
+MONGODB_DB_NAME = os.getenv("MONGODB_DB_NAME", "opentelemetry-tests")
+MONGODB_HOST = os.getenv("MONGODB_HOST", "localhost")
+MONGODB_PORT = int(os.getenv("MONGODB_PORT", "27017"))
+MYSQL_DB_NAME = os.getenv("MYSQL_DB_NAME ", "opentelemetry-tests")
+MYSQL_HOST = os.getenv("MYSQL_HOST ", "localhost")
+MYSQL_PORT = int(os.getenv("MYSQL_PORT ", "3306"))
+MYSQL_USER = os.getenv("MYSQL_USER ", "testuser")
+MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD ", "testpassword")
+POSTGRES_DB_NAME = os.getenv("POSTGRESQL_DB_NAME", "opentelemetry-tests")
+POSTGRES_HOST = os.getenv("POSTGRESQL_HOST", "localhost")
+POSTGRES_PASSWORD = os.getenv("POSTGRESQL_HOST", "testpassword")
+POSTGRES_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
+POSTGRES_USER = os.getenv("POSTGRESQL_HOST", "testuser")
+RETRY_COUNT = 5
+RETRY_INTERVAL = 5  # Seconds
+
+logger = logging.getLogger(__name__)
+
+
+def check_pymongo_connection():
+    # Try to connect to DB
+    for i in range(RETRY_COUNT):
+        try:
+            client = pymongo.MongoClient(
+                MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
+            )
+            db = client[MONGODB_DB_NAME]
+            collection = db[MONGODB_COLLECTION_NAME]
+            collection.find_one()
+            client.close()
+            break
+        except Exception as ex:
+            if i == RETRY_COUNT - 1:
+                raise (ex)
+            logger.exception(ex)
+        time.sleep(RETRY_INTERVAL)
+
+
+def check_mysql_connection():
+    # Try to connect to DB
+    for i in range(RETRY_COUNT):
+        try:
+            connection = mysql.connector.connect(
+                user=MYSQL_USER,
+                password=MYSQL_PASSWORD,
+                host=MYSQL_HOST,
+                port=MYSQL_PORT,
+                database=MYSQL_DB_NAME,
+            )
+            connection.close()
+            break
+        except Exception as ex:
+            if i == RETRY_COUNT - 1:
+                raise (ex)
+            logger.exception(ex)
+        time.sleep(RETRY_INTERVAL)
+
+
+def check_postgres_connection():
+    # Try to connect to DB
+    for i in range(RETRY_COUNT):
+        try:
+            connection = psycopg2.connect(
+                dbname=POSTGRES_DB_NAME,
+                user=POSTGRES_USER,
+                password=POSTGRES_PASSWORD,
+                host=POSTGRES_HOST,
+                port=POSTGRES_PORT,
+            )
+            connection.close()
+            break
+        except Exception as ex:
+            if i == RETRY_COUNT - 1:
+                raise (ex)
+            logger.exception(ex)
+        time.sleep(RETRY_INTERVAL)
+
+
+def check_docker_services_availability():
+    # Check if Docker services accept connections
+    check_pymongo_connection()
+    check_mysql_connection()
+    check_postgres_connection()
+
+
+check_docker_services_availability()

--- a/instrumentation/opentelemetry-instrumentation-docker-tests/tests/docker-compose.yml
+++ b/instrumentation/opentelemetry-instrumentation-docker-tests/tests/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  otmongo:
+    ports:
+     - "27017:27017"
+    image: mongo:latest
+  otmysql:
+      ports:
+       - "3306:3306"
+      image: mysql:latest
+      restart: always
+      environment:
+        MYSQL_USER: testuser
+        MYSQL_PASSWORD: testpassword
+        MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        MYSQL_DATABASE: opentelemetry-tests
+  otpostgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpassword
+      POSTGRES_DB: opentelemetry-tests
+

--- a/instrumentation/opentelemetry-instrumentation-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/instrumentation/opentelemetry-instrumentation-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -1,0 +1,108 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import typing
+import unittest
+
+from pymongo import MongoClient
+
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.pymongo import trace_integration
+from opentelemetry.sdk.trace import Span, Tracer, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+MONGODB_HOST = os.getenv("MONGODB_HOST ", "localhost")
+MONGODB_PORT = int(os.getenv("MONGODB_PORT ", "27017"))
+MONGODB_DB_NAME = os.getenv("MONGODB_DB_NAME ", "opentelemetry-tests")
+MONGODB_COLLECTION_NAME = "test"
+
+
+class TestFunctionalPymongo(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tracer_provider = TracerProvider()
+        cls._tracer = Tracer(cls._tracer_provider, None)
+        cls._span_exporter = InMemorySpanExporter()
+        cls._span_processor = SimpleExportSpanProcessor(cls._span_exporter)
+        cls._tracer_provider.add_span_processor(cls._span_processor)
+        trace_integration(cls._tracer)
+        client = MongoClient(
+            MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
+        )
+        db = client[MONGODB_DB_NAME]
+        cls._collection = db[MONGODB_COLLECTION_NAME]
+
+    def setUp(self):
+        self._span_exporter.clear()
+
+    def validate_spans(self):
+        spans = self._span_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        for span in spans:
+            if span.name == "rootSpan":
+                root_span = span
+            else:
+                pymongo_span = span
+            self.assertIsInstance(span.start_time, int)
+            self.assertIsInstance(span.end_time, int)
+        self.assertIsNot(root_span, None)
+        self.assertIsNot(pymongo_span, None)
+        self.assertIsNotNone(pymongo_span.parent)
+        self.assertEqual(pymongo_span.parent.name, root_span.name)
+        self.assertIs(pymongo_span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(
+            pymongo_span.attributes["db.instance"], MONGODB_DB_NAME
+        )
+        self.assertEqual(
+            pymongo_span.attributes["net.peer.name"], MONGODB_HOST
+        )
+        self.assertEqual(
+            pymongo_span.attributes["net.peer.port"], MONGODB_PORT
+        )
+
+    def test_insert(self):
+        """Should create a child span for insert
+        """
+        with self._tracer.start_as_current_span("rootSpan"):
+            self._collection.insert_one(
+                {"name": "testName", "value": "testValue"}
+            )
+        self.validate_spans()
+
+    def test_update(self):
+        """Should create a child span for update
+        """
+        with self._tracer.start_as_current_span("rootSpan"):
+            self._collection.update_one(
+                {"name": "testName"}, {"$set": {"value": "someOtherValue"}}
+            )
+        self.validate_spans()
+
+    def test_find(self):
+        """Should create a child span for find
+        """
+        with self._tracer.start_as_current_span("rootSpan"):
+            self._collection.find_one()
+        self.validate_spans()
+
+    def test_delete(self):
+        """Should create a child span for delete
+        """
+        with self._tracer.start_as_current_span("rootSpan"):
+            self._collection.delete_one({"name": "testName"})
+        self.validate_spans()

--- a/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## Unreleased
+
+## 0.4a0
+
+Released 2020-02-21
+
+- Updating network connection attribute names
+  ([#350](https://github.com/open-telemetry/opentelemetry-python/pull/350))
+
+## 0.3a0
+
+Released 2019-12-11
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-pymongo/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-pymongo/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
@@ -1,0 +1,21 @@
+OpenTelemetry pymongo Integration
+=================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-pymongo.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-pymongo/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-pymongo
+
+
+References
+----------
+* `OpenTelemetry pymongo Integration <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/pymongo/pymongo.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api # == 0.7.dev0
+    opentelemetry-api == 0.6b0
     pymongo ~= 3.1
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -1,0 +1,47 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-pymongo
+description = OpenTelemetry pymongo integration
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/instrumentation/opentelemetry-instrumentation-pymongo
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.4
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api # == 0.7.dev0
+    pymongo ~= 3.1
+
+[options.packages.find]
+where = src

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymongo",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -1,0 +1,135 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The integration with MongoDB supports the `pymongo`_ library and is specified
+to ``trace_integration`` using ``'pymongo'``.
+
+.. _pymongo: https://pypi.org/project/pymongo
+
+Usage
+-----
+
+.. code:: python
+
+    from pymongo import MongoClient
+    from opentelemetry.trace import TracerProvider
+    from opentelemetry.trace.instrumentation.pymongo import trace_integration
+
+    trace.set_tracer_provider(TracerProvider())
+    tracer = trace.get_tracer(__name__)
+
+    trace_integration(tracer)
+    client = MongoClient()
+    db = client["MongoDB_Database"]
+    collection = db["MongoDB_Collection"]
+    collection.find_one()
+
+API
+---
+"""
+
+from pymongo import monitoring
+
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+DATABASE_TYPE = "mongodb"
+COMMAND_ATTRIBUTES = ["filter", "sort", "skip", "limit", "pipeline"]
+
+
+def trace_integration(tracer=None):
+    """Integrate with pymongo to trace it using event listener.
+       https://api.mongodb.com/python/current/api/pymongo/monitoring.html
+    """
+
+    monitoring.register(CommandTracer(tracer))
+
+
+class CommandTracer(monitoring.CommandListener):
+    def __init__(self, tracer):
+        if tracer is None:
+            raise ValueError("The tracer is not provided.")
+        self._tracer = tracer
+        self._span_dict = {}
+
+    def started(self, event: monitoring.CommandStartedEvent):
+        """ Method to handle a pymongo CommandStartedEvent """
+        command = event.command.get(event.command_name, "")
+        name = DATABASE_TYPE + "." + event.command_name
+        statement = event.command_name
+        if command:
+            name += "." + command
+            statement += " " + command
+
+        try:
+            span = self._tracer.start_span(name, kind=SpanKind.CLIENT)
+            span.set_attribute("component", DATABASE_TYPE)
+            span.set_attribute("db.type", DATABASE_TYPE)
+            span.set_attribute("db.instance", event.database_name)
+            span.set_attribute("db.statement", statement)
+            if event.connection_id is not None:
+                span.set_attribute("net.peer.name", event.connection_id[0])
+                span.set_attribute("net.peer.port", event.connection_id[1])
+
+            # pymongo specific, not specified by spec
+            span.set_attribute("db.mongo.operation_id", event.operation_id)
+            span.set_attribute("db.mongo.request_id", event.request_id)
+
+            for attr in COMMAND_ATTRIBUTES:
+                _attr = event.command.get(attr)
+                if _attr is not None:
+                    span.set_attribute("db.mongo." + attr, str(_attr))
+
+            # Add Span to dictionary
+            self._span_dict[_get_span_dict_key(event)] = span
+        except Exception as ex:  # noqa pylint: disable=broad-except
+            if span is not None:
+                span.set_status(Status(StatusCanonicalCode.INTERNAL, str(ex)))
+                span.end()
+                self._remove_span(event)
+
+    def succeeded(self, event: monitoring.CommandSucceededEvent):
+        """ Method to handle a pymongo CommandSucceededEvent """
+        span = self._get_span(event)
+        if span is not None:
+            span.set_attribute(
+                "db.mongo.duration_micros", event.duration_micros
+            )
+            span.set_status(Status(StatusCanonicalCode.OK, event.reply))
+            span.end()
+            self._remove_span(event)
+
+    def failed(self, event: monitoring.CommandFailedEvent):
+        """ Method to handle a pymongo CommandFailedEvent """
+        span = self._get_span(event)
+        if span is not None:
+            span.set_attribute(
+                "db.mongo.duration_micros", event.duration_micros
+            )
+            span.set_status(Status(StatusCanonicalCode.UNKNOWN, event.failure))
+            span.end()
+            self._remove_span(event)
+
+    def _get_span(self, event):
+        return self._span_dict.get(_get_span_dict_key(event))
+
+    def _remove_span(self, event):
+        self._span_dict.pop(_get_span_dict_key(event))
+
+
+def _get_span_dict_key(event):
+    if event.connection_id is not None:
+        return (event.request_id, event.connection_id)
+    return event.request_id

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.7.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -1,0 +1,190 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.pymongo import (
+    CommandTracer,
+    trace_integration,
+)
+from opentelemetry.util import time_ns
+
+
+class TestPymongo(unittest.TestCase):
+    def test_trace_integration(self):
+        mock_register = mock.Mock()
+        patch = mock.patch(
+            "pymongo.monitoring.register", side_effect=mock_register
+        )
+        mock_tracer = MockTracer()
+        with patch:
+            trace_integration(mock_tracer)
+
+        self.assertTrue(mock_register.called)
+
+    def test_started(self):
+        command_attrs = {
+            "filter": "filter",
+            "sort": "sort",
+            "limit": "limit",
+            "pipeline": "pipeline",
+            "command_name": "find",
+        }
+        mock_tracer = MockTracer()
+        command_tracer = CommandTracer(mock_tracer)
+        mock_event = MockEvent(
+            command_attrs, ("test.com", "1234"), "test_request_id"
+        )
+        command_tracer.started(event=mock_event)
+        # pylint: disable=protected-access
+        span = command_tracer._get_span(mock_event)
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.name, "mongodb.command_name.find")
+        self.assertEqual(span.attributes["component"], "mongodb")
+        self.assertEqual(span.attributes["db.type"], "mongodb")
+        self.assertEqual(span.attributes["db.instance"], "database_name")
+        self.assertEqual(span.attributes["db.statement"], "command_name find")
+        self.assertEqual(span.attributes["net.peer.name"], "test.com")
+        self.assertEqual(span.attributes["net.peer.port"], "1234")
+        self.assertEqual(
+            span.attributes["db.mongo.operation_id"], "operation_id"
+        )
+        self.assertEqual(
+            span.attributes["db.mongo.request_id"], "test_request_id"
+        )
+
+        self.assertEqual(span.attributes["db.mongo.filter"], "filter")
+        self.assertEqual(span.attributes["db.mongo.sort"], "sort")
+        self.assertEqual(span.attributes["db.mongo.limit"], "limit")
+        self.assertEqual(span.attributes["db.mongo.pipeline"], "pipeline")
+
+    def test_succeeded(self):
+        mock_tracer = MockTracer()
+        mock_event = MockEvent({})
+        command_tracer = CommandTracer(mock_tracer)
+        command_tracer.started(event=mock_event)
+        # pylint: disable=protected-access
+        span = command_tracer._get_span(mock_event)
+        command_tracer.succeeded(event=mock_event)
+        self.assertEqual(
+            span.attributes["db.mongo.duration_micros"], "duration_micros"
+        )
+        self.assertIs(
+            span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
+        )
+        self.assertEqual(span.status.description, "reply")
+        self.assertIsNotNone(span.end_time)
+
+    def test_failed(self):
+        mock_tracer = MockTracer()
+        mock_event = MockEvent({})
+        command_tracer = CommandTracer(mock_tracer)
+        command_tracer.started(event=mock_event)
+        # pylint: disable=protected-access
+        span = command_tracer._get_span(mock_event)
+        command_tracer.failed(event=mock_event)
+        self.assertEqual(
+            span.attributes["db.mongo.duration_micros"], "duration_micros"
+        )
+        self.assertIs(
+            span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.UNKNOWN,
+        )
+        self.assertEqual(span.status.description, "failure")
+        self.assertIsNotNone(span.end_time)
+
+    def test_multiple_commands(self):
+        mock_tracer = MockTracer()
+        first_mock_event = MockEvent({}, ("firstUrl", "123"), "first")
+        second_mock_event = MockEvent({}, ("secondUrl", "456"), "second")
+        command_tracer = CommandTracer(mock_tracer)
+        command_tracer.started(event=first_mock_event)
+        # pylint: disable=protected-access
+        first_span = command_tracer._get_span(first_mock_event)
+        command_tracer.started(event=second_mock_event)
+        # pylint: disable=protected-access
+        second_span = command_tracer._get_span(second_mock_event)
+        command_tracer.succeeded(event=first_mock_event)
+        command_tracer.failed(event=second_mock_event)
+
+        self.assertEqual(first_span.attributes["db.mongo.request_id"], "first")
+        self.assertIs(
+            first_span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.OK,
+        )
+        self.assertEqual(
+            second_span.attributes["db.mongo.request_id"], "second"
+        )
+        self.assertIs(
+            second_span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.UNKNOWN,
+        )
+
+
+class MockCommand:
+    def __init__(self, command_attrs):
+        self.command_attrs = command_attrs
+
+    def get(self, key, default=""):
+        return self.command_attrs.get(key, default)
+
+
+class MockEvent:
+    def __init__(self, command_attrs, connection_id=None, request_id=""):
+        self.command = MockCommand(command_attrs)
+        self.connection_id = connection_id
+        self.request_id = request_id
+
+    def __getattr__(self, item):
+        return item
+
+
+class MockSpan:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def __init__(self):
+        self.status = None
+        self.name = ""
+        self.kind = trace_api.SpanKind.INTERNAL
+        self.attributes = None
+        self.end_time = None
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def set_status(self, status):
+        self.status = status
+
+    def end(self, end_time=None):
+        self.end_time = end_time if end_time is not None else time_ns()
+
+
+class MockTracer:
+    def __init__(self):
+        self.end_span = mock.Mock()
+
+    # pylint: disable=no-self-use
+    def start_span(self, name, kind):
+        span = MockSpan()
+        span.attributes = {}
+        span.status = None
+        span.name = name
+        span.kind = kind
+        return span

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ envlist =
   ; py3{4,5,6,7,8}-test-flask
   ; pypy3-test-flask
 
-  ; py3{4,5,6,7,8}-test-django
-  ; pypy3-test-django
+  py3{4,5,6,7,8}-test-instrumentation-pymongo
+  pypy3-test-instrumentation-pymongo
   lint
 
 [travis]
@@ -25,7 +25,7 @@ deps =
 
 changedir =
   ;flask: instrumentors/flask/tests
-  ;django: instrumentors/django/tests
+  pymongo: instrumentation/opentelemetry-instrumentation-pymongo/tests
 
 commands_pre =
 ; Install without -e to test the actual installation
@@ -34,8 +34,8 @@ commands_pre =
   ;flask: pip install {toxinidir}/instrumentors/flask
   ;flask: pip install {toxinidir}/instrumentors/flask[test]
 
-  ;django: pip install {toxinidir}/instrumentors/django
-  ;django: pip install {toxinidir}/instrumentors/django[test]
+  pymongo: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo
+  # pymongo: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo[test]
 
 commands =
   test: pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
   py3{4,5,6,7,8}-test-instrumentation-pymongo
   pypy3-test-instrumentation-pymongo
   lint
+  docker-tests
 
 [travis]
 python =
@@ -56,3 +57,27 @@ commands_pre =
 
 commands =
   python scripts/eachdist.py lint --check-only
+
+[testenv:docker-tests]
+deps =
+  pytest
+  docker-compose >= 1.25.2
+  mysql-connector-python ~=  8.0
+  pymongo ~= 3.1
+  psycopg2 ~= 2.8.4
+  opentelemetry-api
+  opentelemetry-sdk
+
+changedir =
+  instrumentation/opentelemetry-instrumentation-docker-tests/tests
+
+commands_pre =
+  pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo
+  docker-compose up -d
+  python check_availability.py
+
+commands =
+  pytest {posargs}
+
+commands_post =
+  docker-compose down


### PR DESCRIPTION
Moving the pymongo code from the opentelemetry-python repo into the contrib repo. Using this as a first attempt at migrating some of the code over and ensuring we have all the pieces in place to make contributing as easy as possible.

One thing to note, I wanted to ensure the original authors attributions remained on the files/changes, I committed the changes with the `--author` flag. I'm open to suggestions if there's a better way to do this.

Steps to move the instrumentation from opentelemetry-python to opentelemetry-python-contrib repo:
1. copy code to instrumentation directory
2. copy integration tests to instrumentation/opentelemetry-instrumentation-docker-tests directory
3. get a list of the original authors: `git log . | grep Author | sort | uniq`
4. commit the initial move with the list of authors as `Co-authored by:`
5. add targets to tox