### PR TITLE
Move instrumentation celery

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-celery/README.rst
@@ -63,6 +63,6 @@ accomplish this as shown in the example above.
 
 References
 ----------
-* `OpenTelemetry Celery Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/ext/celery/celery.html>`_
+* `OpenTelemetry Celery Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/celery/celery.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     celery ~= 4.0
 
 [options.extras_require]
 test =
     pytest
     celery ~= 4.0
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -67,8 +67,8 @@ from opentelemetry import propagators, trace
 from opentelemetry.instrumentation.celery import utils
 from opentelemetry.instrumentation.celery.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.trace.propagation import get_current_span
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.propagation.textmap import DictGetter
+from opentelemetry.trace.status import Status, StatusCode
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,20 @@ _TASK_REVOKED_REASON_KEY = "celery.revoked.reason"
 _TASK_REVOKED_TERMINATED_SIGNAL_KEY = "celery.terminated.signal"
 _TASK_NAME_KEY = "celery.task_name"
 _MESSAGE_ID_ATTRIBUTE_NAME = "messaging.message_id"
+
+
+class CarrierGetter(DictGetter):
+    def get(self, carrier, key):
+        value = getattr(carrier, key, [])
+        if isinstance(value, str) or not isinstance(value, Iterable):
+            value = (value,)
+        return value
+
+    def keys(self, carrier):
+        return []
+
+
+carrier_getter = CarrierGetter()
 
 
 class CeleryInstrumentor(BaseInstrumentor):
@@ -118,7 +132,7 @@ class CeleryInstrumentor(BaseInstrumentor):
             return
 
         request = task.request
-        tracectx = propagators.extract(carrier_extractor, request) or None
+        tracectx = propagators.extract(carrier_getter, request) or None
 
         logger.debug("prerun signal start task_id=%s", task_id)
 
@@ -214,7 +228,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         if span is None or not span.is_recording():
             return
 
-        status_kwargs = {"canonical_code": StatusCanonicalCode.UNKNOWN}
+        status_kwargs = {"status_code": StatusCode.ERROR}
 
         ex = kwargs.get("einfo")
 
@@ -227,7 +241,6 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         if ex is not None:
             status_kwargs["description"] = str(ex)
-
         span.set_status(Status(**status_kwargs))
 
     @staticmethod
@@ -247,10 +260,3 @@ class CeleryInstrumentor(BaseInstrumentor):
         # Use `str(reason)` instead of `reason.message` in case we get
         # something that isn't an `Exception`
         span.set_attribute(_TASK_RETRY_REASON_KEY, str(reason))
-
-
-def carrier_extractor(carrier, key):
-    value = getattr(carrier, key, [])
-    if isinstance(value, str) or not isinstance(value, Iterable):
-        value = (value,)
-    return value

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-celery`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
