### PR TITLE
Move instrumentation redis

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-redis/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Update default SpanKind to `SpanKind.CLIENT` ([#965](https://github.com/open-telemetry/opentelemetry-python/pull/965))
+- Change package name to opentelemetry-instrumentation-redis
+  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-redis/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-redis/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-redis/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-redis/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry Redis Instrumentation
+===================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-redis.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-redis/
+
+This library allows tracing requests made by the Redis library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-redis
+
+
+References
+----------
+
+* `OpenTelemetry Redis Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/ext/opentelemetry-instrumentation-redis/opentelemetry-instrumentation-redis.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -1,0 +1,57 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-redis
+description = OpenTelemetry Redis instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-redis
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    redis >= 2.6
+    wrapt >= 1.12.1
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+    opentelemetry-sdk == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    redis = opentelemetry.instrumentation.redis:RedisInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "redis", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -1,0 +1,166 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Instrument `redis`_ to report Redis queries.
+
+There are two options for instrumenting code. The first option is to use the
+``opentelemetry-instrumentation`` executable which will automatically
+instrument your Redis client. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _redis: https://pypi.org/project/redis/
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+    from opentelemetry.sdk.trace import TracerProvider
+    import redis
+
+    trace.set_tracer_provider(TracerProvider())
+
+    # Instrument redis
+    RedisInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+
+    # This will report a span with the default settings
+    client = redis.StrictRedis(host="localhost", port=6379)
+    client.get("my-key")
+
+API
+---
+"""
+
+import redis
+from wrapt import ObjectProxy, wrap_function_wrapper
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.redis.util import (
+    _extract_conn_attributes,
+    _format_command_args,
+)
+from opentelemetry.instrumentation.redis.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+
+_DEFAULT_SERVICE = "redis"
+_RAWCMD = "db.statement"
+_CMD = "redis.command"
+
+
+def _set_connection_attributes(span, conn):
+    if not span.is_recording():
+        return
+    for key, value in _extract_conn_attributes(
+        conn.connection_pool.connection_kwargs
+    ).items():
+        span.set_attribute(key, value)
+
+
+def _traced_execute_command(func, instance, args, kwargs):
+    tracer = getattr(redis, "_opentelemetry_tracer")
+    query = _format_command_args(args)
+    with tracer.start_as_current_span(
+        _CMD, kind=trace.SpanKind.CLIENT
+    ) as span:
+        if span.is_recording():
+            span.set_attribute("service", tracer.instrumentation_info.name)
+            span.set_attribute(_RAWCMD, query)
+            _set_connection_attributes(span, instance)
+            span.set_attribute("redis.args_length", len(args))
+        return func(*args, **kwargs)
+
+
+def _traced_execute_pipeline(func, instance, args, kwargs):
+    tracer = getattr(redis, "_opentelemetry_tracer")
+
+    cmds = [_format_command_args(c) for c, _ in instance.command_stack]
+    resource = "\n".join(cmds)
+
+    with tracer.start_as_current_span(
+        _CMD, kind=trace.SpanKind.CLIENT
+    ) as span:
+        if span.is_recording():
+            span.set_attribute("service", tracer.instrumentation_info.name)
+            span.set_attribute(_RAWCMD, resource)
+            _set_connection_attributes(span, instance)
+            span.set_attribute(
+                "redis.pipeline_length", len(instance.command_stack)
+            )
+        return func(*args, **kwargs)
+
+
+class RedisInstrumentor(BaseInstrumentor):
+    """An instrumentor for Redis
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        tracer_provider = kwargs.get(
+            "tracer_provider", trace.get_tracer_provider()
+        )
+        setattr(
+            redis,
+            "_opentelemetry_tracer",
+            tracer_provider.get_tracer(_DEFAULT_SERVICE, __version__),
+        )
+
+        if redis.VERSION < (3, 0, 0):
+            wrap_function_wrapper(
+                "redis", "StrictRedis.execute_command", _traced_execute_command
+            )
+            wrap_function_wrapper(
+                "redis.client",
+                "BasePipeline.execute",
+                _traced_execute_pipeline,
+            )
+            wrap_function_wrapper(
+                "redis.client",
+                "BasePipeline.immediate_execute_command",
+                _traced_execute_command,
+            )
+        else:
+            wrap_function_wrapper(
+                "redis", "Redis.execute_command", _traced_execute_command
+            )
+            wrap_function_wrapper(
+                "redis.client", "Pipeline.execute", _traced_execute_pipeline
+            )
+            wrap_function_wrapper(
+                "redis.client",
+                "Pipeline.immediate_execute_command",
+                _traced_execute_command,
+            )
+
+    def _uninstrument(self, **kwargs):
+        if redis.VERSION < (3, 0, 0):
+            unwrap(redis.StrictRedis, "execute_command")
+            unwrap(redis.StrictRedis, "pipeline")
+            unwrap(redis.Redis, "pipeline")
+            unwrap(
+                redis.client.BasePipeline,  # pylint:disable=no-member
+                "execute",
+            )
+            unwrap(
+                redis.client.BasePipeline,  # pylint:disable=no-member
+                "immediate_execute_command",
+            )
+        else:
+            unwrap(redis.Redis, "execute_command")
+            unwrap(redis.Redis, "pipeline")
+            unwrap(redis.client.Pipeline, "execute")
+            unwrap(redis.client.Pipeline, "immediate_execute_command")

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
@@ -1,0 +1,57 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Some utils used by the redis integration
+"""
+
+
+def _extract_conn_attributes(conn_kwargs):
+    """ Transform redis conn info into dict """
+    attributes = {
+        "db.type": "redis",
+        "db.instance": conn_kwargs.get("db", 0),
+    }
+    try:
+        attributes["db.url"] = "redis://{}:{}".format(
+            conn_kwargs["host"], conn_kwargs["port"]
+        )
+    except KeyError:
+        pass  # don't include url attribute
+
+    return attributes
+
+
+def _format_command_args(args):
+    """Format command arguments and trim them as needed"""
+    value_max_len = 100
+    value_too_long_mark = "..."
+    cmd_max_len = 1000
+    length = 0
+    out = []
+    for arg in args:
+        cmd = str(arg)
+
+        if len(cmd) > value_max_len:
+            cmd = cmd[:value_max_len] + value_too_long_mark
+
+        if length + len(cmd) > cmd_max_len:
+            prefix = cmd[: cmd_max_len - length]
+            out.append("%s%s" % (prefix, value_too_long_mark))
+            break
+
+        out.append(cmd)
+        length += len(cmd)
+
+    return " ".join(out)

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -1,0 +1,84 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import redis
+
+from opentelemetry.instrumentation.redis import RedisInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind
+
+
+class TestRedis(TestBase):
+    def test_span_properties(self):
+        redis_client = redis.Redis()
+        RedisInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+        with mock.patch.object(redis_client, "connection"):
+            redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "redis.command")
+        self.assertEqual(span.kind, SpanKind.CLIENT)
+
+    def test_not_recording(self):
+        redis_client = redis.Redis()
+        RedisInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with mock.patch("opentelemetry.trace.get_tracer") as tracer:
+            with mock.patch.object(redis_client, "connection"):
+                tracer.return_value = mock_tracer
+                redis_client.get("key")
+                self.assertFalse(mock_span.is_recording())
+                self.assertTrue(mock_span.is_recording.called)
+                self.assertFalse(mock_span.set_attribute.called)
+                self.assertFalse(mock_span.set_status.called)
+
+    def test_instrument_uninstrument(self):
+        redis_client = redis.Redis()
+        RedisInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+        with mock.patch.object(redis_client, "connection"):
+            redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.memory_exporter.clear()
+
+        # Test uninstrument
+        RedisInstrumentor().uninstrument()
+
+        with mock.patch.object(redis_client, "connection"):
+            redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+        self.memory_exporter.clear()
+
+        # Test instrument again
+        RedisInstrumentor().instrument()
+
+        with mock.patch.object(redis_client, "connection"):
+            redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-redis` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-redis

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
