### PR TITLE
Move instrumentation sqlalchemy

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires = 
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.15b0
     wrapt >= 1.11.2
     sqlalchemy
 
 [options.extras_require]
 test =
-    opentelemetry-sdk == 0.15.dev0
+    opentelemetry-sdk == 0.15b0
     pytest
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -16,7 +16,7 @@ from sqlalchemy.event import listen
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.sqlalchemy.version import __version__
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.status import Status, StatusCode
 
 # Network attribute semantic convention here:
 # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
@@ -112,10 +112,7 @@ class EngineTracer:
         try:
             if self.current_span.is_recording():
                 self.current_span.set_status(
-                    Status(
-                        StatusCanonicalCode.UNKNOWN,
-                        str(context.original_exception),
-                    )
+                    Status(StatusCode.ERROR, str(context.original_exception),)
                 )
         finally:
             self.current_span.end()

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-sqlalchemy`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
