### PR TITLE
Move instrumentation flask

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+## Version 0.15b0
+
+Released 2020-11-02
+
 - Use `url.rule` instead of `request.endpoint` for span name
   ([#1260](https://github.com/open-telemetry/opentelemetry-python/pull/1260))
-- Record span status and http.status_code attribute on exception 
-  ([#1257](https://github.com/open-telemetry/opentelemetry-python/pull/1257))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -40,14 +40,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     flask ~= 1.0
-    opentelemetry-instrumentation-wsgi == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
-    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation-wsgi == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.15b0
 
 [options.extras_require]
 test =
     flask~=1.0
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -118,7 +118,7 @@ def _before_request():
     if span_name is None:
         span_name = otel_wsgi.get_default_span_name(environ)
     token = context.attach(
-        propagators.extract(otel_wsgi.get_header_from_environ, environ)
+        propagators.extract(otel_wsgi.carrier_getter, environ)
     )
 
     tracer = trace.get_tracer(__name__, __version__)

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-flask`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
