### PR TITLE
Move instrumentation falcon

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-falcon/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.14b0
+
+Released 2020-10-13
+
+- Added support for `OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS` ([#1158](https://github.com/open-telemetry/opentelemetry-python/pull/1158))
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Initial release. Added instrumentation for Falcon 2.0+

--- a/instrumentation/opentelemetry-instrumentation-falcon/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-falcon/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-falcon/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-falcon/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-falcon/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-falcon/README.rst
@@ -1,0 +1,53 @@
+OpenTelemetry Falcon Tracing
+============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-falcon.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-falcon/
+
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Falcon applications.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-falcon
+
+Configuration
+-------------
+
+Exclude lists
+*************
+To exclude certain URLs from being tracked, set the environment variable ``OTEL_PYTHON_FALCON_EXCLUDED_URLS`` with comma delimited regexes representing which URLs to exclude.
+
+For example,
+
+::
+
+    export OTEL_PYTHON_FALCON_EXCLUDED_URLS="client/.*/info,healthcheck"
+
+will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
+
+Request attributes
+********************
+To extract certain attributes from Falcon's request object and use them as span attributes, set the environment variable ``OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS`` to a comma
+delimited list of request attribute names. 
+
+For example,
+
+::
+
+    export OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS='query_string,uri_template'
+
+will extract path_info and content_type attributes from every traced request and add them as span attritbues.
+
+Falcon Request object reference: https://falcon.readthedocs.io/en/stable/api/request_and_response.html#id1
+
+References
+----------
+
+* `OpenTelemetry Falcon Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/falcon/falcon.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -1,0 +1,59 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-falcon
+description = Falcon instrumentation for OpenTelemetry
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-falcon
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.4
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    falcon ~= 2.0
+    opentelemetry-instrumentation-wsgi == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15.dev0
+
+[options.extras_require]
+test =
+    falcon ~= 2.0
+    opentelemetry-test == 0.15.dev0
+    parameterized == 0.7.4
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    falcon = opentelemetry.instrumentation.falcon:FalconInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "falcon", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -1,0 +1,222 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Falcon applications. In addition to opentelemetry-instrumentation-wsgi,
+it supports falcon-specific features such as:
+
+* The Falcon resource and method name is used as the Span name.
+* The ``falcon.resource`` Span attribute is set so the matched resource.
+* Error from Falcon resources are properly caught and recorded.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from falcon import API
+    from opentelemetry.instrumentation.falcon import FalconInstrumentor
+
+    FalconInstrumentor().instrument()
+
+    app = falcon.API()
+
+    class HelloWorldResource(object):
+        def on_get(self, req, resp):
+            resp.body = 'Hello World'
+
+    app.add_route('/hello', HelloWorldResource())
+
+API
+---
+"""
+
+import sys
+from logging import getLogger
+
+import falcon
+
+import opentelemetry.instrumentation.wsgi as otel_wsgi
+from opentelemetry import configuration, context, propagators, trace
+from opentelemetry.configuration import Configuration
+from opentelemetry.instrumentation.falcon.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import (
+    extract_attributes_from_object,
+    http_status_to_canonical_code,
+)
+from opentelemetry.trace.status import Status
+from opentelemetry.util import ExcludeList, time_ns
+
+_logger = getLogger(__name__)
+
+_ENVIRON_STARTTIME_KEY = "opentelemetry-falcon.starttime_key"
+_ENVIRON_SPAN_KEY = "opentelemetry-falcon.span_key"
+_ENVIRON_ACTIVATION_KEY = "opentelemetry-falcon.activation_key"
+_ENVIRON_TOKEN = "opentelemetry-falcon.token"
+_ENVIRON_EXC = "opentelemetry-falcon.exc"
+
+
+def get_excluded_urls():
+    urls = configuration.Configuration().FALCON_EXCLUDED_URLS or ""
+    if urls:
+        urls = str.split(urls, ",")
+    return ExcludeList(urls)
+
+
+_excluded_urls = get_excluded_urls()
+
+
+class FalconInstrumentor(BaseInstrumentor):
+    # pylint: disable=protected-access,attribute-defined-outside-init
+    """An instrumentor for falcon.API
+
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        self._original_falcon_api = falcon.API
+        falcon.API = _InstrumentedFalconAPI
+
+    def _uninstrument(self, **kwargs):
+        falcon.API = self._original_falcon_api
+
+
+class _InstrumentedFalconAPI(falcon.API):
+    def __init__(self, *args, **kwargs):
+        middlewares = kwargs.pop("middleware", [])
+        if not isinstance(middlewares, (list, tuple)):
+            middlewares = [middlewares]
+
+        self._tracer = trace.get_tracer(__name__, __version__)
+        trace_middleware = _TraceMiddleware(
+            self._tracer, kwargs.get("traced_request_attributes")
+        )
+        middlewares.insert(0, trace_middleware)
+        kwargs["middleware"] = middlewares
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, env, start_response):
+        if _excluded_urls.url_disabled(env.get("PATH_INFO", "/")):
+            return super().__call__(env, start_response)
+
+        start_time = time_ns()
+
+        token = context.attach(
+            propagators.extract(otel_wsgi.get_header_from_environ, env)
+        )
+        span = self._tracer.start_span(
+            otel_wsgi.get_default_span_name(env),
+            kind=trace.SpanKind.SERVER,
+            start_time=start_time,
+        )
+        if span.is_recording():
+            attributes = otel_wsgi.collect_request_attributes(env)
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+
+        activation = self._tracer.use_span(span, end_on_exit=True)
+        activation.__enter__()
+        env[_ENVIRON_SPAN_KEY] = span
+        env[_ENVIRON_ACTIVATION_KEY] = activation
+
+        def _start_response(status, response_headers, *args, **kwargs):
+            otel_wsgi.add_response_attributes(span, status, response_headers)
+            response = start_response(
+                status, response_headers, *args, **kwargs
+            )
+            activation.__exit__(None, None, None)
+            context.detach(token)
+            return response
+
+        try:
+            return super().__call__(env, _start_response)
+        except Exception as exc:
+            activation.__exit__(
+                type(exc), exc, getattr(exc, "__traceback__", None),
+            )
+            context.detach(token)
+            raise
+
+
+class _TraceMiddleware:
+    # pylint:disable=R0201,W0613
+
+    def __init__(self, tracer=None, traced_request_attrs=None):
+        self.tracer = tracer
+        self._traced_request_attrs = traced_request_attrs or [
+            attr.strip()
+            for attr in (
+                Configuration().FALCON_TRACED_REQUEST_ATTRS or ""
+            ).split(",")
+        ]
+
+    def process_request(self, req, resp):
+        span = req.env.get(_ENVIRON_SPAN_KEY)
+        if not span or not span.is_recording():
+            return
+
+        attributes = extract_attributes_from_object(
+            req, self._traced_request_attrs
+        )
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+
+    def process_resource(self, req, resp, resource, params):
+        span = req.env.get(_ENVIRON_SPAN_KEY)
+        if not span or not span.is_recording():
+            return
+
+        resource_name = resource.__class__.__name__
+        span.set_attribute("falcon.resource", resource_name)
+        span.update_name(
+            "{0}.on_{1}".format(resource_name, req.method.lower())
+        )
+
+    def process_response(
+        self, req, resp, resource, req_succeeded=None
+    ):  # pylint:disable=R0201
+        span = req.env.get(_ENVIRON_SPAN_KEY)
+        if not span or not span.is_recording():
+            return
+
+        status = resp.status
+        reason = None
+        if resource is None:
+            status = "404"
+            reason = "NotFound"
+
+        exc_type, exc, _ = sys.exc_info()
+        if exc_type and not req_succeeded:
+            if "HTTPNotFound" in exc_type.__name__:
+                status = "404"
+                reason = "NotFound"
+            else:
+                status = "500"
+                reason = "{}: {}".format(exc_type.__name__, exc)
+
+        status = status.split(" ")[0]
+        try:
+            status_code = int(status)
+        except ValueError:
+            pass
+        finally:
+            span.set_attribute("http.status_code", status_code)
+            span.set_status(
+                Status(
+                    canonical_code=http_status_to_canonical_code(status_code),
+                    description=reason,
+                )
+            )

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
@@ -1,0 +1,41 @@
+import falcon
+
+# pylint:disable=R0201,W0613,E0602
+
+
+class HelloWorldResource:
+    def _handle_request(self, _, resp):
+        # pylint: disable=no-member
+        resp.status = falcon.HTTP_201
+        resp.body = "Hello World"
+
+    def on_get(self, req, resp):
+        self._handle_request(req, resp)
+
+    def on_put(self, req, resp):
+        self._handle_request(req, resp)
+
+    def on_patch(self, req, resp):
+        self._handle_request(req, resp)
+
+    def on_post(self, req, resp):
+        self._handle_request(req, resp)
+
+    def on_delete(self, req, resp):
+        self._handle_request(req, resp)
+
+    def on_head(self, req, resp):
+        self._handle_request(req, resp)
+
+
+class ErrorResource:
+    def on_get(self, req, resp):
+        print(non_existent_var)  # noqa
+
+
+def make_app():
+    app = falcon.API()
+    app.add_route("/hello", HelloWorldResource())
+    app.add_route("/ping", HelloWorldResource())
+    app.add_route("/error", ErrorResource())
+    return app

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -1,0 +1,205 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from falcon import testing
+
+from opentelemetry.instrumentation.falcon import FalconInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.util import ExcludeList
+
+from .app import make_app
+
+
+class TestFalconInstrumentation(TestBase):
+    def setUp(self):
+        super().setUp()
+        FalconInstrumentor().instrument()
+        self.app = make_app()
+
+    def client(self):
+        return testing.TestClient(self.app)
+
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            FalconInstrumentor().uninstrument()
+
+    def test_get(self):
+        self._test_method("GET")
+
+    def test_post(self):
+        self._test_method("POST")
+
+    def test_patch(self):
+        self._test_method("PATCH")
+
+    def test_put(self):
+        self._test_method("PUT")
+
+    def test_delete(self):
+        self._test_method("DELETE")
+
+    def test_head(self):
+        self._test_method("HEAD")
+
+    def _test_method(self, method):
+        self.client().simulate_request(method=method, path="/hello")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(
+            span.name, "HelloWorldResource.on_{0}".format(method.lower())
+        )
+        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assert_span_has_attributes(
+            span,
+            {
+                "component": "http",
+                "http.method": method,
+                "http.server_name": "falconframework.org",
+                "http.scheme": "http",
+                "host.port": 80,
+                "http.host": "falconframework.org",
+                "http.target": "/",
+                "net.peer.ip": "127.0.0.1",
+                "net.peer.port": "65133",
+                "http.flavor": "1.1",
+                "falcon.resource": "HelloWorldResource",
+                "http.status_text": "Created",
+                "http.status_code": 201,
+            },
+        )
+        self.memory_exporter.clear()
+
+    def test_404(self):
+        self.client().simulate_get("/does-not-exist")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "HTTP GET")
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.NOT_FOUND
+        )
+        self.assert_span_has_attributes(
+            span,
+            {
+                "component": "http",
+                "http.method": "GET",
+                "http.server_name": "falconframework.org",
+                "http.scheme": "http",
+                "host.port": 80,
+                "http.host": "falconframework.org",
+                "http.target": "/",
+                "net.peer.ip": "127.0.0.1",
+                "net.peer.port": "65133",
+                "http.flavor": "1.1",
+                "http.status_text": "Not Found",
+                "http.status_code": 404,
+            },
+        )
+
+    def test_500(self):
+        try:
+            self.client().simulate_get("/error")
+        except NameError:
+            pass
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "ErrorResource.on_get")
+        self.assertFalse(span.status.is_ok)
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.INTERNAL
+        )
+        self.assertEqual(
+            span.status.description,
+            "NameError: name 'non_existent_var' is not defined",
+        )
+        self.assert_span_has_attributes(
+            span,
+            {
+                "component": "http",
+                "http.method": "GET",
+                "http.server_name": "falconframework.org",
+                "http.scheme": "http",
+                "host.port": 80,
+                "http.host": "falconframework.org",
+                "http.target": "/",
+                "net.peer.ip": "127.0.0.1",
+                "net.peer.port": "65133",
+                "http.flavor": "1.1",
+                "http.status_code": 500,
+            },
+        )
+
+    def test_uninstrument(self):
+        self.client().simulate_get(path="/hello")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        self.memory_exporter.clear()
+
+        FalconInstrumentor().uninstrument()
+        self.app = make_app()
+        self.client().simulate_get(path="/hello")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+    @patch(
+        "opentelemetry.instrumentation.falcon._excluded_urls",
+        ExcludeList(["ping"]),
+    )
+    def test_exclude_lists(self):
+        self.client().simulate_get(path="/ping")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+        self.client().simulate_get(path="/hello")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    def test_traced_request_attributes(self):
+        self.client().simulate_get(path="/hello?q=abc")
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertNotIn("query_string", span.attributes)
+        self.memory_exporter.clear()
+
+        middleware = self.app._middleware[0][  # pylint:disable=W0212
+            0
+        ].__self__
+        with patch.object(
+            middleware, "_traced_request_attrs", ["query_string"]
+        ):
+            self.client().simulate_get(path="/hello?q=abc")
+            span = self.memory_exporter.get_finished_spans()[0]
+            self.assertIn("query_string", span.attributes)
+            self.assertEqual(span.attributes["query_string"], "q=abc")
+
+    def test_traced_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = mock_span
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            self.client().simulate_get(path="/hello?q=abc")
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-falcon` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-falcon

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
