### PR TITLE
Commit benchmark results to gh-pages branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,28 +58,27 @@ jobs:
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
-        # TODO: Add at least one benchmark to every package type to remove this
+        # TODO: Add at least one benchmark to every package type to remove this (#249)
         if: matrix.package == 'sdkextension'
         run: >-
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
           **/**/tests/*${{ matrix.package }}*-benchmark.json > output.json
       - name: Report on benchmark results
-        # TODO: Add at least one benchmark to every package type to remove this
+        # TODO: Add at least one benchmark to every package type to remove this (#249)
         if: matrix.package == 'sdkextension'
         uses: rhysd/github-action-benchmark@v1
         with:
-          name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package-group }}
+          name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}
           tool: pytest
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Alert with a commit comment on possible performance regression
           alert-threshold: 200%
-          comment-always: true
           fail-on-alert: true
           # Make a commit on `gh-pages` with benchmarks from previous step
           auto-push: ${{ github.ref == 'refs/heads/master' }}
-          gh-pages-branch: master
+          gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks
   misc:
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ for more detail on available tox commands.
 
 ### Benchmarks
 
-Performance progression of benchmarks for packages distributed by OpenTelemetry Python can be viewed as a [graph of throughput vs commit history](https://open-telemetry.github.io/opentelemetry-python-contrib/benchmarks/index.html). From this page, you can download a JSON file with the performance results.
+Performance progression of benchmarks for packages distributed by OpenTelemetry Python can be viewed as a [graph of throughput vs commit history](https://opentelemetry-python-contrib.readthedocs.io/en/latest/performance/benchmarks.html). From the linked page, you can download a JSON file with the performance results.
 
 Running the `tox` tests also runs the performance tests if any are available. Benchmarking tests are done with `pytest-benchmark` and they output a table with results to the console.
 

--- a/docs/performance/benchmarks.rst
+++ b/docs/performance/benchmarks.rst
@@ -1,0 +1,4 @@
+Performance Tests - Benchmarks
+==============================
+
+Click `here <https://open-telemetry.github.io/opentelemetry-python-contrib/benchmarks/index.html>_` to view the latest performance benchmarks for packages in this repo.


### PR DESCRIPTION
# Description

A follow up to the Core PR that adds benchmarking tests: https://github.com/open-telemetry/opentelemetry-python/pull/1443

We added an issue in #249 and link the issue in the code here

We also found out that the GitHub action [will fetch the branch even if it on that branch which produces an error](https://github.com/rhysd/github-action-benchmark/issues/51).

This PR goes back to using `gh-pages` and adds a link in the ReadTheDocs directory to point to the benchmarks graphs which will live on the `gh-pages` branch.

This is also a good idea to reduce the noise on the `master` branch.

This will fix the current Contrib Repo Tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See [my example repo](https://github.com/NathanielRN/github-benchmarks-example/runs/1532810344?check_suite_focus=true#step:8:25) which uses `gh-pages` correctly to publish to https://nathanielrn.github.io/github-benchmarks-example/benchmarks/index.html

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
