### PR TITLE
Move instrumentation jinja2

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-jinja2/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-jinja2
+  ([#969](https://github.com/open-telemetry/opentelemetry-python/pull/969))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Add jinja2 instrumentation ([#643](https://github.com/open-telemetry/opentelemetry-python/pull/643))

--- a/instrumentation/opentelemetry-instrumentation-jinja2/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-jinja2/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-jinja2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/README.rst
@@ -1,0 +1,21 @@
+OpenTelemetry jinja2 integration
+================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-jinja2.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-jinja2/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-jinja2
+
+
+References
+----------
+
+* `OpenTelemetry jinja2 integration <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/jinja2/jinja2.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-jinja2
+description = OpenTelemetry jinja2 instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-jinja2
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    jinja2~=2.7
+    wrapt >= 1.0.0, < 2.0.0
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    jinja2 = opentelemetry.instrumentation.jinja2:Jinja2Instrumentor

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "jinja2", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
@@ -1,0 +1,147 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+
+Usage
+-----
+
+The OpenTelemetry ``jinja2`` integration traces templates loading, compilation
+and rendering.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from jinja2 import Environment, FileSystemLoader
+    from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
+    from opentelemetry import trace
+    from opentelemetry.trace import TracerProvider
+
+    trace.set_tracer_provider(TracerProvider())
+
+    Jinja2Instrumentor().instrument()
+
+    env = Environment(loader=FileSystemLoader("templates"))
+    template = env.get_template("mytemplate.html")
+
+API
+---
+"""
+# pylint: disable=no-value-for-parameter
+
+import logging
+
+import jinja2
+from wrapt import ObjectProxy
+from wrapt import wrap_function_wrapper as _wrap
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.jinja2.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+logger = logging.getLogger(__name__)
+
+ATTRIBUTE_JINJA2_TEMPLATE_NAME = "jinja2.template_name"
+ATTRIBUTE_JINJA2_TEMPLATE_PATH = "jinja2.template_path"
+DEFAULT_TEMPLATE_NAME = "<memory>"
+
+
+def _with_tracer_wrapper(func):
+    """Helper for providing tracer for wrapper functions.
+    """
+
+    def _with_tracer(tracer):
+        def wrapper(wrapped, instance, args, kwargs):
+            return func(tracer, wrapped, instance, args, kwargs)
+
+        return wrapper
+
+    return _with_tracer
+
+
+@_with_tracer_wrapper
+def _wrap_render(tracer, wrapped, instance, args, kwargs):
+    """Wrap `Template.render()` or `Template.generate()`
+    """
+    with tracer.start_as_current_span(
+        "jinja2.render", kind=SpanKind.INTERNAL,
+    ) as span:
+        if span.is_recording():
+            template_name = instance.name or DEFAULT_TEMPLATE_NAME
+            span.set_attribute(ATTRIBUTE_JINJA2_TEMPLATE_NAME, template_name)
+        return wrapped(*args, **kwargs)
+
+
+@_with_tracer_wrapper
+def _wrap_compile(tracer, wrapped, _, args, kwargs):
+    with tracer.start_as_current_span(
+        "jinja2.compile", kind=SpanKind.INTERNAL,
+    ) as span:
+        if span.is_recording():
+            template_name = (
+                args[1]
+                if len(args) > 1
+                else kwargs.get("name", DEFAULT_TEMPLATE_NAME)
+            )
+            span.set_attribute(ATTRIBUTE_JINJA2_TEMPLATE_NAME, template_name)
+        return wrapped(*args, **kwargs)
+
+
+@_with_tracer_wrapper
+def _wrap_load_template(tracer, wrapped, _, args, kwargs):
+    with tracer.start_as_current_span(
+        "jinja2.load", kind=SpanKind.INTERNAL,
+    ) as span:
+        if span.is_recording():
+            template_name = kwargs.get("name", args[0])
+            span.set_attribute(ATTRIBUTE_JINJA2_TEMPLATE_NAME, template_name)
+        template = None
+        try:
+            template = wrapped(*args, **kwargs)
+            return template
+        finally:
+            if template and span.is_recording():
+                span.set_attribute(
+                    ATTRIBUTE_JINJA2_TEMPLATE_PATH, template.filename
+                )
+
+
+class Jinja2Instrumentor(BaseInstrumentor):
+    """An instrumentor for jinja2
+
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = get_tracer(__name__, __version__, tracer_provider)
+
+        _wrap(jinja2, "environment.Template.render", _wrap_render(tracer))
+        _wrap(jinja2, "environment.Template.generate", _wrap_render(tracer))
+        _wrap(jinja2, "environment.Environment.compile", _wrap_compile(tracer))
+        _wrap(
+            jinja2,
+            "environment.Environment._load_template",
+            _wrap_load_template(tracer),
+        )
+
+    def _uninstrument(self, **kwargs):
+        unwrap(jinja2.Template, "render")
+        unwrap(jinja2.Template, "generate")
+        unwrap(jinja2.Environment, "compile")
+        unwrap(jinja2.Environment, "_load_template")

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/templates/base.html
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/templates/base.html
@@ -1,0 +1,1 @@
+Message: {% block content %}{% endblock %}

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/templates/template.html
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/templates/template.html
@@ -1,0 +1,2 @@
+{% extends 'base.html' %}
+{% block content %}Hello {{name}}!{% endblock %}

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -1,0 +1,210 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest import mock
+
+import jinja2
+
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import get_tracer
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+TMPL_DIR = os.path.join(TEST_DIR, "templates")
+
+
+class TestJinja2Instrumentor(TestBase):
+    def setUp(self):
+        super().setUp()
+        Jinja2Instrumentor().instrument()
+        # prevent cache effects when using Template('code...')
+        # pylint: disable=protected-access
+        jinja2.environment._spontaneous_environments.clear()
+        self.tracer = get_tracer(__name__)
+
+    def tearDown(self):
+        super().tearDown()
+        Jinja2Instrumentor().uninstrument()
+
+    def test_render_inline_template_with_root(self):
+        with self.tracer.start_as_current_span("root"):
+            template = jinja2.environment.Template("Hello {{name}}!")
+            self.assertEqual(template.render(name="Jinja"), "Hello Jinja!")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 3)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        render, template, root = spans[:3]
+
+        self.assertIs(render.parent, root.get_span_context())
+        self.assertIs(template.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_render_not_recording(self):
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = mock_span
+        with mock.patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            jinja2.environment.Template("Hello {{name}}!")
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_render_inline_template(self):
+        template = jinja2.environment.Template("Hello {{name}}!")
+        self.assertEqual(template.render(name="Jinja"), "Hello Jinja!")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        template, render = spans
+
+        self.assertEqual(template.name, "jinja2.compile")
+        self.assertIs(template.kind, trace_api.SpanKind.INTERNAL)
+        self.assertEqual(
+            template.attributes, {"jinja2.template_name": "<memory>"},
+        )
+
+        self.assertEqual(render.name, "jinja2.render")
+        self.assertIs(render.kind, trace_api.SpanKind.INTERNAL)
+        self.assertEqual(
+            render.attributes, {"jinja2.template_name": "<memory>"},
+        )
+
+    def test_generate_inline_template_with_root(self):
+        with self.tracer.start_as_current_span("root"):
+            template = jinja2.environment.Template("Hello {{name}}!")
+            self.assertEqual(
+                "".join(template.generate(name="Jinja")), "Hello Jinja!"
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 3)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        template, generate, root = spans
+
+        self.assertIs(generate.parent, root.get_span_context())
+        self.assertIs(template.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_generate_inline_template(self):
+        template = jinja2.environment.Template("Hello {{name}}!")
+        self.assertEqual(
+            "".join(template.generate(name="Jinja")), "Hello Jinja!"
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        template, generate = spans[:2]
+
+        self.assertEqual(template.name, "jinja2.compile")
+        self.assertIs(template.kind, trace_api.SpanKind.INTERNAL)
+        self.assertEqual(
+            template.attributes, {"jinja2.template_name": "<memory>"},
+        )
+
+        self.assertEqual(generate.name, "jinja2.render")
+        self.assertIs(generate.kind, trace_api.SpanKind.INTERNAL)
+        self.assertEqual(
+            generate.attributes, {"jinja2.template_name": "<memory>"},
+        )
+
+    def test_file_template_with_root(self):
+        with self.tracer.start_as_current_span("root"):
+            loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
+            env = jinja2.Environment(loader=loader)
+            template = env.get_template("template.html")
+            self.assertEqual(
+                template.render(name="Jinja"), "Message: Hello Jinja!"
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 6)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        compile2, load2, compile1, load1, render, root = spans
+
+        self.assertIs(compile2.parent, load2.get_span_context())
+        self.assertIs(load2.parent, root.get_span_context())
+        self.assertIs(compile1.parent, load1.get_span_context())
+        self.assertIs(load1.parent, render.get_span_context())
+        self.assertIs(render.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_file_template(self):
+        loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
+        env = jinja2.Environment(loader=loader)
+        template = env.get_template("template.html")
+        self.assertEqual(
+            template.render(name="Jinja"), "Message: Hello Jinja!"
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 5)
+
+        # pylint:disable=unbalanced-tuple-unpacking
+        compile2, load2, compile1, load1, render = spans
+
+        self.assertEqual(compile2.name, "jinja2.compile")
+        self.assertEqual(load2.name, "jinja2.load")
+        self.assertEqual(compile1.name, "jinja2.compile")
+        self.assertEqual(load1.name, "jinja2.load")
+        self.assertEqual(render.name, "jinja2.render")
+
+        self.assertEqual(
+            compile2.attributes, {"jinja2.template_name": "template.html"},
+        )
+        self.assertEqual(
+            load2.attributes,
+            {
+                "jinja2.template_name": "template.html",
+                "jinja2.template_path": os.path.join(
+                    TMPL_DIR, "template.html"
+                ),
+            },
+        )
+        self.assertEqual(
+            compile1.attributes, {"jinja2.template_name": "base.html"},
+        )
+        self.assertEqual(
+            load1.attributes,
+            {
+                "jinja2.template_name": "base.html",
+                "jinja2.template_path": os.path.join(TMPL_DIR, "base.html"),
+            },
+        )
+        self.assertEqual(
+            render.attributes, {"jinja2.template_name": "template.html"},
+        )
+
+    def test_uninstrumented(self):
+        Jinja2Instrumentor().uninstrument()
+
+        jinja2.environment.Template("Hello {{name}}!")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+        Jinja2Instrumentor().instrument()


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-jinja2` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-jinja2

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
