### PR TITLE
Add propagator injection for botocore calls

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Add propagator injection for botocore calls
+  ([#181](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/181))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -26,7 +26,9 @@ from moto import (  # pylint: disable=import-error
 )
 
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry import propagators
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
 
 
@@ -275,3 +277,56 @@ class TestBotocoreInstrumentor(TestBase):
 
         # checking for protection on sts against security leak
         self.assertTrue("params" not in span.attributes.keys())
+
+    @mock_ec2
+    def test_propagator_injects_into_request(self):
+        headers = {}
+        previous_propagator = propagators.get_global_textmap()
+
+        def check_headers(**kwargs):
+            nonlocal headers
+            headers = kwargs["request"].headers
+
+        try:
+            propagators.set_global_textmap(MockTextMapPropagator())
+
+            ec2 = self.session.create_client("ec2", region_name="us-west-2")
+            ec2.meta.events.register_first(
+                "before-send.ec2.DescribeInstances", check_headers
+            )
+            ec2.describe_instances()
+
+            spans = self.memory_exporter.get_finished_spans()
+            assert spans
+            span = spans[0]
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(span.attributes["aws.agent"], "botocore")
+            self.assertEqual(span.attributes["aws.region"], "us-west-2")
+            self.assertEqual(
+                span.attributes["aws.operation"], "DescribeInstances"
+            )
+            assert_span_http_status_code(span, 200)
+            self.assertEqual(
+                span.resource,
+                Resource(
+                    attributes={
+                        "endpoint": "ec2",
+                        "operation": "describeinstances",
+                    }
+                ),
+            )
+            self.assertEqual(span.name, "ec2.command")
+
+            self.assertIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().trace_id),
+                headers[MockTextMapPropagator.TRACE_ID_KEY],
+            )
+            self.assertIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().span_id),
+                headers[MockTextMapPropagator.SPAN_ID_KEY],
+            )
+
+        finally:
+            propagators.set_global_textmap(previous_propagator)

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -25,8 +25,8 @@ from moto import (  # pylint: disable=import-error
     mock_sqs,
 )
 
-from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
 from opentelemetry import propagators
+from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase


### PR DESCRIPTION
# Description

Calls using the `botocore` SDK now use the global propagator to inject context into the request headers before they are sent to AWS.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test to verify a function which wraps `Endpoint.prepare_request` gets called and inserts a value using the global propagator

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
