### PR TITLE
TypeError: Can't instantiate abstract class TracerProvider with abstract methods get_tracer

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
@@ -23,7 +23,7 @@ Usage
 
     from opentelemetry import trace
     from opentelemetry.instrumentation.aiopg import trace_integration
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
 
     trace.set_tracer_provider(TracerProvider())
 

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
@@ -23,9 +23,6 @@ Usage
 
     from opentelemetry import trace
     from opentelemetry.instrumentation.aiopg import trace_integration
-    from opentelemetry.sdk.trace import TracerProvider
-
-    trace.set_tracer_provider(TracerProvider())
 
     trace_integration(aiopg.connection, "_connect", "postgresql", "sql")
 

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -26,15 +26,12 @@ Usage
 
 .. code:: python
 
-    from opentelemetry import trace
     from opentelemetry.instrumentation.boto import BotoInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
     import boto
 
-    trace.set_tracer_provider(TracerProvider())
 
     # Instrument Boto
-    BotoInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+    BotoInstrumentor().instrument()
 
     # This will create a span with Boto-specific attributes
     ec2 = boto.ec2.connect_to_region("us-west-2")

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -27,17 +27,12 @@ Usage
 
 .. code:: python
 
-    from opentelemetry import trace
     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
     import botocore
 
-    trace.set_tracer_provider(TracerProvider())
 
     # Instrument Botocore
-    BotocoreInstrumentor().instrument(
-        tracer_provider=trace.get_tracer_provider()
-    )
+    BotocoreInstrumentor().instrument()
 
     # This will create a span with Botocore-specific attributes
     session = botocore.session.get_session()

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -30,9 +30,6 @@ Usage
 
 .. code:: python
 
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
     from opentelemetry.instrumentation.celery import CeleryInstrumentor
 
     from celery import Celery
@@ -40,9 +37,6 @@ Usage
 
     @worker_process_init.connect(weak=False)
     def init_celery_tracing(*args, **kwargs):
-        trace.set_tracer_provider(TracerProvider())
-        span_processor = BatchExportSpanProcessor(ConsoleSpanExporter())
-        trace.get_tracer_provider().add_span_processor(span_processor)
         CeleryInstrumentor().instrument()
 
     app = Celery("tasks", broker="amqp://localhost")

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -25,11 +25,8 @@ Usage
     import mysql.connector
     import pyodbc
 
-    from opentelemetry import trace
     from opentelemetry.instrumentation.dbapi import trace_integration
-    from opentelemetry.sdk.trace import TracerProvider
 
-    trace.set_tracer_provider(TracerProvider())
 
     # Ex: mysql.connector
     trace_integration(mysql.connector, "connect", "mysql", "sql")

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -27,7 +27,7 @@ Usage
 
     from opentelemetry import trace
     from opentelemetry.instrumentation.dbapi import trace_integration
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
 
     trace.set_tracer_provider(TracerProvider())
 

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -85,8 +85,7 @@ class ElasticsearchInstrumentor(BaseInstrumentor):
     def __init__(self, span_name_prefix=None):
         if not span_name_prefix:
             span_name_prefix = environ.get(
-                "OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX",
-                "Elasticsearch",
+                "OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX", "Elasticsearch",
             )
         self._span_name_prefix = span_name_prefix.strip()
         super().__init__()
