### PR TITLE
When Flask activation is missing, do not emit a log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/212))
 - `opentelemetry-instrumentation-fastapi` Added support for excluding some routes with env var `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS`
   ([#237](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/237))
+- `opentelemetry-instrumentation-flask` Do not emit a warning message for request contexts created with `app.test_request_context` or manually.
+  ([#253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/253))
 - `opentelemetry-instrumentation-starlette` Added support for excluding some routes with env var `OTEL_PYTHON_STARLETTE_EXCLUDED_URLS`
   ([#237](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/237))
 - Add Prometheus Remote Write Exporter integration tests in opentelemetry-docker-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/212))
 - `opentelemetry-instrumentation-fastapi` Added support for excluding some routes with env var `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS`
   ([#237](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/237))
-- `opentelemetry-instrumentation-flask` Do not emit a warning message for request contexts created with `app.test_request_context` or manually.
-  ([#253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/253))
 - `opentelemetry-instrumentation-starlette` Added support for excluding some routes with env var `OTEL_PYTHON_STARLETTE_EXCLUDED_URLS`
   ([#237](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/237))
 - Add Prometheus Remote Write Exporter integration tests in opentelemetry-docker-tests
@@ -37,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#236](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/236))
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-falcon`, `opentelemetry-instrumentation-flask`, `opentelemetry-instrumentation-pyramid`, `opentelemetry-instrumentation-wsgi` Renamed `host.port` attribute to `net.host.port`
   ([#242](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/242))  
+- `opentelemetry-instrumentation-flask` Do not emit a warning message for request contexts created with `app.test_request_context`
+  ([#253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/253))
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.16b1) - 2020-11-26
 

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -149,11 +149,9 @@ def _teardown_request(exc):
 
     activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
     if not activation:
-        _logger.warning(
-            "Flask environ's OpenTelemetry activation missing"
-            "at _teardown_flask_request(%s)",
-            exc,
-        )
+        # This request didn't start a span, maybe because it was created in a
+        # way that doesn't run `before_request`, like when it is created with
+        # `app.test_request_context`.
         return
 
     if exc is None:


### PR DESCRIPTION
# Description

If a Flask request doesn't have an active span, it just means that it was initialized via a mechanism that doesn't run `before_request`, like `app.test_request_context` or even manually. It is okay and instrumentation still works.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/160.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran the same script that is in https://github.com/open-telemetry/opentelemetry-python-contrib/issues/160 and I didn't get the warning message.

# Does This PR Require a Core Repo Change?

- [ ] Yes
- [x] No

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] ~Unit tests have been added~ Not needed
- [ ] ~Documentation has been updated~ Not needed
