### PR TITLE
Move instrumentation pymongo

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     pymongo ~= 3.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -46,7 +46,7 @@ from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.pymongo.version import __version__
 from opentelemetry.trace import SpanKind, get_tracer
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.status import Status, StatusCode
 
 DATABASE_TYPE = "mongodb"
 COMMAND_ATTRIBUTES = ["filter", "sort", "skip", "limit", "pipeline"]
@@ -92,11 +92,8 @@ class CommandTracer(monitoring.CommandListener):
             # Add Span to dictionary
             self._span_dict[_get_span_dict_key(event)] = span
         except Exception as ex:  # noqa pylint: disable=broad-except
-            if span is not None:
-                if span.is_recording():
-                    span.set_status(
-                        Status(StatusCanonicalCode.INTERNAL, str(ex))
-                    )
+            if span is not None and span.is_recording():
+                span.set_status(Status(StatusCode.ERROR, str(ex)))
                 span.end()
                 self._pop_span(event)
 
@@ -111,7 +108,6 @@ class CommandTracer(monitoring.CommandListener):
             span.set_attribute(
                 "db.mongo.duration_micros", event.duration_micros
             )
-            span.set_status(Status(StatusCanonicalCode.OK, event.reply))
         span.end()
 
     def failed(self, event: monitoring.CommandFailedEvent):
@@ -125,7 +121,7 @@ class CommandTracer(monitoring.CommandListener):
             span.set_attribute(
                 "db.mongo.duration_micros", event.duration_micros
             )
-            span.set_status(Status(StatusCanonicalCode.UNKNOWN, event.failure))
+            span.set_status(Status(StatusCode.ERROR, event.failure))
         span.end()
 
     def _pop_span(self, event):

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -86,9 +86,8 @@ class TestPymongo(TestBase):
             span.attributes["db.mongo.duration_micros"], "duration_micros"
         )
         self.assertIs(
-            span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
+            span.status.status_code, trace_api.status.StatusCode.UNSET
         )
-        self.assertEqual(span.status.description, "reply")
         self.assertIsNotNone(span.end_time)
 
     def test_not_recording(self):
@@ -121,8 +120,7 @@ class TestPymongo(TestBase):
             span.attributes["db.mongo.duration_micros"], "duration_micros"
         )
         self.assertIs(
-            span.status.canonical_code,
-            trace_api.status.StatusCanonicalCode.UNKNOWN,
+            span.status.status_code, trace_api.status.StatusCode.ERROR,
         )
         self.assertEqual(span.status.description, "failure")
         self.assertIsNotNone(span.end_time)
@@ -143,15 +141,13 @@ class TestPymongo(TestBase):
 
         self.assertEqual(first_span.attributes["db.mongo.request_id"], "first")
         self.assertIs(
-            first_span.status.canonical_code,
-            trace_api.status.StatusCanonicalCode.OK,
+            first_span.status.status_code, trace_api.status.StatusCode.UNSET,
         )
         self.assertEqual(
             second_span.attributes["db.mongo.request_id"], "second"
         )
         self.assertIs(
-            second_span.status.canonical_code,
-            trace_api.status.StatusCanonicalCode.UNKNOWN,
+            second_span.status.status_code, trace_api.status.StatusCode.ERROR,
         )
 
     def test_int_command(self):


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-pymongo`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
