### PR TITLE
Move instrumentation starlette

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-instrumentation-asgi == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation-asgi == 0.15b0
 
 [options.entry_points]
 opentelemetry_instrumentor =
@@ -47,7 +47,7 @@ opentelemetry_instrumentor =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
     starlette ~= 0.13.0
     requests ~= 2.23.0 # needed for testclient
 

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-starlette`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
