### PR TITLE
Add test to validate propagator fields method

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/propagation/test_aws_xray_format.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/propagation/test_aws_xray_format.py
@@ -153,6 +153,21 @@ class AwsXRayPropagatorTest(unittest.TestCase):
 
         self.assertEqual(injected_items, expected_items)
 
+    def test_inject_reported_fields_matches_carrier_fields(self):
+        carrier = CaseInsensitiveDict()
+
+        AwsXRayPropagatorTest.XRAY_PROPAGATOR.inject(
+            AwsXRayPropagatorTest.carrier_setter,
+            carrier,
+            build_test_current_context(),
+        )
+
+        injected_keys = set(carrier.keys())
+
+        self.assertEqual(
+            injected_keys, AwsXRayPropagatorTest.XRAY_PROPAGATOR.fields()
+        )
+
     # Extract Tests
 
     def test_extract_empty_carrier_from_invalid_context(self):


### PR DESCRIPTION
# Description

Follow up to #226, where a `fields()` method was added, this test validates that the the keys set by the `inject` method match the values returned by this `fields()` method.

## Type of change

Testing

# How Has This Been Tested?

- [x] Added unit test to validate new `fields()` method

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [] Changelogs have been updated~
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
