### PR TITLE
Move instrumentation django

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Unreleased
 
-- Django instrumentation is now enabled by default but can be disabled by setting `OTEL_PYTHON_DJANGO_INSTRUMENT` to `False` ([#1239](https://github.com/open-telemetry/opentelemetry-python/pull/1239))
+## Version 0.15b0
+
+Released 2020-11-02
+
+- Django instrumentation is now enabled by default but can be disabled by setting `OTEL_PYTHON_DJANGO_INSTRUMENT` to `False`
+  ([#1239](https://github.com/open-telemetry/opentelemetry-python/pull/1239))
+- Bugfix use request.path replace request.get_full_path(). It will get correct span name
+  ([#1309](https://github.com/open-telemetry/opentelemetry-python/pull/1309#))
+- Record span status and http.status_code attribute on exception 
+  ([#1257](https://github.com/open-telemetry/opentelemetry-python/pull/1257))
+- Added capture of http.route
+  ([#1226](https://github.com/open-telemetry/opentelemetry-python/issues/1226))
+- Add support for tracking http metrics
+  ([#1230](https://github.com/open-telemetry/opentelemetry-python/pull/1230))
 
 ## Version 0.14b0
 
@@ -10,9 +23,6 @@ Released 2020-10-13
 
 - Changed span name extraction from request to comply semantic convention ([#992](https://github.com/open-telemetry/opentelemetry-python/pull/992)) 
 - Added support for `OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS` ([#1154](https://github.com/open-telemetry/opentelemetry-python/pull/1154))
-- Added capture of http.route ([#1226](https://github.com/open-telemetry/opentelemetry-python/issues/1226))
-- Add support for tracking http metrics
-  ([#1230](https://github.com/open-telemetry/opentelemetry-python/pull/1230))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -40,13 +40,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     django >= 1.10
-    opentelemetry-instrumentation-wsgi == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
-    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation-wsgi == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.15b0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -23,8 +23,8 @@ from opentelemetry.instrumentation.django.version import __version__
 from opentelemetry.instrumentation.utils import extract_attributes_from_object
 from opentelemetry.instrumentation.wsgi import (
     add_response_attributes,
+    carrier_getter,
     collect_request_attributes,
-    get_header_from_environ,
 )
 from opentelemetry.propagators import extract
 from opentelemetry.trace import SpanKind, get_tracer
@@ -81,7 +81,7 @@ class _DjangoMiddleware(MiddlewareMixin):
             if getattr(request, "resolver_match"):
                 match = request.resolver_match
             else:
-                match = resolve(request.get_full_path())
+                match = resolve(request.path)
 
             if hasattr(match, "route"):
                 return match.route
@@ -125,7 +125,7 @@ class _DjangoMiddleware(MiddlewareMixin):
 
         environ = request.META
 
-        token = attach(extract(get_header_from_environ, environ))
+        token = attach(extract(carrier_getter, environ))
 
         tracer = get_tracer(__name__, __version__)
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.util import get_dict_as_key
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 from opentelemetry.trace import SpanKind
-from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.trace.status import StatusCode
 from opentelemetry.util import ExcludeList
 
 # pylint: disable=import-error
@@ -87,7 +87,7 @@ class TestMiddleware(TestBase, WsgiTestBase):
             else "tests.views.traced",
         )
         self.assertEqual(span.kind, SpanKind.SERVER)
-        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.status.status_code, StatusCode.UNSET)
         self.assertEqual(span.attributes["http.method"], "GET")
         self.assertEqual(
             span.attributes["http.url"],
@@ -113,7 +113,7 @@ class TestMiddleware(TestBase, WsgiTestBase):
             span.name, "^traced/" if DJANGO_2_2 else "tests.views.traced"
         )
         self.assertEqual(span.kind, SpanKind.SERVER)
-        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.status.status_code, StatusCode.UNSET)
         self.assertEqual(span.attributes["http.method"], "GET")
         self.assertEqual(
             span.attributes["http.url"], "http://testserver/traced/"
@@ -170,7 +170,7 @@ class TestMiddleware(TestBase, WsgiTestBase):
             span.name, "^traced/" if DJANGO_2_2 else "tests.views.traced"
         )
         self.assertEqual(span.kind, SpanKind.SERVER)
-        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertEqual(span.status.status_code, StatusCode.UNSET)
         self.assertEqual(span.attributes["http.method"], "POST")
         self.assertEqual(
             span.attributes["http.url"], "http://testserver/traced/"
@@ -193,9 +193,7 @@ class TestMiddleware(TestBase, WsgiTestBase):
             span.name, "^error/" if DJANGO_2_2 else "tests.views.error"
         )
         self.assertEqual(span.kind, SpanKind.SERVER)
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.INTERNAL
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
         self.assertEqual(span.attributes["http.method"], "GET")
         self.assertEqual(
             span.attributes["http.url"], "http://testserver/error/"
@@ -252,7 +250,24 @@ class TestMiddleware(TestBase, WsgiTestBase):
         self.assertEqual(len(span_list), 1)
 
     def test_span_name(self):
+        # test no query_string
         Client().get("/span_name/1234/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        span = span_list[0]
+        self.assertEqual(
+            span.name,
+            "^span_name/([0-9]{4})/$"
+            if DJANGO_2_2
+            else "tests.views.route_span_name",
+        )
+
+    def test_span_name_for_query_string(self):
+        """
+        request not have query string
+        """
+        Client().get("/span_name/1234/?query=test")
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
 


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-django`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
