### PR TITLE
Add more tests, fix compliance to semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#237](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/237))
 - Add Prometheus Remote Write Exporter integration tests in opentelemetry-docker-tests
   ([#216](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/216))
+- `opentelemetry-instrumentation-grpc` Add tests for grpc span attributes, grpc `abort()` conditions
+  ([#236](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/236))
 
 ### Changed
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-wsgi` Return `None` for `CarrierGetter` if key not found
   ([#1374](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/233))
+- `opentelemetry-instrumentation-grpc` Comply with updated spec, rework tests
+  ([#236](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/236))
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.16b1) - 2020-11-26
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -113,7 +113,7 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
     def abort(self, code, details):
         self.code = code
         self.details = details
-        self._active_span.set_attribute("rpc.grpc.status_code", code.name)
+        self._active_span.set_attribute("rpc.grpc.status_code", code.value[0])
         self._active_span.set_status(
             Status(status_code=StatusCode.ERROR, description=details)
         )
@@ -126,17 +126,19 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.code = code
         # use details if we already have it, otherwise the status description
         details = self.details or code.value[1]
-        self._active_span.set_attribute("rpc.grpc.status_code", code.name)
-        self._active_span.set_status(
-            Status(status_code=StatusCode.ERROR, description=details)
-        )
+        self._active_span.set_attribute("rpc.grpc.status_code", code.value[0])
+        if code != grpc.StatusCode.OK:
+            self._active_span.set_status(
+                Status(status_code=StatusCode.ERROR, description=details)
+            )
         return self._servicer_context.set_code(code)
 
     def set_details(self, details):
         self.details = details
-        self._active_span.set_status(
-            Status(status_code=StatusCode.ERROR, description=details)
-        )
+        if self.code != grpc.StatusCode.OK:
+            self._active_span.set_status(
+                Status(status_code=StatusCode.ERROR, description=details)
+            )
         return self._servicer_context.set_details(details)
 
 
@@ -181,10 +183,15 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
     def _start_span(self, handler_call_details, context):
 
+        # split the handler method into service and method
+        service, method = handler_call_details.method.lstrip('/').split('/', 1)
+
+        # standard attributes
         attributes = {
-            "rpc.method": handler_call_details.method,
+            "rpc.method": method,
+            "rpc.service": service,
             "rpc.system": "grpc",
-            "rpc.grpc.status_code": grpc.StatusCode.OK,
+            "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
         }
 
         metadata = dict(context.invocation_metadata())

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -191,11 +191,12 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
         # if we have details about the call, split into service and method
         if handler_call_details.method:
-            service, method = handler_call_details.method.lstrip('/').split('/', 1)
-            attributes.update({
-                "rpc.method": method,
-                "rpc.service": service,
-            })
+            service, method = handler_call_details.method.lstrip("/").split(
+                "/", 1
+            )
+            attributes.update(
+                {"rpc.method": method, "rpc.service": service}
+            )
 
         # add some attributes from the metadata
         metadata = dict(context.invocation_metadata())

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -194,9 +194,7 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
             service, method = handler_call_details.method.lstrip("/").split(
                 "/", 1
             )
-            attributes.update(
-                {"rpc.method": method, "rpc.service": service}
-            )
+            attributes.update({"rpc.method": method, "rpc.service": service})
 
         # add some attributes from the metadata
         metadata = dict(context.invocation_metadata())

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -115,7 +115,10 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.details = details
         self._active_span.set_attribute("rpc.grpc.status_code", code.value[0])
         self._active_span.set_status(
-            Status(status_code=StatusCode.ERROR, description=details)
+            Status(
+                status_code=StatusCode.ERROR,
+                description="{}:{}".format(code, details),
+            )
         )
         return self._servicer_context.abort(code, details)
 
@@ -129,7 +132,10 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self._active_span.set_attribute("rpc.grpc.status_code", code.value[0])
         if code != grpc.StatusCode.OK:
             self._active_span.set_status(
-                Status(status_code=StatusCode.ERROR, description=details)
+                Status(
+                    status_code=StatusCode.ERROR,
+                    description="{}:{}".format(code, details),
+                )
             )
         return self._servicer_context.set_code(code)
 
@@ -137,7 +143,10 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.details = details
         if self.code != grpc.StatusCode.OK:
             self._active_span.set_status(
-                Status(status_code=StatusCode.ERROR, description=details)
+                Status(
+                    status_code=StatusCode.ERROR,
+                    description="{}:{}".format(self.code, details),
+                )
             )
         return self._servicer_context.set_details(details)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -183,16 +183,20 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
     def _start_span(self, handler_call_details, context):
 
-        # split the handler method into service and method
-        service, method = handler_call_details.method.lstrip('/').split('/', 1)
-
         # standard attributes
         attributes = {
-            "rpc.method": method,
-            "rpc.service": service,
             "rpc.system": "grpc",
             "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
         }
+
+        # if we have details about the call, split into service and method
+        if handler_call_details.method:
+            service, method = handler_call_details.method.lstrip('/').split('/', 1)
+            attributes.update({
+                "rpc.method": method,
+                "rpc.service": service,
+            })
+
 
         metadata = dict(context.invocation_metadata())
         if "user-agent" in metadata:

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -22,13 +22,13 @@ import grpc
 
 import opentelemetry.instrumentation.grpc
 from opentelemetry import trace
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.instrumentation.grpc import (
     GrpcInstrumentorServer,
     server_interceptor,
 )
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.status import StatusCode
 
 
 class UnaryUnaryMethodHandler(grpc.RpcMethodHandler):

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -385,7 +385,12 @@ class TestOpenTelemetryServerInterceptor(TestBase):
 
         # make sure this span errored, with the right status and detail
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
-        self.assertEqual(span.status.description, failure_message)
+        self.assertEqual(
+            span.status.description,
+            "{}:{}".format(
+                grpc.StatusCode.FAILED_PRECONDITION, failure_message
+            ),
+        )
 
         # Check attributes
         self.assert_span_has_attributes(

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -87,14 +87,17 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         )
 
         # Check attributes
-        self.assert_span_has_attributes(span, {
-            'net.peer.ip': '[::1]',
-            'net.peer.name': 'localhost',
-            'rpc.method': 'handler',
-            'rpc.service': 'TestServicer',
-            'rpc.system': 'grpc',
-            'rpc.grpc.status_code': grpc.StatusCode.OK.value[0],
-        })
+        self.assert_span_has_attributes(
+            span,
+            {
+                "net.peer.ip": "[::1]",
+                "net.peer.name": "localhost",
+                "rpc.method": "handler",
+                "rpc.service": "TestServicer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
+        )
 
         grpc_server_instrumentor.uninstrument()
 
@@ -166,14 +169,17 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         )
 
         # Check attributes
-        self.assert_span_has_attributes(span, {
-            'net.peer.ip': '[::1]',
-            'net.peer.name': 'localhost',
-            'rpc.method': 'handler',
-            'rpc.service': 'TestServicer',
-            'rpc.system': 'grpc',
-            'rpc.grpc.status_code': grpc.StatusCode.OK.value[0],
-        })
+        self.assert_span_has_attributes(
+            span,
+            {
+                "net.peer.ip": "[::1]",
+                "net.peer.name": "localhost",
+                "rpc.method": "handler",
+                "rpc.service": "TestServicer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
+        )
 
     def test_span_lifetime(self):
         """Check that the span is active for the duration of the call."""
@@ -252,14 +258,17 @@ class TestOpenTelemetryServerInterceptor(TestBase):
             self.assertIsNone(span2.parent)
 
             # check attributes
-            self.assert_span_has_attributes(span, {
-                'net.peer.ip': '[::1]',
-                'net.peer.name': 'localhost',
-                'rpc.method': 'handler',
-                'rpc.service': 'TestServicer',
-                'rpc.system': 'grpc',
-                'rpc.grpc.status_code': grpc.StatusCode.OK.value[0],
-            })
+            self.assert_span_has_attributes(
+                span,
+                {
+                    "net.peer.ip": "[::1]",
+                    "net.peer.name": "localhost",
+                    "rpc.method": "handler",
+                    "rpc.service": "TestServicer",
+                    "rpc.system": "grpc",
+                    "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+                },
+            )
 
     def test_concurrent_server_spans(self):
         """Check that concurrent RPC calls don't interfere with each other.
@@ -296,8 +305,12 @@ class TestOpenTelemetryServerInterceptor(TestBase):
             # Interleave calls so spans are active on each thread at the same
             # time
             with futures.ThreadPoolExecutor(max_workers=2) as tpe:
-                f1 = tpe.submit(channel.unary_unary("TestServicer/handler"), b"")
-                f2 = tpe.submit(channel.unary_unary("TestServicer/handler"), b"")
+                f1 = tpe.submit(
+                    channel.unary_unary("TestServicer/handler"), b""
+                )
+                f2 = tpe.submit(
+                    channel.unary_unary("TestServicer/handler"), b""
+                )
             futures.wait((f1, f2))
         finally:
             server.stop(None)
@@ -314,15 +327,17 @@ class TestOpenTelemetryServerInterceptor(TestBase):
             self.assertIsNone(span2.parent)
 
             # check attributes
-            self.assert_span_has_attributes(span, {
-                'net.peer.ip': '[::1]',
-                'net.peer.name': 'localhost',
-                'rpc.method': 'handler',
-                'rpc.service': 'TestServicer',
-                'rpc.system': 'grpc',
-                'rpc.grpc.status_code': grpc.StatusCode.OK.value[0],
-            })
-
+            self.assert_span_has_attributes(
+                span,
+                {
+                    "net.peer.ip": "[::1]",
+                    "net.peer.name": "localhost",
+                    "rpc.method": "handler",
+                    "rpc.service": "TestServicer",
+                    "rpc.system": "grpc",
+                    "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+                },
+            )
 
     def test_abort(self):
         """Check that we can catch an abort properly"""
@@ -373,14 +388,19 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         self.assertEqual(span.status.description, failure_message)
 
         # Check attributes
-        self.assert_span_has_attributes(span, {
-            'net.peer.ip': '[::1]',
-            'net.peer.name': 'localhost',
-            'rpc.method': 'handler',
-            'rpc.service': 'TestServicer',
-            'rpc.system': 'grpc',
-            'rpc.grpc.status_code': grpc.StatusCode.FAILED_PRECONDITION.value[0],
-        })
+        self.assert_span_has_attributes(
+            span,
+            {
+                "net.peer.ip": "[::1]",
+                "net.peer.name": "localhost",
+                "rpc.method": "handler",
+                "rpc.service": "TestServicer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.FAILED_PRECONDITION.value[
+                    0
+                ],
+            },
+        )
 
 
 def get_latch(num):


### PR DESCRIPTION
# Description

## A whole bunch of reworking the tests

I've updated tests to use proper handler names - In the real world, the interceptor is always going to be passed a HandlerCallDetails object with the `method` field set to something valid... previously these tests set this to an empty string, but that's not what happens in a real case. So I've updated the tests to do that right, but also made sure that the span processing allows this to be unset, just in case someone was expecting this behavior to be present.

I've added more checks into the existing tests, now we're checking that span attributes are set as expected.

Fixed a few bugs in the tests where things which were intended to be checked, actually were not.

And finally, I've added a test to catch the gRPC `abort()` and verify the error status in the span.

## Updated status codes to be compliant with specifications

The previous PR I made had the gRPC status codes using the English names for the status, but the spec has been clarified to require the integer value.

Also, the specs say to not use `span.set_status()` for a non-error condition, so I've added a check for that in a few places.

## Added additional attributes

Also as the spec has been clarified, I've added the `rpc.method` and `rpc.service` attributes.

Fixes #173
Fixes #139 

# Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

As most of this is either test changes or changes covered by new or existing tests, I've just run a bunch of tests :)


# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
