### PR TITLE
[REQUIRED FIRST] Update Contrib packages to 0.16dev0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
     - 'release/*'
   pull_request:
+env:
+  CORE_REPO_SHA: 47483865854c7adae7455f8441dab7f814f4ce2a
 
 jobs:
   build:
@@ -32,13 +34,13 @@ jobs:
             python-version: py35
             package: instrumentation
     steps:
-      - name: Checkout Contrib Repo at SHA - ${{ github.sha }}
+      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v2
-      - name: Checkout Core Repo @ tag v0.15b0
+      - name: Checkout Core Repo @ SHA - ${{ env.CORE_REPO_SHA }}
         uses: actions/checkout@v2
         with:
           repository: open-telemetry/opentelemetry-python
-          ref: v0.15b0
+          ref: ${{ env.CORE_REPO_SHA }}
           path: opentelemetry-python-core
       - name: Set up Python ${{ env[matrix.python-version] }}
         uses: actions/setup-python@v2
@@ -62,13 +64,13 @@ jobs:
     name: ${{ matrix.tox-environment }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Contrib Repo at SHA - ${{ github.sha }}
+      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v2
-      - name: Checkout Core Repo @ tag v0.15b0
+      - name: Checkout Core Repo @ SHA ${{ env.CORE_REPO_SHA }}
         uses: actions/checkout@v2
         with:
           repository: open-telemetry/opentelemetry-python
-          ref: v0.15b0
+          ref: ${{ env.CORE_REPO_SHA }}
           path: opentelemetry-python-core
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Maintainers ([@open-telemetry/python-maintainers](https://github.com/orgs/open-t
 3. Activate your virtual env. `source my_test_venv/bin/activate`.
 4. Clone the [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) Python Core repo to a folder named `opentelemetry-python-core`. `git clone git@github.com:open-telemetry/opentelemetry-python.git opentelemetry-python-core`.
 5. Change directory to the repo that was just cloned. `cd opentelemetry-python-core`.
-6. Move the head of this repo to the hash you want your tests to use. This is currently the tag `v0.15b0` as seen in `.github/workflows/test.yml`. Use `git fetch --tags && git checkout v0.15b0`.
+6. Move the head of this repo to the hash you want your tests to use. This is currently the SHA `47483865854c7adae7455f8441dab7f814f4ce2a` as seen in `.github/workflows/test.yml`. Use `git fetch && git checkout 47483865854c7adae7455f8441dab7f814f4ce2a`.
 7. Go back to the root directory. `cd ../`.
 8. Make sure you have `tox` installed. `pip install tox`.
 9. Run tests for a package. (e.g. `tox -e test-instrumentation-flask`.)

--- a/_template/setup.cfg
+++ b/_template/setup.cfg
@@ -46,8 +46,7 @@ package_dir=
 packages=find_namespace:
 
 install_requires =
-    # add any package dependencies here
-    "<REPLACE ME>"
+    opentelemetry-api == 0.16.dev0
 
 [options.extras_require]
 test =

--- a/_template/version.py
+++ b/_template/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "<REPLACE ME>"
+__version__ = "0.16.dev0"

--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     ddtrace>=0.34.0
-    opentelemetry-api == 0.15b0
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     aiohttp ~= 3.0
     wrapt >= 1.0.0, < 2.0.0
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-dbapi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-dbapi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     aiopg >= 0.13.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     asgiref ~= 3.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     asyncpg >= 0.12.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/version.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -40,15 +40,15 @@ package_dir=
 packages=find_namespace:
 install_requires =
     boto ~= 2.0
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-instrumentation-botocore == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-instrumentation-botocore == 0.16.dev0
 
 [options.extras_require]
 test =
     boto~=2.0
     moto~=1.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -40,13 +40,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     botocore ~= 1.0
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
 
 [options.extras_require]
 test =
     moto ~= 1.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     celery ~= 4.0
 
 [options.extras_require]
 test =
     pytest
     celery ~= 4.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -40,13 +40,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     django >= 1.10
-    opentelemetry-instrumentation-wsgi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation-wsgi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-api == 0.16.dev0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     wrapt >= 1.0.0, < 2.0.0
     elasticsearch >= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
     elasticsearch-dsl >= 2.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -41,14 +41,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     falcon ~= 2.0
-    opentelemetry-instrumentation-wsgi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation-wsgi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-api == 0.16.dev0
 
 [options.extras_require]
 test =
     falcon ~= 2.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
     parameterized == 0.7.4
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-asgi == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-asgi == 0.16.dev0
 
 [options.entry_points]
 opentelemetry_instrumentor =
@@ -47,7 +47,7 @@ opentelemetry_instrumentor =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
     fastapi ~= 0.58.1
     requests ~= 2.23.0 # needed for testclient
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -40,14 +40,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     flask ~= 1.0
-    opentelemetry-instrumentation-wsgi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation-wsgi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-api == 0.16.dev0
 
 [options.extras_require]
 test =
     flask~=1.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
     grpcio ~= 1.27
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-test == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
     protobuf == 3.12.2
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/version.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -38,14 +38,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     jinja2~=2.7
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-dbapi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-dbapi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     mysql-connector-python ~= 8.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/version.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-dbapi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-dbapi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/version.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     pymemcache ~= 1.3
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     pymongo ~= 3.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-dbapi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-dbapi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     PyMySQL ~=  0.10.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -40,15 +40,15 @@ package_dir=
 packages=find_namespace:
 install_requires =
     pyramid >= 1.7
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-wsgi == 0.15b0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-wsgi == 0.16.dev0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
     werkzeug == 0.16.1
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     redis >= 2.6
     wrapt >= 1.12.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-test == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     requests ~= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
     httpretty ~= 1.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires = 
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     wrapt >= 1.11.2
     sqlalchemy
 
 [options.extras_require]
 test =
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-sdk == 0.16.dev0
     pytest
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-dbapi == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-dbapi == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation-asgi == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation-asgi == 0.16.dev0
 
 [options.entry_points]
 opentelemetry_instrumentor =
@@ -47,7 +47,7 @@ opentelemetry_instrumentor =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
     starlette ~= 0.13.0
     requests ~= 2.23.0 # needed for testclient
 

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-sdk == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
     psutil ~= 5.7.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/version.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     tornado >= 6.0
-    opentelemetry-instrumentation == 0.15b0
-    opentelemetry-api == 0.15b0
+    opentelemetry-instrumentation == 0.16.dev0
+    opentelemetry-api == 0.16.dev0
 
 [options.extras_require]
 test =
     tornado >= 6.0
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"

--- a/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
@@ -39,12 +39,12 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.15b0
-    opentelemetry-instrumentation == 0.15b0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-instrumentation == 0.16.dev0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.15b0
+    opentelemetry-test == 0.16.dev0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15b0"
+__version__ = "0.16.dev0"


### PR DESCRIPTION
# Description

Bump Contrib packages to `0.16dev0` so that when the Core repo pulls this repo, it can run its test against its currently developing Core version `0.16dev0`.

See my [example PR here](https://github.com/NathanielRN/opentelemetry-python/runs/1354579012)