### PR TITLE
Move instrumentation boto

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-boto/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17  
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-boto
+  ([#969](https://github.com/open-telemetry/opentelemetry-python/pull/969))
+
+## Version 0.11b0
+
+Released 2020-07-28
+
+- ext/boto and ext/botocore: fails to export spans via jaeger
+([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
+
+## 0.9b0
+
+Released 2020-06-10
+
+- Initial release
+

--- a/instrumentation/opentelemetry-instrumentation-boto/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-boto/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-boto/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-boto/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-boto/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-boto/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry Boto Tracing
+==========================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-boto.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-boto/
+
+This library allows tracing requests made by the Boto library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-boto
+
+
+References
+----------
+
+* `OpenTelemetry Boto Tracing <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/boto/boto.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -1,0 +1,58 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-boto
+description = OpenTelemetry Boto instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-boto
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    boto ~= 2.0
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-instrumentation-botocore == 0.15.dev0
+
+[options.extras_require]
+test =
+    boto~=2.0
+    moto~=1.0
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    boto = opentelemetry.instrumentation.boto:BotoInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "boto", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -1,0 +1,206 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Instrument `Boto`_ to trace service requests.
+
+There are two options for instrumenting code. The first option is to use the
+``opentelemetry-instrument`` executable which will automatically
+instrument your Boto client. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _boto: https://pypi.org/project/boto/
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.boto import BotoInstrumentor
+    from opentelemetry.sdk.trace import TracerProvider
+    import boto
+
+    trace.set_tracer_provider(TracerProvider())
+
+    # Instrument Boto
+    BotoInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+
+    # This will create a span with Boto-specific attributes
+    ec2 = boto.ec2.connect_to_region("us-west-2")
+    ec2.get_all_instances()
+
+API
+---
+"""
+
+import logging
+from inspect import currentframe
+
+from boto.connection import AWSAuthConnection, AWSQueryConnection
+from wrapt import wrap_function_wrapper
+
+from opentelemetry.instrumentation.boto.version import __version__
+from opentelemetry.instrumentation.botocore import add_span_arg_tags, unwrap
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace import Resource
+from opentelemetry.trace import SpanKind, get_tracer
+
+logger = logging.getLogger(__name__)
+
+
+def _get_instance_region_name(instance):
+    region = getattr(instance, "region", None)
+
+    if not region:
+        return None
+    if isinstance(region, str):
+        return region.split(":")[1]
+    return region.name
+
+
+class BotoInstrumentor(BaseInstrumentor):
+    """A instrumentor for Boto
+
+    See `BaseInstrumentor`
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._original_boto = None
+
+    def _instrument(self, **kwargs):
+        # AWSQueryConnection and AWSAuthConnection are two different classes
+        # called by different services for connection.
+        # For exemple EC2 uses AWSQueryConnection and S3 uses
+        # AWSAuthConnection
+
+        # FIXME should the tracer provider be accessed via Configuration
+        # instead?
+        # pylint: disable=attribute-defined-outside-init
+        self._tracer = get_tracer(
+            __name__, __version__, kwargs.get("tracer_provider")
+        )
+
+        wrap_function_wrapper(
+            "boto.connection",
+            "AWSQueryConnection.make_request",
+            self._patched_query_request,
+        )
+        wrap_function_wrapper(
+            "boto.connection",
+            "AWSAuthConnection.make_request",
+            self._patched_auth_request,
+        )
+
+    def _uninstrument(self, **kwargs):
+        unwrap(AWSQueryConnection, "make_request")
+        unwrap(AWSAuthConnection, "make_request")
+
+    def _common_request(  # pylint: disable=too-many-locals
+        self,
+        args_name,
+        traced_args,
+        operation_name,
+        original_func,
+        instance,
+        args,
+        kwargs,
+    ):
+
+        endpoint_name = getattr(instance, "host").split(".")[0]
+
+        with self._tracer.start_as_current_span(
+            "{}.command".format(endpoint_name), kind=SpanKind.CONSUMER,
+        ) as span:
+            if args:
+                http_method = args[0]
+                span.resource = Resource(
+                    attributes={
+                        "endpoint": endpoint_name,
+                        "http_method": http_method.lower(),
+                    }
+                )
+            else:
+                span.resource = Resource(
+                    attributes={"endpoint": endpoint_name}
+                )
+
+            # Original func returns a boto.connection.HTTPResponse object
+            result = original_func(*args, **kwargs)
+
+            if span.is_recording():
+                add_span_arg_tags(
+                    span, endpoint_name, args, args_name, traced_args,
+                )
+
+                # Obtaining region name
+                region_name = _get_instance_region_name(instance)
+
+                meta = {
+                    "aws.agent": "boto",
+                    "aws.operation": operation_name,
+                }
+                if region_name:
+                    meta["aws.region"] = region_name
+
+                for key, value in meta.items():
+                    span.set_attribute(key, value)
+
+                span.set_attribute(
+                    "http.status_code", getattr(result, "status")
+                )
+                span.set_attribute("http.method", getattr(result, "_method"))
+
+            return result
+
+    def _patched_query_request(self, original_func, instance, args, kwargs):
+
+        return self._common_request(
+            ("operation_name", "params", "path", "verb"),
+            ["operation_name", "params", "path"],
+            args[0] if args else None,
+            original_func,
+            instance,
+            args,
+            kwargs,
+        )
+
+    def _patched_auth_request(self, original_func, instance, args, kwargs):
+        operation_name = None
+
+        frame = currentframe().f_back
+        operation_name = None
+        while frame:
+            if frame.f_code.co_name == "make_request":
+                operation_name = frame.f_back.f_code.co_name
+                break
+            frame = frame.f_back
+
+        return self._common_request(
+            (
+                "method",
+                "path",
+                "headers",
+                "data",
+                "host",
+                "auth_path",
+                "sender",
+            ),
+            ["path", "data", "host"],
+            operation_name,
+            original_func,
+            instance,
+            args,
+            kwargs,
+        )

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-boto/tests/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/tests/conftest.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import environ
+
+
+def pytest_sessionstart(session):
+    # pylint: disable=unused-argument
+    environ["AWS_ACCESS_KEY_ID"] = "testing"
+    environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    environ["AWS_SECURITY_TOKEN"] = "testing"
+    environ["AWS_SESSION_TOKEN"] = "testing"
+
+
+def pytest_sessionfinish(session):
+    # pylint: disable=unused-argument
+    environ.pop("AWS_ACCESS_KEY_ID")
+    environ.pop("AWS_SECRET_ACCESS_KEY")
+    environ.pop("AWS_SECURITY_TOKEN")
+    environ.pop("AWS_SESSION_TOKEN")

--- a/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
@@ -1,0 +1,294 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import skipUnless
+from unittest.mock import Mock, patch
+
+import boto.awslambda
+import boto.ec2
+import boto.elasticache
+import boto.s3
+import boto.sts
+from moto import (  # pylint: disable=import-error
+    mock_ec2_deprecated,
+    mock_lambda_deprecated,
+    mock_s3_deprecated,
+    mock_sts_deprecated,
+)
+
+from opentelemetry.instrumentation.boto import BotoInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.test.test_base import TestBase
+
+
+def assert_span_http_status_code(span, code):
+    """Assert on the span's 'http.status_code' tag"""
+    tag = span.attributes["http.status_code"]
+    assert tag == code, "%r != %r" % (tag, code)
+
+
+class TestBotoInstrumentor(TestBase):
+    """Botocore integration testsuite"""
+
+    def setUp(self):
+        super().setUp()
+        BotoInstrumentor().instrument()
+
+    def tearDown(self):
+        BotoInstrumentor().uninstrument()
+
+    @mock_ec2_deprecated
+    def test_ec2_client(self):
+        ec2 = boto.ec2.connect_to_region("us-west-2")
+
+        ec2.get_all_instances()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.attributes["aws.operation"], "DescribeInstances")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(span.attributes["http.method"], "POST")
+        self.assertEqual(span.attributes["aws.region"], "us-west-2")
+
+        # Create an instance
+        ec2.run_instances(21)
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 2)
+        span = spans[1]
+        self.assertEqual(span.attributes["aws.operation"], "RunInstances")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "ec2", "http_method": "runinstances"}
+            ),
+        )
+        self.assertEqual(span.attributes["http.method"], "POST")
+        self.assertEqual(span.attributes["aws.region"], "us-west-2")
+        self.assertEqual(span.name, "ec2.command")
+
+    @mock_ec2_deprecated
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            ec2 = boto.ec2.connect_to_region("us-west-2")
+            ec2.get_all_instances()
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    @mock_ec2_deprecated
+    def test_analytics_enabled_with_rate(self):
+        ec2 = boto.ec2.connect_to_region("us-west-2")
+
+        ec2.get_all_instances()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+
+    @mock_ec2_deprecated
+    def test_analytics_enabled_without_rate(self):
+        ec2 = boto.ec2.connect_to_region("us-west-2")
+
+        ec2.get_all_instances()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+
+    @mock_s3_deprecated
+    def test_s3_client(self):
+        s3 = boto.s3.connect_to_region("us-east-1")
+
+        s3.get_all_buckets()
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(span.attributes["http.method"], "GET")
+        self.assertEqual(span.attributes["aws.operation"], "get_all_buckets")
+
+        # Create a bucket command
+        s3.create_bucket("cheese")
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 2)
+        span = spans[1]
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(span.attributes["http.method"], "PUT")
+        self.assertEqual(span.attributes["path"], "/")
+        self.assertEqual(span.attributes["aws.operation"], "create_bucket")
+
+        # Get the created bucket
+        s3.get_bucket("cheese")
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 3)
+        span = spans[2]
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(attributes={"endpoint": "s3", "http_method": "head"}),
+        )
+        self.assertEqual(span.attributes["http.method"], "HEAD")
+        self.assertEqual(span.attributes["aws.operation"], "head_bucket")
+        self.assertEqual(span.name, "s3.command")
+
+        # Checking for resource incase of error
+        try:
+            s3.get_bucket("big_bucket")
+        except Exception:  # pylint: disable=broad-except
+            spans = self.memory_exporter.get_finished_spans()
+            assert spans
+            span = spans[2]
+            self.assertEqual(
+                span.resource,
+                Resource(attributes={"endpoint": "s3", "http_method": "head"}),
+            )
+
+    @mock_s3_deprecated
+    def test_s3_put(self):
+        s3 = boto.s3.connect_to_region("us-east-1")
+        s3.create_bucket("mybucket")
+        bucket = s3.get_bucket("mybucket")
+        key = boto.s3.key.Key(bucket)
+        key.key = "foo"
+        key.set_contents_from_string("bar")
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        # create bucket
+        self.assertEqual(len(spans), 3)
+        self.assertEqual(spans[0].attributes["aws.operation"], "create_bucket")
+        assert_span_http_status_code(spans[0], 200)
+        self.assertEqual(
+            spans[0].resource,
+            Resource(attributes={"endpoint": "s3", "http_method": "put"}),
+        )
+        # get bucket
+        self.assertEqual(spans[1].attributes["aws.operation"], "head_bucket")
+        self.assertEqual(
+            spans[1].resource,
+            Resource(attributes={"endpoint": "s3", "http_method": "head"}),
+        )
+        # put object
+        self.assertEqual(
+            spans[2].attributes["aws.operation"], "_send_file_internal"
+        )
+        self.assertEqual(
+            spans[2].resource,
+            Resource(attributes={"endpoint": "s3", "http_method": "put"}),
+        )
+
+    @mock_lambda_deprecated
+    def test_unpatch(self):
+
+        lamb = boto.awslambda.connect_to_region("us-east-2")
+
+        BotoInstrumentor().uninstrument()
+
+        # multiple calls
+        lamb.list_functions()
+        spans = self.memory_exporter.get_finished_spans()
+        assert not spans, spans
+
+    @mock_s3_deprecated
+    def test_double_patch(self):
+        s3 = boto.s3.connect_to_region("us-east-1")
+
+        BotoInstrumentor().instrument()
+        BotoInstrumentor().instrument()
+
+        # Get the created bucket
+        s3.create_bucket("cheese")
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 1)
+
+    @mock_lambda_deprecated
+    def test_lambda_client(self):
+        lamb = boto.awslambda.connect_to_region("us-east-2")
+
+        # multiple calls
+        lamb.list_functions()
+        lamb.list_functions()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 2)
+        span = spans[0]
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(attributes={"endpoint": "lambda", "http_method": "get"}),
+        )
+        self.assertEqual(span.attributes["http.method"], "GET")
+        self.assertEqual(span.attributes["aws.region"], "us-east-2")
+        self.assertEqual(span.attributes["aws.operation"], "list_functions")
+
+    @mock_sts_deprecated
+    def test_sts_client(self):
+        sts = boto.sts.connect_to_region("us-west-2")
+
+        sts.get_federation_token(12, duration=10)
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={
+                    "endpoint": "sts",
+                    "http_method": "getfederationtoken",
+                }
+            ),
+        )
+        self.assertEqual(span.attributes["aws.region"], "us-west-2")
+        self.assertEqual(
+            span.attributes["aws.operation"], "GetFederationToken"
+        )
+
+        # checking for protection on sts against security leak
+        self.assertTrue("args.path" not in span.attributes.keys())
+
+    @skipUnless(
+        False,
+        (
+            "Test to reproduce the case where args sent to patched function "
+            "are None, can't be mocked: needs AWS credentials"
+        ),
+    )
+    def test_elasticache_client(self):
+        elasticache = boto.elasticache.connect_to_region("us-west-2")
+
+        elasticache.describe_cache_clusters()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(
+            span.resource, Resource(attributes={"endpoint": "elasticcache"})
+        )
+        self.assertEqual(span.attributes["aws.region"], "us-west-2")


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-boto` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-boto

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
