### PR TITLE
Move exporter zipkin

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.14b0
+
+Released 2020-10-13
+
+- Zipkin exporter now accepts a ``max_tag_value_length`` attribute to customize the
+  maximum allowed size a tag value can have. ([#1151](https://github.com/open-telemetry/opentelemetry-python/pull/1151)) 
+- Fixed OTLP events to Zipkin annotations translation. ([#1161](https://github.com/open-telemetry/opentelemetry-python/pull/1161))
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Add support for OTEL_EXPORTER_ZIPKIN_ENDPOINT env var. As part of this change, the 
+  configuration of the ZipkinSpanExporter exposes a `url` argument to replace `host_name`,
+  `port`, `protocol`, `endpoint`. This brings this implementation inline with other
+  implementations. 
+  ([#1064](https://github.com/open-telemetry/opentelemetry-python/pull/1064))
+- Zipkin exporter report instrumentation info. 
+  ([#1097](https://github.com/open-telemetry/opentelemetry-python/pull/1097))  
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+- Add status mapping to tags
+  ([#1111](https://github.com/open-telemetry/opentelemetry-python/issues/1111))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-exporter-zipkin
+  ([#953](https://github.com/open-telemetry/opentelemetry-python/pull/953))
+- Add proper length zero padding to hex strings of traceId, spanId, parentId sent on the wire, for compatibility with jaeger-collector
+  ([#908](https://github.com/open-telemetry/opentelemetry-python/pull/908))
+
+## 0.8b0
+
+Released 2020-05-27
+
+- Transform resource to tags when exporting
+  ([#707](https://github.com/open-telemetry/opentelemetry-python/pull/707))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- bugfix: 'debug' field is now correct
+  ([#549](https://github.com/open-telemetry/opentelemetry-python/pull/549))
+
+## 0.4a0
+
+Released 2020-02-21
+
+- Initial release

--- a/exporter/opentelemetry-exporter-zipkin/LICENSE
+++ b/exporter/opentelemetry-exporter-zipkin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/opentelemetry-exporter-zipkin/MANIFEST.in
+++ b/exporter/opentelemetry-exporter-zipkin/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/exporter/opentelemetry-exporter-zipkin/README.rst
+++ b/exporter/opentelemetry-exporter-zipkin/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry Zipkin Exporter
+=============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-exporter-zipkin.svg
+   :target: https://pypi.org/project/opentelemetry-exporter-zipkin/
+
+This library allows to export tracing data to `Zipkin <https://zipkin.io/>`_.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-exporter-zipkin
+
+
+References
+----------
+
+* `OpenTelemetry Zipkin Exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/zipkin/zipkin.html>`_
+* `Zipkin <https://zipkin.io/>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -1,0 +1,50 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-exporter-zipkin
+description = Zipkin Span Exporter for OpenTelemetry
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-exporter-zipkin
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    requests ~= 2.7
+    opentelemetry-api == 0.15.dev0
+    opentelemetry-sdk == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test =

--- a/exporter/opentelemetry-exporter-zipkin/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "exporter", "zipkin", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
@@ -1,0 +1,263 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This library allows to export tracing data to `Zipkin <https://zipkin.io/>`_.
+
+Usage
+-----
+
+The **OpenTelemetry Zipkin Exporter** allows to export `OpenTelemetry`_ traces to `Zipkin`_.
+This exporter always send traces to the configured Zipkin collector using HTTP.
+
+
+.. _Zipkin: https://zipkin.io/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+.. _Specification: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#zipkin-exporter
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.exporter import zipkin
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+    trace.set_tracer_provider(TracerProvider())
+    tracer = trace.get_tracer(__name__)
+
+    # create a ZipkinSpanExporter
+    zipkin_exporter = zipkin.ZipkinSpanExporter(
+        service_name="my-helloworld-service",
+        # optional:
+        # url="http://localhost:9411/api/v2/spans",
+        # ipv4="",
+        # ipv6="",
+        # retry=False,
+    )
+
+    # Create a BatchExportSpanProcessor and add the exporter to it
+    span_processor = BatchExportSpanProcessor(zipkin_exporter)
+
+    # add to the tracer
+    trace.get_tracer_provider().add_span_processor(span_processor)
+
+    with tracer.start_as_current_span("foo"):
+        print("Hello world!")
+
+The exporter supports endpoint configuration via the OTEL_EXPORTER_ZIPKIN_ENDPOINT environment variables as defined in the `Specification`_
+
+API
+---
+"""
+
+import json
+import logging
+import os
+from typing import Optional, Sequence
+from urllib.parse import urlparse
+
+import requests
+
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.trace import Span, SpanContext, SpanKind
+
+DEFAULT_RETRY = False
+DEFAULT_URL = "http://localhost:9411/api/v2/spans"
+DEFAULT_MAX_TAG_VALUE_LENGTH = 128
+ZIPKIN_HEADERS = {"Content-Type": "application/json"}
+
+SPAN_KIND_MAP = {
+    SpanKind.INTERNAL: None,
+    SpanKind.SERVER: "SERVER",
+    SpanKind.CLIENT: "CLIENT",
+    SpanKind.PRODUCER: "PRODUCER",
+    SpanKind.CONSUMER: "CONSUMER",
+}
+
+SUCCESS_STATUS_CODES = (200, 202)
+
+logger = logging.getLogger(__name__)
+
+
+class ZipkinSpanExporter(SpanExporter):
+    """Zipkin span exporter for OpenTelemetry.
+
+    Args:
+        service_name: Service that logged an annotation in a trace.Classifier
+            when query for spans.
+        url: The Zipkin endpoint URL
+        ipv4: Primary IPv4 address associated with this connection.
+        ipv6: Primary IPv6 address associated with this connection.
+        retry: Set to True to configure the exporter to retry on failure.
+    """
+
+    def __init__(
+        self,
+        service_name: str,
+        url: str = None,
+        ipv4: Optional[str] = None,
+        ipv6: Optional[str] = None,
+        retry: Optional[str] = DEFAULT_RETRY,
+        max_tag_value_length: Optional[int] = DEFAULT_MAX_TAG_VALUE_LENGTH,
+    ):
+        self.service_name = service_name
+        if url is None:
+            self.url = os.environ.get(
+                "OTEL_EXPORTER_ZIPKIN_ENDPOINT", DEFAULT_URL
+            )
+        else:
+            self.url = url
+
+        self.port = urlparse(self.url).port
+
+        self.ipv4 = ipv4
+        self.ipv6 = ipv6
+        self.retry = retry
+        self.max_tag_value_length = max_tag_value_length
+
+    def export(self, spans: Sequence[Span]) -> SpanExportResult:
+        zipkin_spans = self._translate_to_zipkin(spans)
+        result = requests.post(
+            url=self.url, data=json.dumps(zipkin_spans), headers=ZIPKIN_HEADERS
+        )
+
+        if result.status_code not in SUCCESS_STATUS_CODES:
+            logger.error(
+                "Traces cannot be uploaded; status code: %s, message %s",
+                result.status_code,
+                result.text,
+            )
+
+            if self.retry:
+                return SpanExportResult.FAILURE
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def _translate_to_zipkin(self, spans: Sequence[Span]):
+
+        local_endpoint = {"serviceName": self.service_name, "port": self.port}
+
+        if self.ipv4 is not None:
+            local_endpoint["ipv4"] = self.ipv4
+
+        if self.ipv6 is not None:
+            local_endpoint["ipv6"] = self.ipv6
+
+        zipkin_spans = []
+        for span in spans:
+            context = span.get_span_context()
+            trace_id = context.trace_id
+            span_id = context.span_id
+
+            # Timestamp in zipkin spans is int of microseconds.
+            # see: https://zipkin.io/pages/instrumenting.html
+            start_timestamp_mus = _nsec_to_usec_round(span.start_time)
+            duration_mus = _nsec_to_usec_round(span.end_time - span.start_time)
+
+            zipkin_span = {
+                # Ensure left-zero-padding of traceId, spanId, parentId
+                "traceId": format(trace_id, "032x"),
+                "id": format(span_id, "016x"),
+                "name": span.name,
+                "timestamp": start_timestamp_mus,
+                "duration": duration_mus,
+                "localEndpoint": local_endpoint,
+                "kind": SPAN_KIND_MAP[span.kind],
+                "tags": self._extract_tags_from_span(span),
+                "annotations": self._extract_annotations_from_events(
+                    span.events
+                ),
+            }
+
+            if span.instrumentation_info is not None:
+                zipkin_span["tags"][
+                    "otel.instrumentation_library.name"
+                ] = span.instrumentation_info.name
+                zipkin_span["tags"][
+                    "otel.instrumentation_library.version"
+                ] = span.instrumentation_info.version
+
+            if span.status is not None:
+                zipkin_span["tags"]["otel.status_code"] = str(
+                    span.status.canonical_code.value
+                )
+                if span.status.description is not None:
+                    zipkin_span["tags"][
+                        "otel.status_description"
+                    ] = span.status.description
+
+            if context.trace_flags.sampled:
+                zipkin_span["debug"] = True
+
+            if isinstance(span.parent, Span):
+                zipkin_span["parentId"] = format(
+                    span.parent.get_span_context().span_id, "016x"
+                )
+            elif isinstance(span.parent, SpanContext):
+                zipkin_span["parentId"] = format(span.parent.span_id, "016x")
+
+            zipkin_spans.append(zipkin_span)
+        return zipkin_spans
+
+    def _extract_tags_from_dict(self, tags_dict):
+        tags = {}
+        if not tags_dict:
+            return tags
+        for attribute_key, attribute_value in tags_dict.items():
+            if isinstance(attribute_value, (int, bool, float)):
+                value = str(attribute_value)
+            elif isinstance(attribute_value, str):
+                value = attribute_value
+            else:
+                logger.warning("Could not serialize tag %s", attribute_key)
+                continue
+
+            if self.max_tag_value_length > 0:
+                value = value[: self.max_tag_value_length]
+            tags[attribute_key] = value
+        return tags
+
+    def _extract_tags_from_span(self, span: Span):
+        tags = self._extract_tags_from_dict(getattr(span, "attributes", None))
+        if span.resource:
+            tags.update(self._extract_tags_from_dict(span.resource.attributes))
+        return tags
+
+    def _extract_annotations_from_events(self, events):
+        if not events:
+            return None
+
+        annotations = []
+        for event in events:
+            attrs = {}
+            for key, value in event.attributes.items():
+                if isinstance(value, str):
+                    value = value[: self.max_tag_value_length]
+                attrs[key] = value
+
+            annotations.append(
+                {
+                    "timestamp": _nsec_to_usec_round(event.timestamp),
+                    "value": json.dumps({event.name: attrs}),
+                }
+            )
+        return annotations
+
+
+def _nsec_to_usec_round(nsec):
+    """Round nanoseconds to microseconds"""
+    return (nsec + 500) // 10 ** 3

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/exporter/opentelemetry-exporter-zipkin/tests/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -1,0 +1,431 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.zipkin import ZipkinSpanExporter
+from opentelemetry.sdk import trace
+from opentelemetry.sdk.trace import Resource
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.trace import TraceFlags
+from opentelemetry.trace.status import Status, StatusCanonicalCode
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.text = status_code
+
+
+class TestZipkinSpanExporter(unittest.TestCase):
+    def setUp(self):
+        # create and save span to be used in tests
+        context = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000DEADBEEF,
+            span_id=0x00000000DEADBEF0,
+            is_remote=False,
+        )
+
+        self._test_span = trace._Span("test_span", context=context)
+        self._test_span.start()
+        self._test_span.end()
+
+    def tearDown(self):
+        if "OTEL_EXPORTER_ZIPKIN_ENDPOINT" in os.environ:
+            del os.environ["OTEL_EXPORTER_ZIPKIN_ENDPOINT"]
+
+    def test_constructor_env_var(self):
+        """Test the default values assigned by constructor."""
+        url = "https://foo:9911/path"
+        os.environ["OTEL_EXPORTER_ZIPKIN_ENDPOINT"] = url
+        service_name = "my-service-name"
+        port = 9911
+        exporter = ZipkinSpanExporter(service_name)
+        ipv4 = None
+        ipv6 = None
+
+        self.assertEqual(exporter.service_name, service_name)
+        self.assertEqual(exporter.ipv4, ipv4)
+        self.assertEqual(exporter.ipv6, ipv6)
+        self.assertEqual(exporter.url, url)
+        self.assertEqual(exporter.port, port)
+
+    def test_constructor_default(self):
+        """Test the default values assigned by constructor."""
+        service_name = "my-service-name"
+        port = 9411
+        exporter = ZipkinSpanExporter(service_name)
+        ipv4 = None
+        ipv6 = None
+        url = "http://localhost:9411/api/v2/spans"
+
+        self.assertEqual(exporter.service_name, service_name)
+        self.assertEqual(exporter.port, port)
+        self.assertEqual(exporter.ipv4, ipv4)
+        self.assertEqual(exporter.ipv6, ipv6)
+        self.assertEqual(exporter.url, url)
+
+    def test_constructor_explicit(self):
+        """Test the constructor passing all the options."""
+        service_name = "my-opentelemetry-zipkin"
+        port = 15875
+        ipv4 = "1.2.3.4"
+        ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        url = "https://opentelemetry.io:15875/myapi/traces?format=zipkin"
+        exporter = ZipkinSpanExporter(
+            service_name=service_name, url=url, ipv4=ipv4, ipv6=ipv6,
+        )
+
+        self.assertEqual(exporter.service_name, service_name)
+        self.assertEqual(exporter.port, port)
+        self.assertEqual(exporter.ipv4, ipv4)
+        self.assertEqual(exporter.ipv6, ipv6)
+        self.assertEqual(exporter.url, url)
+
+    # pylint: disable=too-many-locals,too-many-statements
+    def test_export(self):
+        span_names = ("test1", "test2", "test3", "test4")
+        trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
+        span_id = 0x34BF92DEEFC58C92
+        parent_id = 0x1111111111111111
+        other_id = 0x2222222222222222
+
+        base_time = 683647322 * 10 ** 9  # in ns
+        start_times = (
+            base_time,
+            base_time + 150 * 10 ** 6,
+            base_time + 300 * 10 ** 6,
+            base_time + 400 * 10 ** 6,
+        )
+        durations = (50 * 10 ** 6, 100 * 10 ** 6, 200 * 10 ** 6, 300 * 10 ** 6)
+        end_times = (
+            start_times[0] + durations[0],
+            start_times[1] + durations[1],
+            start_times[2] + durations[2],
+            start_times[3] + durations[3],
+        )
+
+        span_context = trace_api.SpanContext(
+            trace_id,
+            span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        parent_span_context = trace_api.SpanContext(
+            trace_id, parent_id, is_remote=False
+        )
+        other_context = trace_api.SpanContext(
+            trace_id, other_id, is_remote=False
+        )
+
+        event_attributes = {
+            "annotation_bool": True,
+            "annotation_string": "annotation_test",
+            "key_float": 0.3,
+        }
+
+        event_timestamp = base_time + 50 * 10 ** 6
+        event = trace.Event(
+            name="event0",
+            timestamp=event_timestamp,
+            attributes=event_attributes,
+        )
+
+        link_attributes = {"key_bool": True}
+
+        link = trace_api.Link(
+            context=other_context, attributes=link_attributes
+        )
+
+        otel_spans = [
+            trace._Span(
+                name=span_names[0],
+                context=span_context,
+                parent=parent_span_context,
+                events=(event,),
+                links=(link,),
+            ),
+            trace._Span(
+                name=span_names[1], context=parent_span_context, parent=None
+            ),
+            trace._Span(
+                name=span_names[2], context=other_context, parent=None
+            ),
+            trace._Span(
+                name=span_names[3], context=other_context, parent=None
+            ),
+        ]
+
+        otel_spans[0].start(start_time=start_times[0])
+        otel_spans[0].resource = Resource({})
+        # added here to preserve order
+        otel_spans[0].set_attribute("key_bool", False)
+        otel_spans[0].set_attribute("key_string", "hello_world")
+        otel_spans[0].set_attribute("key_float", 111.22)
+        otel_spans[0].set_status(
+            Status(StatusCanonicalCode.UNKNOWN, "Example description")
+        )
+        otel_spans[0].end(end_time=end_times[0])
+
+        otel_spans[1].start(start_time=start_times[1])
+        otel_spans[1].resource = Resource(
+            attributes={"key_resource": "some_resource"}
+        )
+        otel_spans[1].end(end_time=end_times[1])
+
+        otel_spans[2].start(start_time=start_times[2])
+        otel_spans[2].set_attribute("key_string", "hello_world")
+        otel_spans[2].resource = Resource(
+            attributes={"key_resource": "some_resource"}
+        )
+        otel_spans[2].end(end_time=end_times[2])
+
+        otel_spans[3].start(start_time=start_times[3])
+        otel_spans[3].resource = Resource({})
+        otel_spans[3].end(end_time=end_times[3])
+        otel_spans[3].instrumentation_info = InstrumentationInfo(
+            name="name", version="version"
+        )
+
+        service_name = "test-service"
+        local_endpoint = {"serviceName": service_name, "port": 9411}
+
+        exporter = ZipkinSpanExporter(service_name)
+        expected_spans = [
+            {
+                "traceId": format(trace_id, "x"),
+                "id": format(span_id, "x"),
+                "name": span_names[0],
+                "timestamp": start_times[0] // 10 ** 3,
+                "duration": durations[0] // 10 ** 3,
+                "localEndpoint": local_endpoint,
+                "kind": None,
+                "tags": {
+                    "key_bool": "False",
+                    "key_string": "hello_world",
+                    "key_float": "111.22",
+                    "otel.status_code": "2",
+                    "otel.status_description": "Example description",
+                },
+                "debug": True,
+                "parentId": format(parent_id, "x"),
+                "annotations": [
+                    {
+                        "timestamp": event_timestamp // 10 ** 3,
+                        "value": {
+                            "event0": {
+                                "annotation_bool": True,
+                                "annotation_string": "annotation_test",
+                                "key_float": 0.3,
+                            }
+                        },
+                    }
+                ],
+            },
+            {
+                "traceId": format(trace_id, "x"),
+                "id": format(parent_id, "x"),
+                "name": span_names[1],
+                "timestamp": start_times[1] // 10 ** 3,
+                "duration": durations[1] // 10 ** 3,
+                "localEndpoint": local_endpoint,
+                "kind": None,
+                "tags": {
+                    "key_resource": "some_resource",
+                    "otel.status_code": "0",
+                },
+                "annotations": None,
+            },
+            {
+                "traceId": format(trace_id, "x"),
+                "id": format(other_id, "x"),
+                "name": span_names[2],
+                "timestamp": start_times[2] // 10 ** 3,
+                "duration": durations[2] // 10 ** 3,
+                "localEndpoint": local_endpoint,
+                "kind": None,
+                "tags": {
+                    "key_string": "hello_world",
+                    "key_resource": "some_resource",
+                    "otel.status_code": "0",
+                },
+                "annotations": None,
+            },
+            {
+                "traceId": format(trace_id, "x"),
+                "id": format(other_id, "x"),
+                "name": span_names[3],
+                "timestamp": start_times[3] // 10 ** 3,
+                "duration": durations[3] // 10 ** 3,
+                "localEndpoint": local_endpoint,
+                "kind": None,
+                "tags": {
+                    "otel.instrumentation_library.name": "name",
+                    "otel.instrumentation_library.version": "version",
+                    "otel.status_code": "0",
+                },
+                "annotations": None,
+            },
+        ]
+
+        mock_post = MagicMock()
+        with patch("requests.post", mock_post):
+            mock_post.return_value = MockResponse(200)
+            status = exporter.export(otel_spans)
+            self.assertEqual(SpanExportResult.SUCCESS, status)
+
+        # pylint: disable=unsubscriptable-object
+        kwargs = mock_post.call_args[1]
+
+        self.assertEqual(kwargs["url"], "http://localhost:9411/api/v2/spans")
+        actual_spans = sorted(
+            json.loads(kwargs["data"]), key=lambda span: span["timestamp"]
+        )
+        for expected, actual in zip(expected_spans, actual_spans):
+            expected_annotations = expected.pop("annotations", None)
+            actual_annotations = actual.pop("annotations", None)
+            if actual_annotations:
+                for annotation in actual_annotations:
+                    annotation["value"] = json.loads(annotation["value"])
+            self.assertEqual(expected, actual)
+            self.assertEqual(expected_annotations, actual_annotations)
+
+    # pylint: disable=too-many-locals
+    def test_zero_padding(self):
+        """test that hex ids starting with 0
+        are properly padded to 16 or 32 hex chars
+        when exported
+        """
+
+        span_names = "testZeroes"
+        trace_id = 0x0E0C63257DE34C926F9EFCD03927272E
+        span_id = 0x04BF92DEEFC58C92
+        parent_id = 0x0AAAAAAAAAAAAAAA
+
+        start_time = 683647322 * 10 ** 9  # in ns
+        duration = 50 * 10 ** 6
+        end_time = start_time + duration
+
+        span_context = trace_api.SpanContext(
+            trace_id,
+            span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        parent_span_context = trace_api.SpanContext(
+            trace_id, parent_id, is_remote=False
+        )
+
+        otel_span = trace._Span(
+            name=span_names[0],
+            context=span_context,
+            parent=parent_span_context,
+        )
+
+        otel_span.start(start_time=start_time)
+        otel_span.resource = Resource({})
+        otel_span.end(end_time=end_time)
+
+        service_name = "test-service"
+        local_endpoint = {"serviceName": service_name, "port": 9411}
+
+        exporter = ZipkinSpanExporter(service_name)
+        # Check traceId are properly lowercase 16 or 32 hex
+        expected = [
+            {
+                "traceId": "0e0c63257de34c926f9efcd03927272e",
+                "id": "04bf92deefc58c92",
+                "name": span_names[0],
+                "timestamp": start_time // 10 ** 3,
+                "duration": duration // 10 ** 3,
+                "localEndpoint": local_endpoint,
+                "kind": None,
+                "tags": {"otel.status_code": "0"},
+                "annotations": None,
+                "debug": True,
+                "parentId": "0aaaaaaaaaaaaaaa",
+            }
+        ]
+
+        mock_post = MagicMock()
+        with patch("requests.post", mock_post):
+            mock_post.return_value = MockResponse(200)
+            status = exporter.export([otel_span])
+            self.assertEqual(SpanExportResult.SUCCESS, status)
+
+        mock_post.assert_called_with(
+            url="http://localhost:9411/api/v2/spans",
+            data=json.dumps(expected),
+            headers={"Content-Type": "application/json"},
+        )
+
+    @patch("requests.post")
+    def test_invalid_response(self, mock_post):
+        mock_post.return_value = MockResponse(404)
+        spans = []
+        exporter = ZipkinSpanExporter("test-service")
+        status = exporter.export(spans)
+        self.assertEqual(SpanExportResult.FAILURE, status)
+
+    def test_max_tag_length(self):
+        service_name = "test-service"
+
+        span_context = trace_api.SpanContext(
+            0x0E0C63257DE34C926F9EFCD03927272E,
+            0x04BF92DEEFC58C92,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+
+        span = trace._Span(name="test-span", context=span_context,)
+
+        span.start()
+        span.resource = Resource({})
+        # added here to preserve order
+        span.set_attribute("k1", "v" * 500)
+        span.set_attribute("k2", "v" * 50)
+        span.set_status(
+            Status(StatusCanonicalCode.UNKNOWN, "Example description")
+        )
+        span.end()
+
+        exporter = ZipkinSpanExporter(service_name)
+        mock_post = MagicMock()
+        with patch("requests.post", mock_post):
+            mock_post.return_value = MockResponse(200)
+            status = exporter.export([span])
+            self.assertEqual(SpanExportResult.SUCCESS, status)
+
+        _, kwargs = mock_post.call_args  # pylint: disable=E0633
+
+        tags = json.loads(kwargs["data"])[0]["tags"]
+        self.assertEqual(len(tags["k1"]), 128)
+        self.assertEqual(len(tags["k2"]), 50)
+
+        exporter = ZipkinSpanExporter(service_name, max_tag_value_length=2)
+        mock_post = MagicMock()
+        with patch("requests.post", mock_post):
+            mock_post.return_value = MockResponse(200)
+            status = exporter.export([span])
+            self.assertEqual(SpanExportResult.SUCCESS, status)
+
+        _, kwargs = mock_post.call_args  # pylint: disable=E0633
+        tags = json.loads(kwargs["data"])[0]["tags"]
+        self.assertEqual(len(tags["k1"]), 2)
+        self.assertEqual(len(tags["k2"]), 2)


### PR DESCRIPTION
# Description

Moves the `exporter/opentelemetry-exporter-zipkin` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-exporter-zipkin

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
