### PR TITLE
Move instrumentation tornado

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     tornado >= 6.0
-    opentelemetry-instrumentation == 0.15.dev0
-    opentelemetry-api == 0.15.dev0
+    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.15b0
 
 [options.extras_require]
 test =
     tornado >= 6.0
-    opentelemetry-test == 0.15.dev0
+    opentelemetry-test == 0.15b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
@@ -3,7 +3,7 @@ import functools
 from tornado.httpclient import HTTPError, HTTPRequest
 
 from opentelemetry import propagators, trace
-from opentelemetry.instrumentation.utils import http_status_to_canonical_code
+from opentelemetry.instrumentation.utils import http_status_to_status_code
 from opentelemetry.trace.status import Status
 from opentelemetry.util import time_ns
 
@@ -74,7 +74,7 @@ def _finish_tracing_callback(future, span):
         span.set_attribute("http.status_code", status_code)
         span.set_status(
             Status(
-                canonical_code=http_status_to_canonical_code(status_code),
+                status_code=http_status_to_status_code(status_code),
                 description=description,
             )
         )

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `instrumentation/opentelemetry-instrumentation-tornado`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
