### PR TITLE
Move instrumentation elasticsearch

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     wrapt >= 1.0.0, < 2.0.0
     elasticsearch >= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
     elasticsearch-dsl >= 2.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -64,7 +64,7 @@ from opentelemetry.instrumentation.elasticsearch.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import SpanKind, get_tracer
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.status import Status, StatusCode
 
 logger = getLogger(__name__)
 
@@ -156,11 +156,7 @@ def _wrap_perform_request(tracer, span_name_prefix):
                 return rv
             except Exception as ex:  # pylint: disable=broad-except
                 if span.is_recording():
-                    if isinstance(ex, elasticsearch.exceptions.NotFoundError):
-                        status = StatusCanonicalCode.NOT_FOUND
-                    else:
-                        status = StatusCanonicalCode.UNKNOWN
-                    span.set_status(Status(status, str(ex)))
+                    span.set_status(Status(StatusCode.ERROR, str(ex)))
                 raise ex
 
     return wrapper

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -27,7 +27,7 @@ from opentelemetry.instrumentation.elasticsearch import (
     ElasticsearchInstrumentor,
 )
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.trace.status import StatusCode
 
 major_version = elasticsearch.VERSION[0]
 
@@ -153,14 +153,14 @@ class TestElasticsearchIntegration(TestBase):
     def test_trace_error_unknown(self, request_mock):
         exc = RuntimeError("custom error")
         request_mock.side_effect = exc
-        self._test_trace_error(StatusCanonicalCode.UNKNOWN, exc)
+        self._test_trace_error(StatusCode.ERROR, exc)
 
     def test_trace_error_not_found(self, request_mock):
         msg = "record not found"
         exc = elasticsearch.exceptions.NotFoundError(404, msg)
         request_mock.return_value = (1, {}, {})
         request_mock.side_effect = exc
-        self._test_trace_error(StatusCanonicalCode.NOT_FOUND, exc)
+        self._test_trace_error(StatusCode.ERROR, exc)
 
     def _test_trace_error(self, code, exc):
         es = Elasticsearch()
@@ -173,7 +173,7 @@ class TestElasticsearchIntegration(TestBase):
         self.assertEqual(1, len(spans))
         span = spans[0]
         self.assertFalse(span.status.is_ok)
-        self.assertEqual(span.status.canonical_code, code)
+        self.assertEqual(span.status.status_code, code)
         self.assertEqual(span.status.description, str(exc))
 
     def test_parent(self, request_mock):


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-elasticsearch`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
