### PR TITLE
Move instrumentation requests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## Version 0.15b0
+
+Released 2020-11-02
+
+- Add support for tracking http metrics
+  ([#1230](https://github.com/open-telemetry/opentelemetry-python/pull/1230))
+
 ## Version 0.13b0
 
 Released 2020-09-17
@@ -10,7 +17,7 @@ Released 2020-09-17
   ([#1040](https://github.com/open-telemetry/opentelemetry-python/pull/1040))
 - Drop support for Python 3.4
   ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
-- Add support for tracking http metrics
+- Add support for http metrics
   ([#1116](https://github.com/open-telemetry/opentelemetry-python/pull/1116))
 
 ## Version 0.12b0

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     requests ~= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
     httpretty ~= 1.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk import resources
 from opentelemetry.sdk.util import get_dict_as_key
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.trace.status import StatusCode
 
 
 class RequestsIntegrationTestBase(abc.ABC):
@@ -81,9 +81,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             },
         )
 
-        self.assertIs(
-            span.status.canonical_code, trace.status.StatusCanonicalCode.OK
-        )
+        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
 
         self.check_span_instrumentation_info(
             span, opentelemetry.instrumentation.requests
@@ -123,8 +121,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
 
         self.assertIs(
-            span.status.canonical_code,
-            trace.status.StatusCanonicalCode.NOT_FOUND,
+            span.status.status_code, trace.status.StatusCode.ERROR,
         )
 
     def test_uninstrument(self):
@@ -263,9 +260,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             span.attributes,
             {"component": "http", "http.method": "GET", "http.url": self.URL},
         )
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.UNKNOWN
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
         self.assertIsNotNone(RequestsInstrumentor().meter)
         self.assertEqual(len(RequestsInstrumentor().meter.metrics), 1)
@@ -307,9 +302,7 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.status_text": "Internal Server Error",
             },
         )
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.INTERNAL
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
         self.assertIsNotNone(RequestsInstrumentor().meter)
         self.assertEqual(len(RequestsInstrumentor().meter.metrics), 1)
         recorder = RequestsInstrumentor().meter.metrics.pop()
@@ -334,9 +327,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.perform_request(self.URL)
 
         span = self.assert_span()
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.UNKNOWN
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
     @mock.patch(
         "requests.adapters.HTTPAdapter.send", side_effect=requests.Timeout
@@ -346,9 +337,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.perform_request(self.URL)
 
         span = self.assert_span()
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.DEADLINE_EXCEEDED
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
 
 class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
@@ -371,9 +360,7 @@ class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
             span.attributes,
             {"component": "http", "http.method": "POST", "http.url": url},
         )
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.INVALID_ARGUMENT
-        )
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
     def test_if_headers_equals_none(self):
         result = requests.get(self.URL, headers=None)


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-requests`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
