### PR TITLE
Move instrumentation sqlalchemy

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-sqlalchemy
+  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry SQLAlchemy Instrumentation
+========================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-sqlalchemy.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-sqlalchemy/
+
+This library allows tracing requests made by the SQLAlchemy library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-sqlalchemy
+
+
+References
+----------
+
+* `SQLAlchemy Project <https://www.sqlalchemy.org/>`_
+* `OpenTelemetry SQLAlchemy Tracing <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/sqlalchemy/sqlalchemy.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -1,0 +1,57 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-sqlalchemy
+description = OpenTelemetry SQLAlchemy instrumentation
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-sqlalchemy
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires = 
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    wrapt >= 1.11.2
+    sqlalchemy
+
+[options.extras_require]
+test =
+    opentelemetry-sdk == 0.15.dev0
+    pytest
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    sqlalchemy = opentelemetry.instrumentation.sqlalchemy:SQLAlchemyInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "sqlalchemy",
+    "version.py",
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -1,0 +1,91 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Instrument `sqlalchemy`_ to report SQL queries.
+
+There are two options for instrumenting code. The first option is to use
+the ``opentelemetry-instrument`` executable which will automatically
+instrument your SQLAlchemy engine. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _sqlalchemy: https://pypi.org/project/sqlalchemy/
+
+Usage
+-----
+.. code:: python
+
+    from sqlalchemy import create_engine
+
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+    from opentelemetry.sdk.trace import TracerProvider
+    import sqlalchemy
+
+    trace.set_tracer_provider(TracerProvider())
+    engine = create_engine("sqlite:///:memory:")
+    SQLAlchemyInstrumentor().instrument(
+        engine=engine,
+        service="service-A",
+    )
+
+API
+---
+"""
+import sqlalchemy
+import wrapt
+from wrapt import wrap_function_wrapper as _w
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.sqlalchemy.engine import (
+    EngineTracer,
+    _get_tracer,
+    _wrap_create_engine,
+)
+from opentelemetry.instrumentation.utils import unwrap
+
+
+class SQLAlchemyInstrumentor(BaseInstrumentor):
+    """An instrumentor for SQLAlchemy
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        """Instruments SQLAlchemy engine creation methods and the engine
+        if passed as an argument.
+
+        Args:
+            **kwargs: Optional arguments
+                ``engine``: a SQLAlchemy engine instance
+                ``tracer_provider``: a TracerProvider, defaults to global
+                ``service``: the name of the service to trace.
+
+        Returns:
+            An instrumented engine if passed in as an argument, None otherwise.
+        """
+        _w("sqlalchemy", "create_engine", _wrap_create_engine)
+        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine)
+        if kwargs.get("engine") is not None:
+            return EngineTracer(
+                _get_tracer(
+                    kwargs.get("engine"), kwargs.get("tracer_provider")
+                ),
+                kwargs.get("service"),
+                kwargs.get("engine"),
+            )
+        return None
+
+    def _uninstrument(self, **kwargs):
+        unwrap(sqlalchemy, "create_engine")
+        unwrap(sqlalchemy.engine, "create_engine")

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -1,0 +1,151 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy.event import listen
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.sqlalchemy.version import __version__
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+# Network attribute semantic convention here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
+_HOST = "net.peer.name"
+_PORT = "net.peer.port"
+# Database semantic conventions here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md
+_ROWS = "sql.rows"  # number of rows returned by a query
+_STMT = "db.statement"
+_DB = "db.type"
+_URL = "db.url"
+
+
+def _normalize_vendor(vendor):
+    """Return a canonical name for a type of database."""
+    if not vendor:
+        return "db"  # should this ever happen?
+
+    if "sqlite" in vendor:
+        return "sqlite"
+
+    if "postgres" in vendor or vendor == "psycopg2":
+        return "postgres"
+
+    return vendor
+
+
+def _get_tracer(engine, tracer_provider=None):
+    if tracer_provider is None:
+        tracer_provider = trace.get_tracer_provider()
+    return tracer_provider.get_tracer(
+        _normalize_vendor(engine.name), __version__
+    )
+
+
+# pylint: disable=unused-argument
+def _wrap_create_engine(func, module, args, kwargs):
+    """Trace the SQLAlchemy engine, creating an `EngineTracer`
+    object that will listen to SQLAlchemy events.
+    """
+    engine = func(*args, **kwargs)
+    EngineTracer(_get_tracer(engine), None, engine)
+    return engine
+
+
+class EngineTracer:
+    def __init__(self, tracer, service, engine):
+        self.tracer = tracer
+        self.engine = engine
+        self.vendor = _normalize_vendor(engine.name)
+        self.service = service or self.vendor
+        self.name = "%s.query" % self.vendor
+        self.current_span = None
+
+        listen(engine, "before_cursor_execute", self._before_cur_exec)
+        listen(engine, "after_cursor_execute", self._after_cur_exec)
+        listen(engine, "handle_error", self._handle_error)
+
+    # pylint: disable=unused-argument
+    def _before_cur_exec(self, conn, cursor, statement, *args):
+        self.current_span = self.tracer.start_span(self.name)
+        with self.tracer.use_span(self.current_span, end_on_exit=False):
+            if self.current_span.is_recording():
+                self.current_span.set_attribute("service", self.vendor)
+                self.current_span.set_attribute(_STMT, statement)
+
+                if not _set_attributes_from_url(
+                    self.current_span, conn.engine.url
+                ):
+                    _set_attributes_from_cursor(
+                        self.current_span, self.vendor, cursor
+                    )
+
+    # pylint: disable=unused-argument
+    def _after_cur_exec(self, conn, cursor, statement, *args):
+        if self.current_span is None:
+            return
+
+        try:
+            if (
+                cursor
+                and cursor.rowcount >= 0
+                and self.current_span.is_recording()
+            ):
+                self.current_span.set_attribute(_ROWS, cursor.rowcount)
+        finally:
+            self.current_span.end()
+
+    def _handle_error(self, context):
+        if self.current_span is None:
+            return
+
+        try:
+            if self.current_span.is_recording():
+                self.current_span.set_status(
+                    Status(
+                        StatusCanonicalCode.UNKNOWN,
+                        str(context.original_exception),
+                    )
+                )
+        finally:
+            self.current_span.end()
+
+
+def _set_attributes_from_url(span: trace.Span, url):
+    """Set connection tags from the url. return true if successful."""
+    if span.is_recording():
+        if url.host:
+            span.set_attribute(_HOST, url.host)
+        if url.port:
+            span.set_attribute(_PORT, url.port)
+        if url.database:
+            span.set_attribute(_DB, url.database)
+
+    return bool(url.host)
+
+
+def _set_attributes_from_cursor(span: trace.Span, vendor, cursor):
+    """Attempt to set db connection attributes by introspecting the cursor."""
+    if not span.is_recording():
+        return
+    if vendor == "postgres":
+        # pylint: disable=import-outside-toplevel
+        from psycopg2.extensions import parse_dsn
+
+        if hasattr(cursor, "connection") and hasattr(cursor.connection, "dsn"):
+            dsn = getattr(cursor.connection, "dsn", None)
+            if dsn:
+                data = parse_dsn(dsn)
+                span.set_attribute(_DB, data.get("dbname"))
+                span.set_attribute(_HOST, data.get("host"))
+                span.set_attribute(_PORT, int(data.get("port")))

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+from sqlalchemy import create_engine
+
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.test.test_base import TestBase
+
+
+class TestSqlalchemyInstrumentation(TestBase):
+    def tearDown(self):
+        super().tearDown()
+        SQLAlchemyInstrumentor().uninstrument()
+
+    def test_trace_integration(self):
+        engine = create_engine("sqlite:///:memory:")
+        SQLAlchemyInstrumentor().instrument(
+            engine=engine,
+            tracer_provider=self.tracer_provider,
+            service="my-database",
+        )
+        cnx = engine.connect()
+        cnx.execute("SELECT	1 + 1;").fetchall()
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].name, "sqlite.query")
+
+    def test_not_recording(self):
+        mock_tracer = mock.Mock()
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with mock.patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            engine = create_engine("sqlite:///:memory:")
+            SQLAlchemyInstrumentor().instrument(
+                engine=engine,
+                tracer_provider=self.tracer_provider,
+                service="my-database",
+            )
+            cnx = engine.connect()
+            cnx.execute("SELECT	1 + 1;").fetchall()
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_create_engine_wrapper(self):
+        SQLAlchemyInstrumentor().instrument()
+        from sqlalchemy import create_engine  # pylint: disable-all
+
+        engine = create_engine("sqlite:///:memory:")
+        cnx = engine.connect()
+        cnx.execute("SELECT	1 + 1;").fetchall()
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].name, "sqlite.query")


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-sqlalchemy` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-sqlalchemy

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
