### PR TITLE
Celery: Add support for new major version 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.16b1...HEAD)
 
 ### Added
-- `opentelemetry-instrumentation-celery` Add support for version 5.x
+- `opentelemetry-instrumentation-celery` Add support for Celery version 5.x
   ([#266](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/266))
 - `opentelemetry-instrumentation-urllib` Add urllib instrumentation
   ([#222](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/222))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.16b1...HEAD)
 
 ### Added
+- `opentelemetry-instrumentation-celery` Add support for version 5.x
+  ([#266](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/266))
 - `opentelemetry-instrumentation-urllib` Add urllib instrumentation
   ([#222](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/222))
 - `opentelemetry-exporter-datadog` Add fields method
@@ -36,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-grpc` Comply with updated spec, rework tests
   ([#236](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/236))
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-falcon`, `opentelemetry-instrumentation-flask`, `opentelemetry-instrumentation-pyramid`, `opentelemetry-instrumentation-wsgi` Renamed `host.port` attribute to `net.host.port`
-  ([#242](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/242))  
+  ([#242](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/242))
 - `opentelemetry-instrumentation-flask` Do not emit a warning message for request contexts created with `app.test_request_context`
   ([#253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/253))
 - `opentelemetry-instrumentation-requests`, `opentelemetry-instrumentation-urllib` Fix span name callback parameters

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
+    celery >= 4.0, < 6.0
     opentelemetry-api == 0.17.dev0
     opentelemetry-instrumentation == 0.17.dev0
-    celery ~= 4.0
 
 [options.extras_require]
 test =
     pytest
-    celery ~= 4.0
+    celery >= 4.0, < 6.0
     opentelemetry-test == 0.17.dev0
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -349,7 +349,7 @@ deps =
   aiopg >= 0.13.0
   sqlalchemy ~= 1.3.16
   redis ~= 3.3.11
-  celery ~= 4.0, != 4.4.4
+  celery >= 4.0, < 6.0
   protobuf>=3.13.0
   requests==2.25.0
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -349,7 +349,7 @@ deps =
   aiopg >= 0.13.0
   sqlalchemy ~= 1.3.16
   redis ~= 3.3.11
-  celery >= 4.0, < 6.0
+  celery[pytest] >= 4.0, < 6.0
   protobuf>=3.13.0
   requests==2.25.0
 changedir =


### PR DESCRIPTION
# Description

Add support for Celery v5, which apparently didn't introduce changes that affect the current instrumentation code [0].

[0] https://github.com/celery/celery/blob/master/Changelog.rst#500


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested locally using:
```
tox -e test-instrumentation-celery
```

# Does This PR Require a Core Repo Change?

- [x] No.


# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
