### PR TITLE
DBAPI: Add param to control capturing of db.statement.parameters

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
@@ -199,7 +199,11 @@ class TestAiopgIntegration(TestBase):
             "user": "user",
         }
         db_integration = AiopgIntegration(
-            self.tracer, "testcomponent", "testtype", connection_attributes
+            self.tracer,
+            "testcomponent",
+            "testtype",
+            connection_attributes,
+            capture_parameters=True,
         )
         mock_connection = async_call(
             db_integration.wrapped_connection(

--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Stop capturing query parameters by default
-  ([#????](https://github.com/open-telemetry/opentelemetry-python/pull/???))
+  ([#156](https://github.com/open-telemetry/opentelemetry-python/pull/156))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Stop capturing query parameters by default
+  ([#????](https://github.com/open-telemetry/opentelemetry-python/pull/???))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Stop capturing query parameters by default
-  ([#156](https://github.com/open-telemetry/opentelemetry-python/pull/156))
+  ([#156](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/156))
 
 ## Version 0.13b0
 
@@ -19,7 +19,7 @@ Released 2020-09-17
 Released 2020-08-14
 
 - Change package name to opentelemetry-instrumentation-dbapi
-  ([#156](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/156))
+  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
 
 ## 0.7b1
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -19,7 +19,7 @@ Released 2020-09-17
 Released 2020-08-14
 
 - Change package name to opentelemetry-instrumentation-dbapi
-  ([#966](https://github.com/open-telemetry/opentelemetry-python/pull/966))
+  ([#156](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/156))
 
 ## 0.7b1
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -62,6 +62,7 @@ def trace_integration(
     database_type: str = "",
     connection_attributes: typing.Dict = None,
     tracer_provider: typing.Optional[TracerProvider] = None,
+    capture_parameters: bool = False,
 ):
     """Integrate with DB API library.
         https://www.python.org/dev/peps/pep-0249/
@@ -76,6 +77,7 @@ def trace_integration(
                 user in Connection object.
             tracer_provider: The :class:`opentelemetry.trace.TracerProvider` to
                 use. If ommited the current configured one is used.
+            capture_parameters: Configure if db.statement.parameters should be captured.
     """
     wrap_connect(
         __name__,
@@ -86,6 +88,7 @@ def trace_integration(
         connection_attributes,
         version=__version__,
         tracer_provider=tracer_provider,
+        capture_parameters=capture_parameters,
     )
 
 
@@ -98,6 +101,7 @@ def wrap_connect(
     connection_attributes: typing.Dict = None,
     version: str = "",
     tracer_provider: typing.Optional[TracerProvider] = None,
+    capture_parameters: bool = False,
 ):
     """Integrate with DB API library.
         https://www.python.org/dev/peps/pep-0249/
@@ -111,6 +115,8 @@ def wrap_connect(
             database_type: The Database type. For any SQL database, "sql".
             connection_attributes: Attribute names for database, port, host and
                 user in Connection object.
+            capture_parameters: Configure if db.statement.parameters should be captured.
+
     """
 
     # pylint: disable=unused-argument
@@ -127,6 +133,7 @@ def wrap_connect(
             connection_attributes=connection_attributes,
             version=version,
             tracer_provider=tracer_provider,
+            capture_parameters=capture_parameters,
         )
         return db_integration.wrapped_connection(wrapped, args, kwargs)
 
@@ -159,6 +166,7 @@ def instrument_connection(
     connection_attributes: typing.Dict = None,
     version: str = "",
     tracer_provider: typing.Optional[TracerProvider] = None,
+    capture_parameters=False,
 ):
     """Enable instrumentation in a database connection.
 
@@ -170,7 +178,7 @@ def instrument_connection(
         database_type: The Database type. For any SQL database, "sql".
         connection_attributes: Attribute names for database, port, host and
             user in a connection object.
-
+        capture_parameters: Configure if db.statement.parameters should be captured.
     Returns:
         An instrumented connection.
     """
@@ -181,6 +189,7 @@ def instrument_connection(
         connection_attributes=connection_attributes,
         version=version,
         tracer_provider=tracer_provider,
+        capture_parameters=capture_parameters,
     )
     db_integration.get_connection_attributes(connection)
     return get_traced_connection_proxy(connection, db_integration)
@@ -211,6 +220,7 @@ class DatabaseApiIntegration:
         connection_attributes=None,
         version: str = "",
         tracer_provider: typing.Optional[TracerProvider] = None,
+        capture_parameters: bool = False,
     ):
         self.connection_attributes = connection_attributes
         if self.connection_attributes is None:
@@ -223,6 +233,7 @@ class DatabaseApiIntegration:
         self._name = name
         self._version = version
         self._tracer_provider = tracer_provider
+        self.capture_parameters = capture_parameters
         self.database_component = database_component
         self.database_type = database_type
         self.connection_props = {}
@@ -327,7 +338,7 @@ class TracedCursor:
         ) in self._db_api_integration.span_attributes.items():
             span.set_attribute(attribute_key, attribute_value)
 
-        if len(args) > 1:
+        if self._db_api_integration.capture_parameters and len(args) > 1:
             span.set_attribute("db.statement.parameters", str(args[1]))
 
     def traced_execution(

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -65,7 +65,7 @@ class TestDBApiIntegration(TestBase):
             span.status.status_code, trace_api.status.StatusCode.UNSET,
         )
 
-    def test_span_succeeded_without_capture_of_statement_parameters(self):
+    def test_span_succeeded_with_capture_of_statement_parameters(self):
         connection_props = {
             "database": "testdatabase",
             "server_host": "testhost",

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -57,6 +57,49 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(span.attributes["db.type"], "testtype")
         self.assertEqual(span.attributes["db.instance"], "testdatabase")
         self.assertEqual(span.attributes["db.statement"], "Test query")
+        self.assertFalse("db.statement.parameters" in span.attributes)
+        self.assertEqual(span.attributes["db.user"], "testuser")
+        self.assertEqual(span.attributes["net.peer.name"], "testhost")
+        self.assertEqual(span.attributes["net.peer.port"], 123)
+        self.assertIs(
+            span.status.status_code, trace_api.status.StatusCode.UNSET,
+        )
+
+    def test_span_succeeded_without_capture_of_statement_parameters(self):
+        connection_props = {
+            "database": "testdatabase",
+            "server_host": "testhost",
+            "server_port": 123,
+            "user": "testuser",
+        }
+        connection_attributes = {
+            "database": "database",
+            "port": "server_port",
+            "host": "server_host",
+            "user": "user",
+        }
+        db_integration = dbapi.DatabaseApiIntegration(
+            self.tracer,
+            "testcomponent",
+            "testtype",
+            connection_attributes,
+            capture_parameters=True,
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, connection_props
+        )
+        cursor = mock_connection.cursor()
+        cursor.execute("Test query", ("param1Value", False))
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "testcomponent.testdatabase")
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+
+        self.assertEqual(span.attributes["component"], "testcomponent")
+        self.assertEqual(span.attributes["db.type"], "testtype")
+        self.assertEqual(span.attributes["db.instance"], "testdatabase")
+        self.assertEqual(span.attributes["db.statement"], "Test query")
         self.assertEqual(
             span.attributes["db.statement.parameters"],
             "('param1Value', False)",


### PR DESCRIPTION
# Description

Switched DBAPI so that it will not capture parameterized query parameters.  Capturing this would be a problem in production environments since they will contain sensitive information such as session tokens and hashed passwords.

Have added a parameter to the instrumentation constructor to allow for this feature to be turned on.

I will mark this as a breaking change since I am removing the db.statement.parameter span attribute and something might be depending on it. 

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/157

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests

# Checklist:

- [ x] Followed the style guidelines of this project
- [ x] Changelogs have been updated
- [ x] Unit tests have been added
- [ ] Documentation has been updated

