### PR TITLE
Move instrumentation pymemcache

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymemcache/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-pymemcache
+  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+
+## Version 0.10b0
+
+Released 2020-06-23
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/MANIFEST.IN
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/MANIFEST.IN
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/README.rst
@@ -1,0 +1,20 @@
+OpenTelemetry pymemcache Instrumentation
+========================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-pymemcache.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-pymemcache/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-pymemcache
+
+
+References
+----------
+* `OpenTelemetry Pymemcache Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/pymemcache/pymemcache.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-pymemcache
+description = OpenTelemetry pymemcache instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/instrumentation/opentelemetry-instrumentation-pymemcache
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    pymemcache ~= 1.3
+    wrapt >= 1.0.0, < 2.0.0
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    pymemcache = opentelemetry.instrumentation.pymemcache:PymemcacheInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.py
@@ -1,0 +1,32 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymemcache",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
@@ -1,0 +1,199 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+
+Usage
+-----
+
+The OpenTelemetry ``pymemcache`` integration traces pymemcache client operations
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.instrumentation.pymemcache import PymemcacheInstrumentor
+    trace.set_tracer_provider(TracerProvider())
+    PymemcacheInstrumentor().instrument()
+    from pymemcache.client.base import Client
+    client = Client(('localhost', 11211))
+    client.set('some_key', 'some_value')
+
+API
+---
+"""
+# pylint: disable=no-value-for-parameter
+
+import logging
+
+import pymemcache
+from wrapt import ObjectProxy
+from wrapt import wrap_function_wrapper as _wrap
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pymemcache.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import SpanKind, get_tracer
+
+logger = logging.getLogger(__name__)
+
+# Network attribute semantic convention here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
+_HOST = "net.peer.name"
+_PORT = "net.peer.port"
+# Database semantic conventions here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md
+_DB = "db.type"
+_URL = "db.url"
+
+_DEFAULT_SERVICE = "memcached"
+_RAWCMD = "db.statement"
+_CMD = "memcached.command"
+COMMANDS = [
+    "set",
+    "set_many",
+    "add",
+    "replace",
+    "append",
+    "prepend",
+    "cas",
+    "get",
+    "get_many",
+    "gets",
+    "gets_many",
+    "delete",
+    "delete_many",
+    "incr",
+    "decr",
+    "touch",
+    "stats",
+    "version",
+    "flush_all",
+    "quit",
+    "set_multi",
+    "get_multi",
+]
+
+
+def _set_connection_attributes(span, instance):
+    if not span.is_recording():
+        return
+    for key, value in _get_address_attributes(instance).items():
+        span.set_attribute(key, value)
+
+
+def _with_tracer_wrapper(func):
+    """Helper for providing tracer for wrapper functions."""
+
+    def _with_tracer(tracer, cmd):
+        def wrapper(wrapped, instance, args, kwargs):
+            # prevent double wrapping
+            if hasattr(wrapped, "__wrapped__"):
+                return wrapped(*args, **kwargs)
+
+            return func(tracer, cmd, wrapped, instance, args, kwargs)
+
+        return wrapper
+
+    return _with_tracer
+
+
+@_with_tracer_wrapper
+def _wrap_cmd(tracer, cmd, wrapped, instance, args, kwargs):
+    with tracer.start_as_current_span(
+        _CMD, kind=SpanKind.INTERNAL, attributes={}
+    ) as span:
+        try:
+            if span.is_recording():
+                if not args:
+                    vals = ""
+                else:
+                    vals = _get_query_string(args[0])
+
+                query = "{}{}{}".format(cmd, " " if vals else "", vals)
+                span.set_attribute(_RAWCMD, query)
+
+                _set_connection_attributes(span, instance)
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning(
+                "Failed to set attributes for pymemcache span %s", str(ex)
+            )
+
+        return wrapped(*args, **kwargs)
+
+
+def _get_query_string(arg):
+
+    """Return the query values given the first argument to a pymemcache command.
+
+    If there are multiple query values, they are joined together
+    space-separated.
+    """
+    keys = ""
+
+    if isinstance(arg, dict):
+        arg = list(arg)
+
+    if isinstance(arg, str):
+        keys = arg
+    elif isinstance(arg, bytes):
+        keys = arg.decode()
+    elif isinstance(arg, list) and len(arg) >= 1:
+        if isinstance(arg[0], str):
+            keys = " ".join(arg)
+        elif isinstance(arg[0], bytes):
+            keys = b" ".join(arg).decode()
+
+    return keys
+
+
+def _get_address_attributes(instance):
+    """Attempt to get host and port from Client instance."""
+    address_attributes = {}
+    address_attributes[_DB] = "memcached"
+
+    # client.base.Client contains server attribute which is either a host/port tuple, or unix socket path string
+    # https://github.com/pinterest/pymemcache/blob/f02ddf73a28c09256589b8afbb3ee50f1171cac7/pymemcache/client/base.py#L228
+    if hasattr(instance, "server"):
+        if isinstance(instance.server, tuple):
+            host, port = instance.server
+            address_attributes[_HOST] = host
+            address_attributes[_PORT] = port
+            address_attributes[_URL] = "memcached://{}:{}".format(host, port)
+        elif isinstance(instance.server, str):
+            address_attributes[_URL] = "memcached://{}".format(instance.server)
+
+    return address_attributes
+
+
+class PymemcacheInstrumentor(BaseInstrumentor):
+    """An instrumentor for pymemcache See `BaseInstrumentor`"""
+
+    def _instrument(self, **kwargs):
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = get_tracer(__name__, __version__, tracer_provider)
+
+        for cmd in COMMANDS:
+            _wrap(
+                "pymemcache.client.base",
+                "Client.{}".format(cmd),
+                _wrap_cmd(tracer, cmd),
+            )
+
+    def _uninstrument(self, **kwargs):
+        for command in COMMANDS:
+            unwrap(pymemcache.client.base.Client, "{}".format(command))

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
@@ -1,0 +1,542 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import pymemcache
+from pymemcache.exceptions import (
+    MemcacheClientError,
+    MemcacheIllegalInputError,
+    MemcacheServerError,
+    MemcacheUnknownCommandError,
+    MemcacheUnknownError,
+)
+
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.pymemcache import PymemcacheInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import get_tracer
+from opentelemetry.trace.status import StatusCanonicalCode
+
+from .utils import MockSocket, _str
+
+TEST_HOST = "localhost"
+TEST_PORT = 117711
+
+
+class PymemcacheClientTestCase(
+    TestBase
+):  # pylint: disable=too-many-public-methods
+    """ Tests for a patched pymemcache.client.base.Client. """
+
+    def setUp(self):
+        super().setUp()
+        PymemcacheInstrumentor().instrument()
+
+        # pylint: disable=protected-access
+        self.tracer = get_tracer(__name__)
+
+    def tearDown(self):
+        super().tearDown()
+        PymemcacheInstrumentor().uninstrument()
+
+    def make_client(self, mock_socket_values, **kwargs):
+        # pylint: disable=attribute-defined-outside-init
+        self.client = pymemcache.client.base.Client(
+            (TEST_HOST, TEST_PORT), **kwargs
+        )
+        self.client.sock = MockSocket(list(mock_socket_values))
+        return self.client
+
+    def check_spans(self, spans, num_expected, queries_expected):
+        """A helper for validating basic span information."""
+        self.assertEqual(num_expected, len(spans))
+
+        for span, query in zip(spans, queries_expected):
+            self.assertEqual(span.name, "memcached.command")
+            self.assertIs(span.kind, trace_api.SpanKind.INTERNAL)
+            self.assertEqual(
+                span.attributes["net.peer.name"], "{}".format(TEST_HOST)
+            )
+            self.assertEqual(span.attributes["net.peer.port"], TEST_PORT)
+            self.assertEqual(span.attributes["db.type"], "memcached")
+            self.assertEqual(
+                span.attributes["db.url"],
+                "memcached://{}:{}".format(TEST_HOST, TEST_PORT),
+            )
+            self.assertEqual(span.attributes["db.statement"], query)
+
+    def test_set_success(self):
+        client = self.make_client([b"STORED\r\n"])
+        result = client.set(b"key", b"value", noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["set key"])
+
+    def test_set_not_recording(self):
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with mock.patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            client = self.make_client([b"STORED\r\n"])
+            result = client.set(b"key", b"value", noreply=False)
+            self.assertTrue(result)
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_get_many_none_found(self):
+        client = self.make_client([b"END\r\n"])
+        result = client.get_many([b"key1", b"key2"])
+        assert result == {}
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["get_many key1 key2"])
+
+    def test_get_multi_none_found(self):
+        client = self.make_client([b"END\r\n"])
+        # alias for get_many
+        result = client.get_multi([b"key1", b"key2"])
+        assert result == {}
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["get_multi key1 key2"])
+
+    def test_set_multi_success(self):
+        client = self.make_client([b"STORED\r\n"])
+        # Alias for set_many, a convienance function that calls set for every key
+        result = client.set_multi({b"key": b"value"}, noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["set key", "set_multi key"])
+
+    def test_delete_not_found(self):
+        client = self.make_client([b"NOT_FOUND\r\n"])
+        result = client.delete(b"key", noreply=False)
+        assert result is False
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["delete key"])
+
+    def test_incr_found(self):
+        client = self.make_client([b"STORED\r\n", b"1\r\n"])
+        client.set(b"key", 0, noreply=False)
+        result = client.incr(b"key", 1, noreply=False)
+        assert result == 1
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["set key", "incr key"])
+
+    def test_get_found(self):
+        client = self.make_client(
+            [b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"]
+        )
+        result = client.set(b"key", b"value", noreply=False)
+        result = client.get(b"key")
+        assert result == b"value"
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["set key", "get key"])
+
+    def test_decr_found(self):
+        client = self.make_client([b"STORED\r\n", b"1\r\n"])
+        client.set(b"key", 2, noreply=False)
+        result = client.decr(b"key", 1, noreply=False)
+        assert result == 1
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["set key", "decr key"])
+
+    def test_add_stored(self):
+        client = self.make_client([b"STORED\r", b"\n"])
+        result = client.add(b"key", b"value", noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["add key"])
+
+    def test_delete_many_found(self):
+        client = self.make_client([b"STORED\r", b"\n", b"DELETED\r\n"])
+        result = client.add(b"key", b"value", noreply=False)
+        # a convienance function that calls delete for every key
+        result = client.delete_many([b"key"], noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(
+            spans, 3, ["add key", "delete key", "delete_many key"]
+        )
+
+    def test_set_many_success(self):
+        client = self.make_client([b"STORED\r\n"])
+        # a convienance function that calls set for every key
+        result = client.set_many({b"key": b"value"}, noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["set key", "set_many key"])
+
+    def test_set_get(self):
+        client = self.make_client(
+            [b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"]
+        )
+        client.set(b"key", b"value", noreply=False)
+        result = client.get(b"key")
+        assert _str(result) == "value"
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(
+            spans[0].attributes["db.url"],
+            "memcached://{}:{}".format(TEST_HOST, TEST_PORT),
+        )
+
+    def test_append_stored(self):
+        client = self.make_client([b"STORED\r\n"])
+        result = client.append(b"key", b"value", noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["append key"])
+
+    def test_prepend_stored(self):
+        client = self.make_client([b"STORED\r\n"])
+        result = client.prepend(b"key", b"value", noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["prepend key"])
+
+    def test_cas_stored(self):
+        client = self.make_client([b"STORED\r\n"])
+        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["cas key"])
+
+    def test_cas_exists(self):
+        client = self.make_client([b"EXISTS\r\n"])
+        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        assert result is False
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["cas key"])
+
+    def test_cas_not_found(self):
+        client = self.make_client([b"NOT_FOUND\r\n"])
+        result = client.cas(b"key", b"value", b"cas", noreply=False)
+        assert result is None
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["cas key"])
+
+    def test_delete_exception(self):
+        client = self.make_client([Exception("fail")])
+
+        def _delete():
+            client.delete(b"key", noreply=False)
+
+        with self.assertRaises(Exception):
+            _delete()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["delete key"])
+
+    def test_flush_all(self):
+        client = self.make_client([b"OK\r\n"])
+        result = client.flush_all(noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["flush_all"])
+
+    def test_incr_exception(self):
+        client = self.make_client([Exception("fail")])
+
+        def _incr():
+            client.incr(b"key", 1)
+
+        with self.assertRaises(Exception):
+            _incr()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["incr key"])
+
+    def test_get_error(self):
+        client = self.make_client([b"ERROR\r\n"])
+
+        def _get():
+            client.get(b"key")
+
+        with self.assertRaises(MemcacheUnknownCommandError):
+            _get()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["get key"])
+
+    def test_get_unknown_error(self):
+        client = self.make_client([b"foobarbaz\r\n"])
+
+        def _get():
+            client.get(b"key")
+
+        with self.assertRaises(MemcacheUnknownError):
+            _get()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["get key"])
+
+    def test_gets_found(self):
+        client = self.make_client([b"VALUE key 0 5 10\r\nvalue\r\nEND\r\n"])
+        result = client.gets(b"key")
+        assert result == (b"value", b"10")
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["gets key"])
+
+    def test_touch_not_found(self):
+        client = self.make_client([b"NOT_FOUND\r\n"])
+        result = client.touch(b"key", noreply=False)
+        assert result is False
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["touch key"])
+
+    def test_set_client_error(self):
+        client = self.make_client([b"CLIENT_ERROR some message\r\n"])
+
+        def _set():
+            client.set("key", "value", noreply=False)
+
+        with self.assertRaises(MemcacheClientError):
+            _set()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["set key"])
+
+    def test_set_server_error(self):
+        client = self.make_client([b"SERVER_ERROR some message\r\n"])
+
+        def _set():
+            client.set(b"key", b"value", noreply=False)
+
+        with self.assertRaises(MemcacheServerError):
+            _set()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["set key"])
+
+    def test_set_key_with_space(self):
+        client = self.make_client([b""])
+
+        def _set():
+            client.set(b"key has space", b"value", noreply=False)
+
+        with self.assertRaises(MemcacheIllegalInputError):
+            _set()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        span = spans[0]
+
+        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+
+        self.check_spans(spans, 1, ["set key has space"])
+
+    def test_quit(self):
+        client = self.make_client([])
+        assert client.quit() is None
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["quit"])
+
+    def test_replace_not_stored(self):
+        client = self.make_client([b"NOT_STORED\r\n"])
+        result = client.replace(b"key", b"value", noreply=False)
+        assert result is False
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["replace key"])
+
+    def test_version_success(self):
+        client = self.make_client(
+            [b"VERSION 1.2.3\r\n"], default_noreply=False
+        )
+        result = client.version()
+        assert result == b"1.2.3"
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["version"])
+
+    def test_stats(self):
+        client = self.make_client([b"STAT fake_stats 1\r\n", b"END\r\n"])
+        result = client.stats()
+        assert client.sock.send_bufs == [b"stats \r\n"]
+        assert result == {b"fake_stats": 1}
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 1, ["stats"])
+
+    def test_uninstrumented(self):
+        PymemcacheInstrumentor().uninstrument()
+
+        client = self.make_client(
+            [b"STORED\r\n", b"VALUE key 0 5\r\nvalue\r\nEND\r\n"]
+        )
+        client.set(b"key", b"value", noreply=False)
+        result = client.get(b"key")
+        assert _str(result) == "value"
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 0)
+
+        PymemcacheInstrumentor().instrument()
+
+
+class PymemcacheHashClientTestCase(TestBase):
+    """ Tests for a patched pymemcache.client.hash.HashClient. """
+
+    def setUp(self):
+        super().setUp()
+        PymemcacheInstrumentor().instrument()
+
+        # pylint: disable=protected-access
+        self.tracer = get_tracer(__name__)
+
+    def tearDown(self):
+        super().tearDown()
+        PymemcacheInstrumentor().uninstrument()
+
+    def make_client_pool(
+        self, hostname, mock_socket_values, serializer=None, **kwargs
+    ):  # pylint: disable=no-self-use
+        mock_client = pymemcache.client.base.Client(
+            hostname, serializer=serializer, **kwargs
+        )
+        mock_client.sock = MockSocket(mock_socket_values)
+        client = pymemcache.client.base.PooledClient(
+            hostname, serializer=serializer
+        )
+        client.client_pool = pymemcache.pool.ObjectPool(lambda: mock_client)
+        return mock_client
+
+    def make_client(self, *mock_socket_values, **kwargs):
+        current_port = TEST_PORT
+
+        # pylint: disable=import-outside-toplevel
+        from pymemcache.client.hash import HashClient
+
+        # pylint: disable=attribute-defined-outside-init
+        self.client = HashClient([], **kwargs)
+        ip = TEST_HOST
+
+        for vals in mock_socket_values:
+            url_string = "{}:{}".format(ip, current_port)
+            clnt_pool = self.make_client_pool(
+                (ip, current_port), vals, **kwargs
+            )
+            self.client.clients[url_string] = clnt_pool
+            self.client.hasher.add_node(url_string)
+            current_port += 1
+        return self.client
+
+    def check_spans(self, spans, num_expected, queries_expected):
+        """A helper for validating basic span information."""
+        self.assertEqual(num_expected, len(spans))
+
+        for span, query in zip(spans, queries_expected):
+            self.assertEqual(span.name, "memcached.command")
+            self.assertIs(span.kind, trace_api.SpanKind.INTERNAL)
+            self.assertEqual(
+                span.attributes["net.peer.name"], "{}".format(TEST_HOST)
+            )
+            self.assertEqual(span.attributes["net.peer.port"], TEST_PORT)
+            self.assertEqual(span.attributes["db.type"], "memcached")
+            self.assertEqual(
+                span.attributes["db.url"],
+                "memcached://{}:{}".format(TEST_HOST, TEST_PORT),
+            )
+            self.assertEqual(span.attributes["db.statement"], query)
+
+    def test_delete_many_found(self):
+        client = self.make_client([b"STORED\r", b"\n", b"DELETED\r\n"])
+        result = client.add(b"key", b"value", noreply=False)
+        result = client.delete_many([b"key"], noreply=False)
+        self.assertTrue(result)
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.check_spans(spans, 2, ["add key", "delete key"])

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/tests/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/tests/utils.py
@@ -1,0 +1,74 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import socket
+
+
+class MockSocket:
+    def __init__(self, recv_bufs, connect_failure=None):
+        self.recv_bufs = collections.deque(recv_bufs)
+        self.send_bufs = []
+        self.closed = False
+        self.timeouts = []
+        self.connect_failure = connect_failure
+        self.connections = []
+        self.socket_options = []
+
+    def sendall(self, value):
+        self.send_bufs.append(value)
+
+    def close(self):
+        self.closed = True
+
+    def recv(self, size):  # pylint: disable=unused-argument
+        value = self.recv_bufs.popleft()
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def settimeout(self, timeout):
+        self.timeouts.append(timeout)
+
+    def connect(self, server):
+        if isinstance(self.connect_failure, Exception):
+            raise self.connect_failure
+        self.connections.append(server)
+
+    def setsockopt(self, level, option, value):
+        self.socket_options.append((level, option, value))
+
+
+class MockSocketModule:
+    def __init__(self, connect_failure=None):
+        self.connect_failure = connect_failure
+        self.sockets = []
+
+    def socket(self):  # noqa: A002
+        soket = MockSocket([], connect_failure=self.connect_failure)
+        self.sockets.append(soket)
+        return soket
+
+    def __getattr__(self, name):
+        return getattr(socket, name)
+
+
+# Compatibility to get a string back from a request
+def _str(string_input):
+    if isinstance(string_input, str):
+        return string_input
+    if isinstance(string_input, bytes):
+        return string_input.decode()
+
+    return str(string_input)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-pymemcache` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymemcache

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
