### PR TITLE
Move instrumentation dbapi

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -50,7 +50,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.dbapi.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import SpanKind, TracerProvider, get_tracer
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.status import Status, StatusCode
 
 logger = logging.getLogger(__name__)
 
@@ -343,14 +343,10 @@ class TracedCursor:
             self._populate_span(span, *args)
             try:
                 result = query_method(*args, **kwargs)
-                if span.is_recording():
-                    span.set_status(Status(StatusCanonicalCode.OK))
                 return result
             except Exception as ex:  # pylint: disable=broad-except
                 if span.is_recording():
-                    span.set_status(
-                        Status(StatusCanonicalCode.UNKNOWN, str(ex))
-                    )
+                    span.set_status(Status(StatusCode.ERROR, str(ex)))
                 raise ex
 
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -65,8 +65,7 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(span.attributes["net.peer.name"], "testhost")
         self.assertEqual(span.attributes["net.peer.port"], 123)
         self.assertIs(
-            span.status.canonical_code,
-            trace_api.status.StatusCanonicalCode.OK,
+            span.status.status_code, trace_api.status.StatusCode.UNSET,
         )
 
     def test_span_not_recording(self):
@@ -117,8 +116,7 @@ class TestDBApiIntegration(TestBase):
         span = spans_list[0]
         self.assertEqual(span.attributes["db.statement"], "Test query")
         self.assertIs(
-            span.status.canonical_code,
-            trace_api.status.StatusCanonicalCode.UNKNOWN,
+            span.status.status_code, trace_api.status.StatusCode.ERROR,
         )
         self.assertEqual(span.status.description, "Test Exception")
 


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-dbapi`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
