### PR TITLE
Move instrumentation pyramid

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pyramid/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-pyramid ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+- Update environment variable names, prefix changed from `OPENTELEMETRY` to `OTEL` ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
+
+## Version 0.11b0
+
+- Use one general exclude list instead of two ([#872](https://github.com/open-telemetry/opentelemetry-python/pull/872))
+
+## 0.9b0
+
+Released 2020-06-10
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-pyramid/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-pyramid/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-pyramid/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/README.rst
@@ -1,0 +1,32 @@
+OpenTelemetry Pyramid Instrumentation
+=====================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-pyramid.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-pyramid/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-pyramid
+
+Exclude lists
+*************
+To exclude certain URLs from being tracked, set the environment variable ``OTEL_PYTHON_PYRAMID_EXCLUDED_URLS`` with comma delimited regexes representing which URLs to exclude.
+
+For example, 
+
+::
+
+    export OTEL_PYTHON_PYRAMID_EXCLUDED_URLS="client/.*/info,healthcheck"
+
+will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
+
+References
+----------
+* `OpenTelemetry Pyramid Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/pyramid/pyramid.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -1,0 +1,58 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-pyramid
+description = OpenTelemetry Pyramid instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pyramid
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    pyramid >= 1.7
+    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation-wsgi == 0.15.dev0
+    wrapt >= 1.0.0, < 2.0.0
+
+[options.extras_require]
+test =
+    werkzeug == 0.16.1
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    pyramid = opentelemetry.instrumentation.pyramid:PyramidInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pyramid",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
@@ -1,0 +1,148 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pyramid instrumentation supporting `pyramid`_, it can be enabled by
+using ``PyramidInstrumentor``.
+
+.. _pyramid: https://docs.pylonsproject.org/projects/pyramid/en/latest/
+
+Usage
+-----
+There are two methods to instrument Pyramid:
+
+Method 1 (Instrument all Configurators):
+----------------------------------------
+
+.. code:: python
+
+    from pyramid.config import Configurator
+    from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+
+    PyramidInstrumentor().instrument()
+
+    config = Configurator()
+
+    # use your config as normal
+    config.add_route('index', '/')
+
+Method 2 (Instrument one Configurator):
+---------------------------------------
+
+.. code:: python
+
+    from pyramid.config import Configurator
+    from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+
+    config = Configurator()
+    PyramidInstrumentor().instrument_config(config)
+
+    # use your config as normal
+    config.add_route('index', '/')
+
+Using ``pyramid.tweens`` setting:
+---------------------------------
+
+If you use Method 2 and then set tweens for your application with the ``pyramid.tweens`` setting,
+you need to add ``opentelemetry.instrumentation.pyramid.trace_tween_factory`` explicity to the list,
+*as well as* instrumenting the config as shown above.
+
+For example:
+
+.. code:: python
+
+    from pyramid.config import Configurator
+    from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+
+    settings = {
+        'pyramid.tweens', 'opentelemetry.instrumentation.pyramid.trace_tween_factory\\nyour_tween_no_1\\nyour_tween_no_2',
+    }
+    config = Configurator(settings=settings)
+    PyramidInstrumentor().instrument_config(config)
+
+    # use your config as normal.
+    config.add_route('index', '/')
+
+API
+---
+"""
+
+import typing
+
+from pyramid.config import Configurator
+from pyramid.path import caller_package
+from pyramid.settings import aslist
+from wrapt import ObjectProxy
+from wrapt import wrap_function_wrapper as _wrap
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pyramid.callbacks import (
+    SETTING_TRACE_ENABLED,
+    TWEEN_NAME,
+    trace_tween_factory,
+)
+from opentelemetry.instrumentation.pyramid.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import TracerProvider, get_tracer
+
+
+def _traced_init(wrapped, instance, args, kwargs):
+    settings = kwargs.get("settings", {})
+    tweens = aslist(settings.get("pyramid.tweens", []))
+
+    if tweens and TWEEN_NAME not in settings:
+        # pyramid.tweens.EXCVIEW is the name of built-in exception view provided by
+        # pyramid.  We need our tween to be before it, otherwise unhandled
+        # exceptions will be caught before they reach our tween.
+        tweens = [TWEEN_NAME] + tweens
+
+        settings["pyramid.tweens"] = "\n".join(tweens)
+
+    kwargs["settings"] = settings
+
+    # `caller_package` works by walking a fixed amount of frames up the stack
+    # to find the calling package. So if we let the original `__init__`
+    # function call it, our wrapper will mess things up.
+    if not kwargs.get("package", None):
+        # Get the package for the third frame up from this one.
+        # Default is `level=2` which will give us the package from `wrapt`
+        # instead of the desired package (the caller)
+        kwargs["package"] = caller_package(level=3)
+
+    wrapped(*args, **kwargs)
+    instance.include("opentelemetry.instrumentation.pyramid.callbacks")
+
+
+class PyramidInstrumentor(BaseInstrumentor):
+    def _instrument(self, **kwargs):
+        """Integrate with Pyramid Python library.
+        https://docs.pylonsproject.org/projects/pyramid/en/latest/
+        """
+        _wrap("pyramid.config", "Configurator.__init__", _traced_init)
+
+    def _uninstrument(self, **kwargs):
+        """"Disable Pyramid instrumentation"""
+        unwrap(Configurator, "__init__")
+
+    # pylint:disable=no-self-use
+    def instrument_config(self, config):
+        """Enable instrumentation in a Pyramid configurator.
+
+        Args:
+            config: The Configurator to instrument.
+        """
+        config.include("opentelemetry.instrumentation.pyramid.callbacks")
+
+    def uninstrument_config(self, config):
+        config.add_settings({SETTING_TRACE_ENABLED: False})

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -1,0 +1,165 @@
+from logging import getLogger
+
+from pyramid.events import BeforeTraversal
+from pyramid.httpexceptions import HTTPException
+from pyramid.settings import asbool
+from pyramid.tweens import EXCVIEW
+
+import opentelemetry.instrumentation.wsgi as otel_wsgi
+from opentelemetry import configuration, context, propagators, trace
+from opentelemetry.instrumentation.pyramid.version import __version__
+from opentelemetry.util import ExcludeList, time_ns
+
+TWEEN_NAME = "opentelemetry.instrumentation.pyramid.trace_tween_factory"
+SETTING_TRACE_ENABLED = "opentelemetry-pyramid.trace_enabled"
+
+_ENVIRON_STARTTIME_KEY = "opentelemetry-pyramid.starttime_key"
+_ENVIRON_SPAN_KEY = "opentelemetry-pyramid.span_key"
+_ENVIRON_ACTIVATION_KEY = "opentelemetry-pyramid.activation_key"
+_ENVIRON_ENABLED_KEY = "opentelemetry-pyramid.tracing_enabled_key"
+_ENVIRON_TOKEN = "opentelemetry-pyramid.token"
+
+_logger = getLogger(__name__)
+
+
+def get_excluded_urls():
+    urls = configuration.Configuration().PYRAMID_EXCLUDED_URLS or []
+    if urls:
+        urls = str.split(urls, ",")
+    return ExcludeList(urls)
+
+
+_excluded_urls = get_excluded_urls()
+
+
+def includeme(config):
+    config.add_settings({SETTING_TRACE_ENABLED: True})
+
+    config.add_subscriber(_before_traversal, BeforeTraversal)
+    _insert_tween(config)
+
+
+def _insert_tween(config):
+    settings = config.get_settings()
+    tweens = settings.get("pyramid.tweens")
+    # If the list is empty, pyramid does not consider the tweens have been
+    # set explicitly. And if our tween is already there, nothing to do
+    if not tweens or not tweens.strip():
+        # Add our tween just before the default exception handler
+        config.add_tween(TWEEN_NAME, over=EXCVIEW)
+
+
+def _before_traversal(event):
+    request = event.request
+    environ = request.environ
+    span_name = otel_wsgi.get_default_span_name(environ)
+
+    enabled = environ.get(_ENVIRON_ENABLED_KEY)
+    if enabled is None:
+        _logger.warning(
+            "Opentelemetry pyramid tween 'opentelemetry.instrumentation.pyramid.trace_tween_factory'"
+            "was not called. Make sure that the tween is included in 'pyramid.tweens' if"
+            "the tween list was created manually"
+        )
+        return
+
+    if not enabled:
+        # Tracing not enabled, return
+        return
+
+    start_time = environ.get(_ENVIRON_STARTTIME_KEY)
+
+    token = context.attach(
+        propagators.extract(otel_wsgi.get_header_from_environ, environ)
+    )
+    tracer = trace.get_tracer(__name__, __version__)
+
+    if request.matched_route:
+        span_name = request.matched_route.pattern
+    else:
+        span_name = otel_wsgi.get_default_span_name(environ)
+
+    span = tracer.start_span(
+        span_name, kind=trace.SpanKind.SERVER, start_time=start_time,
+    )
+
+    if span.is_recording():
+        attributes = otel_wsgi.collect_request_attributes(environ)
+        if request.matched_route:
+            attributes["http.route"] = request.matched_route.pattern
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+
+    activation = tracer.use_span(span, end_on_exit=True)
+    activation.__enter__()
+    environ[_ENVIRON_ACTIVATION_KEY] = activation
+    environ[_ENVIRON_SPAN_KEY] = span
+    environ[_ENVIRON_TOKEN] = token
+
+
+def trace_tween_factory(handler, registry):
+    settings = registry.settings
+    enabled = asbool(settings.get(SETTING_TRACE_ENABLED, True))
+
+    if not enabled:
+        # If disabled, make a tween that signals to the
+        # BeforeTraversal subscriber that tracing is disabled
+        def disabled_tween(request):
+            request.environ[_ENVIRON_ENABLED_KEY] = False
+            return handler(request)
+
+        return disabled_tween
+
+    # make a request tracing function
+    def trace_tween(request):
+        if _excluded_urls.url_disabled(request.url):
+            request.environ[_ENVIRON_ENABLED_KEY] = False
+            # short-circuit when we don't want to trace anything
+            return handler(request)
+
+        request.environ[_ENVIRON_ENABLED_KEY] = True
+        request.environ[_ENVIRON_STARTTIME_KEY] = time_ns()
+
+        try:
+            response = handler(request)
+            response_or_exception = response
+        except HTTPException as exc:
+            # If the exception is a pyramid HTTPException,
+            # that's still valuable information that isn't necessarily
+            # a 500. For instance, HTTPFound is a 302.
+            # As described in docs, Pyramid exceptions are all valid
+            # response types
+            response_or_exception = exc
+            raise
+        finally:
+            span = request.environ.get(_ENVIRON_SPAN_KEY)
+            enabled = request.environ.get(_ENVIRON_ENABLED_KEY)
+            if not span and enabled:
+                _logger.warning(
+                    "Pyramid environ's OpenTelemetry span missing."
+                    "If the OpenTelemetry tween was added manually, make sure"
+                    "PyramidInstrumentor().instrument_config(config) is called"
+                )
+            elif enabled:
+                otel_wsgi.add_response_attributes(
+                    span,
+                    response_or_exception.status,
+                    response_or_exception.headers,
+                )
+
+                activation = request.environ.get(_ENVIRON_ACTIVATION_KEY)
+
+                if isinstance(response_or_exception, HTTPException):
+                    activation.__exit__(
+                        type(response_or_exception),
+                        response_or_exception,
+                        getattr(response_or_exception, "__traceback__", None),
+                    )
+                else:
+                    activation.__exit__(None, None, None)
+
+                context.detach(request.environ.get(_ENVIRON_TOKEN))
+
+        return response
+
+    return trace_tween

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
@@ -1,0 +1,54 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyramid.httpexceptions as exc
+from pyramid.response import Response
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+
+from opentelemetry.configuration import Configuration
+
+
+class InstrumentationTest:
+    def setUp(self):  # pylint: disable=invalid-name
+        super().setUp()  # pylint: disable=no-member
+        Configuration._reset()  # pylint: disable=protected-access
+
+    @staticmethod
+    def _hello_endpoint(request):
+        helloid = int(request.matchdict["helloid"])
+        if helloid == 500:
+            raise exc.HTTPInternalServerError()
+        return Response("Hello: " + str(helloid))
+
+    def _common_initialization(self, config):
+        # pylint: disable=unused-argument
+        def excluded_endpoint(request):
+            return Response("excluded")
+
+        # pylint: disable=unused-argument
+        def excluded2_endpoint(request):
+            return Response("excluded2")
+
+        config.add_route("hello", "/hello/{helloid}")
+        config.add_view(self._hello_endpoint, route_name="hello")
+        config.add_route("excluded_arg", "/excluded/{helloid}")
+        config.add_view(self._hello_endpoint, route_name="excluded_arg")
+        config.add_route("excluded", "/excluded_noarg")
+        config.add_view(excluded_endpoint, route_name="excluded")
+        config.add_route("excluded2", "/excluded_noarg2")
+        config.add_view(excluded2_endpoint, route_name="excluded2")
+
+        # pylint: disable=attribute-defined-outside-init
+        self.client = Client(config.make_wsgi_app(), BaseResponse)

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -1,0 +1,79 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyramid.config import Configurator
+
+from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.test.wsgitestutil import WsgiTestBase
+
+# pylint: disable=import-error
+from .pyramid_base_test import InstrumentationTest
+
+
+class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+
+        PyramidInstrumentor().instrument()
+
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            PyramidInstrumentor().uninstrument()
+
+    def test_uninstrument(self):
+        # pylint: disable=access-member-before-definition
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        PyramidInstrumentor().uninstrument()
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    def test_tween_list(self):
+        tween_list = "pyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        self._common_initialization(config)
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        PyramidInstrumentor().uninstrument()
+
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
@@ -1,0 +1,209 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from pyramid.config import Configurator
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.test.wsgitestutil import WsgiTestBase
+from opentelemetry.util import ExcludeList
+
+# pylint: disable=import-error
+from .pyramid_base_test import InstrumentationTest
+
+
+def expected_attributes(override_attributes):
+    default_attributes = {
+        "component": "http",
+        "http.method": "GET",
+        "http.server_name": "localhost",
+        "http.scheme": "http",
+        "host.port": 80,
+        "http.host": "localhost",
+        "http.target": "/",
+        "http.flavor": "1.1",
+        "http.status_text": "OK",
+        "http.status_code": 200,
+    }
+    for key, val in override_attributes.items():
+        default_attributes[key] = val
+    return default_attributes
+
+
+class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+        config = Configurator()
+        PyramidInstrumentor().instrument_config(config)
+
+        self.config = config
+
+        self._common_initialization(self.config)
+
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            PyramidInstrumentor().uninstrument_config(self.config)
+
+    def test_uninstrument(self):
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        PyramidInstrumentor().uninstrument_config(self.config)
+        # Need to remake the WSGI app export
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    def test_simple(self):
+        expected_attrs = expected_attributes(
+            {"http.target": "/hello/123", "http.route": "/hello/{helloid}"}
+        )
+        self.client.get("/hello/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "/hello/{helloid}")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with patch("opentelemetry.trace.get_tracer"):
+            self.client.get("/hello/123")
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 0)
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_404(self):
+        expected_attrs = expected_attributes(
+            {
+                "http.method": "POST",
+                "http.target": "/bye",
+                "http.status_text": "Not Found",
+                "http.status_code": 404,
+            }
+        )
+
+        resp = self.client.post("/bye")
+        self.assertEqual(404, resp.status_code)
+        resp.close()
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "HTTP POST")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_internal_error(self):
+        expected_attrs = expected_attributes(
+            {
+                "http.target": "/hello/500",
+                "http.route": "/hello/{helloid}",
+                "http.status_text": "Internal Server Error",
+                "http.status_code": 500,
+            }
+        )
+        resp = self.client.get("/hello/500")
+        self.assertEqual(500, resp.status_code)
+        resp.close()
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "/hello/{helloid}")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_tween_list(self):
+        tween_list = "opentelemetry.instrumentation.pyramid.trace_tween_factory\npyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        PyramidInstrumentor().instrument_config(config)
+        self._common_initialization(config)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        PyramidInstrumentor().uninstrument_config(config)
+        # Need to remake the WSGI app export
+        self._common_initialization(config)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    @patch("opentelemetry.instrumentation.pyramid.callbacks._logger")
+    def test_warnings(self, mock_logger):
+        tween_list = "pyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        PyramidInstrumentor().instrument_config(config)
+        self._common_initialization(config)
+
+        self.client.get("/hello/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+        self.assertEqual(mock_logger.warning.called, True)
+
+        mock_logger.warning.called = False
+
+        tween_list = (
+            "opentelemetry.instrumentation.pyramid.trace_tween_factory"
+        )
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        self._common_initialization(config)
+
+        self.client.get("/hello/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+        self.assertEqual(mock_logger.warning.called, True)
+
+    @patch(
+        "opentelemetry.instrumentation.pyramid.callbacks._excluded_urls",
+        ExcludeList(["http://localhost/excluded_arg/123", "excluded_noarg"]),
+    )
+    def test_exclude_lists(self):
+        self.client.get("/excluded_arg/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+        self.client.get("/excluded_arg/125")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        self.client.get("/excluded_noarg")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        self.client.get("/excluded_noarg2")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-pyramid` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pyramid

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
