### PR TITLE
Move exporter datadog

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 0.15b0
+
+Released 2020-11-02
+
  - Make `SpanProcessor.on_start` accept parent Context
   ([#1251](https://github.com/open-telemetry/opentelemetry-python/pull/1251))
 

--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     ddtrace>=0.34.0
-    opentelemetry-api == 0.15.dev0
-    opentelemetry-sdk == 0.15.dev0
+    opentelemetry-api == 0.15b0
+    opentelemetry-sdk == 0.15b0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/exporter.py
@@ -23,7 +23,6 @@ from ddtrace.span import Span as DatadogSpan
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace import sampling
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.trace.status import StatusCanonicalCode
 
 # pylint:disable=relative-beyond-top-level
 from .constants import (
@@ -145,7 +144,7 @@ class DatadogSpanExporter(SpanExporter):
             datadog_span.start_ns = span.start_time
             datadog_span.duration_ns = span.end_time - span.start_time
 
-            if span.status.canonical_code is not StatusCanonicalCode.OK:
+            if not span.status.is_ok:
                 datadog_span.error = 1
                 if span.status.description:
                     exc_type, exc_val = _get_exc_info(span)

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -39,25 +39,23 @@ class DatadogFormat(TextMapPropagator):
 
     def extract(
         self,
-        get_from_carrier: Getter[TextMapPropagatorT],
+        getter: Getter[TextMapPropagatorT],
         carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         trace_id = extract_first_element(
-            get_from_carrier(carrier, self.TRACE_ID_KEY)
+            getter.get(carrier, self.TRACE_ID_KEY)
         )
 
         span_id = extract_first_element(
-            get_from_carrier(carrier, self.PARENT_ID_KEY)
+            getter.get(carrier, self.PARENT_ID_KEY)
         )
 
         sampled = extract_first_element(
-            get_from_carrier(carrier, self.SAMPLING_PRIORITY_KEY)
+            getter.get(carrier, self.SAMPLING_PRIORITY_KEY)
         )
 
-        origin = extract_first_element(
-            get_from_carrier(carrier, self.ORIGIN_KEY)
-        )
+        origin = extract_first_element(getter.get(carrier, self.ORIGIN_KEY))
 
         trace_flags = trace.TraceFlags()
         if sampled and int(sampled) in (

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
@@ -119,7 +119,8 @@ class DatadogExportSpanProcessor(SpanProcessor):
                 with self.condition:
                     self.condition.wait(timeout)
                     if not self.check_traces_queue:
-                        # spurious notification, let's wait again
+                        # spurious notification, let's wait again, reset timeout
+                        timeout = self.schedule_delay_millis / 1e3
                         continue
                     if self.done:
                         # missing spans will be sent when calling flush

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.dev0"
+__version__ = "0.15b0"


### PR DESCRIPTION
# Description

Changes for package `exporter/opentelemetry-exporter-datadog`.

Adds remaining changes needed to get instrumentation packages to tag `v0.15b0` at https://github.com/open-telemetry/opentelemetry-python/commit/725655a20b370c5f2efcab6797dd841bad8e8600 of the Core Repo

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests will be added in a future PR

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
