### PR TITLE
botocore: switch setter for injecting headers into propagator

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 def _patched_endpoint_prepare_request(wrapped, instance, args, kwargs):
     request = args[0]
     headers = request.headers
-    propagators.inject(type(headers).__setitem__, headers)
+    propagators.inject(type(headers).add_header, headers)
     return wrapped(*args, **kwargs)
 
 


### PR DESCRIPTION
# Description

Occasionally not all of the headers available to botocore are strings - I've noticed this when a call is being made with an active span passed from a different application (specifically via gRPC).  Botocore does allow this, using the `add_header` method rather than `__setitem__`.  According to the docs for `botocore.compat.HTTPHeaders`:

```
If a parameter value contains non-ASCII characters it can be specified
as a three-tuple of (charset, language, value), in which case it will be
encoded according to RFC2231 rules.  Otherwise it will be encoded using
the utf-8 charset and a language of ''
```

Whereas using `__setitem__` does not do this conversion.

I'm not convinced this is the right place to fix this, however - I've only encountered it in the situation described in #262, and haven't been able to find what would be passing in a non-string header in the first place.  I'll be happy to dig more if anyone has a better suggestion, but as far as I can tell, this is also an innocuous change.

One question I have though is about how I could test this - I don't know how to simulate (in the botocore tests) having an active trace passed through from another application, so advice on this would be welcome.

Fixes #262
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All existing tests still pass, and I've been working with the situation described in #262 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
