### PR TITLE
Move instrumentation opentracing shim

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/setup.cfg
@@ -41,11 +41,11 @@ packages=find_namespace:
 install_requires =
     Deprecated >= 1.2.6
     opentracing ~= 2.0
-    opentelemetry-api == 0.15.dev0
+    opentelemetry-api == 0.15b0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
     opentracing ~= 2.2.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/version.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-opentracing-shim`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
