### PR TITLE
Fix requests and urllib instrumentations span name callback parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#242](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/242))  
 - `opentelemetry-instrumentation-flask` Do not emit a warning message for request contexts created with `app.test_request_context`
   ([#253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/253))
+- `opentelemetry-instrumentation-requests`, `opentelemetry-instrumentation-urllib` Fix span name callback parameters
+- ([#259](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/259))
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.16b1) - 2020-11-26
 

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -122,7 +122,7 @@ def _instrument(tracer_provider=None, span_callback=None, name_callback=None):
         method = method.upper()
         span_name = ""
         if name_callback is not None:
-            span_name = name_callback()
+            span_name = name_callback(method, url)
         if not span_name or not isinstance(span_name, str):
             span_name = get_default_span_name(method)
 

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -108,8 +108,8 @@ class RequestsIntegrationTestBase(abc.ABC):
                 self.assertGreaterEqual(view_data.aggregator.current.sum, 0)
 
     def test_name_callback(self):
-        def name_callback():
-            return "test_name"
+        def name_callback(method, url):
+            return "GET" + url
 
         RequestsInstrumentor().uninstrument()
         RequestsInstrumentor().instrument(name_callback=name_callback)
@@ -117,10 +117,10 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(result.text, "Hello!")
         span = self.assert_span()
 
-        self.assertEqual(span.name, "test_name")
+        self.assertEqual(span.name, "GET" + self.URL)
 
     def test_name_callback_default(self):
-        def name_callback():
+        def name_callback(method, url):
             return 123
 
         RequestsInstrumentor().uninstrument()

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -101,9 +101,7 @@ class URLLibInstrumentor(BaseInstrumentor, MetricMixin):
         _uninstrument_from(opener, restore_as_bound_func=True)
 
 
-# pylint: disable=unused-argument
-# pylint: disable=R0915
-def get_default_span_name(method):
+def get_default_span_name(method, url):
     """Default implementation for name_callback, returns HTTP {method_name}."""
     return "HTTP {}".format(method).strip()
 
@@ -145,7 +143,7 @@ def _instrument(tracer_provider=None, span_callback=None, name_callback=None):
 
         span_name = ""
         if name_callback is not None:
-            span_name = name_callback()
+            span_name = name_callback(method, url)
         if not span_name or not isinstance(span_name, str):
             span_name = get_default_span_name(method)
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -101,7 +101,7 @@ class URLLibInstrumentor(BaseInstrumentor, MetricMixin):
         _uninstrument_from(opener, restore_as_bound_func=True)
 
 
-def get_default_span_name(method, url):
+def get_default_span_name(method):
     """Default implementation for name_callback, returns HTTP {method_name}."""
     return "HTTP {}".format(method).strip()
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -137,8 +137,8 @@ class RequestsIntegrationTestBase(abc.ABC):
                 self.assertGreaterEqual(view_data.aggregator.current.sum, 0)
 
     def test_name_callback(self):
-        def name_callback():
-            return "test_name"
+        def name_callback(method, url):
+            return "GET" + url
 
         URLLibInstrumentor().uninstrument()
         URLLibInstrumentor().instrument(name_callback=name_callback)
@@ -147,10 +147,10 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(result.read(), b"Hello!")
         span = self.assert_span()
 
-        self.assertEqual(span.name, "test_name")
+        self.assertEqual(span.name, "GET" + self.URL)
 
     def test_name_callback_default(self):
-        def name_callback():
+        def name_callback(method, url):
             return 123
 
         URLLibInstrumentor().uninstrument()


### PR DESCRIPTION
Addresses this [comment](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/149#issuecomment-745074789)