### PR TITLE
Move instrumentation django

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## Unreleased
+
+- Django instrumentation is now enabled by default but can be disabled by setting `OTEL_PYTHON_DJANGO_INSTRUMENT` to `False` ([#1239](https://github.com/open-telemetry/opentelemetry-python/pull/1239))
+
+## Version 0.14b0
+
+Released 2020-10-13
+
+- Changed span name extraction from request to comply semantic convention ([#992](https://github.com/open-telemetry/opentelemetry-python/pull/992)) 
+- Added support for `OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS` ([#1154](https://github.com/open-telemetry/opentelemetry-python/pull/1154))
+- Added capture of http.route ([#1226](https://github.com/open-telemetry/opentelemetry-python/issues/1226))
+- Add support for tracking http metrics
+  ([#1230](https://github.com/open-telemetry/opentelemetry-python/pull/1230))
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-django
+  ([#961](https://github.com/open-telemetry/opentelemetry-python/pull/961))
+- Update environment variable names, prefix changed from `OPENTELEMETRY` to `OTEL` ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
+
+## Version 0.11b0
+
+Released 2020-07-28
+
+- Use one general exclude list instead of two ([#872](https://github.com/open-telemetry/opentelemetry-python/pull/872))
+
+## 0.8b0
+
+Released 2020-05-27
+
+- Add exclude list for paths and hosts to prevent from tracing
+  ([#670](https://github.com/open-telemetry/opentelemetry-python/pull/670))
+- Add support for django >= 1.10 (#717)
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-django/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-django/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-django/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-django/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-django/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-django/README.rst
@@ -1,0 +1,53 @@
+OpenTelemetry Django Tracing
+============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-django.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-django/
+
+This library allows tracing requests for Django applications.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-django
+
+Configuration
+-------------
+
+Exclude lists
+*************
+To exclude certain URLs from being tracked, set the environment variable ``OTEL_PYTHON_DJANGO_EXCLUDED_URLS`` with comma delimited regexes representing which URLs to exclude.
+
+For example,
+
+::
+
+    export OTEL_PYTHON_DJANGO_EXCLUDED_URLS="client/.*/info,healthcheck"
+
+will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
+
+Request attributes
+********************
+To extract certain attributes from Django's request object and use them as span attributes, set the environment variable ``OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS`` to a comma
+delimited list of request attribute names. 
+
+For example,
+
+::
+
+    export OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS='path_info,content_type'
+
+will extract path_info and content_type attributes from every traced request and add them as span attritbues.
+
+Django Request object reference: https://docs.djangoproject.com/en/3.1/ref/request-response/#attributes
+
+References
+----------
+
+* `Django <https://www.djangoproject.com/>`_
+* `OpenTelemetry Instrumentation for Django <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/django/django.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-django
+description = OpenTelemetry Instrumentation for Django
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-django
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    django >= 1.10
+    opentelemetry-instrumentation-wsgi == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15.dev0
+
+[options.extras_require]
+test =
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    django = opentelemetry.instrumentation.django:DjangoInstrumentor

--- a/instrumentation/opentelemetry-instrumentation-django/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.py
@@ -1,0 +1,32 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os.path import dirname, join
+
+from setuptools import setup
+
+PACKAGE_INFO = {}
+with open(
+    join(
+        dirname(__file__),
+        "src",
+        "opentelemetry",
+        "instrumentation",
+        "django",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setup(version=PACKAGE_INFO["__version__"])

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -1,0 +1,87 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from logging import getLogger
+
+from django.conf import settings
+
+from opentelemetry.configuration import Configuration
+from opentelemetry.instrumentation.django.middleware import _DjangoMiddleware
+from opentelemetry.instrumentation.django.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.metric import (
+    HTTPMetricRecorder,
+    HTTPMetricType,
+    MetricMixin,
+)
+
+_logger = getLogger(__name__)
+
+
+class DjangoInstrumentor(BaseInstrumentor, MetricMixin):
+    """An instrumentor for Django
+
+    See `BaseInstrumentor`
+    """
+
+    _opentelemetry_middleware = ".".join(
+        [_DjangoMiddleware.__module__, _DjangoMiddleware.__qualname__]
+    )
+
+    def _instrument(self, **kwargs):
+
+        # FIXME this is probably a pattern that will show up in the rest of the
+        # ext. Find a better way of implementing this.
+        # FIXME Probably the evaluation of strings into boolean values can be
+        # built inside the Configuration class itself with the magic method
+        # __bool__
+
+        if Configuration().DJANGO_INSTRUMENT is False:
+            return
+
+        # This can not be solved, but is an inherent problem of this approach:
+        # the order of middleware entries matters, and here you have no control
+        # on that:
+        # https://docs.djangoproject.com/en/3.0/topics/http/middleware/#activating-middleware
+        # https://docs.djangoproject.com/en/3.0/ref/middleware/#middleware-ordering
+
+        settings_middleware = getattr(settings, "MIDDLEWARE", [])
+        # Django allows to specify middlewares as a tuple, so we convert this tuple to a
+        # list, otherwise we wouldn't be able to call append/remove
+        if isinstance(settings_middleware, tuple):
+            settings_middleware = list(settings_middleware)
+
+        settings_middleware.insert(0, self._opentelemetry_middleware)
+        self.init_metrics(
+            __name__, __version__,
+        )
+        metric_recorder = HTTPMetricRecorder(self.meter, HTTPMetricType.SERVER)
+        setattr(settings, "OTEL_METRIC_RECORDER", metric_recorder)
+        setattr(settings, "MIDDLEWARE", settings_middleware)
+
+    def _uninstrument(self, **kwargs):
+        settings_middleware = getattr(settings, "MIDDLEWARE", None)
+
+        # FIXME This is starting to smell like trouble. We have 2 mechanisms
+        # that may make this condition be True, one implemented in
+        # BaseInstrumentor and another one implemented in _instrument. Both
+        # stop _instrument from running and thus, settings_middleware not being
+        # set.
+        if settings_middleware is None or (
+            self._opentelemetry_middleware not in settings_middleware
+        ):
+            return
+
+        settings_middleware.remove(self._opentelemetry_middleware)
+        setattr(settings, "MIDDLEWARE", settings_middleware)

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -1,0 +1,232 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from logging import getLogger
+
+from django.conf import settings
+
+from opentelemetry.configuration import Configuration
+from opentelemetry.context import attach, detach
+from opentelemetry.instrumentation.django.version import __version__
+from opentelemetry.instrumentation.utils import extract_attributes_from_object
+from opentelemetry.instrumentation.wsgi import (
+    add_response_attributes,
+    collect_request_attributes,
+    get_header_from_environ,
+)
+from opentelemetry.propagators import extract
+from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.util import ExcludeList
+
+try:
+    from django.core.urlresolvers import (  # pylint: disable=no-name-in-module
+        resolve,
+        Resolver404,
+    )
+except ImportError:
+    from django.urls import resolve, Resolver404
+
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+_logger = getLogger(__name__)
+_attributes_by_preference = [
+    ["http.scheme", "http.host", "http.target"],
+    ["http.scheme", "http.server_name", "net.host.port", "http.target"],
+    ["http.scheme", "net.host.name", "net.host.port", "http.target"],
+    ["http.url"],
+]
+
+
+class _DjangoMiddleware(MiddlewareMixin):
+    """Django Middleware for OpenTelemetry"""
+
+    _environ_activation_key = (
+        "opentelemetry-instrumentor-django.activation_key"
+    )
+    _environ_token = "opentelemetry-instrumentor-django.token"
+    _environ_span_key = "opentelemetry-instrumentor-django.span_key"
+    _environ_exception_key = "opentelemetry-instrumentor-django.exception_key"
+
+    _excluded_urls = Configuration().DJANGO_EXCLUDED_URLS or []
+    if _excluded_urls:
+        _excluded_urls = ExcludeList(str.split(_excluded_urls, ","))
+    else:
+        _excluded_urls = ExcludeList(_excluded_urls)
+
+    _traced_request_attrs = [
+        attr.strip()
+        for attr in (Configuration().DJANGO_TRACED_REQUEST_ATTRS or "").split(
+            ","
+        )
+    ]
+
+    @staticmethod
+    def _get_span_name(request):
+        try:
+            if getattr(request, "resolver_match"):
+                match = request.resolver_match
+            else:
+                match = resolve(request.get_full_path())
+
+            if hasattr(match, "route"):
+                return match.route
+
+            # Instead of using `view_name`, better to use `_func_name` as some applications can use similar
+            # view names in different modules
+            if hasattr(match, "_func_name"):
+                return match._func_name  # pylint: disable=protected-access
+
+            # Fallback for safety as `_func_name` private field
+            return match.view_name
+
+        except Resolver404:
+            return "HTTP {}".format(request.method)
+
+    @staticmethod
+    def _get_metric_labels_from_attributes(attributes):
+        labels = {}
+        labels["http.method"] = attributes.get("http.method", "")
+        for attrs in _attributes_by_preference:
+            labels_from_attributes = {
+                attr: attributes.get(attr, None) for attr in attrs
+            }
+            if set(attrs).issubset(attributes.keys()):
+                labels.update(labels_from_attributes)
+                break
+        if attributes.get("http.flavor"):
+            labels["http.flavor"] = attributes.get("http.flavor")
+        return labels
+
+    def process_request(self, request):
+        # request.META is a dictionary containing all available HTTP headers
+        # Read more about request.META here:
+        # https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.META
+
+        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+            return
+
+        # pylint:disable=W0212
+        request._otel_start_time = time.time()
+
+        environ = request.META
+
+        token = attach(extract(get_header_from_environ, environ))
+
+        tracer = get_tracer(__name__, __version__)
+
+        span = tracer.start_span(
+            self._get_span_name(request),
+            kind=SpanKind.SERVER,
+            start_time=environ.get(
+                "opentelemetry-instrumentor-django.starttime_key"
+            ),
+        )
+
+        attributes = collect_request_attributes(environ)
+        # pylint:disable=W0212
+        request._otel_labels = self._get_metric_labels_from_attributes(
+            attributes
+        )
+
+        if span.is_recording():
+            attributes = extract_attributes_from_object(
+                request, self._traced_request_attrs, attributes
+            )
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+
+        activation = tracer.use_span(span, end_on_exit=True)
+        activation.__enter__()
+
+        request.META[self._environ_activation_key] = activation
+        request.META[self._environ_span_key] = span
+        request.META[self._environ_token] = token
+
+    # pylint: disable=unused-argument
+    def process_view(self, request, view_func, *args, **kwargs):
+        # Process view is executed before the view function, here we get the
+        # route template from request.resolver_match.  It is not set yet in process_request
+        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+            return
+
+        if (
+            self._environ_activation_key in request.META.keys()
+            and self._environ_span_key in request.META.keys()
+        ):
+            span = request.META[self._environ_span_key]
+
+            if span.is_recording():
+                match = getattr(request, "resolver_match")
+                if match:
+                    route = getattr(match, "route")
+                    if route:
+                        span.set_attribute("http.route", route)
+
+    def process_exception(self, request, exception):
+        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+            return
+
+        if self._environ_activation_key in request.META.keys():
+            request.META[self._environ_exception_key] = exception
+
+    def process_response(self, request, response):
+        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+            return response
+
+        if (
+            self._environ_activation_key in request.META.keys()
+            and self._environ_span_key in request.META.keys()
+        ):
+            add_response_attributes(
+                request.META[self._environ_span_key],
+                "{} {}".format(response.status_code, response.reason_phrase),
+                response,
+            )
+            # pylint:disable=W0212
+            request._otel_labels["http.status_code"] = str(
+                response.status_code
+            )
+            request.META.pop(self._environ_span_key)
+
+            exception = request.META.pop(self._environ_exception_key, None)
+            if exception:
+                request.META[self._environ_activation_key].__exit__(
+                    type(exception),
+                    exception,
+                    getattr(exception, "__traceback__", None),
+                )
+            else:
+                request.META[self._environ_activation_key].__exit__(
+                    None, None, None
+                )
+            request.META.pop(self._environ_activation_key)
+
+        if self._environ_token in request.META.keys():
+            detach(request.environ.get(self._environ_token))
+            request.META.pop(self._environ_token)
+
+        try:
+            metric_recorder = getattr(settings, "OTEL_METRIC_RECORDER", None)
+            if metric_recorder is not None:
+                # pylint:disable=W0212
+                metric_recorder.record_server_duration_range(
+                    request._otel_start_time, time.time(), request._otel_labels
+                )
+        except Exception as ex:  # pylint: disable=W0703
+            _logger.warning("Error recording duration metrics: %s", ex)
+        return response

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -1,0 +1,300 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sys import modules
+from unittest.mock import Mock, patch
+
+from django import VERSION
+from django.conf import settings
+from django.conf.urls import url
+from django.test import Client
+from django.test.utils import setup_test_environment, teardown_test_environment
+
+from opentelemetry.configuration import Configuration
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.sdk.util import get_dict_as_key
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.test.wsgitestutil import WsgiTestBase
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.util import ExcludeList
+
+# pylint: disable=import-error
+from .views import (
+    error,
+    excluded,
+    excluded_noarg,
+    excluded_noarg2,
+    route_span_name,
+    traced,
+    traced_template,
+)
+
+DJANGO_2_2 = VERSION >= (2, 2)
+
+urlpatterns = [
+    url(r"^traced/", traced),
+    url(r"^route/(?P<year>[0-9]{4})/template/$", traced_template),
+    url(r"^error/", error),
+    url(r"^excluded_arg/", excluded),
+    url(r"^excluded_noarg/", excluded_noarg),
+    url(r"^excluded_noarg2/", excluded_noarg2),
+    url(r"^span_name/([0-9]{4})/$", route_span_name),
+]
+_django_instrumentor = DjangoInstrumentor()
+
+
+class TestMiddleware(TestBase, WsgiTestBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        settings.configure(ROOT_URLCONF=modules[__name__])
+
+    def setUp(self):
+        super().setUp()
+        setup_test_environment()
+        _django_instrumentor.instrument()
+        Configuration._reset()  # pylint: disable=protected-access
+
+    def tearDown(self):
+        super().tearDown()
+        teardown_test_environment()
+        _django_instrumentor.uninstrument()
+
+    def test_templated_route_get(self):
+        Client().get("/route/2020/template/")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+
+        self.assertEqual(
+            span.name,
+            "^route/(?P<year>[0-9]{4})/template/$"
+            if DJANGO_2_2
+            else "tests.views.traced",
+        )
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.attributes["http.method"], "GET")
+        self.assertEqual(
+            span.attributes["http.url"],
+            "http://testserver/route/2020/template/",
+        )
+        self.assertEqual(
+            span.attributes["http.route"],
+            "^route/(?P<year>[0-9]{4})/template/$",
+        )
+        self.assertEqual(span.attributes["http.scheme"], "http")
+        self.assertEqual(span.attributes["http.status_code"], 200)
+        self.assertEqual(span.attributes["http.status_text"], "OK")
+
+    def test_traced_get(self):
+        Client().get("/traced/")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+
+        self.assertEqual(
+            span.name, "^traced/" if DJANGO_2_2 else "tests.views.traced"
+        )
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.attributes["http.method"], "GET")
+        self.assertEqual(
+            span.attributes["http.url"], "http://testserver/traced/"
+        )
+        self.assertEqual(span.attributes["http.route"], "^traced/")
+        self.assertEqual(span.attributes["http.scheme"], "http")
+        self.assertEqual(span.attributes["http.status_code"], 200)
+        self.assertEqual(span.attributes["http.status_text"], "OK")
+
+        self.assertIsNotNone(_django_instrumentor.meter)
+        self.assertEqual(len(_django_instrumentor.meter.metrics), 1)
+        recorder = _django_instrumentor.meter.metrics.pop()
+        match_key = get_dict_as_key(
+            {
+                "http.flavor": "1.1",
+                "http.method": "GET",
+                "http.status_code": "200",
+                "http.url": "http://testserver/traced/",
+            }
+        )
+        for key in recorder.bound_instruments.keys():
+            self.assertEqual(key, match_key)
+            # pylint: disable=protected-access
+            bound = recorder.bound_instruments.get(key)
+            for view_data in bound.view_datas:
+                self.assertEqual(view_data.labels, key)
+                self.assertEqual(view_data.aggregator.current.count, 1)
+                self.assertGreaterEqual(view_data.aggregator.current.sum, 0)
+
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = True
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            Client().get("/traced/")
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_traced_post(self):
+        Client().post("/traced/")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+
+        self.assertEqual(
+            span.name, "^traced/" if DJANGO_2_2 else "tests.views.traced"
+        )
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.attributes["http.method"], "POST")
+        self.assertEqual(
+            span.attributes["http.url"], "http://testserver/traced/"
+        )
+        self.assertEqual(span.attributes["http.route"], "^traced/")
+        self.assertEqual(span.attributes["http.scheme"], "http")
+        self.assertEqual(span.attributes["http.status_code"], 200)
+        self.assertEqual(span.attributes["http.status_text"], "OK")
+
+    def test_error(self):
+        with self.assertRaises(ValueError):
+            Client().get("/error/")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+
+        self.assertEqual(
+            span.name, "^error/" if DJANGO_2_2 else "tests.views.error"
+        )
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.INTERNAL
+        )
+        self.assertEqual(span.attributes["http.method"], "GET")
+        self.assertEqual(
+            span.attributes["http.url"], "http://testserver/error/"
+        )
+        self.assertEqual(span.attributes["http.route"], "^error/")
+        self.assertEqual(span.attributes["http.scheme"], "http")
+        self.assertEqual(span.attributes["http.status_code"], 500)
+        self.assertIsNotNone(_django_instrumentor.meter)
+        self.assertEqual(len(_django_instrumentor.meter.metrics), 1)
+
+        self.assertEqual(len(span.events), 1)
+        event = span.events[0]
+        self.assertEqual(event.name, "exception")
+        self.assertEqual(event.attributes["exception.type"], "ValueError")
+        self.assertEqual(event.attributes["exception.message"], "error")
+
+        recorder = _django_instrumentor.meter.metrics.pop()
+        match_key = get_dict_as_key(
+            {
+                "http.flavor": "1.1",
+                "http.method": "GET",
+                "http.status_code": "500",
+                "http.url": "http://testserver/error/",
+            }
+        )
+        for key in recorder.bound_instruments.keys():
+            self.assertEqual(key, match_key)
+            # pylint: disable=protected-access
+            bound = recorder.bound_instruments.get(key)
+            for view_data in bound.view_datas:
+                self.assertEqual(view_data.labels, key)
+                self.assertEqual(view_data.aggregator.current.count, 1)
+
+    @patch(
+        "opentelemetry.instrumentation.django.middleware._DjangoMiddleware._excluded_urls",
+        ExcludeList(["http://testserver/excluded_arg/123", "excluded_noarg"]),
+    )
+    def test_exclude_lists(self):
+        client = Client()
+        client.get("/excluded_arg/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+        client.get("/excluded_arg/125")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        client.get("/excluded_noarg/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        client.get("/excluded_noarg2/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    def test_span_name(self):
+        Client().get("/span_name/1234/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        span = span_list[0]
+        self.assertEqual(
+            span.name,
+            "^span_name/([0-9]{4})/$"
+            if DJANGO_2_2
+            else "tests.views.route_span_name",
+        )
+
+    def test_span_name_404(self):
+        Client().get("/span_name/1234567890/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        span = span_list[0]
+        self.assertEqual(span.name, "HTTP GET")
+
+    def test_traced_request_attrs(self):
+        with patch(
+            "opentelemetry.instrumentation.django.middleware._DjangoMiddleware._traced_request_attrs",
+            [],
+        ):
+            Client().get("/span_name/1234/", CONTENT_TYPE="test/ct")
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+
+            span = span_list[0]
+            self.assertNotIn("path_info", span.attributes)
+            self.assertNotIn("content_type", span.attributes)
+            self.memory_exporter.clear()
+
+        with patch(
+            "opentelemetry.instrumentation.django.middleware._DjangoMiddleware._traced_request_attrs",
+            ["path_info", "content_type", "non_existing_variable"],
+        ):
+            Client().get("/span_name/1234/", CONTENT_TYPE="test/ct")
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+
+            span = span_list[0]
+            self.assertEqual(span.attributes["path_info"], "/span_name/1234/")
+            self.assertEqual(span.attributes["content_type"], "test/ct")
+            self.assertNotIn("non_existing_variable", span.attributes)

--- a/instrumentation/opentelemetry-instrumentation-django/tests/views.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/views.py
@@ -1,0 +1,31 @@
+from django.http import HttpResponse
+
+
+def traced(request):  # pylint: disable=unused-argument
+    return HttpResponse()
+
+
+def traced_template(request, year):  # pylint: disable=unused-argument
+    return HttpResponse()
+
+
+def error(request):  # pylint: disable=unused-argument
+    raise ValueError("error")
+
+
+def excluded(request):  # pylint: disable=unused-argument
+    return HttpResponse()
+
+
+def excluded_noarg(request):  # pylint: disable=unused-argument
+    return HttpResponse()
+
+
+def excluded_noarg2(request):  # pylint: disable=unused-argument
+    return HttpResponse()
+
+
+def route_span_name(
+    request, *args, **kwargs
+):  # pylint: disable=unused-argument
+    return HttpResponse()


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-django` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-django

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
