### PR TITLE
Move instrumentation aiopg

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.11b0
+
+Released 2020-07-28
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-aiopg/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-aiopg/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-aiopg/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/README.rst
@@ -1,0 +1,21 @@
+OpenTelemetry aiopg instrumentation
+===================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-aiopg.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-aiopg/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-aiopg
+
+
+References
+----------
+
+* `OpenTelemetry aiopg Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/aiopg/aiopg.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
@@ -1,0 +1,58 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-aiopg
+description = OpenTelemetry aiopg instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-aiopg
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation-dbapi == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    aiopg >= 0.13.0
+    wrapt >= 1.0.0, < 2.0.0
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    aiopg = opentelemetry.instrumentation.aiopg:AiopgInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "aiopg", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
@@ -1,0 +1,121 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The integration with PostgreSQL supports the aiopg library,
+it can be enabled by using ``AiopgInstrumentor``.
+
+.. aiopg: https://github.com/aio-libs/aiopg
+
+Usage
+-----
+
+.. code-block:: python
+
+    import aiopg
+    from opentelemetry.instrumentation.aiopg import AiopgInstrumentor
+
+    AiopgInstrumentor().instrument()
+
+    cnx = await aiopg.connect(database='Database')
+    cursor = await cnx.cursor()
+    await cursor.execute("INSERT INTO test (testField) VALUES (123)")
+    cursor.close()
+    cnx.close()
+
+    pool = await aiopg.create_pool(database='Database')
+    cnx = await pool.acquire()
+    cursor = await cnx.cursor()
+    await cursor.execute("INSERT INTO test (testField) VALUES (123)")
+    cursor.close()
+    cnx.close()
+
+API
+---
+"""
+
+from opentelemetry.instrumentation.aiopg import wrappers
+from opentelemetry.instrumentation.aiopg.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+
+
+class AiopgInstrumentor(BaseInstrumentor):
+    _CONNECTION_ATTRIBUTES = {
+        "database": "info.dbname",
+        "port": "info.port",
+        "host": "info.host",
+        "user": "info.user",
+    }
+
+    _DATABASE_COMPONENT = "postgresql"
+    _DATABASE_TYPE = "sql"
+
+    def _instrument(self, **kwargs):
+        """Integrate with PostgreSQL aiopg library.
+        aiopg: https://github.com/aio-libs/aiopg
+        """
+
+        tracer_provider = kwargs.get("tracer_provider")
+
+        wrappers.wrap_connect(
+            __name__,
+            self._DATABASE_COMPONENT,
+            self._DATABASE_TYPE,
+            self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
+        )
+
+        wrappers.wrap_create_pool(
+            __name__,
+            self._DATABASE_COMPONENT,
+            self._DATABASE_TYPE,
+            self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
+        )
+
+    def _uninstrument(self, **kwargs):
+        """"Disable aiopg instrumentation"""
+        wrappers.unwrap_connect()
+        wrappers.unwrap_create_pool()
+
+    # pylint:disable=no-self-use
+    def instrument_connection(self, connection):
+        """Enable instrumentation in a aiopg connection.
+
+        Args:
+            connection: The connection to instrument.
+
+        Returns:
+            An instrumented connection.
+        """
+        return wrappers.instrument_connection(
+            __name__,
+            connection,
+            self._DATABASE_COMPONENT,
+            self._DATABASE_TYPE,
+            self._CONNECTION_ATTRIBUTES,
+        )
+
+    def uninstrument_connection(self, connection):
+        """Disable instrumentation in a aiopg connection.
+
+        Args:
+            connection: The connection to uninstrument.
+
+        Returns:
+            An uninstrumented connection.
+        """
+        return wrappers.uninstrument_connection(connection)

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -1,0 +1,150 @@
+import typing
+
+import wrapt
+from aiopg.utils import _ContextManager, _PoolAcquireContextManager
+
+from opentelemetry.instrumentation.dbapi import (
+    DatabaseApiIntegration,
+    TracedCursor,
+)
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+
+# pylint: disable=abstract-method
+class AsyncProxyObject(wrapt.ObjectProxy):
+    def __aiter__(self):
+        return self.__wrapped__.__aiter__()
+
+    async def __anext__(self):
+        result = await self.__wrapped__.__anext__()
+        return result
+
+    async def __aenter__(self):
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
+
+    def __await__(self):
+        return self.__wrapped__.__await__()
+
+
+class AiopgIntegration(DatabaseApiIntegration):
+    async def wrapped_connection(
+        self,
+        connect_method: typing.Callable[..., typing.Any],
+        args: typing.Tuple[typing.Any, typing.Any],
+        kwargs: typing.Dict[typing.Any, typing.Any],
+    ):
+        """Add object proxy to connection object."""
+        connection = await connect_method(*args, **kwargs)
+        # pylint: disable=protected-access
+        self.get_connection_attributes(connection._conn)
+        return get_traced_connection_proxy(connection, self)
+
+    async def wrapped_pool(self, create_pool_method, args, kwargs):
+        pool = await create_pool_method(*args, **kwargs)
+        async with pool.acquire() as connection:
+            # pylint: disable=protected-access
+            self.get_connection_attributes(connection._conn)
+        return get_traced_pool_proxy(pool, self)
+
+
+def get_traced_connection_proxy(
+    connection, db_api_integration, *args, **kwargs
+):
+    # pylint: disable=abstract-method
+    class TracedConnectionProxy(AsyncProxyObject):
+        # pylint: disable=unused-argument
+        def __init__(self, connection, *args, **kwargs):
+            super().__init__(connection)
+
+        def cursor(self, *args, **kwargs):
+            coro = self._cursor(*args, **kwargs)
+            return _ContextManager(coro)
+
+        async def _cursor(self, *args, **kwargs):
+            # pylint: disable=protected-access
+            cursor = await self.__wrapped__._cursor(*args, **kwargs)
+            return get_traced_cursor_proxy(cursor, db_api_integration)
+
+    return TracedConnectionProxy(connection, *args, **kwargs)
+
+
+def get_traced_pool_proxy(pool, db_api_integration, *args, **kwargs):
+    # pylint: disable=abstract-method
+    class TracedPoolProxy(AsyncProxyObject):
+        # pylint: disable=unused-argument
+        def __init__(self, pool, *args, **kwargs):
+            super().__init__(pool)
+
+        def acquire(self):
+            """Acquire free connection from the pool."""
+            coro = self._acquire()
+            return _PoolAcquireContextManager(coro, self)
+
+        async def _acquire(self):
+            # pylint: disable=protected-access
+            connection = await self.__wrapped__._acquire()
+            return get_traced_connection_proxy(
+                connection, db_api_integration, *args, **kwargs
+            )
+
+    return TracedPoolProxy(pool, *args, **kwargs)
+
+
+class AsyncTracedCursor(TracedCursor):
+    async def traced_execution(
+        self,
+        query_method: typing.Callable[..., typing.Any],
+        *args: typing.Tuple[typing.Any, typing.Any],
+        **kwargs: typing.Dict[typing.Any, typing.Any]
+    ):
+
+        with self._db_api_integration.get_tracer().start_as_current_span(
+            self._db_api_integration.name, kind=SpanKind.CLIENT
+        ) as span:
+            self._populate_span(span, *args)
+            try:
+                result = await query_method(*args, **kwargs)
+                if span.is_recording():
+                    span.set_status(Status(StatusCanonicalCode.OK))
+                return result
+            except Exception as ex:  # pylint: disable=broad-except
+                if span.is_recording():
+                    span.set_status(
+                        Status(StatusCanonicalCode.UNKNOWN, str(ex))
+                    )
+                raise ex
+
+
+def get_traced_cursor_proxy(cursor, db_api_integration, *args, **kwargs):
+    _traced_cursor = AsyncTracedCursor(db_api_integration)
+
+    # pylint: disable=abstract-method
+    class AsyncTracedCursorProxy(AsyncProxyObject):
+
+        # pylint: disable=unused-argument
+        def __init__(self, cursor, *args, **kwargs):
+            super().__init__(cursor)
+
+        async def execute(self, *args, **kwargs):
+            result = await _traced_cursor.traced_execution(
+                self.__wrapped__.execute, *args, **kwargs
+            )
+            return result
+
+        async def executemany(self, *args, **kwargs):
+            result = await _traced_cursor.traced_execution(
+                self.__wrapped__.executemany, *args, **kwargs
+            )
+            return result
+
+        async def callproc(self, *args, **kwargs):
+            result = await _traced_cursor.traced_execution(
+                self.__wrapped__.callproc, *args, **kwargs
+            )
+            return result
+
+    return AsyncTracedCursorProxy(cursor, *args, **kwargs)

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
@@ -1,0 +1,223 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The trace integration with aiopg based on dbapi integration,
+where replaced sync wrap methods to async
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.aiopg import trace_integration
+    from opentelemetry.trace import TracerProvider
+
+    trace.set_tracer_provider(TracerProvider())
+
+    trace_integration(aiopg.connection, "_connect", "postgresql", "sql")
+
+API
+---
+"""
+import logging
+import typing
+
+import aiopg
+import wrapt
+
+from opentelemetry.instrumentation.aiopg.aiopg_integration import (
+    AiopgIntegration,
+    get_traced_connection_proxy,
+)
+from opentelemetry.instrumentation.aiopg.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import TracerProvider
+
+logger = logging.getLogger(__name__)
+
+
+def trace_integration(
+    database_component: str,
+    database_type: str = "",
+    connection_attributes: typing.Dict = None,
+    tracer_provider: typing.Optional[TracerProvider] = None,
+):
+    """Integrate with aiopg library.
+    based on dbapi integration, where replaced sync wrap methods to async
+
+    Args:
+        database_component: Database driver name or
+            database name "postgreSQL".
+        database_type: The Database type. For any SQL database, "sql".
+        connection_attributes: Attribute names for database, port, host and
+            user in Connection object.
+        tracer_provider: The :class:`opentelemetry.trace.TracerProvider` to
+            use. If ommited the current configured one is used.
+    """
+
+    wrap_connect(
+        __name__,
+        database_component,
+        database_type,
+        connection_attributes,
+        __version__,
+        tracer_provider,
+    )
+
+
+def wrap_connect(
+    name: str,
+    database_component: str,
+    database_type: str = "",
+    connection_attributes: typing.Dict = None,
+    version: str = "",
+    tracer_provider: typing.Optional[TracerProvider] = None,
+):
+    """Integrate with aiopg library.
+    https://github.com/aio-libs/aiopg
+
+    Args:
+        name: Name of opentelemetry extension for aiopg.
+        database_component: Database driver name
+            or database name "postgreSQL".
+        database_type: The Database type. For any SQL database, "sql".
+        connection_attributes: Attribute names for database, port, host and
+            user in Connection object.
+        version: Version of opentelemetry extension for aiopg.
+        tracer_provider: The :class:`opentelemetry.trace.TracerProvider` to
+            use. If ommited the current configured one is used.
+    """
+
+    # pylint: disable=unused-argument
+    async def wrap_connect_(
+        wrapped: typing.Callable[..., typing.Any],
+        instance: typing.Any,
+        args: typing.Tuple[typing.Any, typing.Any],
+        kwargs: typing.Dict[typing.Any, typing.Any],
+    ):
+        db_integration = AiopgIntegration(
+            name,
+            database_component,
+            database_type=database_type,
+            connection_attributes=connection_attributes,
+            version=version,
+            tracer_provider=tracer_provider,
+        )
+        return await db_integration.wrapped_connection(wrapped, args, kwargs)
+
+    try:
+        wrapt.wrap_function_wrapper(aiopg, "connect", wrap_connect_)
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.warning("Failed to integrate with aiopg. %s", str(ex))
+
+
+def unwrap_connect():
+    """Disable integration with aiopg library.
+    https://github.com/aio-libs/aiopg
+    """
+
+    unwrap(aiopg, "connect")
+
+
+def instrument_connection(
+    name: str,
+    connection,
+    database_component: str,
+    database_type: str = "",
+    connection_attributes: typing.Dict = None,
+    version: str = "",
+    tracer_provider: typing.Optional[TracerProvider] = None,
+):
+    """Enable instrumentation in a database connection.
+
+    Args:
+        name: Name of opentelemetry extension for aiopg.
+        connection: The connection to instrument.
+        database_component: Database driver name or database name "postgreSQL".
+        database_type: The Database type. For any SQL database, "sql".
+        connection_attributes: Attribute names for database, port, host and
+            user in a connection object.
+        version: Version of opentelemetry extension for aiopg.
+        tracer_provider: The :class:`opentelemetry.trace.TracerProvider` to
+            use. If ommited the current configured one is used.
+
+    Returns:
+        An instrumented connection.
+    """
+    db_integration = AiopgIntegration(
+        name,
+        database_component,
+        database_type,
+        connection_attributes=connection_attributes,
+        version=version,
+        tracer_provider=tracer_provider,
+    )
+    db_integration.get_connection_attributes(connection)
+    return get_traced_connection_proxy(connection, db_integration)
+
+
+def uninstrument_connection(connection):
+    """Disable instrumentation in a database connection.
+
+    Args:
+        connection: The connection to uninstrument.
+
+    Returns:
+        An uninstrumented connection.
+    """
+    if isinstance(connection, wrapt.ObjectProxy):
+        return connection.__wrapped__
+
+    logger.warning("Connection is not instrumented")
+    return connection
+
+
+def wrap_create_pool(
+    name: str,
+    database_component: str,
+    database_type: str = "",
+    connection_attributes: typing.Dict = None,
+    version: str = "",
+    tracer_provider: typing.Optional[TracerProvider] = None,
+):
+    # pylint: disable=unused-argument
+    async def wrap_create_pool_(
+        wrapped: typing.Callable[..., typing.Any],
+        instance: typing.Any,
+        args: typing.Tuple[typing.Any, typing.Any],
+        kwargs: typing.Dict[typing.Any, typing.Any],
+    ):
+        db_integration = AiopgIntegration(
+            name,
+            database_component,
+            database_type,
+            connection_attributes=connection_attributes,
+            version=version,
+            tracer_provider=tracer_provider,
+        )
+        return await db_integration.wrapped_pool(wrapped, args, kwargs)
+
+    try:
+        wrapt.wrap_function_wrapper(aiopg, "create_pool", wrap_create_pool_)
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.warning("Failed to integrate with DB API. %s", str(ex))
+
+
+def unwrap_create_pool():
+    """Disable integration with aiopg library.
+    https://github.com/aio-libs/aiopg
+    """
+    unwrap(aiopg, "create_pool")

--- a/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
@@ -1,0 +1,506 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+from unittest import mock
+from unittest.mock import MagicMock
+
+import aiopg
+from aiopg.utils import _ContextManager, _PoolAcquireContextManager
+
+import opentelemetry.instrumentation.aiopg
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.aiopg import AiopgInstrumentor, wrappers
+from opentelemetry.instrumentation.aiopg.aiopg_integration import (
+    AiopgIntegration,
+)
+from opentelemetry.sdk import resources
+from opentelemetry.test.test_base import TestBase
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+class TestAiopgInstrumentor(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.origin_aiopg_connect = aiopg.connect
+        self.origin_aiopg_create_pool = aiopg.create_pool
+        aiopg.connect = mock_connect
+        aiopg.create_pool = mock_create_pool
+
+    def tearDown(self):
+        super().tearDown()
+        aiopg.connect = self.origin_aiopg_connect
+        aiopg.create_pool = self.origin_aiopg_create_pool
+        with self.disable_logging():
+            AiopgInstrumentor().uninstrument()
+
+    def test_instrumentor_connect(self):
+        AiopgInstrumentor().instrument()
+
+        cnx = async_call(aiopg.connect(database="test"))
+
+        cursor = async_call(cnx.cursor())
+
+        query = "SELECT * FROM test"
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        # Check version and name in span's instrumentation info
+        self.check_span_instrumentation_info(
+            span, opentelemetry.instrumentation.aiopg
+        )
+
+        # check that no spans are generated after uninstrument
+        AiopgInstrumentor().uninstrument()
+
+        cnx = async_call(aiopg.connect(database="test"))
+        cursor = async_call(cnx.cursor())
+        query = "SELECT * FROM test"
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+    def test_instrumentor_create_pool(self):
+        AiopgInstrumentor().instrument()
+
+        pool = async_call(aiopg.create_pool(database="test"))
+        cnx = async_call(pool.acquire())
+        cursor = async_call(cnx.cursor())
+
+        query = "SELECT * FROM test"
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        # Check version and name in span's instrumentation info
+        self.check_span_instrumentation_info(
+            span, opentelemetry.instrumentation.aiopg
+        )
+
+        # check that no spans are generated after uninstrument
+        AiopgInstrumentor().uninstrument()
+
+        pool = async_call(aiopg.create_pool(database="test"))
+        cnx = async_call(pool.acquire())
+        cursor = async_call(cnx.cursor())
+        query = "SELECT * FROM test"
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+    def test_custom_tracer_provider_connect(self):
+        resource = resources.Resource.create({})
+        result = self.create_tracer_provider(resource=resource)
+        tracer_provider, exporter = result
+
+        AiopgInstrumentor().instrument(tracer_provider=tracer_provider)
+
+        cnx = async_call(aiopg.connect(database="test"))
+        cursor = async_call(cnx.cursor())
+        query = "SELECT * FROM test"
+        async_call(cursor.execute(query))
+
+        spans_list = exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertIs(span.resource, resource)
+
+    def test_custom_tracer_provider_create_pool(self):
+        resource = resources.Resource.create({})
+        result = self.create_tracer_provider(resource=resource)
+        tracer_provider, exporter = result
+
+        AiopgInstrumentor().instrument(tracer_provider=tracer_provider)
+
+        pool = async_call(aiopg.create_pool(database="test"))
+        cnx = async_call(pool.acquire())
+        cursor = async_call(cnx.cursor())
+        query = "SELECT * FROM test"
+        async_call(cursor.execute(query))
+
+        spans_list = exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        self.assertIs(span.resource, resource)
+
+    def test_instrument_connection(self):
+        cnx = async_call(aiopg.connect(database="test"))
+        query = "SELECT * FROM test"
+        cursor = async_call(cnx.cursor())
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+        cnx = AiopgInstrumentor().instrument_connection(cnx)
+        cursor = async_call(cnx.cursor())
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+    def test_uninstrument_connection(self):
+        AiopgInstrumentor().instrument()
+        cnx = async_call(aiopg.connect(database="test"))
+        query = "SELECT * FROM test"
+        cursor = async_call(cnx.cursor())
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+        cnx = AiopgInstrumentor().uninstrument_connection(cnx)
+        cursor = async_call(cnx.cursor())
+        async_call(cursor.execute(query))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+
+class TestAiopgIntegration(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
+
+    def test_span_succeeded(self):
+        connection_props = {
+            "database": "testdatabase",
+            "server_host": "testhost",
+            "server_port": 123,
+            "user": "testuser",
+        }
+        connection_attributes = {
+            "database": "database",
+            "port": "server_port",
+            "host": "server_host",
+            "user": "user",
+        }
+        db_integration = AiopgIntegration(
+            self.tracer, "testcomponent", "testtype", connection_attributes
+        )
+        mock_connection = async_call(
+            db_integration.wrapped_connection(
+                mock_connect, {}, connection_props
+            )
+        )
+        cursor = async_call(mock_connection.cursor())
+        async_call(cursor.execute("Test query", ("param1Value", False)))
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "testcomponent.testdatabase")
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+
+        self.assertEqual(span.attributes["component"], "testcomponent")
+        self.assertEqual(span.attributes["db.type"], "testtype")
+        self.assertEqual(span.attributes["db.instance"], "testdatabase")
+        self.assertEqual(span.attributes["db.statement"], "Test query")
+        self.assertEqual(
+            span.attributes["db.statement.parameters"],
+            "('param1Value', False)",
+        )
+        self.assertEqual(span.attributes["db.user"], "testuser")
+        self.assertEqual(span.attributes["net.peer.name"], "testhost")
+        self.assertEqual(span.attributes["net.peer.port"], 123)
+        self.assertIs(
+            span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.OK,
+        )
+
+    def test_span_not_recording(self):
+        connection_props = {
+            "database": "testdatabase",
+            "server_host": "testhost",
+            "server_port": 123,
+            "user": "testuser",
+        }
+        connection_attributes = {
+            "database": "database",
+            "port": "server_port",
+            "host": "server_host",
+            "user": "user",
+        }
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        db_integration = AiopgIntegration(
+            mock_tracer, "testcomponent", "testtype", connection_attributes
+        )
+        mock_connection = async_call(
+            db_integration.wrapped_connection(
+                mock_connect, {}, connection_props
+            )
+        )
+        cursor = async_call(mock_connection.cursor())
+        async_call(cursor.execute("Test query", ("param1Value", False)))
+        self.assertFalse(mock_span.is_recording())
+        self.assertTrue(mock_span.is_recording.called)
+        self.assertFalse(mock_span.set_attribute.called)
+        self.assertFalse(mock_span.set_status.called)
+
+    def test_span_failed(self):
+        db_integration = AiopgIntegration(self.tracer, "testcomponent")
+        mock_connection = async_call(
+            db_integration.wrapped_connection(mock_connect, {}, {})
+        )
+        cursor = async_call(mock_connection.cursor())
+        with self.assertRaises(Exception):
+            async_call(cursor.execute("Test query", throw_exception=True))
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.attributes["db.statement"], "Test query")
+        self.assertIs(
+            span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.UNKNOWN,
+        )
+        self.assertEqual(span.status.description, "Test Exception")
+
+    def test_executemany(self):
+        db_integration = AiopgIntegration(self.tracer, "testcomponent")
+        mock_connection = async_call(
+            db_integration.wrapped_connection(mock_connect, {}, {})
+        )
+        cursor = async_call(mock_connection.cursor())
+        async_call(cursor.executemany("Test query"))
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.attributes["db.statement"], "Test query")
+
+    def test_callproc(self):
+        db_integration = AiopgIntegration(self.tracer, "testcomponent")
+        mock_connection = async_call(
+            db_integration.wrapped_connection(mock_connect, {}, {})
+        )
+        cursor = async_call(mock_connection.cursor())
+        async_call(cursor.callproc("Test stored procedure"))
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(
+            span.attributes["db.statement"], "Test stored procedure"
+        )
+
+    def test_wrap_connect(self):
+        aiopg_mock = AiopgMock()
+        with mock.patch("aiopg.connect", aiopg_mock.connect):
+            wrappers.wrap_connect(self.tracer, "-")
+            connection = async_call(aiopg.connect())
+            self.assertEqual(aiopg_mock.connect_call_count, 1)
+            self.assertIsInstance(connection.__wrapped__, mock.Mock)
+
+    def test_unwrap_connect(self):
+        wrappers.wrap_connect(self.tracer, "-")
+        aiopg_mock = AiopgMock()
+        with mock.patch("aiopg.connect", aiopg_mock.connect):
+            connection = async_call(aiopg.connect())
+            self.assertEqual(aiopg_mock.connect_call_count, 1)
+            wrappers.unwrap_connect()
+            connection = async_call(aiopg.connect())
+            self.assertEqual(aiopg_mock.connect_call_count, 2)
+            self.assertIsInstance(connection, mock.Mock)
+
+    def test_wrap_create_pool(self):
+        async def check_connection(pool):
+            async with pool.acquire() as connection:
+                self.assertEqual(aiopg_mock.create_pool_call_count, 1)
+                self.assertIsInstance(
+                    connection.__wrapped__, AiopgConnectionMock
+                )
+
+        aiopg_mock = AiopgMock()
+        with mock.patch("aiopg.create_pool", aiopg_mock.create_pool):
+            wrappers.wrap_create_pool(self.tracer, "-")
+            pool = async_call(aiopg.create_pool())
+            async_call(check_connection(pool))
+
+    def test_unwrap_create_pool(self):
+        async def check_connection(pool):
+            async with pool.acquire() as connection:
+                self.assertEqual(aiopg_mock.create_pool_call_count, 2)
+                self.assertIsInstance(connection, AiopgConnectionMock)
+
+        aiopg_mock = AiopgMock()
+        with mock.patch("aiopg.create_pool", aiopg_mock.create_pool):
+            wrappers.wrap_create_pool(self.tracer, "-")
+            pool = async_call(aiopg.create_pool())
+            self.assertEqual(aiopg_mock.create_pool_call_count, 1)
+
+            wrappers.unwrap_create_pool()
+            pool = async_call(aiopg.create_pool())
+            async_call(check_connection(pool))
+
+    def test_instrument_connection(self):
+        connection = mock.Mock()
+        # Avoid get_attributes failing because can't concatenate mock
+        connection.database = "-"
+        connection2 = wrappers.instrument_connection(
+            self.tracer, connection, "-"
+        )
+        self.assertIs(connection2.__wrapped__, connection)
+
+    def test_uninstrument_connection(self):
+        connection = mock.Mock()
+        # Set connection.database to avoid a failure because mock can't
+        # be concatenated
+        connection.database = "-"
+        connection2 = wrappers.instrument_connection(
+            self.tracer, connection, "-"
+        )
+        self.assertIs(connection2.__wrapped__, connection)
+
+        connection3 = wrappers.uninstrument_connection(connection2)
+        self.assertIs(connection3, connection)
+
+        with self.assertLogs(level=logging.WARNING):
+            connection4 = wrappers.uninstrument_connection(connection)
+        self.assertIs(connection4, connection)
+
+
+# pylint: disable=unused-argument
+async def mock_connect(*args, **kwargs):
+    database = kwargs.get("database")
+    server_host = kwargs.get("server_host")
+    server_port = kwargs.get("server_port")
+    user = kwargs.get("user")
+    return MockConnection(database, server_port, server_host, user)
+
+
+# pylint: disable=unused-argument
+async def mock_create_pool(*args, **kwargs):
+    database = kwargs.get("database")
+    server_host = kwargs.get("server_host")
+    server_port = kwargs.get("server_port")
+    user = kwargs.get("user")
+    return MockPool(database, server_port, server_host, user)
+
+
+class MockPool:
+    def __init__(self, database, server_port, server_host, user):
+        self.database = database
+        self.server_port = server_port
+        self.server_host = server_host
+        self.user = user
+
+    async def release(self, conn):
+        return conn
+
+    def acquire(self):
+        """Acquire free connection from the pool."""
+        coro = self._acquire()
+        return _PoolAcquireContextManager(coro, self)
+
+    async def _acquire(self):
+        connect = await mock_connect(
+            self.database, self.server_port, self.server_host, self.user
+        )
+        return connect
+
+
+class MockPsycopg2Connection:
+    def __init__(self, database, server_port, server_host, user):
+        self.database = database
+        self.server_port = server_port
+        self.server_host = server_host
+        self.user = user
+
+
+class MockConnection:
+    def __init__(self, database, server_port, server_host, user):
+        self._conn = MockPsycopg2Connection(
+            database, server_port, server_host, user
+        )
+
+    # pylint: disable=no-self-use
+    def cursor(self):
+        coro = self._cursor()
+        return _ContextManager(coro)
+
+    async def _cursor(self):
+        return MockCursor()
+
+    def close(self):
+        pass
+
+
+class MockCursor:
+    # pylint: disable=unused-argument, no-self-use
+    async def execute(self, query, params=None, throw_exception=False):
+        if throw_exception:
+            raise Exception("Test Exception")
+
+    # pylint: disable=unused-argument, no-self-use
+    async def executemany(self, query, params=None, throw_exception=False):
+        if throw_exception:
+            raise Exception("Test Exception")
+
+    # pylint: disable=unused-argument, no-self-use
+    async def callproc(self, query, params=None, throw_exception=False):
+        if throw_exception:
+            raise Exception("Test Exception")
+
+
+class AiopgConnectionMock:
+    _conn = MagicMock()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def __aenter__(self):
+        return MagicMock()
+
+
+class AiopgPoolMock:
+    async def release(self, conn):
+        return conn
+
+    def acquire(self):
+        coro = self._acquire()
+        return _PoolAcquireContextManager(coro, self)
+
+    async def _acquire(self):
+        return AiopgConnectionMock()
+
+
+class AiopgMock:
+    def __init__(self):
+        self.connect_call_count = 0
+        self.create_pool_call_count = 0
+
+    async def connect(self, *args, **kwargs):
+        self.connect_call_count += 1
+        return MagicMock()
+
+    async def create_pool(self, *args, **kwargs):
+        self.create_pool_call_count += 1
+        return AiopgPoolMock()


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-aiopg` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-aiopg

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
