### PR TITLE
Move instrumentation flask

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## Unreleased
+
+- Use `url.rule` instead of `request.endpoint` for span name
+  ([#1260](https://github.com/open-telemetry/opentelemetry-python/pull/1260))
+- Record span status and http.status_code attribute on exception 
+  ([#1257](https://github.com/open-telemetry/opentelemetry-python/pull/1257))
+
+## Version 0.13b0
+
+Released 2020-09-17
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
+## Version 0.12b0
+
+Released 2020-08-14
+
+- Change package name to opentelemetry-instrumentation-flask
+  ([#961](https://github.com/open-telemetry/opentelemetry-python/pull/961))
+- Update environment variable names, prefix changed from `OPENTELEMETRY` to `OTEL` ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
+
+## Version 0.11b0
+
+- Use one general exclude list instead of two ([#872](https://github.com/open-telemetry/opentelemetry-python/pull/872))
+
+## 0.7b1
+
+Released 2020-05-12
+
+- Add exclude list for paths and hosts
+  ([#630](https://github.com/open-telemetry/opentelemetry-python/pull/630))
+
+## 0.6b0
+
+Released 2020-03-30
+
+- Add an entry_point to be usable in auto-instrumentation
+  ([#327](https://github.com/open-telemetry/opentelemetry-python/pull/327))
+
+## 0.4a0
+
+Released 2020-02-21
+
+- Use string keys for WSGI environ values
+  ([#366](https://github.com/open-telemetry/opentelemetry-python/pull/366))
+
+## 0.3a0
+
+Released 2019-12-11
+
+- Initial release

--- a/instrumentation/opentelemetry-instrumentation-flask/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-flask/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-flask/MANIFEST.in
+++ b/instrumentation/opentelemetry-instrumentation-flask/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/instrumentation/opentelemetry-instrumentation-flask/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-flask/README.rst
@@ -1,0 +1,38 @@
+OpenTelemetry Flask Tracing
+===========================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-flask.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-flask/
+
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Flask applications.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-flask
+
+Configuration
+-------------
+
+Exclude lists
+*************
+To exclude certain URLs from being tracked, set the environment variable ``OTEL_PYTHON_FLASK_EXCLUDED_URLS`` with comma delimited regexes representing which URLs to exclude.
+
+For example,
+
+::
+
+    export OTEL_PYTHON_FLASK_EXCLUDED_URLS="client/.*/info,healthcheck"
+
+will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
+
+References
+----------
+
+* `OpenTelemetry Flask Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/flask/flask.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -1,0 +1,53 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-instrumentation-flask
+description = Flask instrumentation for OpenTelemetry
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-flask
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    flask ~= 1.0
+    opentelemetry-instrumentation-wsgi == 0.15.dev0
+    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15.dev0
+
+[options.extras_require]
+test =
+    flask~=1.0
+    opentelemetry-test == 0.15.dev0
+
+[options.packages.find]
+where = src

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.py
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "flask", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"],
+    entry_points={
+        "opentelemetry_instrumentor": [
+            "flask = opentelemetry.instrumentation.flask:FlaskInstrumentor"
+        ]
+    },
+)

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -1,0 +1,227 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: This package is not named "flask" because of
+# https://github.com/PyCQA/pylint/issues/2648
+
+"""
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Flask applications. In addition to opentelemetry-instrumentation-wsgi, it supports
+flask-specific features such as:
+
+* The Flask endpoint name is used as the Span name.
+* The ``http.route`` Span attribute is set so that one can see which URL rule
+  matched a request.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from flask import Flask
+    from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+    app = Flask(__name__)
+
+    FlaskInstrumentor().instrument_app(app)
+
+    @app.route("/")
+    def hello():
+        return "Hello!"
+
+    if __name__ == "__main__":
+        app.run(debug=True)
+
+API
+---
+"""
+
+from logging import getLogger
+
+import flask
+
+import opentelemetry.instrumentation.wsgi as otel_wsgi
+from opentelemetry import configuration, context, propagators, trace
+from opentelemetry.instrumentation.flask.version import __version__
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.util import ExcludeList, time_ns
+
+_logger = getLogger(__name__)
+
+_ENVIRON_STARTTIME_KEY = "opentelemetry-flask.starttime_key"
+_ENVIRON_SPAN_KEY = "opentelemetry-flask.span_key"
+_ENVIRON_ACTIVATION_KEY = "opentelemetry-flask.activation_key"
+_ENVIRON_TOKEN = "opentelemetry-flask.token"
+
+
+def get_excluded_urls():
+    urls = configuration.Configuration().FLASK_EXCLUDED_URLS or []
+    if urls:
+        urls = str.split(urls, ",")
+    return ExcludeList(urls)
+
+
+_excluded_urls = get_excluded_urls()
+
+
+def _rewrapped_app(wsgi_app):
+    def _wrapped_app(environ, start_response):
+        # We want to measure the time for route matching, etc.
+        # In theory, we could start the span here and use
+        # update_name later but that API is "highly discouraged" so
+        # we better avoid it.
+        environ[_ENVIRON_STARTTIME_KEY] = time_ns()
+
+        def _start_response(status, response_headers, *args, **kwargs):
+            if not _excluded_urls.url_disabled(flask.request.url):
+                span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
+
+                if span:
+                    otel_wsgi.add_response_attributes(
+                        span, status, response_headers
+                    )
+                else:
+                    _logger.warning(
+                        "Flask environ's OpenTelemetry span "
+                        "missing at _start_response(%s)",
+                        status,
+                    )
+
+            return start_response(status, response_headers, *args, **kwargs)
+
+        return wsgi_app(environ, _start_response)
+
+    return _wrapped_app
+
+
+def _before_request():
+    if _excluded_urls.url_disabled(flask.request.url):
+        return
+
+    environ = flask.request.environ
+    span_name = None
+    try:
+        span_name = flask.request.url_rule.rule
+    except AttributeError:
+        pass
+    if span_name is None:
+        span_name = otel_wsgi.get_default_span_name(environ)
+    token = context.attach(
+        propagators.extract(otel_wsgi.get_header_from_environ, environ)
+    )
+
+    tracer = trace.get_tracer(__name__, __version__)
+
+    span = tracer.start_span(
+        span_name,
+        kind=trace.SpanKind.SERVER,
+        start_time=environ.get(_ENVIRON_STARTTIME_KEY),
+    )
+    if span.is_recording():
+        attributes = otel_wsgi.collect_request_attributes(environ)
+        if flask.request.url_rule:
+            # For 404 that result from no route found, etc, we
+            # don't have a url_rule.
+            attributes["http.route"] = flask.request.url_rule.rule
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+
+    activation = tracer.use_span(span, end_on_exit=True)
+    activation.__enter__()
+    environ[_ENVIRON_ACTIVATION_KEY] = activation
+    environ[_ENVIRON_SPAN_KEY] = span
+    environ[_ENVIRON_TOKEN] = token
+
+
+def _teardown_request(exc):
+    if _excluded_urls.url_disabled(flask.request.url):
+        return
+
+    activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
+    if not activation:
+        _logger.warning(
+            "Flask environ's OpenTelemetry activation missing"
+            "at _teardown_flask_request(%s)",
+            exc,
+        )
+        return
+
+    if exc is None:
+        activation.__exit__(None, None, None)
+    else:
+        activation.__exit__(
+            type(exc), exc, getattr(exc, "__traceback__", None)
+        )
+    context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+
+
+class _InstrumentedFlask(flask.Flask):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._original_wsgi_ = self.wsgi_app
+        self.wsgi_app = _rewrapped_app(self.wsgi_app)
+
+        self.before_request(_before_request)
+        self.teardown_request(_teardown_request)
+
+
+class FlaskInstrumentor(BaseInstrumentor):
+    # pylint: disable=protected-access,attribute-defined-outside-init
+    """An instrumentor for flask.Flask
+
+    See `BaseInstrumentor`
+    """
+
+    def _instrument(self, **kwargs):
+        self._original_flask = flask.Flask
+        flask.Flask = _InstrumentedFlask
+
+    def instrument_app(self, app):  # pylint: disable=no-self-use
+        if not hasattr(app, "_is_instrumented"):
+            app._is_instrumented = False
+
+        if not app._is_instrumented:
+            app._original_wsgi_app = app.wsgi_app
+            app.wsgi_app = _rewrapped_app(app.wsgi_app)
+
+            app.before_request(_before_request)
+            app.teardown_request(_teardown_request)
+            app._is_instrumented = True
+        else:
+            _logger.warning(
+                "Attempting to instrument Flask app while already instrumented"
+            )
+
+    def _uninstrument(self, **kwargs):
+        flask.Flask = self._original_flask
+
+    def uninstrument_app(self, app):  # pylint: disable=no-self-use
+        if not hasattr(app, "_is_instrumented"):
+            app._is_instrumented = False
+
+        if app._is_instrumented:
+            app.wsgi_app = app._original_wsgi_app
+
+            # FIXME add support for other Flask blueprints that are not None
+            app.before_request_funcs[None].remove(_before_request)
+            app.teardown_request_funcs[None].remove(_teardown_request)
+            del app._original_wsgi_app
+
+            app._is_instrumented = False
+        else:
+            _logger.warning(
+                "Attempting to uninstrument Flask "
+                "app while already uninstrumented"
+            )

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.15.dev0"

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -1,0 +1,46 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+
+from opentelemetry.configuration import Configuration
+
+
+class InstrumentationTest:
+    def setUp(self):  # pylint: disable=invalid-name
+        super().setUp()  # pylint: disable=no-member
+        Configuration._reset()  # pylint: disable=protected-access
+
+    @staticmethod
+    def _hello_endpoint(helloid):
+        if helloid == 500:
+            raise ValueError(":-(")
+        return "Hello: " + str(helloid)
+
+    def _common_initialization(self):
+        def excluded_endpoint():
+            return "excluded"
+
+        def excluded2_endpoint():
+            return "excluded2"
+
+        # pylint: disable=no-member
+        self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        self.app.route("/excluded/<int:helloid>")(self._hello_endpoint)
+        self.app.route("/excluded")(excluded_endpoint)
+        self.app.route("/excluded2")(excluded2_endpoint)
+
+        # pylint: disable=attribute-defined-outside-init
+        self.client = Client(self.app, BaseResponse)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
@@ -1,0 +1,61 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flask
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.test.wsgitestutil import WsgiTestBase
+
+# pylint: disable=import-error
+from .base_test import InstrumentationTest
+
+
+class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+
+        FlaskInstrumentor().instrument()
+
+        self.app = flask.Flask(__name__)
+
+        self._common_initialization()
+
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            FlaskInstrumentor().uninstrument()
+
+    def test_uninstrument(self):
+        # pylint: disable=access-member-before-definition
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        FlaskInstrumentor().uninstrument()
+        self.app = flask.Flask(__name__)
+
+        self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        # pylint: disable=attribute-defined-outside-init
+        self.client = Client(self.app, BaseResponse)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -1,0 +1,180 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from flask import Flask, request
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.test.wsgitestutil import WsgiTestBase
+from opentelemetry.util import ExcludeList
+
+# pylint: disable=import-error
+from .base_test import InstrumentationTest
+
+
+def expected_attributes(override_attributes):
+    default_attributes = {
+        "component": "http",
+        "http.method": "GET",
+        "http.server_name": "localhost",
+        "http.scheme": "http",
+        "host.port": 80,
+        "http.host": "localhost",
+        "http.target": "/",
+        "http.flavor": "1.1",
+        "http.status_text": "OK",
+        "http.status_code": 200,
+    }
+    for key, val in override_attributes.items():
+        default_attributes[key] = val
+    return default_attributes
+
+
+class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+
+        self.app = Flask(__name__)
+
+        FlaskInstrumentor().instrument_app(self.app)
+
+        self._common_initialization()
+
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            FlaskInstrumentor().uninstrument_app(self.app)
+
+    def test_uninstrument(self):
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        FlaskInstrumentor().uninstrument_app(self.app)
+
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+    # pylint: disable=no-member
+    def test_only_strings_in_environ(self):
+        """
+        Some WSGI servers (such as Gunicorn) expect keys in the environ object
+        to be strings
+
+        OpenTelemetry should adhere to this convention.
+        """
+        nonstring_keys = set()
+
+        def assert_environ():
+            for key in request.environ:
+                if not isinstance(key, str):
+                    nonstring_keys.add(key)
+            return "hi"
+
+        self.app.route("/assert_environ")(assert_environ)
+        self.client.get("/assert_environ")
+        self.assertEqual(nonstring_keys, set())
+
+    def test_simple(self):
+        expected_attrs = expected_attributes(
+            {"http.target": "/hello/123", "http.route": "/hello/<int:helloid>"}
+        )
+        self.client.get("/hello/123")
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "/hello/<int:helloid>")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        mock_tracer.use_span.return_value.__enter__ = mock_span
+        mock_tracer.use_span.return_value.__exit__ = mock_span
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            self.client.get("/hello/123")
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    def test_404(self):
+        expected_attrs = expected_attributes(
+            {
+                "http.method": "POST",
+                "http.target": "/bye",
+                "http.status_text": "NOT FOUND",
+                "http.status_code": 404,
+            }
+        )
+
+        resp = self.client.post("/bye")
+        self.assertEqual(404, resp.status_code)
+        resp.close()
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "HTTP POST")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_internal_error(self):
+        expected_attrs = expected_attributes(
+            {
+                "http.target": "/hello/500",
+                "http.route": "/hello/<int:helloid>",
+                "http.status_text": "INTERNAL SERVER ERROR",
+                "http.status_code": 500,
+            }
+        )
+        resp = self.client.get("/hello/500")
+        self.assertEqual(500, resp.status_code)
+        resp.close()
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "/hello/<int:helloid>")
+        self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
+        self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    @patch(
+        "opentelemetry.instrumentation.flask._excluded_urls",
+        ExcludeList(["http://localhost/excluded_arg/123", "excluded_noarg"]),
+    )
+    def test_exclude_lists(self):
+        self.client.get("/excluded_arg/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+        self.client.get("/excluded_arg/125")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        self.client.get("/excluded_noarg")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        self.client.get("/excluded_noarg2")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)


### PR DESCRIPTION
# Description

Moves the `instrumentation/opentelemetry-instrumentation-flask` from the core repo into the contrib repo.

The original code is being copied over from the Core repo here: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-flask

# How Has This Been Tested?

CI tests will confirm it works correctly.

The only reason I didn't add tests yet (and I didn't plan to until we get all the packages we want in) is because the tests introduced here depend on other packages that will be coming (very soon hopefully!) in future PRs.

After the PRs with the packages are merged, I'll take the same approach I took in my large PR #47 where I got the tests to pass.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
