### PR TITLE
Move instrumentation pymemcache

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     pymemcache ~= 1.3
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
@@ -26,7 +26,6 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.pymemcache import PymemcacheInstrumentor
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import get_tracer
-from opentelemetry.trace.status import StatusCanonicalCode
 
 from .utils import MockSocket, _str
 
@@ -278,7 +277,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["delete key"])
 
@@ -304,7 +303,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["incr key"])
 
@@ -321,7 +320,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["get key"])
 
@@ -338,7 +337,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["get key"])
 
@@ -373,7 +372,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["set key"])
 
@@ -390,7 +389,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["set key"])
 
@@ -407,7 +406,7 @@ class PymemcacheClientTestCase(
 
         span = spans[0]
 
-        self.assertNotEqual(span.status.canonical_code, StatusCanonicalCode.OK)
+        self.assertFalse(span.status.is_ok)
 
         self.check_spans(spans, 1, ["set key has space"])
 


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-pymemcache`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
