### PR TITLE
Move instrumentation aiohttp client

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Updating span name to match semantic conventions
+  ([#972](https://github.com/open-telemetry/opentelemetry-python/pull/972))
+- Add instrumentor and auto instrumentation support for aiohttp
+  ([#1075](https://github.com/open-telemetry/opentelemetry-python/pull/1075))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-aiohttp-client
+  ([#961](https://github.com/open-telemetry/opentelemetry-python/pull/961))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry aiohttp client Integration
+========================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-aiohttp-client.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-aiohttp-client/
+
+This library allows tracing HTTP requests made by the
+`aiohttp client <https://docs.aiohttp.org/en/stable/client.html>`_ library.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-instrumentation-aiohttp-client
+
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `aiohttp client Tracing <https://docs.aiohttp.org/en/stable/tracing_reference.html>`_

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -1,0 +1,55 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-aiohttp-client
+description = OpenTelemetry aiohttp client instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/instrumentation/opentelemetry-instrumentation-aiohttp-client
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5.3
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    aiohttp ~= 3.0
+    wrapt >= 1.0.0, < 2.0.0
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test =
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    aiohttp-client = opentelemetry.instrumentation.aiohttp_client:AioHttpClientInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.py
@@ -1,0 +1,31 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "aiohttp_client",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -1,0 +1,331 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The opentelemetry-instrumentation-aiohttp-client package allows tracing HTTP
+requests made by the aiohttp client library.
+
+Usage
+-----
+Explicitly instrumenting a single client session:
+
+.. code:: python
+
+    import aiohttp
+    from opentelemetry.instrumentation.aiohttp_client import (
+        create_trace_config,
+        url_path_span_name
+    )
+    import yarl
+
+    def strip_query_params(url: yarl.URL) -> str:
+        return str(url.with_query(None))
+
+    async with aiohttp.ClientSession(trace_configs=[create_trace_config(
+            # Remove all query params from the URL attribute on the span.
+            url_filter=strip_query_params,
+            # Use the URL's path as the span name.
+            span_name=url_path_span_name
+    )]) as session:
+        async with session.get(url) as response:
+            await response.text()
+
+Instrumenting all client sessions:
+
+.. code:: python
+
+    import aiohttp
+    from opentelemetry.instrumentation.aiohttp_client import (
+        AioHttpClientInstrumentor
+    )
+
+    # Enable instrumentation
+    AioHttpClientInstrumentor().instrument()
+
+    # Create a session and make an HTTP get request
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            await response.text()
+
+API
+---
+"""
+
+import socket
+import types
+import typing
+
+import aiohttp
+import wrapt
+
+from opentelemetry import context as context_api
+from opentelemetry import propagators, trace
+from opentelemetry.instrumentation.aiohttp_client.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import (
+    http_status_to_canonical_code,
+    unwrap,
+)
+from opentelemetry.trace import SpanKind, TracerProvider, get_tracer
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+_UrlFilterT = typing.Optional[typing.Callable[[str], str]]
+_SpanNameT = typing.Optional[
+    typing.Union[typing.Callable[[aiohttp.TraceRequestStartParams], str], str]
+]
+
+
+def url_path_span_name(params: aiohttp.TraceRequestStartParams) -> str:
+    """Extract a span name from the request URL path.
+
+    A simple callable to extract the path portion of the requested URL
+    for use as the span name.
+
+    :param aiohttp.TraceRequestStartParams params: Parameters describing
+        the traced request.
+
+    :return: The URL path.
+    :rtype: str
+    """
+    return params.url.path
+
+
+def create_trace_config(
+    url_filter: _UrlFilterT = None,
+    span_name: _SpanNameT = None,
+    tracer_provider: TracerProvider = None,
+) -> aiohttp.TraceConfig:
+    """Create an aiohttp-compatible trace configuration.
+
+    One span is created for the entire HTTP request, including initial
+    TCP/TLS setup if the connection doesn't exist.
+
+    By default the span name is set to the HTTP request method.
+
+    Example usage:
+
+    .. code:: python
+
+        import aiohttp
+        from opentelemetry.instrumentation.aiohttp_client import create_trace_config
+
+        async with aiohttp.ClientSession(trace_configs=[create_trace_config()]) as session:
+            async with session.get(url) as response:
+                await response.text()
+
+
+    :param url_filter: A callback to process the requested URL prior to adding
+        it as a span attribute. This can be useful to remove sensitive data
+        such as API keys or user personal information.
+
+    :param str span_name: Override the default span name.
+    :param tracer_provider: optional TracerProvider from which to get a Tracer
+
+    :return: An object suitable for use with :py:class:`aiohttp.ClientSession`.
+    :rtype: :py:class:`aiohttp.TraceConfig`
+    """
+    # `aiohttp.TraceRequestStartParams` resolves to `aiohttp.tracing.TraceRequestStartParams`
+    # which doesn't exist in the aiottp intersphinx inventory.
+    # Explicitly specify the type for the `span_name` param and rtype to work
+    # around this issue.
+
+    tracer = get_tracer(__name__, __version__, tracer_provider)
+
+    def _end_trace(trace_config_ctx: types.SimpleNamespace):
+        context_api.detach(trace_config_ctx.token)
+        trace_config_ctx.span.end()
+
+    async def on_request_start(
+        unused_session: aiohttp.ClientSession,
+        trace_config_ctx: types.SimpleNamespace,
+        params: aiohttp.TraceRequestStartParams,
+    ):
+        if context_api.get_value("suppress_instrumentation"):
+            trace_config_ctx.span = None
+            return
+
+        http_method = params.method.upper()
+        if trace_config_ctx.span_name is None:
+            request_span_name = "HTTP {}".format(http_method)
+        elif callable(trace_config_ctx.span_name):
+            request_span_name = str(trace_config_ctx.span_name(params))
+        else:
+            request_span_name = str(trace_config_ctx.span_name)
+
+        trace_config_ctx.span = trace_config_ctx.tracer.start_span(
+            request_span_name, kind=SpanKind.CLIENT,
+        )
+
+        if trace_config_ctx.span.is_recording():
+            attributes = {
+                "component": "http",
+                "http.method": http_method,
+                "http.url": trace_config_ctx.url_filter(params.url)
+                if callable(trace_config_ctx.url_filter)
+                else str(params.url),
+            }
+            for key, value in attributes.items():
+                trace_config_ctx.span.set_attribute(key, value)
+
+        trace_config_ctx.token = context_api.attach(
+            trace.set_span_in_context(trace_config_ctx.span)
+        )
+
+        propagators.inject(type(params.headers).__setitem__, params.headers)
+
+    async def on_request_end(
+        unused_session: aiohttp.ClientSession,
+        trace_config_ctx: types.SimpleNamespace,
+        params: aiohttp.TraceRequestEndParams,
+    ):
+        if trace_config_ctx.span is None:
+            return
+
+        if trace_config_ctx.span.is_recording():
+            trace_config_ctx.span.set_status(
+                Status(
+                    http_status_to_canonical_code(int(params.response.status))
+                )
+            )
+            trace_config_ctx.span.set_attribute(
+                "http.status_code", params.response.status
+            )
+            trace_config_ctx.span.set_attribute(
+                "http.status_text", params.response.reason
+            )
+        _end_trace(trace_config_ctx)
+
+    async def on_request_exception(
+        unused_session: aiohttp.ClientSession,
+        trace_config_ctx: types.SimpleNamespace,
+        params: aiohttp.TraceRequestExceptionParams,
+    ):
+        if trace_config_ctx.span is None:
+            return
+
+        if trace_config_ctx.span.is_recording():
+            if isinstance(
+                params.exception,
+                (aiohttp.ServerTimeoutError, aiohttp.TooManyRedirects),
+            ):
+                status = StatusCanonicalCode.DEADLINE_EXCEEDED
+            # Assume any getaddrinfo error is a DNS failure.
+            elif isinstance(
+                params.exception, aiohttp.ClientConnectorError
+            ) and isinstance(params.exception.os_error, socket.gaierror):
+                # DNS resolution failed
+                status = StatusCanonicalCode.UNKNOWN
+            else:
+                status = StatusCanonicalCode.UNAVAILABLE
+
+            trace_config_ctx.span.set_status(Status(status))
+            trace_config_ctx.span.record_exception(params.exception)
+        _end_trace(trace_config_ctx)
+
+    def _trace_config_ctx_factory(**kwargs):
+        kwargs.setdefault("trace_request_ctx", {})
+        return types.SimpleNamespace(
+            span_name=span_name, tracer=tracer, url_filter=url_filter, **kwargs
+        )
+
+    trace_config = aiohttp.TraceConfig(
+        trace_config_ctx_factory=_trace_config_ctx_factory
+    )
+
+    trace_config.on_request_start.append(on_request_start)
+    trace_config.on_request_end.append(on_request_end)
+    trace_config.on_request_exception.append(on_request_exception)
+
+    return trace_config
+
+
+def _instrument(
+    tracer_provider: TracerProvider = None,
+    url_filter: _UrlFilterT = None,
+    span_name: _SpanNameT = None,
+):
+    """Enables tracing of all ClientSessions
+
+    When a ClientSession gets created a TraceConfig is automatically added to
+    the session's trace_configs.
+    """
+    # pylint:disable=unused-argument
+    def instrumented_init(wrapped, instance, args, kwargs):
+        if context_api.get_value("suppress_instrumentation"):
+            return wrapped(*args, **kwargs)
+
+        trace_configs = list(kwargs.get("trace_configs") or ())
+
+        trace_config = create_trace_config(
+            url_filter=url_filter,
+            span_name=span_name,
+            tracer_provider=tracer_provider,
+        )
+        trace_config.opentelemetry_aiohttp_instrumented = True
+        trace_configs.append(trace_config)
+
+        kwargs["trace_configs"] = trace_configs
+        return wrapped(*args, **kwargs)
+
+    wrapt.wrap_function_wrapper(
+        aiohttp.ClientSession, "__init__", instrumented_init
+    )
+
+
+def _uninstrument():
+    """Disables instrumenting for all newly created ClientSessions"""
+    unwrap(aiohttp.ClientSession, "__init__")
+
+
+def _uninstrument_session(client_session: aiohttp.ClientSession):
+    """Disables instrumentation for the given ClientSession"""
+    # pylint: disable=protected-access
+    trace_configs = client_session._trace_configs
+    client_session._trace_configs = [
+        trace_config
+        for trace_config in trace_configs
+        if not hasattr(trace_config, "opentelemetry_aiohttp_instrumented")
+    ]
+
+
+class AioHttpClientInstrumentor(BaseInstrumentor):
+    """An instrumentor for aiohttp client sessions
+
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        """Instruments aiohttp ClientSession
+
+        Args:
+            **kwargs: Optional arguments
+                ``tracer_provider``: a TracerProvider, defaults to global
+                ``url_filter``: A callback to process the requested URL prior to adding
+                    it as a span attribute. This can be useful to remove sensitive data
+                    such as API keys or user personal information.
+                ``span_name``: Override the default span name.
+        """
+        _instrument(
+            tracer_provider=kwargs.get("tracer_provider"),
+            url_filter=kwargs.get("url_filter"),
+            span_name=kwargs.get("span_name"),
+        )
+
+    def _uninstrument(self, **kwargs):
+        _uninstrument()
+
+    @staticmethod
+    def uninstrument_session(client_session: aiohttp.ClientSession):
+        """Disables instrumentation for the given session"""
+        _uninstrument_session(client_session)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
@@ -1,0 +1,15 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1,0 +1,503 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import contextlib
+import typing
+import unittest
+import urllib.parse
+from http import HTTPStatus
+from unittest import mock
+
+import aiohttp
+import aiohttp.test_utils
+import yarl
+from pkg_resources import iter_entry_points
+
+from opentelemetry import context
+from opentelemetry.instrumentation import aiohttp_client
+from opentelemetry.instrumentation.aiohttp_client import (
+    AioHttpClientInstrumentor,
+)
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.status import StatusCanonicalCode
+
+
+def run_with_test_server(
+    runnable: typing.Callable, url: str, handler: typing.Callable
+) -> typing.Tuple[str, int]:
+    async def do_request():
+        app = aiohttp.web.Application()
+        parsed_url = urllib.parse.urlparse(url)
+        app.add_routes([aiohttp.web.get(parsed_url.path, handler)])
+        app.add_routes([aiohttp.web.post(parsed_url.path, handler)])
+        app.add_routes([aiohttp.web.patch(parsed_url.path, handler)])
+
+        with contextlib.suppress(aiohttp.ClientError):
+            async with aiohttp.test_utils.TestServer(app) as server:
+                netloc = (server.host, server.port)
+                await server.start_server()
+                await runnable(server)
+        return netloc
+
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(do_request())
+
+
+class TestAioHttpIntegration(TestBase):
+    def assert_spans(self, spans):
+        self.assertEqual(
+            [
+                (
+                    span.name,
+                    (span.status.canonical_code, span.status.description),
+                    dict(span.attributes),
+                )
+                for span in self.memory_exporter.get_finished_spans()
+            ],
+            spans,
+        )
+
+    def test_url_path_span_name(self):
+        for url, expected in (
+            (
+                yarl.URL("http://hostname.local:1234/some/path?query=params"),
+                "/some/path",
+            ),
+            (yarl.URL("http://hostname.local:1234"), "/"),
+        ):
+            with self.subTest(url=url):
+                params = aiohttp.TraceRequestStartParams("METHOD", url, {})
+                actual = aiohttp_client.url_path_span_name(params)
+                self.assertEqual(actual, expected)
+                self.assertIsInstance(actual, str)
+
+    @staticmethod
+    def _http_request(
+        trace_config,
+        url: str,
+        method: str = "GET",
+        status_code: int = HTTPStatus.OK,
+        request_handler: typing.Callable = None,
+        **kwargs
+    ) -> typing.Tuple[str, int]:
+        """Helper to start an aiohttp test server and send an actual HTTP request to it."""
+
+        async def default_handler(request):
+            assert "traceparent" in request.headers
+            return aiohttp.web.Response(status=int(status_code))
+
+        async def client_request(server: aiohttp.test_utils.TestServer):
+            async with aiohttp.test_utils.TestClient(
+                server, trace_configs=[trace_config]
+            ) as client:
+                await client.request(
+                    method, url, trace_request_ctx={}, **kwargs
+                )
+
+        handler = request_handler or default_handler
+        return run_with_test_server(client_request, url, handler)
+
+    def test_status_codes(self):
+        for status_code, span_status in (
+            (HTTPStatus.OK, StatusCanonicalCode.OK),
+            (HTTPStatus.TEMPORARY_REDIRECT, StatusCanonicalCode.OK),
+            (HTTPStatus.SERVICE_UNAVAILABLE, StatusCanonicalCode.UNAVAILABLE),
+            (
+                HTTPStatus.GATEWAY_TIMEOUT,
+                StatusCanonicalCode.DEADLINE_EXCEEDED,
+            ),
+        ):
+            with self.subTest(status_code=status_code):
+                host, port = self._http_request(
+                    trace_config=aiohttp_client.create_trace_config(),
+                    url="/test-path?query=param#foobar",
+                    status_code=status_code,
+                )
+
+                self.assert_spans(
+                    [
+                        (
+                            "HTTP GET",
+                            (span_status, None),
+                            {
+                                "component": "http",
+                                "http.method": "GET",
+                                "http.url": "http://{}:{}/test-path?query=param#foobar".format(
+                                    host, port
+                                ),
+                                "http.status_code": int(status_code),
+                                "http.status_text": status_code.phrase,
+                            },
+                        )
+                    ]
+                )
+
+                self.memory_exporter.clear()
+
+    def test_not_recording(self):
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        with mock.patch("opentelemetry.trace.get_tracer"):
+            # pylint: disable=W0612
+            host, port = self._http_request(
+                trace_config=aiohttp_client.create_trace_config(),
+                url="/test-path?query=param#foobar",
+            )
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_span_name_option(self):
+        for span_name, method, path, expected in (
+            ("static", "POST", "/static-span-name", "static"),
+            (
+                lambda params: "{} - {}".format(
+                    params.method, params.url.path
+                ),
+                "PATCH",
+                "/some/path",
+                "PATCH - /some/path",
+            ),
+        ):
+            with self.subTest(span_name=span_name, method=method, path=path):
+                host, port = self._http_request(
+                    trace_config=aiohttp_client.create_trace_config(
+                        span_name=span_name
+                    ),
+                    method=method,
+                    url=path,
+                    status_code=HTTPStatus.OK,
+                )
+
+                self.assert_spans(
+                    [
+                        (
+                            expected,
+                            (StatusCanonicalCode.OK, None),
+                            {
+                                "component": "http",
+                                "http.method": method,
+                                "http.url": "http://{}:{}{}".format(
+                                    host, port, path
+                                ),
+                                "http.status_code": int(HTTPStatus.OK),
+                                "http.status_text": HTTPStatus.OK.phrase,
+                            },
+                        )
+                    ]
+                )
+                self.memory_exporter.clear()
+
+    def test_url_filter_option(self):
+        # Strips all query params from URL before adding as a span attribute.
+        def strip_query_params(url: yarl.URL) -> str:
+            return str(url.with_query(None))
+
+        host, port = self._http_request(
+            trace_config=aiohttp_client.create_trace_config(
+                url_filter=strip_query_params
+            ),
+            url="/some/path?query=param&other=param2",
+            status_code=HTTPStatus.OK,
+        )
+
+        self.assert_spans(
+            [
+                (
+                    "HTTP GET",
+                    (StatusCanonicalCode.OK, None),
+                    {
+                        "component": "http",
+                        "http.method": "GET",
+                        "http.url": "http://{}:{}/some/path".format(
+                            host, port
+                        ),
+                        "http.status_code": int(HTTPStatus.OK),
+                        "http.status_text": HTTPStatus.OK.phrase,
+                    },
+                )
+            ]
+        )
+
+    def test_connection_errors(self):
+        trace_configs = [aiohttp_client.create_trace_config()]
+
+        for url, expected_status in (
+            ("http://this-is-unknown.local/", StatusCanonicalCode.UNKNOWN),
+            ("http://127.0.0.1:1/", StatusCanonicalCode.UNAVAILABLE),
+        ):
+            with self.subTest(expected_status=expected_status):
+
+                async def do_request(url):
+                    async with aiohttp.ClientSession(
+                        trace_configs=trace_configs,
+                    ) as session:
+                        async with session.get(url):
+                            pass
+
+                loop = asyncio.get_event_loop()
+                with self.assertRaises(aiohttp.ClientConnectorError):
+                    loop.run_until_complete(do_request(url))
+
+            self.assert_spans(
+                [
+                    (
+                        "HTTP GET",
+                        (expected_status, None),
+                        {
+                            "component": "http",
+                            "http.method": "GET",
+                            "http.url": url,
+                        },
+                    )
+                ]
+            )
+            self.memory_exporter.clear()
+
+    def test_timeout(self):
+        async def request_handler(request):
+            await asyncio.sleep(1)
+            assert "traceparent" in request.headers
+            return aiohttp.web.Response()
+
+        host, port = self._http_request(
+            trace_config=aiohttp_client.create_trace_config(),
+            url="/test_timeout",
+            request_handler=request_handler,
+            timeout=aiohttp.ClientTimeout(sock_read=0.01),
+        )
+
+        self.assert_spans(
+            [
+                (
+                    "HTTP GET",
+                    (StatusCanonicalCode.DEADLINE_EXCEEDED, None),
+                    {
+                        "component": "http",
+                        "http.method": "GET",
+                        "http.url": "http://{}:{}/test_timeout".format(
+                            host, port
+                        ),
+                    },
+                )
+            ]
+        )
+
+    def test_too_many_redirects(self):
+        async def request_handler(request):
+            # Create a redirect loop.
+            location = request.url
+            assert "traceparent" in request.headers
+            raise aiohttp.web.HTTPFound(location=location)
+
+        host, port = self._http_request(
+            trace_config=aiohttp_client.create_trace_config(),
+            url="/test_too_many_redirects",
+            request_handler=request_handler,
+            max_redirects=2,
+        )
+
+        self.assert_spans(
+            [
+                (
+                    "HTTP GET",
+                    (StatusCanonicalCode.DEADLINE_EXCEEDED, None),
+                    {
+                        "component": "http",
+                        "http.method": "GET",
+                        "http.url": "http://{}:{}/test_too_many_redirects".format(
+                            host, port
+                        ),
+                    },
+                )
+            ]
+        )
+
+
+class TestAioHttpClientInstrumentor(TestBase):
+    URL = "/test-path"
+
+    def setUp(self):
+        super().setUp()
+        AioHttpClientInstrumentor().instrument()
+
+    def tearDown(self):
+        super().tearDown()
+        AioHttpClientInstrumentor().uninstrument()
+
+    @staticmethod
+    # pylint:disable=unused-argument
+    async def default_handler(request):
+        return aiohttp.web.Response(status=int(200))
+
+    @staticmethod
+    def get_default_request(url: str = URL):
+        async def default_request(server: aiohttp.test_utils.TestServer):
+            async with aiohttp.test_utils.TestClient(server) as session:
+                await session.get(url)
+
+        return default_request
+
+    def assert_spans(self, num_spans: int):
+        finished_spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(num_spans, len(finished_spans))
+        if num_spans == 0:
+            return None
+        if num_spans == 1:
+            return finished_spans[0]
+        return finished_spans
+
+    def test_instrument(self):
+        host, port = run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self.assert_spans(1)
+        self.assertEqual("http", span.attributes["component"])
+        self.assertEqual("GET", span.attributes["http.method"])
+        self.assertEqual(
+            "http://{}:{}/test-path".format(host, port),
+            span.attributes["http.url"],
+        )
+        self.assertEqual(200, span.attributes["http.status_code"])
+        self.assertEqual("OK", span.attributes["http.status_text"])
+
+    def test_instrument_with_existing_trace_config(self):
+        trace_config = aiohttp.TraceConfig()
+
+        async def create_session(server: aiohttp.test_utils.TestServer):
+            async with aiohttp.test_utils.TestClient(
+                server, trace_configs=[trace_config]
+            ) as client:
+                # pylint:disable=protected-access
+                trace_configs = client.session._trace_configs
+                self.assertEqual(2, len(trace_configs))
+                self.assertTrue(trace_config in trace_configs)
+                async with client as session:
+                    await session.get(TestAioHttpClientInstrumentor.URL)
+
+        run_with_test_server(create_session, self.URL, self.default_handler)
+        self.assert_spans(1)
+
+    def test_uninstrument(self):
+        AioHttpClientInstrumentor().uninstrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+
+        self.assert_spans(0)
+
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        self.assert_spans(1)
+
+    def test_uninstrument_session(self):
+        async def uninstrument_request(server: aiohttp.test_utils.TestServer):
+            client = aiohttp.test_utils.TestClient(server)
+            AioHttpClientInstrumentor().uninstrument_session(client.session)
+            async with client as session:
+                await session.get(self.URL)
+
+        run_with_test_server(
+            uninstrument_request, self.URL, self.default_handler
+        )
+        self.assert_spans(0)
+
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        self.assert_spans(1)
+
+    def test_suppress_instrumentation(self):
+        token = context.attach(
+            context.set_value("suppress_instrumentation", True)
+        )
+        try:
+            run_with_test_server(
+                self.get_default_request(), self.URL, self.default_handler
+            )
+        finally:
+            context.detach(token)
+        self.assert_spans(0)
+
+    @staticmethod
+    async def suppressed_request(server: aiohttp.test_utils.TestServer):
+        async with aiohttp.test_utils.TestClient(server) as client:
+            token = context.attach(
+                context.set_value("suppress_instrumentation", True)
+            )
+            await client.get(TestAioHttpClientInstrumentor.URL)
+            context.detach(token)
+
+    def test_suppress_instrumentation_after_creation(self):
+        run_with_test_server(
+            self.suppressed_request, self.URL, self.default_handler
+        )
+        self.assert_spans(0)
+
+    def test_suppress_instrumentation_with_server_exception(self):
+        # pylint:disable=unused-argument
+        async def raising_handler(request):
+            raise aiohttp.web.HTTPFound(location=self.URL)
+
+        run_with_test_server(
+            self.suppressed_request, self.URL, raising_handler
+        )
+        self.assert_spans(0)
+
+    def test_url_filter(self):
+        def strip_query_params(url: yarl.URL) -> str:
+            return str(url.with_query(None))
+
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument(url_filter=strip_query_params)
+
+        url = "/test-path?query=params"
+        host, port = run_with_test_server(
+            self.get_default_request(url), url, self.default_handler
+        )
+        span = self.assert_spans(1)
+        self.assertEqual(
+            "http://{}:{}/test-path".format(host, port),
+            span.attributes["http.url"],
+        )
+
+    def test_span_name(self):
+        def span_name_callback(params: aiohttp.TraceRequestStartParams) -> str:
+            return "{} - {}".format(params.method, params.url.path)
+
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument(span_name=span_name_callback)
+
+        url = "/test-path"
+        run_with_test_server(
+            self.get_default_request(url), url, self.default_handler
+        )
+        span = self.assert_spans(1)
+        self.assertEqual("GET - /test-path", span.name)
+
+
+class TestLoadingAioHttpInstrumentor(unittest.TestCase):
+    def test_loading_instrumentor(self):
+        entry_points = iter_entry_points(
+            "opentelemetry_instrumentor", "aiohttp-client"
+        )
+
+        instrumentor = next(entry_points).load()()
+        self.assertIsInstance(instrumentor, AioHttpClientInstrumentor)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-aiohttp-client` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-aiohttp-client

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

For example the files in this PR have these import statements:

```
from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
from opentelemetry.instrumentation.utils import (
    http_status_to_canonical_code,
    unwrap,
)
```

Both of which don't exist yet in this repo until I add them, in future PRs.

After the PRs with the packages are merged, I'll create a final PR to add tests. (And I count on it working based on my big #47 PR)

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