@@ -125,8 +124,7 @@ def _wrap_perform_request(tracer, span_name_prefix):
         body = kwargs.get("body", None)
 
         with tracer.start_as_current_span(
-            op_name,
-            kind=SpanKind.CLIENT,
+            op_name, kind=SpanKind.CLIENT,
         ) as span:
             if span.is_recording():
                 attributes = {

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -21,15 +21,12 @@ Usage
 
 .. code-block:: python
 
-    from opentelemetry import trace
-    from opentelemetry.instrumentation.elasticsearch import ElasticsearchInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.instrumentation.elasticsearch import ElasticSearchInstrumentor
     import elasticsearch
 
-    trace.set_tracer_provider(TracerProvider())
 
     # instrument elasticsearch
-    ElasticsearchInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+    ElasticSearchInstrumentor().instrument()
 
     # Using elasticsearch as normal now will automatically generate spans
     es = elasticsearch.Elasticsearch()
@@ -88,7 +85,8 @@ class ElasticsearchInstrumentor(BaseInstrumentor):
     def __init__(self, span_name_prefix=None):
         if not span_name_prefix:
             span_name_prefix = environ.get(
-                "OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX", "Elasticsearch",
+                "OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX",
+                "Elasticsearch",
             )
         self._span_name_prefix = span_name_prefix.strip()
         super().__init__()
@@ -127,7 +125,8 @@ def _wrap_perform_request(tracer, span_name_prefix):
         body = kwargs.get("body", None)
 
         with tracer.start_as_current_span(
-            op_name, kind=SpanKind.CLIENT,
+            op_name,
+            kind=SpanKind.CLIENT,
         ) as span:
             if span.is_recording():
                 attributes = {

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -21,12 +21,12 @@ Usage
 
 .. code-block:: python
 
-    from opentelemetry.instrumentation.elasticsearch import ElasticSearchInstrumentor
+    from opentelemetry.instrumentation.elasticsearch import ElasticsearchInstrumentor
     import elasticsearch
 
 
     # instrument elasticsearch
-    ElasticSearchInstrumentor().instrument()
+    ElasticsearchInstrumentor().instrument()
 
     # Using elasticsearch as normal now will automatically generate spans
     es = elasticsearch.Elasticsearch()
@@ -43,7 +43,7 @@ environment variable or by passing the prefix as an argument to the instrumentor
 
 .. code-block:: python
 
-    ElasticSearchInstrumentor("my-custom-prefix").instrument()
+    ElasticsearchInstrumentor("my-custom-prefix").instrument()
 """
 
 import functools

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
@@ -28,7 +28,7 @@ Usage
     from jinja2 import Environment, FileSystemLoader
     from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
     from opentelemetry import trace
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
 
     trace.set_tracer_provider(TracerProvider())
 

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
@@ -27,10 +27,7 @@ Usage
 
     from jinja2 import Environment, FileSystemLoader
     from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
 
-    trace.set_tracer_provider(TracerProvider())
 
     Jinja2Instrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -25,7 +25,7 @@ Usage
 
     import mysql.connector
     from opentelemetry import trace
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.mysql import MySQLInstrumentor
 
     trace.set_tracer_provider(TracerProvider())

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -24,11 +24,7 @@ Usage
 .. code:: python
 
     import mysql.connector
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.mysql import MySQLInstrumentor
-
-    trace.set_tracer_provider(TracerProvider())
 
     MySQLInstrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -24,11 +24,8 @@ Usage
 .. code-block:: python
 
     import psycopg2
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 
-    trace.set_tracer_provider(TracerProvider())
 
     Psycopg2Instrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
@@ -24,11 +24,10 @@ Usage
 
 .. code-block:: python
 
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.pymemcache import PymemcacheInstrumentor
-    trace.set_tracer_provider(TracerProvider())
+
     PymemcacheInstrumentor().instrument()
+
     from pymemcache.client.base import Client
     client = Client(('localhost', 11211))
     client.set('some_key', 'some_value')

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -25,7 +25,7 @@ Usage
 
     from pymongo import MongoClient
     from opentelemetry import trace
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
 
     trace.set_tracer_provider(TracerProvider())

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -24,11 +24,8 @@ Usage
 .. code:: python
 
     from pymongo import MongoClient
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
 
-    trace.set_tracer_provider(TracerProvider())
 
     PymongoInstrumentor().instrument()
     client = MongoClient()

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -24,11 +24,8 @@ Usage
 .. code:: python
 
     import pymysql
-    from opentelemetry import trace
     from opentelemetry.instrumentation.pymysql import PyMySQLInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
 
-    trace.set_tracer_provider(TracerProvider())
 
     PyMySQLInstrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -27,15 +27,12 @@ Usage
 
 .. code:: python
 
-    from opentelemetry import trace
     from opentelemetry.instrumentation.redis import RedisInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
     import redis
 
-    trace.set_tracer_provider(TracerProvider())
 
     # Instrument redis
-    RedisInstrumentor().instrument(tracer_provider=trace.get_tracer_provider())
+    RedisInstrumentor().instrument()
 
     # This will report a span with the default settings
     client = redis.StrictRedis(host="localhost", port=6379)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -28,12 +28,9 @@ Usage
 
     from sqlalchemy import create_engine
 
-    from opentelemetry import trace
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
-    from opentelemetry.sdk.trace import TracerProvider
     import sqlalchemy
 
-    trace.set_tracer_provider(TracerProvider())
     engine = create_engine("sqlite:///:memory:")
     SQLAlchemyInstrumentor().instrument(
         engine=engine,

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -25,7 +25,7 @@ Usage
 
     import sqlite3
     from opentelemetry import trace
-    from opentelemetry.trace import TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
     trace.set_tracer_provider(TracerProvider())

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -24,11 +24,8 @@ Usage
 .. code:: python
 
     import sqlite3
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
-    trace.set_tracer_provider(TracerProvider())
 
     SQLite3Instrumentor().instrument()
 


### PR DESCRIPTION
Re-opened PR from main repo #[1313](https://github.com/open-telemetry/opentelemetry-python/pull/1313)