### PR TITLE
Move exporter opencensus

### DIFF
--- a/exporter/opentelemetry-exporter-opencensus/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-opencensus/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4'
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-exporter-opencensus
+  ([#953](https://github.com/open-telemetry/opentelemetry-python/pull/953))
+- Send start_timestamp and convert labels to strings
+  ([#937](https://github.com/open-telemetry/opentelemetry-python/pull/937))
+
+## 0.8b0
+
+Released 2020-05-27
+
+- Rename otcollector to opencensus
+  ([#695](https://github.com/open-telemetry/opentelemetry-python/pull/695))
+
+## 0.5b0
+
+Released 2020-03-16
+
+- Initial release.

--- a/exporter/opentelemetry-exporter-opencensus/LICENSE
+++ b/exporter/opentelemetry-exporter-opencensus/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/opentelemetry-exporter-opencensus/MANIFEST.in
+++ b/exporter/opentelemetry-exporter-opencensus/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/exporter/opentelemetry-exporter-opencensus/README.rst
+++ b/exporter/opentelemetry-exporter-opencensus/README.rst
@@ -1,0 +1,24 @@
+OpenCensus Exporter
+===================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-exporter-opencensus.svg
+   :target: https://pypi.org/project/opentelemetry-exporter-opencensus/
+
+This library allows to export traces and metrics using OpenCensus.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-exporter-opencensus
+
+
+References
+----------
+
+* `OpenCensus Exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/opencensus/opencensus.html>`_
+* `OpenTelemetry Collector <https://github.com/open-telemetry/opentelemetry-collector/>`_
+* `OpenTelemetry <https://opentelemetry.io/>`_

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -1,0 +1,52 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-exporter-opencensus
+description = OpenCensus Exporter
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-exporter-opencensus
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    grpcio >= 1.0.0, < 2.0.0
+    opencensus-proto >= 0.1.0, < 1.0.0
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-sdk == 0.15.dev0
+    protobuf >= 3.8.0
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test =

--- a/exporter/opentelemetry-exporter-opencensus/setup.py
+++ b/exporter/opentelemetry-exporter-opencensus/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "exporter", "opencensus", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/__init__.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/__init__.py
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The **OpenCensus Exporter** allows to export traces and metrics using
+OpenCensus.
+"""

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/metrics_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/metrics_exporter/__init__.py
@@ -1,0 +1,209 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenCensus Collector Metrics Exporter."""
+
+import logging
+from typing import Dict, Sequence
+
+import grpc
+from google.protobuf.timestamp_pb2 import Timestamp
+from opencensus.proto.agent.metrics.v1 import (
+    metrics_service_pb2,
+    metrics_service_pb2_grpc,
+)
+from opencensus.proto.metrics.v1 import metrics_pb2
+from opencensus.proto.resource.v1 import resource_pb2
+
+import opentelemetry.exporter.opencensus.util as utils
+from opentelemetry.sdk.metrics import Counter, Metric
+from opentelemetry.sdk.metrics.export import (
+    MetricRecord,
+    MetricsExporter,
+    MetricsExportResult,
+)
+
+DEFAULT_ENDPOINT = "localhost:55678"
+
+# In priority order. See collector impl https://bit.ly/2DvJW6y
+_OT_LABEL_PRESENCE_TO_RESOURCE_TYPE = (
+    ("container.name", "container"),
+    ("k8s.pod.name", "k8s"),
+    ("host.name", "host"),
+    ("cloud.provider", "cloud"),
+)
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=no-member
+class OpenCensusMetricsExporter(MetricsExporter):
+    """OpenCensus metrics exporter.
+
+    Args:
+        endpoint: OpenCensus Collector receiver endpoint.
+        service_name: Name of Collector service.
+        host_name: Host name.
+        client: MetricsService client stub.
+    """
+
+    def __init__(
+        self,
+        endpoint: str = DEFAULT_ENDPOINT,
+        service_name: str = None,
+        host_name: str = None,
+        client: metrics_service_pb2_grpc.MetricsServiceStub = None,
+    ):
+        self.endpoint = endpoint
+        if client is None:
+            channel = grpc.insecure_channel(self.endpoint)
+            self.client = metrics_service_pb2_grpc.MetricsServiceStub(
+                channel=channel
+            )
+        else:
+            self.client = client
+
+        self.node = utils.get_node(service_name, host_name)
+        self.exporter_start_timestamp = Timestamp()
+        self.exporter_start_timestamp.GetCurrentTime()
+
+    def export(
+        self, metric_records: Sequence[MetricRecord]
+    ) -> MetricsExportResult:
+        try:
+            responses = self.client.Export(
+                self.generate_metrics_requests(metric_records)
+            )
+
+            # Read response
+            for _ in responses:
+                pass
+
+        except grpc.RpcError:
+            return MetricsExportResult.FAILURE
+
+        return MetricsExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def generate_metrics_requests(
+        self, metrics: Sequence[MetricRecord]
+    ) -> metrics_service_pb2.ExportMetricsServiceRequest:
+        collector_metrics = translate_to_collector(
+            metrics, self.exporter_start_timestamp
+        )
+        service_request = metrics_service_pb2.ExportMetricsServiceRequest(
+            node=self.node, metrics=collector_metrics
+        )
+        yield service_request
+
+
+# pylint: disable=too-many-branches
+def translate_to_collector(
+    metric_records: Sequence[MetricRecord],
+    exporter_start_timestamp: Timestamp,
+) -> Sequence[metrics_pb2.Metric]:
+    collector_metrics = []
+    for metric_record in metric_records:
+
+        label_values = []
+        label_keys = []
+        for label_tuple in metric_record.labels:
+            label_keys.append(metrics_pb2.LabelKey(key=label_tuple[0]))
+            label_values.append(
+                metrics_pb2.LabelValue(
+                    has_value=label_tuple[1] is not None,
+                    value=str(label_tuple[1]),
+                )
+            )
+
+        metric_descriptor = metrics_pb2.MetricDescriptor(
+            name=metric_record.instrument.name,
+            description=metric_record.instrument.description,
+            unit=metric_record.instrument.unit,
+            type=get_collector_metric_type(metric_record.instrument),
+            label_keys=label_keys,
+        )
+
+        # If cumulative and stateful, explicitly set the start_timestamp to
+        # exporter start time.
+        if metric_record.instrument.meter.processor.stateful:
+            start_timestamp = exporter_start_timestamp
+        else:
+            start_timestamp = None
+
+        timeseries = metrics_pb2.TimeSeries(
+            label_values=label_values,
+            points=[get_collector_point(metric_record)],
+            start_timestamp=start_timestamp,
+        )
+        collector_metrics.append(
+            metrics_pb2.Metric(
+                metric_descriptor=metric_descriptor,
+                timeseries=[timeseries],
+                resource=get_resource(metric_record),
+            )
+        )
+    return collector_metrics
+
+
+# pylint: disable=no-else-return
+def get_collector_metric_type(metric: Metric) -> metrics_pb2.MetricDescriptor:
+    if isinstance(metric, Counter):
+        if metric.value_type == int:
+            return metrics_pb2.MetricDescriptor.CUMULATIVE_INT64
+        elif metric.value_type == float:
+            return metrics_pb2.MetricDescriptor.CUMULATIVE_DOUBLE
+    return metrics_pb2.MetricDescriptor.UNSPECIFIED
+
+
+def get_collector_point(metric_record: MetricRecord) -> metrics_pb2.Point:
+    # TODO: horrible hack to get original list of keys to then get the bound
+    # instrument
+    point = metrics_pb2.Point(
+        timestamp=utils.proto_timestamp_from_time_ns(
+            metric_record.aggregator.last_update_timestamp
+        )
+    )
+    if metric_record.instrument.value_type == int:
+        point.int64_value = metric_record.aggregator.checkpoint
+    elif metric_record.instrument.value_type == float:
+        point.double_value = metric_record.aggregator.checkpoint
+    else:
+        raise TypeError(
+            "Unsupported metric type: {}".format(
+                metric_record.instrument.value_type
+            )
+        )
+    return point
+
+
+def get_resource(metric_record: MetricRecord) -> resource_pb2.Resource:
+    resource_attributes = metric_record.resource.attributes
+    return resource_pb2.Resource(
+        type=infer_oc_resource_type(resource_attributes),
+        labels={k: str(v) for k, v in resource_attributes.items()},
+    )
+
+
+def infer_oc_resource_type(resource_attributes: Dict[str, str]) -> str:
+    """Convert from OT resource labels to OC resource type"""
+    for (
+        ot_resource_key,
+        oc_resource_type,
+    ) in _OT_LABEL_PRESENCE_TO_RESOURCE_TYPE:
+        if ot_resource_key in resource_attributes:
+            return oc_resource_type
+    return ""

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/trace_exporter/__init__.py
@@ -1,0 +1,173 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenCensus Span Exporter."""
+
+import logging
+from typing import Sequence
+
+import grpc
+from opencensus.proto.agent.trace.v1 import (
+    trace_service_pb2,
+    trace_service_pb2_grpc,
+)
+from opencensus.proto.trace.v1 import trace_pb2
+
+import opentelemetry.exporter.opencensus.util as utils
+from opentelemetry.sdk.trace import Span
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+DEFAULT_ENDPOINT = "localhost:55678"
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=no-member
+class OpenCensusSpanExporter(SpanExporter):
+    """OpenCensus Collector span exporter.
+
+    Args:
+        endpoint: OpenCensus Collector receiver endpoint.
+        service_name: Name of Collector service.
+        host_name: Host name.
+        client: TraceService client stub.
+    """
+
+    def __init__(
+        self,
+        endpoint=DEFAULT_ENDPOINT,
+        service_name=None,
+        host_name=None,
+        client=None,
+    ):
+        self.endpoint = endpoint
+        if client is None:
+            self.channel = grpc.insecure_channel(self.endpoint)
+            self.client = trace_service_pb2_grpc.TraceServiceStub(
+                channel=self.channel
+            )
+        else:
+            self.client = client
+
+        self.node = utils.get_node(service_name, host_name)
+
+    def export(self, spans: Sequence[Span]) -> SpanExportResult:
+        try:
+            responses = self.client.Export(self.generate_span_requests(spans))
+
+            # Read response
+            for _ in responses:
+                pass
+
+        except grpc.RpcError:
+            return SpanExportResult.FAILURE
+
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def generate_span_requests(self, spans):
+        collector_spans = translate_to_collector(spans)
+        service_request = trace_service_pb2.ExportTraceServiceRequest(
+            node=self.node, spans=collector_spans
+        )
+        yield service_request
+
+
+# pylint: disable=too-many-branches
+def translate_to_collector(spans: Sequence[Span]):
+    collector_spans = []
+    for span in spans:
+        status = None
+        if span.status is not None:
+            status = trace_pb2.Status(
+                code=span.status.canonical_code.value,
+                message=span.status.description,
+            )
+
+        collector_span = trace_pb2.Span(
+            name=trace_pb2.TruncatableString(value=span.name),
+            kind=utils.get_collector_span_kind(span.kind),
+            trace_id=span.context.trace_id.to_bytes(16, "big"),
+            span_id=span.context.span_id.to_bytes(8, "big"),
+            start_time=utils.proto_timestamp_from_time_ns(span.start_time),
+            end_time=utils.proto_timestamp_from_time_ns(span.end_time),
+            status=status,
+        )
+
+        parent_id = 0
+        if span.parent is not None:
+            parent_id = span.parent.span_id
+
+        collector_span.parent_span_id = parent_id.to_bytes(8, "big")
+
+        if span.context.trace_state is not None:
+            for (key, value) in span.context.trace_state.items():
+                collector_span.tracestate.entries.add(key=key, value=value)
+
+        if span.attributes:
+            for (key, value) in span.attributes.items():
+                utils.add_proto_attribute_value(
+                    collector_span.attributes, key, value
+                )
+
+        if span.events:
+            for event in span.events:
+
+                collector_annotation = trace_pb2.Span.TimeEvent.Annotation(
+                    description=trace_pb2.TruncatableString(value=event.name)
+                )
+
+                if event.attributes:
+                    for (key, value) in event.attributes.items():
+                        utils.add_proto_attribute_value(
+                            collector_annotation.attributes, key, value
+                        )
+
+                collector_span.time_events.time_event.add(
+                    time=utils.proto_timestamp_from_time_ns(event.timestamp),
+                    annotation=collector_annotation,
+                )
+
+        if span.links:
+            for link in span.links:
+                collector_span_link = collector_span.links.link.add()
+                collector_span_link.trace_id = link.context.trace_id.to_bytes(
+                    16, "big"
+                )
+                collector_span_link.span_id = link.context.span_id.to_bytes(
+                    8, "big"
+                )
+
+                collector_span_link.type = (
+                    trace_pb2.Span.Link.Type.TYPE_UNSPECIFIED
+                )
+                if span.parent is not None:
+                    if (
+                        link.context.span_id == span.parent.span_id
+                        and link.context.trace_id == span.parent.trace_id
+                    ):
+                        collector_span_link.type = (
+                            trace_pb2.Span.Link.Type.PARENT_LINKED_SPAN
+                        )
+
+                if link.attributes:
+                    for (key, value) in link.attributes.items():
+                        utils.add_proto_attribute_value(
+                            collector_span_link.attributes, key, value
+                        )
+
+        collector_spans.append(collector_span)
+    return collector_spans

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/util.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/util.py
@@ -1,0 +1,103 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import socket
+import time
+
+import pkg_resources
+from google.protobuf.timestamp_pb2 import Timestamp
+from opencensus.proto.agent.common.v1 import common_pb2
+from opencensus.proto.trace.v1 import trace_pb2
+
+from opentelemetry.exporter.opencensus.version import (
+    __version__ as opencensusexporter_exporter_version,
+)
+from opentelemetry.trace import SpanKind
+
+OPENTELEMETRY_VERSION = pkg_resources.get_distribution(
+    "opentelemetry-api"
+).version
+
+
+def proto_timestamp_from_time_ns(time_ns):
+    """Converts datetime to protobuf timestamp.
+
+    Args:
+        time_ns: Time in nanoseconds
+
+    Returns:
+        Returns protobuf timestamp.
+    """
+    ts = Timestamp()
+    if time_ns is not None:
+        # pylint: disable=no-member
+        ts.FromNanoseconds(time_ns)
+    return ts
+
+
+# pylint: disable=no-member
+def get_collector_span_kind(kind: SpanKind):
+    if kind is SpanKind.SERVER:
+        return trace_pb2.Span.SpanKind.SERVER
+    if kind is SpanKind.CLIENT:
+        return trace_pb2.Span.SpanKind.CLIENT
+    return trace_pb2.Span.SpanKind.SPAN_KIND_UNSPECIFIED
+
+
+def add_proto_attribute_value(pb_attributes, key, value):
+    """Sets string, int, boolean or float value on protobuf
+        span, link or annotation attributes.
+
+    Args:
+        pb_attributes: protobuf Span's attributes property.
+        key: attribute key to set.
+        value: attribute value
+    """
+
+    if isinstance(value, bool):
+        pb_attributes.attribute_map[key].bool_value = value
+    elif isinstance(value, int):
+        pb_attributes.attribute_map[key].int_value = value
+    elif isinstance(value, str):
+        pb_attributes.attribute_map[key].string_value.value = value
+    elif isinstance(value, float):
+        pb_attributes.attribute_map[key].double_value = value
+    else:
+        pb_attributes.attribute_map[key].string_value.value = str(value)
+
+
+# pylint: disable=no-member
+def get_node(service_name, host_name):
+    """Generates Node message from params and system information.
+
+     Args:
+        service_name: Name of Collector service.
+        host_name: Host name.
+    """
+    return common_pb2.Node(
+        identifier=common_pb2.ProcessIdentifier(
+            host_name=socket.gethostname() if host_name is None else host_name,
+            pid=os.getpid(),
+            start_timestamp=proto_timestamp_from_time_ns(
+                int(time.time() * 1e9)
+            ),
+        ),
+        library_info=common_pb2.LibraryInfo(
+            language=common_pb2.LibraryInfo.Language.Value("PYTHON"),
+            exporter_version=opencensusexporter_exporter_version,
+            core_library_version=OPENTELEMETRY_VERSION,
+        ),
+        service_info=common_pb2.ServiceInfo(name=service_name),
+    )

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
@@ -1,0 +1,309 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+import grpc
+from google.protobuf.timestamp_pb2 import Timestamp
+from opencensus.proto.metrics.v1 import metrics_pb2
+
+from opentelemetry import metrics
+from opentelemetry.exporter.opencensus import metrics_exporter
+from opentelemetry.sdk.metrics import (
+    Counter,
+    MeterProvider,
+    ValueRecorder,
+    get_dict_as_key,
+)
+from opentelemetry.sdk.metrics.export import (
+    MetricRecord,
+    MetricsExportResult,
+    aggregate,
+)
+from opentelemetry.sdk.resources import Resource
+
+
+# pylint: disable=no-member
+class TestCollectorMetricsExporter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=protected-access
+        cls._resource_labels = {
+            "key_with_str_value": "some string",
+            "key_with_int_val": 321,
+            "key_with_true": True,
+        }
+        metrics.set_meter_provider(
+            MeterProvider(resource=Resource(cls._resource_labels))
+        )
+        cls._meter = metrics.get_meter(__name__)
+        cls._labels = {"environment": "staging", "number": 321}
+        cls._key_labels = get_dict_as_key(cls._labels)
+
+    def test_constructor(self):
+        mock_get_node = mock.Mock()
+        patch = mock.patch(
+            "opentelemetry.exporter.opencensus.util.get_node",
+            side_effect=mock_get_node,
+        )
+        service_name = "testServiceName"
+        host_name = "testHostName"
+        client = grpc.insecure_channel("")
+        endpoint = "testEndpoint"
+        with patch:
+            exporter = metrics_exporter.OpenCensusMetricsExporter(
+                service_name=service_name,
+                host_name=host_name,
+                endpoint=endpoint,
+                client=client,
+            )
+
+        self.assertIs(exporter.client, client)
+        self.assertEqual(exporter.endpoint, endpoint)
+        mock_get_node.assert_called_with(service_name, host_name)
+
+    def test_get_collector_metric_type(self):
+        result = metrics_exporter.get_collector_metric_type(
+            Counter("testName", "testDescription", "unit", int, None)
+        )
+        self.assertIs(result, metrics_pb2.MetricDescriptor.CUMULATIVE_INT64)
+        result = metrics_exporter.get_collector_metric_type(
+            Counter("testName", "testDescription", "unit", float, None)
+        )
+        self.assertIs(result, metrics_pb2.MetricDescriptor.CUMULATIVE_DOUBLE)
+        result = metrics_exporter.get_collector_metric_type(
+            ValueRecorder("testName", "testDescription", "unit", None, None)
+        )
+        self.assertIs(result, metrics_pb2.MetricDescriptor.UNSPECIFIED)
+
+    def test_get_collector_point(self):
+        aggregator = aggregate.SumAggregator()
+        int_counter = self._meter.create_metric(
+            "testName", "testDescription", "unit", int, Counter
+        )
+        float_counter = self._meter.create_metric(
+            "testName", "testDescription", "unit", float, Counter
+        )
+        valuerecorder = self._meter.create_metric(
+            "testName", "testDescription", "unit", float, ValueRecorder
+        )
+        result = metrics_exporter.get_collector_point(
+            MetricRecord(
+                int_counter,
+                self._key_labels,
+                aggregator,
+                metrics.get_meter_provider().resource,
+            )
+        )
+        self.assertIsInstance(result, metrics_pb2.Point)
+        self.assertIsInstance(result.timestamp, Timestamp)
+        self.assertEqual(result.int64_value, 0)
+        aggregator.update(123.5)
+        aggregator.take_checkpoint()
+        result = metrics_exporter.get_collector_point(
+            MetricRecord(
+                float_counter,
+                self._key_labels,
+                aggregator,
+                metrics.get_meter_provider().resource,
+            )
+        )
+        self.assertEqual(result.double_value, 123.5)
+        self.assertRaises(
+            TypeError,
+            metrics_exporter.get_collector_point(
+                MetricRecord(
+                    valuerecorder,
+                    self._key_labels,
+                    aggregator,
+                    metrics.get_meter_provider().resource,
+                )
+            ),
+        )
+
+    def test_export(self):
+        mock_client = mock.MagicMock()
+        mock_export = mock.MagicMock()
+        mock_client.Export = mock_export
+        host_name = "testHostName"
+        collector_exporter = metrics_exporter.OpenCensusMetricsExporter(
+            client=mock_client, host_name=host_name
+        )
+        test_metric = self._meter.create_metric(
+            "testname", "testdesc", "unit", int, Counter, self._labels.keys(),
+        )
+        record = MetricRecord(
+            test_metric,
+            self._key_labels,
+            aggregate.SumAggregator(),
+            metrics.get_meter_provider().resource,
+        )
+
+        result = collector_exporter.export([record])
+        self.assertIs(result, MetricsExportResult.SUCCESS)
+        # pylint: disable=unsubscriptable-object
+        export_arg = mock_export.call_args[0]
+        service_request = next(export_arg[0])
+        output_metrics = getattr(service_request, "metrics")
+        output_node = getattr(service_request, "node")
+        self.assertEqual(len(output_metrics), 1)
+        self.assertIsNotNone(getattr(output_node, "library_info"))
+        self.assertIsNotNone(getattr(output_node, "service_info"))
+        output_identifier = getattr(output_node, "identifier")
+        self.assertEqual(
+            getattr(output_identifier, "host_name"), "testHostName"
+        )
+
+    def test_translate_to_collector(self):
+        test_metric = self._meter.create_metric(
+            "testname", "testdesc", "unit", int, Counter, self._labels.keys()
+        )
+        aggregator = aggregate.SumAggregator()
+        aggregator.update(123)
+        aggregator.take_checkpoint()
+        record = MetricRecord(
+            test_metric,
+            self._key_labels,
+            aggregator,
+            metrics.get_meter_provider().resource,
+        )
+        start_timestamp = Timestamp()
+        output_metrics = metrics_exporter.translate_to_collector(
+            [record], start_timestamp,
+        )
+        self.assertEqual(len(output_metrics), 1)
+        self.assertIsInstance(output_metrics[0], metrics_pb2.Metric)
+        self.assertEqual(output_metrics[0].metric_descriptor.name, "testname")
+        self.assertEqual(
+            output_metrics[0].metric_descriptor.description, "testdesc"
+        )
+        self.assertEqual(output_metrics[0].metric_descriptor.unit, "unit")
+        self.assertEqual(
+            output_metrics[0].metric_descriptor.type,
+            metrics_pb2.MetricDescriptor.CUMULATIVE_INT64,
+        )
+        self.assertEqual(
+            len(output_metrics[0].metric_descriptor.label_keys), 2
+        )
+        self.assertEqual(
+            output_metrics[0].metric_descriptor.label_keys[0].key,
+            "environment",
+        )
+        self.assertEqual(
+            output_metrics[0].metric_descriptor.label_keys[1].key, "number",
+        )
+
+        self.assertIsNotNone(output_metrics[0].resource)
+        self.assertEqual(
+            output_metrics[0].resource.type, "",
+        )
+        self.assertEqual(
+            output_metrics[0].resource.labels["key_with_str_value"],
+            self._resource_labels["key_with_str_value"],
+        )
+        self.assertIsInstance(
+            output_metrics[0].resource.labels["key_with_int_val"], str,
+        )
+        self.assertEqual(
+            output_metrics[0].resource.labels["key_with_int_val"],
+            str(self._resource_labels["key_with_int_val"]),
+        )
+        self.assertIsInstance(
+            output_metrics[0].resource.labels["key_with_true"], str,
+        )
+        self.assertEqual(
+            output_metrics[0].resource.labels["key_with_true"],
+            str(self._resource_labels["key_with_true"]),
+        )
+
+        self.assertEqual(len(output_metrics[0].timeseries), 1)
+        self.assertEqual(len(output_metrics[0].timeseries[0].label_values), 2)
+        self.assertEqual(
+            output_metrics[0].timeseries[0].start_timestamp, start_timestamp
+        )
+        self.assertEqual(
+            output_metrics[0].timeseries[0].label_values[0].has_value, True
+        )
+        self.assertEqual(
+            output_metrics[0].timeseries[0].label_values[0].value, "staging"
+        )
+        self.assertEqual(len(output_metrics[0].timeseries[0].points), 1)
+        self.assertEqual(
+            output_metrics[0].timeseries[0].points[0].timestamp.seconds,
+            record.aggregator.last_update_timestamp // 1000000000,
+        )
+        self.assertEqual(
+            output_metrics[0].timeseries[0].points[0].timestamp.nanos,
+            record.aggregator.last_update_timestamp % 1000000000,
+        )
+        self.assertEqual(
+            output_metrics[0].timeseries[0].points[0].int64_value, 123
+        )
+
+    def test_infer_ot_resource_type(self):
+        # empty resource
+        self.assertEqual(metrics_exporter.infer_oc_resource_type({}), "")
+
+        # container
+        self.assertEqual(
+            metrics_exporter.infer_oc_resource_type(
+                {
+                    "k8s.cluster.name": "cluster1",
+                    "k8s.pod.name": "pod1",
+                    "k8s.namespace.name": "namespace1",
+                    "container.name": "container-name1",
+                    "cloud.account.id": "proj1",
+                    "cloud.zone": "zone1",
+                }
+            ),
+            "container",
+        )
+
+        # k8s pod
+        self.assertEqual(
+            metrics_exporter.infer_oc_resource_type(
+                {
+                    "k8s.cluster.name": "cluster1",
+                    "k8s.pod.name": "pod1",
+                    "k8s.namespace.name": "namespace1",
+                    "cloud.zone": "zone1",
+                }
+            ),
+            "k8s",
+        )
+
+        # host
+        self.assertEqual(
+            metrics_exporter.infer_oc_resource_type(
+                {
+                    "k8s.cluster.name": "cluster1",
+                    "cloud.zone": "zone1",
+                    "host.name": "node1",
+                }
+            ),
+            "host",
+        )
+
+        # cloud
+        self.assertEqual(
+            metrics_exporter.infer_oc_resource_type(
+                {
+                    "cloud.provider": "gcp",
+                    "host.id": "inst1",
+                    "cloud.zone": "zone1",
+                }
+            ),
+            "cloud",
+        )

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
@@ -1,0 +1,325 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+import grpc
+from google.protobuf.timestamp_pb2 import Timestamp
+from opencensus.proto.trace.v1 import trace_pb2
+
+import opentelemetry.exporter.opencensus.util as utils
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.opencensus.trace_exporter import (
+    OpenCensusSpanExporter,
+    translate_to_collector,
+)
+from opentelemetry.sdk import trace
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.trace import TraceFlags
+
+
+# pylint: disable=no-member
+class TestCollectorSpanExporter(unittest.TestCase):
+    def test_constructor(self):
+        mock_get_node = mock.Mock()
+        patch = mock.patch(
+            "opentelemetry.exporter.opencensus.util.get_node",
+            side_effect=mock_get_node,
+        )
+        service_name = "testServiceName"
+        host_name = "testHostName"
+        client = grpc.insecure_channel("")
+        endpoint = "testEndpoint"
+        with patch:
+            exporter = OpenCensusSpanExporter(
+                service_name=service_name,
+                host_name=host_name,
+                endpoint=endpoint,
+                client=client,
+            )
+
+        self.assertIs(exporter.client, client)
+        self.assertEqual(exporter.endpoint, endpoint)
+        mock_get_node.assert_called_with(service_name, host_name)
+
+    def test_get_collector_span_kind(self):
+        result = utils.get_collector_span_kind(trace_api.SpanKind.SERVER)
+        self.assertIs(result, trace_pb2.Span.SpanKind.SERVER)
+        result = utils.get_collector_span_kind(trace_api.SpanKind.CLIENT)
+        self.assertIs(result, trace_pb2.Span.SpanKind.CLIENT)
+        result = utils.get_collector_span_kind(trace_api.SpanKind.CONSUMER)
+        self.assertIs(result, trace_pb2.Span.SpanKind.SPAN_KIND_UNSPECIFIED)
+        result = utils.get_collector_span_kind(trace_api.SpanKind.PRODUCER)
+        self.assertIs(result, trace_pb2.Span.SpanKind.SPAN_KIND_UNSPECIFIED)
+        result = utils.get_collector_span_kind(trace_api.SpanKind.INTERNAL)
+        self.assertIs(result, trace_pb2.Span.SpanKind.SPAN_KIND_UNSPECIFIED)
+
+    def test_proto_timestamp_from_time_ns(self):
+        result = utils.proto_timestamp_from_time_ns(12345)
+        self.assertIsInstance(result, Timestamp)
+        self.assertEqual(result.nanos, 12345)
+
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-statements
+    def test_translate_to_collector(self):
+        trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
+        span_id = 0x34BF92DEEFC58C92
+        parent_id = 0x1111111111111111
+        base_time = 683647322 * 10 ** 9  # in ns
+        start_times = (
+            base_time,
+            base_time + 150 * 10 ** 6,
+            base_time + 300 * 10 ** 6,
+        )
+        durations = (50 * 10 ** 6, 100 * 10 ** 6, 200 * 10 ** 6)
+        end_times = (
+            start_times[0] + durations[0],
+            start_times[1] + durations[1],
+            start_times[2] + durations[2],
+        )
+        span_context = trace_api.SpanContext(
+            trace_id,
+            span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            trace_state=trace_api.TraceState({"testKey": "testValue"}),
+        )
+        parent_span_context = trace_api.SpanContext(
+            trace_id, parent_id, is_remote=False
+        )
+        other_context = trace_api.SpanContext(
+            trace_id, span_id, is_remote=False
+        )
+        event_attributes = {
+            "annotation_bool": True,
+            "annotation_string": "annotation_test",
+            "key_float": 0.3,
+        }
+        event_timestamp = base_time + 50 * 10 ** 6
+        event = trace.Event(
+            name="event0",
+            timestamp=event_timestamp,
+            attributes=event_attributes,
+        )
+        link_attributes = {"key_bool": True}
+        link_1 = trace_api.Link(
+            context=other_context, attributes=link_attributes
+        )
+        link_2 = trace_api.Link(
+            context=parent_span_context, attributes=link_attributes
+        )
+        span_1 = trace._Span(
+            name="test1",
+            context=span_context,
+            parent=parent_span_context,
+            events=(event,),
+            links=(link_1,),
+            kind=trace_api.SpanKind.CLIENT,
+        )
+        span_2 = trace._Span(
+            name="test2",
+            context=parent_span_context,
+            parent=None,
+            kind=trace_api.SpanKind.SERVER,
+        )
+        span_3 = trace._Span(
+            name="test3",
+            context=other_context,
+            links=(link_2,),
+            parent=span_2.get_span_context(),
+        )
+        otel_spans = [span_1, span_2, span_3]
+        otel_spans[0].start(start_time=start_times[0])
+        otel_spans[0].set_attribute("key_bool", False)
+        otel_spans[0].set_attribute("key_string", "hello_world")
+        otel_spans[0].set_attribute("key_float", 111.22)
+        otel_spans[0].set_attribute("key_int", 333)
+        otel_spans[0].set_status(
+            trace_api.Status(
+                trace_api.status.StatusCanonicalCode.INTERNAL,
+                "test description",
+            )
+        )
+        otel_spans[0].end(end_time=end_times[0])
+        otel_spans[1].start(start_time=start_times[1])
+        otel_spans[1].set_status(
+            trace_api.Status(
+                trace_api.status.StatusCanonicalCode.INTERNAL, {"test", "val"},
+            )
+        )
+        otel_spans[1].end(end_time=end_times[1])
+        otel_spans[2].start(start_time=start_times[2])
+        otel_spans[2].end(end_time=end_times[2])
+        output_spans = translate_to_collector(otel_spans)
+
+        self.assertEqual(len(output_spans), 3)
+        self.assertEqual(
+            output_spans[0].trace_id, b"n\x0cc%}\xe3L\x92o\x9e\xfc\xd09''."
+        )
+        self.assertEqual(
+            output_spans[0].span_id, b"4\xbf\x92\xde\xef\xc5\x8c\x92"
+        )
+        self.assertEqual(
+            output_spans[0].name, trace_pb2.TruncatableString(value="test1")
+        )
+        self.assertEqual(
+            output_spans[1].name, trace_pb2.TruncatableString(value="test2")
+        )
+        self.assertEqual(
+            output_spans[2].name, trace_pb2.TruncatableString(value="test3")
+        )
+        self.assertEqual(
+            output_spans[0].start_time.seconds,
+            int(start_times[0] / 1000000000),
+        )
+        self.assertEqual(
+            output_spans[0].end_time.seconds, int(end_times[0] / 1000000000)
+        )
+        self.assertEqual(output_spans[0].kind, trace_api.SpanKind.CLIENT.value)
+        self.assertEqual(output_spans[1].kind, trace_api.SpanKind.SERVER.value)
+
+        self.assertEqual(
+            output_spans[0].parent_span_id, b"\x11\x11\x11\x11\x11\x11\x11\x11"
+        )
+        self.assertEqual(
+            output_spans[2].parent_span_id, b"\x11\x11\x11\x11\x11\x11\x11\x11"
+        )
+        self.assertEqual(
+            output_spans[0].status.code,
+            trace_api.status.StatusCanonicalCode.INTERNAL.value,
+        )
+        self.assertEqual(output_spans[0].status.message, "test description")
+        self.assertEqual(len(output_spans[0].tracestate.entries), 1)
+        self.assertEqual(output_spans[0].tracestate.entries[0].key, "testKey")
+        self.assertEqual(
+            output_spans[0].tracestate.entries[0].value, "testValue"
+        )
+
+        self.assertEqual(
+            output_spans[0].attributes.attribute_map["key_bool"].bool_value,
+            False,
+        )
+        self.assertEqual(
+            output_spans[0]
+            .attributes.attribute_map["key_string"]
+            .string_value.value,
+            "hello_world",
+        )
+        self.assertEqual(
+            output_spans[0].attributes.attribute_map["key_float"].double_value,
+            111.22,
+        )
+        self.assertEqual(
+            output_spans[0].attributes.attribute_map["key_int"].int_value, 333
+        )
+
+        self.assertEqual(
+            output_spans[0].time_events.time_event[0].time.seconds, 683647322
+        )
+        self.assertEqual(
+            output_spans[0]
+            .time_events.time_event[0]
+            .annotation.description.value,
+            "event0",
+        )
+        self.assertEqual(
+            output_spans[0]
+            .time_events.time_event[0]
+            .annotation.attributes.attribute_map["annotation_bool"]
+            .bool_value,
+            True,
+        )
+        self.assertEqual(
+            output_spans[0]
+            .time_events.time_event[0]
+            .annotation.attributes.attribute_map["annotation_string"]
+            .string_value.value,
+            "annotation_test",
+        )
+        self.assertEqual(
+            output_spans[0]
+            .time_events.time_event[0]
+            .annotation.attributes.attribute_map["key_float"]
+            .double_value,
+            0.3,
+        )
+
+        self.assertEqual(
+            output_spans[0].links.link[0].trace_id,
+            b"n\x0cc%}\xe3L\x92o\x9e\xfc\xd09''.",
+        )
+        self.assertEqual(
+            output_spans[0].links.link[0].span_id,
+            b"4\xbf\x92\xde\xef\xc5\x8c\x92",
+        )
+        self.assertEqual(
+            output_spans[0].links.link[0].type,
+            trace_pb2.Span.Link.Type.TYPE_UNSPECIFIED,
+        )
+        self.assertEqual(
+            output_spans[1].status.code,
+            trace_api.status.StatusCanonicalCode.INTERNAL.value,
+        )
+        self.assertEqual(
+            output_spans[2].links.link[0].type,
+            trace_pb2.Span.Link.Type.PARENT_LINKED_SPAN,
+        )
+        self.assertEqual(
+            output_spans[0]
+            .links.link[0]
+            .attributes.attribute_map["key_bool"]
+            .bool_value,
+            True,
+        )
+
+    def test_export(self):
+        mock_client = mock.MagicMock()
+        mock_export = mock.MagicMock()
+        mock_client.Export = mock_export
+        host_name = "testHostName"
+        collector_exporter = OpenCensusSpanExporter(
+            client=mock_client, host_name=host_name
+        )
+
+        trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
+        span_id = 0x34BF92DEEFC58C92
+        span_context = trace_api.SpanContext(
+            trace_id,
+            span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        otel_spans = [
+            trace._Span(
+                name="test1",
+                context=span_context,
+                kind=trace_api.SpanKind.CLIENT,
+            )
+        ]
+        result_status = collector_exporter.export(otel_spans)
+        self.assertEqual(SpanExportResult.SUCCESS, result_status)
+
+        # pylint: disable=unsubscriptable-object
+        export_arg = mock_export.call_args[0]
+        service_request = next(export_arg[0])
+        output_spans = getattr(service_request, "spans")
+        output_node = getattr(service_request, "node")
+        self.assertEqual(len(output_spans), 1)
+        self.assertIsNotNone(getattr(output_node, "library_info"))
+        self.assertIsNotNone(getattr(output_node, "service_info"))
+        output_identifier = getattr(output_node, "identifier")
+        self.assertEqual(
+            getattr(output_identifier, "host_name"), "testHostName"
+        )


### PR DESCRIPTION
# Description

Moves the `exporter/opentelemetry-exporter-opencensus` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-exporter-opencensus

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
