### PR TITLE
Move instrumentation botocore

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-botocore
+  ([#969](https://github.com/open-telemetry/opentelemetry-python/pull/969))
+
+## Version 0.11b0
+
+Released 2020-07-28
+
+- ext/boto and ext/botocore: fails to export spans via jaeger
+([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
+
+## 0.9b0
+
+Released 2020-06-10
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-botocore/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-botocore/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-botocore/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-botocore/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-botocore/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-botocore/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry Botocore Tracing
+==============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-botocore.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-botocore/
+
+This library allows tracing requests made by the Botocore library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-botocore
+
+
+References
+----------
+
+* `OpenTelemetry Botocore Tracing <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/botocore/botocore.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-botocore
+description = OpenTelemetry Botocore instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-botocore
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    botocore ~= 1.0
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+
+[options.extras_require]
+test =
+    moto ~= 1.0
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    botocore = opentelemetry.instrumentation.botocore:BotocoreInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "botocore",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -1,0 +1,222 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Instrument `Botocore`_ to trace service requests.
+
+There are two options for instrumenting code. The first option is to use the
+``opentelemetry-instrument`` executable which will automatically
+instrument your Botocore client. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _Botocore: https://pypi.org/project/botocore/
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+    from opentelemetry.sdk.trace import TracerProvider
+    import botocore
+
+    trace.set_tracer_provider(TracerProvider())
+
+    # Instrument Botocore
+    BotocoreInstrumentor().instrument(
+        tracer_provider=trace.get_tracer_provider()
+    )
+
+    # This will create a span with Botocore-specific attributes
+    session = botocore.session.get_session()
+    session.set_credentials(
+        access_key="access-key", secret_key="secret-key"
+    )
+    ec2 = self.session.create_client("ec2", region_name="us-west-2")
+    ec2.describe_instances()
+
+API
+---
+"""
+
+import logging
+
+from botocore.client import BaseClient
+from wrapt import ObjectProxy, wrap_function_wrapper
+
+from opentelemetry.instrumentation.botocore.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace import Resource
+from opentelemetry.trace import SpanKind, get_tracer
+
+logger = logging.getLogger(__name__)
+
+
+class BotocoreInstrumentor(BaseInstrumentor):
+    """A instrumentor for Botocore
+
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+
+        # FIXME should the tracer provider be accessed via Configuration
+        # instead?
+        # pylint: disable=attribute-defined-outside-init
+        self._tracer = get_tracer(
+            __name__, __version__, kwargs.get("tracer_provider")
+        )
+
+        wrap_function_wrapper(
+            "botocore.client",
+            "BaseClient._make_api_call",
+            self._patched_api_call,
+        )
+
+    def _uninstrument(self, **kwargs):
+        unwrap(BaseClient, "_make_api_call")
+
+    def _patched_api_call(self, original_func, instance, args, kwargs):
+
+        endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
+
+        with self._tracer.start_as_current_span(
+            "{}.command".format(endpoint_name), kind=SpanKind.CONSUMER,
+        ) as span:
+
+            operation = None
+            if args and span.is_recording():
+                operation = args[0]
+                span.resource = Resource(
+                    attributes={
+                        "endpoint": endpoint_name,
+                        "operation": operation.lower(),
+                    }
+                )
+
+            else:
+                span.resource = Resource(
+                    attributes={"endpoint": endpoint_name}
+                )
+
+            add_span_arg_tags(
+                span,
+                endpoint_name,
+                args,
+                ("action", "params", "path", "verb"),
+                {"params", "path", "verb"},
+            )
+
+            if span.is_recording():
+                region_name = deep_getattr(instance, "meta.region_name")
+
+                meta = {
+                    "aws.agent": "botocore",
+                    "aws.operation": operation,
+                    "aws.region": region_name,
+                }
+                for key, value in meta.items():
+                    span.set_attribute(key, value)
+
+            result = original_func(*args, **kwargs)
+
+            if span.is_recording():
+                span.set_attribute(
+                    "http.status_code",
+                    result["ResponseMetadata"]["HTTPStatusCode"],
+                )
+                span.set_attribute(
+                    "retry_attempts",
+                    result["ResponseMetadata"]["RetryAttempts"],
+                )
+
+            return result
+
+
+def unwrap(obj, attr):
+    function = getattr(obj, attr, None)
+    if (
+        function
+        and isinstance(function, ObjectProxy)
+        and hasattr(function, "__wrapped__")
+    ):
+        setattr(obj, attr, function.__wrapped__)
+
+
+def add_span_arg_tags(span, endpoint_name, args, args_names, args_traced):
+    def truncate_arg_value(value, max_len=1024):
+        """Truncate values which are bytes and greater than `max_len`.
+        Useful for parameters like "Body" in `put_object` operations.
+        """
+        if isinstance(value, bytes) and len(value) > max_len:
+            return b"..."
+
+        return value
+
+    def flatten_dict(dict_, sep=".", prefix=""):
+        """
+        Returns a normalized dict of depth 1 with keys in order of embedding
+        """
+        # adapted from https://stackoverflow.com/a/19647596
+        return (
+            {
+                prefix + sep + k if prefix else k: v
+                for kk, vv in dict_.items()
+                for k, v in flatten_dict(vv, sep, kk).items()
+            }
+            if isinstance(dict_, dict)
+            else {prefix: dict_}
+        )
+
+    if not span.is_recording():
+        return
+
+    if endpoint_name not in {"kms", "sts"}:
+        tags = dict(
+            (name, value)
+            for (name, value) in zip(args_names, args)
+            if name in args_traced
+        )
+        tags = flatten_dict(tags)
+        for key, value in {
+            k: truncate_arg_value(v)
+            for k, v in tags.items()
+            if k not in {"s3": ["params.Body"]}.get(endpoint_name, [])
+        }.items():
+            span.set_attribute(key, value)
+
+
+def deep_getattr(obj, attr_string, default=None):
+    """
+    Returns the attribute of ``obj`` at the dotted path given by
+    ``attr_string``, if no such attribute is reachable, returns ``default``.
+
+    >>> deep_getattr(cass, "cluster")
+    <cassandra.cluster.Cluster object at 0xa20c350
+
+    >>> deep_getattr(cass, "cluster.metadata.partitioner")
+    u"org.apache.cassandra.dht.Murmur3Partitioner"
+
+    >>> deep_getattr(cass, "i.dont.exist", default="default")
+    "default"
+    """
+    attrs = attr_string.split(".")
+    for attr in attrs:
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError:
+            return default
+
+    return obj

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -1,0 +1,277 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import botocore.session
+from botocore.exceptions import ParamValidationError
+from moto import (  # pylint: disable=import-error
+    mock_ec2,
+    mock_kinesis,
+    mock_kms,
+    mock_lambda,
+    mock_s3,
+    mock_sqs,
+)
+
+from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.test.test_base import TestBase
+
+
+def assert_span_http_status_code(span, code):
+    """Assert on the span"s "http.status_code" tag"""
+    tag = span.attributes["http.status_code"]
+    assert tag == code, "%r != %r" % (tag, code)
+
+
+class TestBotocoreInstrumentor(TestBase):
+    """Botocore integration testsuite"""
+
+    def setUp(self):
+        super().setUp()
+        BotocoreInstrumentor().instrument()
+
+        self.session = botocore.session.get_session()
+        self.session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        BotocoreInstrumentor().uninstrument()
+
+    @mock_ec2
+    def test_traced_client(self):
+        ec2 = self.session.create_client("ec2", region_name="us-west-2")
+
+        ec2.describe_instances()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(span.attributes["aws.agent"], "botocore")
+        self.assertEqual(span.attributes["aws.region"], "us-west-2")
+        self.assertEqual(span.attributes["aws.operation"], "DescribeInstances")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={
+                    "endpoint": "ec2",
+                    "operation": "describeinstances",
+                }
+            ),
+        )
+        self.assertEqual(span.name, "ec2.command")
+
+    @mock_ec2
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            ec2 = self.session.create_client("ec2", region_name="us-west-2")
+            ec2.describe_instances()
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    @mock_ec2
+    def test_traced_client_analytics(self):
+        ec2 = self.session.create_client("ec2", region_name="us-west-2")
+        ec2.describe_instances()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+
+    @mock_s3
+    def test_s3_client(self):
+        s3 = self.session.create_client("s3", region_name="us-west-2")
+
+        s3.list_buckets()
+        s3.list_buckets()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(span.attributes["aws.operation"], "ListBuckets")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "s3", "operation": "listbuckets"}
+            ),
+        )
+
+        # testing for span error
+        self.memory_exporter.get_finished_spans()
+        with self.assertRaises(ParamValidationError):
+            s3.list_objects(bucket="mybucket")
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[2]
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "s3", "operation": "listobjects"}
+            ),
+        )
+
+    # Comment test for issue 1088
+    @mock_s3
+    def test_s3_put(self):
+        params = dict(Key="foo", Bucket="mybucket", Body=b"bar")
+        s3 = self.session.create_client("s3", region_name="us-west-2")
+        location = {"LocationConstraint": "us-west-2"}
+        s3.create_bucket(Bucket="mybucket", CreateBucketConfiguration=location)
+        s3.put_object(**params)
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(span.attributes["aws.operation"], "CreateBucket")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "s3", "operation": "createbucket"}
+            ),
+        )
+        self.assertEqual(spans[1].attributes["aws.operation"], "PutObject")
+        self.assertEqual(
+            spans[1].resource,
+            Resource(attributes={"endpoint": "s3", "operation": "putobject"}),
+        )
+        self.assertEqual(spans[1].attributes["params.Key"], str(params["Key"]))
+        self.assertEqual(
+            spans[1].attributes["params.Bucket"], str(params["Bucket"])
+        )
+        self.assertTrue("params.Body" not in spans[1].attributes.keys())
+
+    @mock_sqs
+    def test_sqs_client(self):
+        sqs = self.session.create_client("sqs", region_name="us-east-1")
+
+        sqs.list_queues()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(span.attributes["aws.region"], "us-east-1")
+        self.assertEqual(span.attributes["aws.operation"], "ListQueues")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "sqs", "operation": "listqueues"}
+            ),
+        )
+
+    @mock_kinesis
+    def test_kinesis_client(self):
+        kinesis = self.session.create_client(
+            "kinesis", region_name="us-east-1"
+        )
+
+        kinesis.list_streams()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(span.attributes["aws.region"], "us-east-1")
+        self.assertEqual(span.attributes["aws.operation"], "ListStreams")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "kinesis", "operation": "liststreams"}
+            ),
+        )
+
+    @mock_kinesis
+    def test_unpatch(self):
+        kinesis = self.session.create_client(
+            "kinesis", region_name="us-east-1"
+        )
+
+        BotocoreInstrumentor().uninstrument()
+
+        kinesis.list_streams()
+        spans = self.memory_exporter.get_finished_spans()
+        assert not spans, spans
+
+    @mock_sqs
+    def test_double_patch(self):
+        sqs = self.session.create_client("sqs", region_name="us-east-1")
+
+        BotocoreInstrumentor().instrument()
+        BotocoreInstrumentor().instrument()
+
+        sqs.list_queues()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 1)
+
+    @mock_lambda
+    def test_lambda_client(self):
+        lamb = self.session.create_client("lambda", region_name="us-east-1")
+
+        lamb.list_functions()
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(span.attributes["aws.region"], "us-east-1")
+        self.assertEqual(span.attributes["aws.operation"], "ListFunctions")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(
+                attributes={"endpoint": "lambda", "operation": "listfunctions"}
+            ),
+        )
+
+    @mock_kms
+    def test_kms_client(self):
+        kms = self.session.create_client("kms", region_name="us-east-1")
+
+        kms.list_keys(Limit=21)
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        span = spans[0]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(span.attributes["aws.region"], "us-east-1")
+        self.assertEqual(span.attributes["aws.operation"], "ListKeys")
+        assert_span_http_status_code(span, 200)
+        self.assertEqual(
+            span.resource,
+            Resource(attributes={"endpoint": "kms", "operation": "listkeys"}),
+        )
+
+        # checking for protection on sts against security leak
+        self.assertTrue("params" not in span.attributes.keys())


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-botocore` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-botocore

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
