### PR TITLE
Move instrumentation requests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Add support for instrumenting prepared requests
+  ([#1040](https://github.com/open-telemetry/opentelemetry-python/pull/1040))
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+- Add support for tracking http metrics
+  ([#1116](https://github.com/open-telemetry/opentelemetry-python/pull/1116))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-requests
+  ([#961](https://github.com/open-telemetry/opentelemetry-python/pull/961))
+- Span name reported updated to follow semantic conventions to reduce
+  cardinality ([#972](https://github.com/open-telemetry/opentelemetry-python/pull/972))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Rename package to opentelemetry-ext-requests
+  ([#619](https://github.com/open-telemetry/opentelemetry-python/pull/619))
+- Implement instrumentor interface, enabling auto-instrumentation
+  ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
+- Adding disable_session for more granular instrumentation control
+  ([#573](https://github.com/open-telemetry/opentelemetry-python/pull/573))
+- Add a callback for custom attributes
+  ([#656](https://github.com/open-telemetry/opentelemetry-python/pull/656))
+
+## 0.3a0
+
+Released 2019-10-29
+
+## 0.2a0
+
+Released 2019-10-29
+
+- Updates for core library changes
+
+## 0.1a0
+
+Released 2019-09-30
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-requests/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-requests/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-requests/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-requests/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-requests/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-requests/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry Requests Instrumentation
+======================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-requests.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-requests/
+
+This library allows tracing HTTP requests made by the
+`requests <https://requests.readthedocs.io/en/master/>`_ library.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-instrumentation-requests
+
+References
+----------
+
+* `OpenTelemetry requests Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/requests/requests.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-requests
+description = OpenTelemetry requests instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-requests
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    requests ~= 2.0
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+    httpretty ~= 1.0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    requests = opentelemetry.instrumentation.requests:RequestsInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "requests",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -1,0 +1,266 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This library allows tracing HTTP requests made by the
+`requests <https://requests.readthedocs.io/en/master/>`_ library.
+
+Usage
+-----
+
+.. code-block:: python
+
+    import requests
+    import opentelemetry.instrumentation.requests
+
+    # You can optionally pass a custom TracerProvider to
+    # RequestInstrumentor.instrument()
+    opentelemetry.instrumentation.requests.RequestsInstrumentor().instrument()
+    response = requests.get(url="https://www.example.org/")
+
+API
+---
+"""
+
+import functools
+import types
+
+from requests import Timeout, URLRequired
+from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema
+from requests.sessions import Session
+from requests.structures import CaseInsensitiveDict
+
+from opentelemetry import context, propagators
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.metric import (
+    HTTPMetricRecorder,
+    HTTPMetricType,
+    MetricMixin,
+)
+from opentelemetry.instrumentation.requests.version import __version__
+from opentelemetry.instrumentation.utils import http_status_to_canonical_code
+from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.trace.status import (
+    EXCEPTION_STATUS_FIELD,
+    Status,
+    StatusCanonicalCode,
+)
+
+# A key to a context variable to avoid creating duplicate spans when instrumenting
+# both, Session.request and Session.send, since Session.request calls into Session.send
+_SUPPRESS_REQUESTS_INSTRUMENTATION_KEY = "suppress_requests_instrumentation"
+
+
+# pylint: disable=unused-argument
+# pylint: disable=R0915
+def _instrument(tracer_provider=None, span_callback=None):
+    """Enables tracing of all requests calls that go through
+    :code:`requests.session.Session.request` (this includes
+    :code:`requests.get`, etc.)."""
+
+    # Since
+    # https://github.com/psf/requests/commit/d72d1162142d1bf8b1b5711c664fbbd674f349d1
+    # (v0.7.0, Oct 23, 2011), get, post, etc are implemented via request which
+    # again, is implemented via Session.request (`Session` was named `session`
+    # before v1.0.0, Dec 17, 2012, see
+    # https://github.com/psf/requests/commit/4e5c4a6ab7bb0195dececdd19bb8505b872fe120)
+
+    wrapped_request = Session.request
+    wrapped_send = Session.send
+
+    @functools.wraps(wrapped_request)
+    def instrumented_request(self, method, url, *args, **kwargs):
+        def get_or_create_headers():
+            headers = kwargs.get("headers")
+            if headers is None:
+                headers = {}
+                kwargs["headers"] = headers
+
+            return headers
+
+        def call_wrapped():
+            return wrapped_request(self, method, url, *args, **kwargs)
+
+        return _instrumented_requests_call(
+            method, url, call_wrapped, get_or_create_headers
+        )
+
+    @functools.wraps(wrapped_send)
+    def instrumented_send(self, request, **kwargs):
+        def get_or_create_headers():
+            request.headers = (
+                request.headers
+                if request.headers is not None
+                else CaseInsensitiveDict()
+            )
+            return request.headers
+
+        def call_wrapped():
+            return wrapped_send(self, request, **kwargs)
+
+        return _instrumented_requests_call(
+            request.method, request.url, call_wrapped, get_or_create_headers
+        )
+
+    def _instrumented_requests_call(
+        method: str, url: str, call_wrapped, get_or_create_headers
+    ):
+        if context.get_value("suppress_instrumentation") or context.get_value(
+            _SUPPRESS_REQUESTS_INSTRUMENTATION_KEY
+        ):
+            return call_wrapped()
+
+        # See
+        # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-client
+        method = method.upper()
+        span_name = "HTTP {}".format(method)
+
+        recorder = RequestsInstrumentor().metric_recorder
+
+        labels = {}
+        labels["http.method"] = method
+        labels["http.url"] = url
+
+        with get_tracer(
+            __name__, __version__, tracer_provider
+        ).start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            exception = None
+            with recorder.record_client_duration(labels):
+                if span.is_recording():
+                    span.set_attribute("component", "http")
+                    span.set_attribute("http.method", method)
+                    span.set_attribute("http.url", url)
+
+                headers = get_or_create_headers()
+                propagators.inject(type(headers).__setitem__, headers)
+
+                token = context.attach(
+                    context.set_value(
+                        _SUPPRESS_REQUESTS_INSTRUMENTATION_KEY, True
+                    )
+                )
+                try:
+                    result = call_wrapped()  # *** PROCEED
+                except Exception as exc:  # pylint: disable=W0703
+                    exception = exc
+                    setattr(
+                        exception,
+                        EXCEPTION_STATUS_FIELD,
+                        _exception_to_canonical_code(exception),
+                    )
+                    result = getattr(exc, "response", None)
+                finally:
+                    context.detach(token)
+
+                if result is not None:
+                    if span.is_recording():
+                        span.set_attribute(
+                            "http.status_code", result.status_code
+                        )
+                        span.set_attribute("http.status_text", result.reason)
+                        span.set_status(
+                            Status(
+                                http_status_to_canonical_code(
+                                    result.status_code
+                                )
+                            )
+                        )
+                    labels["http.status_code"] = str(result.status_code)
+                    if result.raw and result.raw.version:
+                        labels["http.flavor"] = (
+                            str(result.raw.version)[:1]
+                            + "."
+                            + str(result.raw.version)[:-1]
+                        )
+                if span_callback is not None:
+                    span_callback(span, result)
+
+            if exception is not None:
+                raise exception.with_traceback(exception.__traceback__)
+
+        return result
+
+    instrumented_request.opentelemetry_instrumentation_requests_applied = True
+    Session.request = instrumented_request
+
+    instrumented_send.opentelemetry_instrumentation_requests_applied = True
+    Session.send = instrumented_send
+
+
+def _uninstrument():
+    """Disables instrumentation of :code:`requests` through this module.
+
+    Note that this only works if no other module also patches requests."""
+    _uninstrument_from(Session)
+
+
+def _uninstrument_from(instr_root, restore_as_bound_func=False):
+    for instr_func_name in ("request", "send"):
+        instr_func = getattr(instr_root, instr_func_name)
+        if not getattr(
+            instr_func,
+            "opentelemetry_instrumentation_requests_applied",
+            False,
+        ):
+            continue
+
+        original = instr_func.__wrapped__  # pylint:disable=no-member
+        if restore_as_bound_func:
+            original = types.MethodType(original, instr_root)
+        setattr(instr_root, instr_func_name, original)
+
+
+def _exception_to_canonical_code(exc: Exception) -> StatusCanonicalCode:
+    if isinstance(
+        exc,
+        (InvalidURL, InvalidSchema, MissingSchema, URLRequired, ValueError),
+    ):
+        return StatusCanonicalCode.INVALID_ARGUMENT
+    if isinstance(exc, Timeout):
+        return StatusCanonicalCode.DEADLINE_EXCEEDED
+    return StatusCanonicalCode.UNKNOWN
+
+
+class RequestsInstrumentor(BaseInstrumentor, MetricMixin):
+    """An instrumentor for requests
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        """Instruments requests module
+
+        Args:
+            **kwargs: Optional arguments
+                ``tracer_provider``: a TracerProvider, defaults to global
+                ``span_callback``: An optional callback invoked before returning the http response. Invoked with Span and requests.Response
+        """
+        _instrument(
+            tracer_provider=kwargs.get("tracer_provider"),
+            span_callback=kwargs.get("span_callback"),
+        )
+        self.init_metrics(
+            __name__, __version__,
+        )
+        # pylint: disable=W0201
+        self.metric_recorder = HTTPMetricRecorder(
+            self.meter, HTTPMetricType.CLIENT
+        )
+
+    def _uninstrument(self, **kwargs):
+        _uninstrument()
+
+    @staticmethod
+    def uninstrument_session(session):
+        """Disables instrumentation on the session object."""
+        _uninstrument_from(session, restore_as_bound_func=True)

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -1,0 +1,393 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+from unittest import mock
+
+import httpretty
+import requests
+
+import opentelemetry.instrumentation.requests
+from opentelemetry import context, propagators, trace
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk import resources
+from opentelemetry.sdk.util import get_dict_as_key
+from opentelemetry.test.mock_textmap import MockTextMapPropagator
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.status import StatusCanonicalCode
+
+
+class RequestsIntegrationTestBase(abc.ABC):
+    # pylint: disable=no-member
+
+    URL = "http://httpbin.org/status/200"
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        super().setUp()
+        RequestsInstrumentor().instrument()
+        httpretty.enable()
+        httpretty.register_uri(httpretty.GET, self.URL, body="Hello!")
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        super().tearDown()
+        RequestsInstrumentor().uninstrument()
+        httpretty.disable()
+
+    def assert_span(self, exporter=None, num_spans=1):
+        if exporter is None:
+            exporter = self.memory_exporter
+        span_list = exporter.get_finished_spans()
+        self.assertEqual(num_spans, len(span_list))
+        if num_spans == 0:
+            return None
+        if num_spans == 1:
+            return span_list[0]
+        return span_list
+
+    @staticmethod
+    @abc.abstractmethod
+    def perform_request(url: str, session: requests.Session = None):
+        pass
+
+    def test_basic(self):
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+        span = self.assert_span()
+
+        self.assertIs(span.kind, trace.SpanKind.CLIENT)
+        self.assertEqual(span.name, "HTTP GET")
+
+        self.assertEqual(
+            span.attributes,
+            {
+                "component": "http",
+                "http.method": "GET",
+                "http.url": self.URL,
+                "http.status_code": 200,
+                "http.status_text": "OK",
+            },
+        )
+
+        self.assertIs(
+            span.status.canonical_code, trace.status.StatusCanonicalCode.OK
+        )
+
+        self.check_span_instrumentation_info(
+            span, opentelemetry.instrumentation.requests
+        )
+
+        self.assertIsNotNone(RequestsInstrumentor().meter)
+        self.assertEqual(len(RequestsInstrumentor().meter.metrics), 1)
+        recorder = RequestsInstrumentor().meter.metrics.pop()
+        match_key = get_dict_as_key(
+            {
+                "http.flavor": "1.1",
+                "http.method": "GET",
+                "http.status_code": "200",
+                "http.url": "http://httpbin.org/status/200",
+            }
+        )
+        for key in recorder.bound_instruments.keys():
+            self.assertEqual(key, match_key)
+            # pylint: disable=protected-access
+            bound = recorder.bound_instruments.get(key)
+            for view_data in bound.view_datas:
+                self.assertEqual(view_data.labels, key)
+                self.assertEqual(view_data.aggregator.current.count, 1)
+                self.assertGreaterEqual(view_data.aggregator.current.sum, 0)
+
+    def test_not_foundbasic(self):
+        url_404 = "http://httpbin.org/status/404"
+        httpretty.register_uri(
+            httpretty.GET, url_404, status=404,
+        )
+        result = self.perform_request(url_404)
+        self.assertEqual(result.status_code, 404)
+
+        span = self.assert_span()
+
+        self.assertEqual(span.attributes.get("http.status_code"), 404)
+        self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
+
+        self.assertIs(
+            span.status.canonical_code,
+            trace.status.StatusCanonicalCode.NOT_FOUND,
+        )
+
+    def test_uninstrument(self):
+        RequestsInstrumentor().uninstrument()
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+        self.assert_span(num_spans=0)
+        # instrument again to avoid annoying warning message
+        RequestsInstrumentor().instrument()
+
+    def test_uninstrument_session(self):
+        session1 = requests.Session()
+        RequestsInstrumentor().uninstrument_session(session1)
+
+        result = self.perform_request(self.URL, session1)
+        self.assertEqual(result.text, "Hello!")
+        self.assert_span(num_spans=0)
+
+        # Test that other sessions as well as global requests is still
+        # instrumented
+        session2 = requests.Session()
+        result = self.perform_request(self.URL, session2)
+        self.assertEqual(result.text, "Hello!")
+        self.assert_span()
+
+        self.memory_exporter.clear()
+
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+        self.assert_span()
+
+    def test_suppress_instrumentation(self):
+        token = context.attach(
+            context.set_value("suppress_instrumentation", True)
+        )
+        try:
+            result = self.perform_request(self.URL)
+            self.assertEqual(result.text, "Hello!")
+        finally:
+            context.detach(token)
+
+        self.assert_span(num_spans=0)
+
+    def test_not_recording(self):
+        with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
+            RequestsInstrumentor().uninstrument()
+            # original_tracer_provider returns a default tracer provider, which
+            # in turn will return an INVALID_SPAN, which is always not recording
+            RequestsInstrumentor().instrument(
+                tracer_provider=self.original_tracer_provider
+            )
+            mock_span.is_recording.return_value = False
+            result = self.perform_request(self.URL)
+            self.assertEqual(result.text, "Hello!")
+            self.assert_span(None, 0)
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_distributed_context(self):
+        previous_propagator = propagators.get_global_textmap()
+        try:
+            propagators.set_global_textmap(MockTextMapPropagator())
+            result = self.perform_request(self.URL)
+            self.assertEqual(result.text, "Hello!")
+
+            span = self.assert_span()
+
+            headers = dict(httpretty.last_request().headers)
+            self.assertIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().trace_id),
+                headers[MockTextMapPropagator.TRACE_ID_KEY],
+            )
+            self.assertIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().span_id),
+                headers[MockTextMapPropagator.SPAN_ID_KEY],
+            )
+
+        finally:
+            propagators.set_global_textmap(previous_propagator)
+
+    def test_span_callback(self):
+        RequestsInstrumentor().uninstrument()
+
+        def span_callback(span, result: requests.Response):
+            span.set_attribute(
+                "http.response.body", result.content.decode("utf-8")
+            )
+
+        RequestsInstrumentor().instrument(
+            tracer_provider=self.tracer_provider, span_callback=span_callback,
+        )
+
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+
+        span = self.assert_span()
+        self.assertEqual(
+            span.attributes,
+            {
+                "component": "http",
+                "http.method": "GET",
+                "http.url": self.URL,
+                "http.status_code": 200,
+                "http.status_text": "OK",
+                "http.response.body": "Hello!",
+            },
+        )
+
+    def test_custom_tracer_provider(self):
+        resource = resources.Resource.create({})
+        result = self.create_tracer_provider(resource=resource)
+        tracer_provider, exporter = result
+        RequestsInstrumentor().uninstrument()
+        RequestsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+
+        span = self.assert_span(exporter=exporter)
+        self.assertIs(span.resource, resource)
+
+    @mock.patch(
+        "requests.adapters.HTTPAdapter.send",
+        side_effect=requests.RequestException,
+    )
+    def test_requests_exception_without_response(self, *_, **__):
+        with self.assertRaises(requests.RequestException):
+            self.perform_request(self.URL)
+
+        span = self.assert_span()
+        self.assertEqual(
+            span.attributes,
+            {"component": "http", "http.method": "GET", "http.url": self.URL},
+        )
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.UNKNOWN
+        )
+
+        self.assertIsNotNone(RequestsInstrumentor().meter)
+        self.assertEqual(len(RequestsInstrumentor().meter.metrics), 1)
+        recorder = RequestsInstrumentor().meter.metrics.pop()
+        match_key = get_dict_as_key(
+            {
+                "http.method": "GET",
+                "http.url": "http://httpbin.org/status/200",
+            }
+        )
+        for key in recorder.bound_instruments.keys():
+            self.assertEqual(key, match_key)
+            # pylint: disable=protected-access
+            bound = recorder.bound_instruments.get(key)
+            for view_data in bound.view_datas:
+                self.assertEqual(view_data.labels, key)
+                self.assertEqual(view_data.aggregator.current.count, 1)
+
+    mocked_response = requests.Response()
+    mocked_response.status_code = 500
+    mocked_response.reason = "Internal Server Error"
+
+    @mock.patch(
+        "requests.adapters.HTTPAdapter.send",
+        side_effect=requests.RequestException(response=mocked_response),
+    )
+    def test_requests_exception_with_response(self, *_, **__):
+        with self.assertRaises(requests.RequestException):
+            self.perform_request(self.URL)
+
+        span = self.assert_span()
+        self.assertEqual(
+            span.attributes,
+            {
+                "component": "http",
+                "http.method": "GET",
+                "http.url": self.URL,
+                "http.status_code": 500,
+                "http.status_text": "Internal Server Error",
+            },
+        )
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.INTERNAL
+        )
+        self.assertIsNotNone(RequestsInstrumentor().meter)
+        self.assertEqual(len(RequestsInstrumentor().meter.metrics), 1)
+        recorder = RequestsInstrumentor().meter.metrics.pop()
+        match_key = get_dict_as_key(
+            {
+                "http.method": "GET",
+                "http.status_code": "500",
+                "http.url": "http://httpbin.org/status/200",
+            }
+        )
+        for key in recorder.bound_instruments.keys():
+            self.assertEqual(key, match_key)
+            # pylint: disable=protected-access
+            bound = recorder.bound_instruments.get(key)
+            for view_data in bound.view_datas:
+                self.assertEqual(view_data.labels, key)
+                self.assertEqual(view_data.aggregator.current.count, 1)
+
+    @mock.patch("requests.adapters.HTTPAdapter.send", side_effect=Exception)
+    def test_requests_basic_exception(self, *_, **__):
+        with self.assertRaises(Exception):
+            self.perform_request(self.URL)
+
+        span = self.assert_span()
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.UNKNOWN
+        )
+
+    @mock.patch(
+        "requests.adapters.HTTPAdapter.send", side_effect=requests.Timeout
+    )
+    def test_requests_timeout_exception(self, *_, **__):
+        with self.assertRaises(Exception):
+            self.perform_request(self.URL)
+
+        span = self.assert_span()
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.DEADLINE_EXCEEDED
+        )
+
+
+class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
+    @staticmethod
+    def perform_request(url: str, session: requests.Session = None):
+        if session is None:
+            return requests.get(url)
+        return session.get(url)
+
+    def test_invalid_url(self):
+        url = "http://[::1/nope"
+
+        with self.assertRaises(ValueError):
+            requests.post(url)
+
+        span = self.assert_span()
+
+        self.assertEqual(span.name, "HTTP POST")
+        self.assertEqual(
+            span.attributes,
+            {"component": "http", "http.method": "POST", "http.url": url},
+        )
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.INVALID_ARGUMENT
+        )
+
+    def test_if_headers_equals_none(self):
+        result = requests.get(self.URL, headers=None)
+        self.assertEqual(result.text, "Hello!")
+        self.assert_span()
+
+
+class TestRequestsIntegrationPreparedRequest(
+    RequestsIntegrationTestBase, TestBase
+):
+    @staticmethod
+    def perform_request(url: str, session: requests.Session = None):
+        if session is None:
+            session = requests.Session()
+        request = requests.Request("GET", url)
+        prepared_request = session.prepare_request(request)
+        return session.send(prepared_request)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-requests` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-requests

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
