### PR TITLE
Make botocore instrumentation check if instrumentation has been suppressed

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Add propagator injection for botocore calls
   ([#181](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/181))
+- Make botocore instrumentation check if instrumentation has been suppressed
+  ([#182](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/182))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -56,6 +56,7 @@ import logging
 from botocore.client import BaseClient
 from wrapt import ObjectProxy, wrap_function_wrapper
 
+from opentelemetry import context as context_api
 from opentelemetry import propagators
 from opentelemetry.instrumentation.botocore.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -104,6 +105,8 @@ class BotocoreInstrumentor(BaseInstrumentor):
         unwrap(BaseClient, "_make_api_call")
 
     def _patched_api_call(self, original_func, instance, args, kwargs):
+        if context_api.get_value("suppress_instrumentation"):
+            return original_func(*args, **kwargs)
 
         endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
 


### PR DESCRIPTION
# Description

Follow up to the PR originally submitted by @wangzlei that was on the Core repo: https://github.com/open-telemetry/opentelemetry-python/pull/1291

By checking if instrumentation has been suppressed, we avoid double instrumentation if a call is already being traced from some other package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test which checks that the flag is used to stop further instrumentation.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
