### PR TITLE
Move instrumentation redis

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-redis/README.rst
@@ -19,5 +19,5 @@ Installation
 References
 ----------
 
-* `OpenTelemetry Redis Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/ext/opentelemetry-instrumentation-redis/opentelemetry-instrumentation-redis.html>`_
+* `OpenTelemetry Redis Instrumentation <https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/opentelemetry-instrumentation-redis/opentelemetry-instrumentation-redis.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     redis >= 2.6
     wrapt >= 1.12.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
-    opentelemetry-sdk == 0.15.dev0
+    opentelemetry-test == 0.15b0
+    opentelemetry-sdk == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-redis`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
