### PR TITLE
Add Prometheus Remote Write Exporter (4/6)

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/CHANGELOG.md
@@ -7,3 +7,5 @@
   ((#206)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/206])
 - Add conversion to TimeSeries methods
   ((#207)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/207])
+- Add request methods
+  ((#212)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/212])

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
@@ -39,6 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
+    protobuf >= 3.13.0
+    requests == 2.25.0
     opentelemetry-api == 0.17.dev0
     opentelemetry-sdk == 0.17.dev0
 

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/version.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.16.dev0"
+__version__ = "0.17.dev0"


### PR DESCRIPTION
# Description
This is PR 3/6 of adding a Prometheus Remote Write Exporter in Python SDK and address Issue https://github.com/open-telemetry/opentelemetry-python/issues/1302

**[Part 1/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/180)**
* Adds class skeleton
* Adds all function signatures


**[Part 2/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/206)**
* Adds validation of exporter constructor commands
* Add unit tests for validation

**[Part 3/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/207)**
* Adds conversion methods from OTel metric types to Prometheus [TimeSeries](https://github.com/prometheus/prometheus/blob/master/prompb/types.proto#L47)
* Add unit tests for conversion


👉 **[Part 4/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/212)**
* Adds methods to export metrics to Remote Write endpoint
* Add unit tests for exporting

**[Part 5/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/216)**
* Add integration tests using sample app and instance of Cortex

**Part 6/6**
* Add README, Design Doc and other necessary documentation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- [ ] Added class `TestValidation` in `test_prometheus_remote_write_exporter.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
cc- @AzfaarQureshi , @alolita 