### PR TITLE
Move instrumentation pymongo

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.14b0
+
+Released 2020-10-13
+
+- Cast PyMongo commands as strings
+  ([#1132](https://github.com/open-telemetry/opentelemetry-python/pull/1132))
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-pymongo
+  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Implement instrumentor interface ([#612](https://github.com/open-telemetry/opentelemetry-python/pull/612))
+
+## 0.4a0
+
+Released 2020-02-21
+
+- Updating network connection attribute names
+  ([#350](https://github.com/open-telemetry/opentelemetry-python/pull/350))
+
+## 0.3a0
+
+Released 2019-12-11
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-pymongo/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-pymongo/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
@@ -1,0 +1,21 @@
+OpenTelemetry pymongo Instrumentation
+=====================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-pymongo.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-pymongo/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-pymongo
+
+
+References
+----------
+* `OpenTelemetry pymongo Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/pymongo/pymongo.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-pymongo
+description = OpenTelemetry pymongo instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymongo
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    pymongo ~= 3.1
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    pymongo = opentelemetry.instrumentation.pymongo:PymongoInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymongo",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -1,0 +1,173 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The integration with MongoDB supports the `pymongo`_ library, it can be
+enabled using the ``PymongoInstrumentor``.
+
+.. _pymongo: https://pypi.org/project/pymongo
+
+Usage
+-----
+
+.. code:: python
+
+    from pymongo import MongoClient
+    from opentelemetry import trace
+    from opentelemetry.trace import TracerProvider
+    from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
+
+    trace.set_tracer_provider(TracerProvider())
+
+    PymongoInstrumentor().instrument()
+    client = MongoClient()
+    db = client["MongoDB_Database"]
+    collection = db["MongoDB_Collection"]
+    collection.find_one()
+
+API
+---
+"""
+
+from pymongo import monitoring
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pymongo.version import __version__
+from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+DATABASE_TYPE = "mongodb"
+COMMAND_ATTRIBUTES = ["filter", "sort", "skip", "limit", "pipeline"]
+
+
+class CommandTracer(monitoring.CommandListener):
+    def __init__(self, tracer):
+        self._tracer = tracer
+        self._span_dict = {}
+        self.is_enabled = True
+
+    def started(self, event: monitoring.CommandStartedEvent):
+        """ Method to handle a pymongo CommandStartedEvent """
+        if not self.is_enabled:
+            return
+        command = event.command.get(event.command_name, "")
+        name = DATABASE_TYPE + "." + event.command_name
+        statement = event.command_name
+        if command:
+            name += "." + str(command)
+            statement += " " + str(command)
+
+        try:
+            span = self._tracer.start_span(name, kind=SpanKind.CLIENT)
+            if span.is_recording():
+                span.set_attribute("component", DATABASE_TYPE)
+                span.set_attribute("db.type", DATABASE_TYPE)
+                span.set_attribute("db.instance", event.database_name)
+                span.set_attribute("db.statement", statement)
+                if event.connection_id is not None:
+                    span.set_attribute("net.peer.name", event.connection_id[0])
+                    span.set_attribute("net.peer.port", event.connection_id[1])
+
+                # pymongo specific, not specified by spec
+                span.set_attribute("db.mongo.operation_id", event.operation_id)
+                span.set_attribute("db.mongo.request_id", event.request_id)
+
+                for attr in COMMAND_ATTRIBUTES:
+                    _attr = event.command.get(attr)
+                    if _attr is not None:
+                        span.set_attribute("db.mongo." + attr, str(_attr))
+
+            # Add Span to dictionary
+            self._span_dict[_get_span_dict_key(event)] = span
+        except Exception as ex:  # noqa pylint: disable=broad-except
+            if span is not None:
+                if span.is_recording():
+                    span.set_status(
+                        Status(StatusCanonicalCode.INTERNAL, str(ex))
+                    )
+                span.end()
+                self._pop_span(event)
+
+    def succeeded(self, event: monitoring.CommandSucceededEvent):
+        """ Method to handle a pymongo CommandSucceededEvent """
+        if not self.is_enabled:
+            return
+        span = self._pop_span(event)
+        if span is None:
+            return
+        if span.is_recording():
+            span.set_attribute(
+                "db.mongo.duration_micros", event.duration_micros
+            )
+            span.set_status(Status(StatusCanonicalCode.OK, event.reply))
+        span.end()
+
+    def failed(self, event: monitoring.CommandFailedEvent):
+        """ Method to handle a pymongo CommandFailedEvent """
+        if not self.is_enabled:
+            return
+        span = self._pop_span(event)
+        if span is None:
+            return
+        if span.is_recording():
+            span.set_attribute(
+                "db.mongo.duration_micros", event.duration_micros
+            )
+            span.set_status(Status(StatusCanonicalCode.UNKNOWN, event.failure))
+        span.end()
+
+    def _pop_span(self, event):
+        return self._span_dict.pop(_get_span_dict_key(event), None)
+
+
+def _get_span_dict_key(event):
+    if event.connection_id is not None:
+        return (event.request_id, event.connection_id)
+    return event.request_id
+
+
+class PymongoInstrumentor(BaseInstrumentor):
+    _commandtracer_instance = None  # type CommandTracer
+    # The instrumentation for PyMongo is based on the event listener interface
+    # https://api.mongodb.com/python/current/api/pymongo/monitoring.html.
+    # This interface only allows to register listeners and does not provide
+    # an unregister API. In order to provide a mechanishm to disable
+    # instrumentation an enabled flag is implemented in CommandTracer,
+    # it's checked in the different listeners.
+
+    def _instrument(self, **kwargs):
+        """Integrate with pymongo to trace it using event listener.
+        https://api.mongodb.com/python/current/api/pymongo/monitoring.html
+
+        Args:
+            tracer_provider: The `TracerProvider` to use. If none is passed the
+                current configured one is used.
+        """
+
+        tracer_provider = kwargs.get("tracer_provider")
+
+        # Create and register a CommandTracer only the first time
+        if self._commandtracer_instance is None:
+            tracer = get_tracer(__name__, __version__, tracer_provider)
+
+            self._commandtracer_instance = CommandTracer(tracer)
+            monitoring.register(self._commandtracer_instance)
+
+        # If already created, just enable it
+        self._commandtracer_instance.is_enabled = True
+
+    def _uninstrument(self, **kwargs):
+        if self._commandtracer_instance is not None:
+            self._commandtracer_instance.is_enabled = False

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -1,0 +1,190 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.pymongo import (
+    CommandTracer,
+    PymongoInstrumentor,
+)
+from opentelemetry.test.test_base import TestBase
+
+
+class TestPymongo(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
+
+    def test_pymongo_instrumentor(self):
+        mock_register = mock.Mock()
+        patch = mock.patch(
+            "pymongo.monitoring.register", side_effect=mock_register
+        )
+        with patch:
+            PymongoInstrumentor().instrument()
+
+        self.assertTrue(mock_register.called)
+
+    def test_started(self):
+        command_attrs = {
+            "filter": "filter",
+            "sort": "sort",
+            "limit": "limit",
+            "pipeline": "pipeline",
+            "command_name": "find",
+        }
+        command_tracer = CommandTracer(self.tracer)
+        mock_event = MockEvent(
+            command_attrs, ("test.com", "1234"), "test_request_id"
+        )
+        command_tracer.started(event=mock_event)
+        # the memory exporter can't be used here because the span isn't ended
+        # yet
+        # pylint: disable=protected-access
+        span = command_tracer._pop_span(mock_event)
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.name, "mongodb.command_name.find")
+        self.assertEqual(span.attributes["component"], "mongodb")
+        self.assertEqual(span.attributes["db.type"], "mongodb")
+        self.assertEqual(span.attributes["db.instance"], "database_name")
+        self.assertEqual(span.attributes["db.statement"], "command_name find")
+        self.assertEqual(span.attributes["net.peer.name"], "test.com")
+        self.assertEqual(span.attributes["net.peer.port"], "1234")
+        self.assertEqual(
+            span.attributes["db.mongo.operation_id"], "operation_id"
+        )
+        self.assertEqual(
+            span.attributes["db.mongo.request_id"], "test_request_id"
+        )
+
+        self.assertEqual(span.attributes["db.mongo.filter"], "filter")
+        self.assertEqual(span.attributes["db.mongo.sort"], "sort")
+        self.assertEqual(span.attributes["db.mongo.limit"], "limit")
+        self.assertEqual(span.attributes["db.mongo.pipeline"], "pipeline")
+
+    def test_succeeded(self):
+        mock_event = MockEvent({})
+        command_tracer = CommandTracer(self.tracer)
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(
+            span.attributes["db.mongo.duration_micros"], "duration_micros"
+        )
+        self.assertIs(
+            span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
+        )
+        self.assertEqual(span.status.description, "reply")
+        self.assertIsNotNone(span.end_time)
+
+    def test_not_recording(self):
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        mock_event = MockEvent({})
+        command_tracer = CommandTracer(mock_tracer)
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+        self.assertFalse(mock_span.is_recording())
+        self.assertTrue(mock_span.is_recording.called)
+        self.assertFalse(mock_span.set_attribute.called)
+        self.assertFalse(mock_span.set_status.called)
+
+    def test_failed(self):
+        mock_event = MockEvent({})
+        command_tracer = CommandTracer(self.tracer)
+        command_tracer.started(event=mock_event)
+        command_tracer.failed(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        self.assertEqual(
+            span.attributes["db.mongo.duration_micros"], "duration_micros"
+        )
+        self.assertIs(
+            span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.UNKNOWN,
+        )
+        self.assertEqual(span.status.description, "failure")
+        self.assertIsNotNone(span.end_time)
+
+    def test_multiple_commands(self):
+        first_mock_event = MockEvent({}, ("firstUrl", "123"), "first")
+        second_mock_event = MockEvent({}, ("secondUrl", "456"), "second")
+        command_tracer = CommandTracer(self.tracer)
+        command_tracer.started(event=first_mock_event)
+        command_tracer.started(event=second_mock_event)
+        command_tracer.succeeded(event=first_mock_event)
+        command_tracer.failed(event=second_mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 2)
+        first_span = spans_list[0]
+        second_span = spans_list[1]
+
+        self.assertEqual(first_span.attributes["db.mongo.request_id"], "first")
+        self.assertIs(
+            first_span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.OK,
+        )
+        self.assertEqual(
+            second_span.attributes["db.mongo.request_id"], "second"
+        )
+        self.assertIs(
+            second_span.status.canonical_code,
+            trace_api.status.StatusCanonicalCode.UNKNOWN,
+        )
+
+    def test_int_command(self):
+        command_attrs = {
+            "command_name": 123,
+        }
+        mock_event = MockEvent(command_attrs)
+
+        command_tracer = CommandTracer(self.tracer)
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        self.assertEqual(span.name, "mongodb.command_name.123")
+
+
+class MockCommand:
+    def __init__(self, command_attrs):
+        self.command_attrs = command_attrs
+
+    def get(self, key, default=""):
+        return self.command_attrs.get(key, default)
+
+
+class MockEvent:
+    def __init__(self, command_attrs, connection_id=None, request_id=""):
+        self.command = MockCommand(command_attrs)
+        self.connection_id = connection_id
+        self.request_id = request_id
+
+    def __getattr__(self, item):
+        return item


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-pymongo` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymongo

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
