### PR TITLE
Fixes and Improvements to botocore instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -235,6 +235,8 @@ def add_span_arg_tags(span, aws_service, args, args_names, args_traced):
     if not span.is_recording():
         return
 
+    # Do not trace `Key Management Service` or `Secure Token Service` API calls
+    # over concerns of security leaks.
     if aws_service not in {"kms", "sts"}:
         tags = dict(
             (name, value)

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -48,8 +48,8 @@ from boto.connection import AWSAuthConnection, AWSQueryConnection
 from wrapt import wrap_function_wrapper
 
 from opentelemetry.instrumentation.boto.version import __version__
-from opentelemetry.instrumentation.botocore import add_span_arg_tags, unwrap
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.sdk.trace import Resource
 from opentelemetry.trace import SpanKind, get_tracer
 
@@ -201,3 +201,46 @@ class BotoInstrumentor(BaseInstrumentor):
             args,
             kwargs,
         )
+
+
+def add_span_arg_tags(span, endpoint_name, args, args_names, args_traced):
+    def truncate_arg_value(value, max_len=1024):
+        """Truncate values which are bytes and greater than `max_len`.
+        Useful for parameters like "Body" in `put_object` operations.
+        """
+        if isinstance(value, bytes) and len(value) > max_len:
+            return b"..."
+
+        return value
+
+    def flatten_dict(dict_, sep=".", prefix=""):
+        """
+        Returns a normalized dict of depth 1 with keys in order of embedding
+        """
+        # adapted from https://stackoverflow.com/a/19647596
+        return (
+            {
+                prefix + sep + k if prefix else k: v
+                for kk, vv in dict_.items()
+                for k, v in flatten_dict(vv, sep, kk).items()
+            }
+            if isinstance(dict_, dict)
+            else {prefix: dict_}
+        )
+
+    if not span.is_recording():
+        return
+
+    if endpoint_name not in {"kms", "sts"}:
+        tags = dict(
+            (name, value)
+            for (name, value) in zip(args_names, args)
+            if name in args_traced
+        )
+        tags = flatten_dict(tags)
+        for key, value in {
+            k: truncate_arg_value(v)
+            for k, v in tags.items()
+            if k not in {"s3": ["params.Body"]}.get(endpoint_name, [])
+        }.items():
+            span.set_attribute(key, value)

--- a/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
@@ -5,6 +5,8 @@
   ([#181](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/181))
 - Make botocore instrumentation check if instrumentation has been suppressed
   ([#182](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/182))
+- Botocore SpanKind as CLIENT and modify existing traced attributes
+  ([#150])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/150)
 
 ## Version 0.13b0
 


### PR DESCRIPTION
# Description

This PR aims to update the `botocore` instrumentation by doing the following:

Fixes:
- Removed code that modified `span.resource` since resource should be immutable
- Change `SpanKind` from `CONSUMER` to `CLIENT` because `botocore` api calls can be considered _remote outgoing_ and _synchronous requests_ requests as laid out in the [SpanKind specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/06d16d7db88c3e266636f84887de61e3363b5429/specification/trace/api.md#spankind) - Important so that AWS services are treated as separate services in Tracing Backends. (See picture below!)
- Use `instrumentation.utils.unwrap` instead of creating the function again


Simplifications:
- Remove code that searches for nested attributes using `deep_getattr` and instead pulls values from properties of the `botocore.BaseClient` class since they should always be there
- Removed _params_ from attributes. There is [a PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1095/files) to add more specific semantic conventions for which params should be trace in AWS SDKs in the specifications so the plan was to revisit when it gets merged


Improvements:
- More comprehensive logic to parse out `request_id` if it can be found in the headers instead of the usual location. Just like [.NET botocore instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/c8c73749e365f9bcddf9ffb45661f18c2effbee2/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Instrumentation/AWSTracingPipelineHandler.cs#L240-L267)
- Add `aws.table_name` and `aws.queue_url` for DynamoDB and SQS specifically as traced properties (this will be added in the specifications)
- Format tests checking of attributes to look nice!

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - Not all params are recorded now
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] With the change to `SpanKind.CLIENT`, S3 (and other services) are considered their own services

Before:
![image](https://user-images.githubusercontent.com/23139455/97763226-3fbc0480-1ac8-11eb-93a8-00b9c2871fed.png)


After:
![image](https://user-images.githubusercontent.com/23139455/97763170-0f746600-1ac8-11eb-8d87-ddfd284c46a1.png)


# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
