### PR TITLE
Move exporter prometheus

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-prometheus/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-exporter-prometheus
+  ([#953](https://github.com/open-telemetry/opentelemetry-python/pull/953))
+
+## 0.4a0
+
+Released 2020-02-21
+
+- Initial release

--- a/exporter/opentelemetry-exporter-prometheus/LICENSE
+++ b/exporter/opentelemetry-exporter-prometheus/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/opentelemetry-exporter-prometheus/MANIFEST.in
+++ b/exporter/opentelemetry-exporter-prometheus/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/exporter/opentelemetry-exporter-prometheus/README.rst
+++ b/exporter/opentelemetry-exporter-prometheus/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry Prometheus Exporter
+=================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-exporter-prometheus.svg
+   :target: https://pypi.org/project/opentelemetry-exporter-prometheus/
+
+This library allows to export metrics data to `Prometheus <https://prometheus.io/>`_.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-exporter-prometheus
+
+References
+----------
+
+* `OpenTelemetry Prometheus Exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/prometheus/prometheus.html>`_
+* `Prometheus <https://prometheus.io/>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/exporter/opentelemetry-exporter-prometheus/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus/setup.cfg
@@ -1,0 +1,50 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-exporter-prometheus
+description = Prometheus Metric Exporter for OpenTelemetry
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-exporter-prometheus
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    prometheus_client >= 0.5.0, < 1.0.0
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-sdk == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test =

--- a/exporter/opentelemetry-exporter-prometheus/setup.py
+++ b/exporter/opentelemetry-exporter-prometheus/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "exporter", "prometheus", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -1,0 +1,195 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This library allows export of metrics data to `Prometheus <https://prometheus.io/>`_.
+
+Usage
+-----
+
+The **OpenTelemetry Prometheus Exporter** allows export of `OpenTelemetry`_ metrics to `Prometheus`_.
+
+
+.. _Prometheus: https://prometheus.io/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+
+.. code:: python
+
+    from opentelemetry import metrics
+    from opentelemetry.exporter.prometheus import PrometheusMetricsExporter
+    from opentelemetry.sdk.metrics import Counter, Meter
+    from prometheus_client import start_http_server
+
+    # Start Prometheus client
+    start_http_server(port=8000, addr="localhost")
+
+    # Meter is responsible for creating and recording metrics
+    metrics.set_meter_provider(MeterProvider())
+    meter = metrics.get_meter(__name__)
+    # exporter to export metrics to Prometheus
+    prefix = "MyAppPrefix"
+    exporter = PrometheusMetricsExporter(prefix)
+    # Starts the collect/export pipeline for metrics
+    metrics.get_meter_provider().start_pipeline(meter, exporter, 5)
+
+    counter = meter.create_metric(
+        "requests",
+        "number of requests",
+        "requests",
+        int,
+        Counter,
+        ("environment",),
+    )
+
+    # Labels are used to identify key-values that are associated with a specific
+    # metric that you want to record. These are useful for pre-aggregation and can
+    # be used to store custom dimensions pertaining to a metric
+    labels = {"environment": "staging"}
+
+    counter.add(25, labels)
+    input("Press any key to exit...")
+
+API
+---
+"""
+
+import collections
+import logging
+import re
+from typing import Iterable, Optional, Sequence, Union
+
+from prometheus_client.core import (
+    REGISTRY,
+    CounterMetricFamily,
+    SummaryMetricFamily,
+    UnknownMetricFamily,
+)
+
+from opentelemetry.metrics import Counter, ValueRecorder
+from opentelemetry.sdk.metrics.export import (
+    MetricRecord,
+    MetricsExporter,
+    MetricsExportResult,
+)
+from opentelemetry.sdk.metrics.export.aggregate import MinMaxSumCountAggregator
+
+logger = logging.getLogger(__name__)
+
+
+class PrometheusMetricsExporter(MetricsExporter):
+    """Prometheus metric exporter for OpenTelemetry.
+
+    Args:
+        prefix: single-word application prefix relevant to the domain
+            the metric belongs to.
+    """
+
+    def __init__(self, prefix: str = ""):
+        self._collector = CustomCollector(prefix)
+        REGISTRY.register(self._collector)
+
+    def export(
+        self, metric_records: Sequence[MetricRecord]
+    ) -> MetricsExportResult:
+        self._collector.add_metrics_data(metric_records)
+        return MetricsExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        REGISTRY.unregister(self._collector)
+
+
+class CustomCollector:
+    """CustomCollector represents the Prometheus Collector object
+    https://github.com/prometheus/client_python#custom-collectors
+    """
+
+    def __init__(self, prefix: str = ""):
+        self._prefix = prefix
+        self._metrics_to_export = collections.deque()
+        self._non_letters_nor_digits_re = re.compile(
+            r"[^\w]", re.UNICODE | re.IGNORECASE
+        )
+
+    def add_metrics_data(self, metric_records: Sequence[MetricRecord]) -> None:
+        self._metrics_to_export.append(metric_records)
+
+    def collect(self):
+        """Collect fetches the metrics from OpenTelemetry
+        and delivers them as Prometheus Metrics.
+        Collect is invoked every time a prometheus.Gatherer is run
+        for example when the HTTP endpoint is invoked by Prometheus.
+        """
+
+        while self._metrics_to_export:
+            for metric_record in self._metrics_to_export.popleft():
+                prometheus_metric = self._translate_to_prometheus(
+                    metric_record
+                )
+                if prometheus_metric is not None:
+                    yield prometheus_metric
+
+    def _translate_to_prometheus(self, metric_record: MetricRecord):
+        prometheus_metric = None
+        label_values = []
+        label_keys = []
+        for label_tuple in metric_record.labels:
+            label_keys.append(self._sanitize(label_tuple[0]))
+            label_values.append(label_tuple[1])
+
+        metric_name = ""
+        if self._prefix != "":
+            metric_name = self._prefix + "_"
+        metric_name += self._sanitize(metric_record.instrument.name)
+
+        description = getattr(metric_record.instrument, "description", "")
+        if isinstance(metric_record.instrument, Counter):
+            prometheus_metric = CounterMetricFamily(
+                name=metric_name, documentation=description, labels=label_keys
+            )
+            prometheus_metric.add_metric(
+                labels=label_values, value=metric_record.aggregator.checkpoint
+            )
+        # TODO: Add support for histograms when supported in OT
+        elif isinstance(metric_record.instrument, ValueRecorder):
+            value = metric_record.aggregator.checkpoint
+            if isinstance(metric_record.aggregator, MinMaxSumCountAggregator):
+                prometheus_metric = SummaryMetricFamily(
+                    name=metric_name,
+                    documentation=description,
+                    labels=label_keys,
+                )
+                prometheus_metric.add_metric(
+                    labels=label_values,
+                    count_value=value.count,
+                    sum_value=value.sum,
+                )
+            else:
+                prometheus_metric = UnknownMetricFamily(
+                    name=metric_name,
+                    documentation=description,
+                    labels=label_keys,
+                )
+                prometheus_metric.add_metric(labels=label_values, value=value)
+
+        else:
+            logger.warning(
+                "Unsupported metric type. %s", type(metric_record.instrument)
+            )
+        return prometheus_metric
+
+    def _sanitize(self, key: str) -> str:
+        """sanitize the given metric name or label according to Prometheus rule.
+        Replace all characters other than [A-Za-z0-9_] with '_'.
+        """
+        return self._non_letters_nor_digits_re.sub("_", key)

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/version.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/exporter/opentelemetry-exporter-prometheus/tests/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -1,0 +1,173 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from prometheus_client import generate_latest
+from prometheus_client.core import CounterMetricFamily
+
+from opentelemetry.exporter.prometheus import (
+    CustomCollector,
+    PrometheusMetricsExporter,
+)
+from opentelemetry.metrics import get_meter_provider, set_meter_provider
+from opentelemetry.sdk import metrics
+from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
+from opentelemetry.sdk.metrics.export.aggregate import (
+    MinMaxSumCountAggregator,
+    SumAggregator,
+)
+from opentelemetry.sdk.util import get_dict_as_key
+
+
+class TestPrometheusMetricExporter(unittest.TestCase):
+    def setUp(self):
+        set_meter_provider(metrics.MeterProvider())
+        self._meter = get_meter_provider().get_meter(__name__)
+        self._test_metric = self._meter.create_metric(
+            "testname", "testdesc", "unit", int, metrics.Counter,
+        )
+        labels = {"environment": "staging"}
+        self._labels_key = get_dict_as_key(labels)
+
+        self._mock_registry_register = mock.Mock()
+        self._registry_register_patch = mock.patch(
+            "prometheus_client.core.REGISTRY.register",
+            side_effect=self._mock_registry_register,
+        )
+
+    # pylint: disable=protected-access
+    def test_constructor(self):
+        """Test the constructor."""
+        with self._registry_register_patch:
+            exporter = PrometheusMetricsExporter("testprefix")
+            self.assertEqual(exporter._collector._prefix, "testprefix")
+            self.assertTrue(self._mock_registry_register.called)
+
+    def test_shutdown(self):
+        with mock.patch(
+            "prometheus_client.core.REGISTRY.unregister"
+        ) as registry_unregister_patch:
+            exporter = PrometheusMetricsExporter()
+            exporter.shutdown()
+            self.assertTrue(registry_unregister_patch.called)
+
+    def test_export(self):
+        with self._registry_register_patch:
+            record = MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                SumAggregator(),
+                get_meter_provider().resource,
+            )
+            exporter = PrometheusMetricsExporter()
+            result = exporter.export([record])
+            # pylint: disable=protected-access
+            self.assertEqual(len(exporter._collector._metrics_to_export), 1)
+            self.assertIs(result, MetricsExportResult.SUCCESS)
+
+    def test_min_max_sum_aggregator_to_prometheus(self):
+        meter = get_meter_provider().get_meter(__name__)
+        metric = meter.create_metric(
+            "test@name", "testdesc", "unit", int, metrics.ValueRecorder, []
+        )
+        labels = {}
+        key_labels = get_dict_as_key(labels)
+        aggregator = MinMaxSumCountAggregator()
+        aggregator.update(123)
+        aggregator.update(456)
+        aggregator.take_checkpoint()
+        record = MetricRecord(
+            metric, key_labels, aggregator, get_meter_provider().resource
+        )
+        collector = CustomCollector("testprefix")
+        collector.add_metrics_data([record])
+        result_bytes = generate_latest(collector)
+        result = result_bytes.decode("utf-8")
+        self.assertIn("testprefix_test_name_count 2.0", result)
+        self.assertIn("testprefix_test_name_sum 579.0", result)
+
+    def test_counter_to_prometheus(self):
+        meter = get_meter_provider().get_meter(__name__)
+        metric = meter.create_metric(
+            "test@name", "testdesc", "unit", int, metrics.Counter,
+        )
+        labels = {"environment@": "staging", "os": "Windows"}
+        key_labels = get_dict_as_key(labels)
+        aggregator = SumAggregator()
+        aggregator.update(123)
+        aggregator.take_checkpoint()
+        record = MetricRecord(
+            metric, key_labels, aggregator, get_meter_provider().resource
+        )
+        collector = CustomCollector("testprefix")
+        collector.add_metrics_data([record])
+
+        for prometheus_metric in collector.collect():
+            self.assertEqual(type(prometheus_metric), CounterMetricFamily)
+            self.assertEqual(prometheus_metric.name, "testprefix_test_name")
+            self.assertEqual(prometheus_metric.documentation, "testdesc")
+            self.assertTrue(len(prometheus_metric.samples) == 1)
+            self.assertEqual(prometheus_metric.samples[0].value, 123)
+            self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
+            self.assertEqual(
+                prometheus_metric.samples[0].labels["environment_"], "staging"
+            )
+            self.assertEqual(
+                prometheus_metric.samples[0].labels["os"], "Windows"
+            )
+
+    # TODO: Add unit test once GaugeAggregator is available
+    # TODO: Add unit test once Measure Aggregators are available
+
+    def test_invalid_metric(self):
+        meter = get_meter_provider().get_meter(__name__)
+        metric = meter.create_metric(
+            "tesname", "testdesc", "unit", int, StubMetric
+        )
+        labels = {"environment": "staging"}
+        key_labels = get_dict_as_key(labels)
+        record = MetricRecord(
+            metric, key_labels, None, get_meter_provider().resource
+        )
+        collector = CustomCollector("testprefix")
+        collector.add_metrics_data([record])
+        collector.collect()
+        self.assertLogs("opentelemetry.exporter.prometheus", level="WARNING")
+
+    def test_sanitize(self):
+        collector = CustomCollector("testprefix")
+        self.assertEqual(
+            collector._sanitize("1!2@3#4$5%6^7&8*9(0)_-"),
+            "1_2_3_4_5_6_7_8_9_0___",
+        )
+        self.assertEqual(collector._sanitize(",./?;:[]{}"), "__________")
+        self.assertEqual(collector._sanitize("TestString"), "TestString")
+        self.assertEqual(collector._sanitize("aAbBcC_12_oi"), "aAbBcC_12_oi")
+
+
+class StubMetric(metrics.Metric):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        unit: str,
+        value_type,
+        meter,
+        enabled: bool = True,
+    ):
+        super().__init__(
+            name, description, unit, value_type, meter, enabled=enabled,
+        )


### PR DESCRIPTION
# Description

Moves the `exporter/opentelemetry-exporter-prometheus` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-exporter-prometheus

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
