### PR TITLE
gRPC instrumentation: client additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#246](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/246))
 - Update TraceState to adhere to specs
   ([#276](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/276))
+- `opentelemetry-instrumentation-grpc` Updated client attributes, added tests, fixed examples, docs
+  ([#269](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/269))
 
 ### Removed
 - Remove Configuration

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -190,9 +190,9 @@ class GrpcInstrumentorClient(BaseInstrumentor):
         # handle legacy argument
         if "channel_type" in kwargs:
             if kwargs.get("channel_type") == "secure":
-                return ("secure_channel", )
+                return ("secure_channel",)
             else:
-                return ("insecure_channel", )
+                return ("insecure_channel",)
 
         # handle modern arguments
         types = []
@@ -207,9 +207,7 @@ class GrpcInstrumentorClient(BaseInstrumentor):
         interval = kwargs.get("interval", 30)
         for ctype in self._which_channel(kwargs):
             _wrap(
-                "grpc",
-                ctype,
-                partial(self.wrapper_fn, exporter, interval),
+                "grpc", ctype, partial(self.wrapper_fn, exporter, interval),
             )
 
     def _uninstrument(self, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -191,8 +191,7 @@ class GrpcInstrumentorClient(BaseInstrumentor):
         if "channel_type" in kwargs:
             if kwargs.get("channel_type") == "secure":
                 return ("secure_channel",)
-            else:
-                return ("insecure_channel",)
+            return ("insecure_channel",)
 
         # handle modern arguments
         types = []

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -199,7 +199,7 @@ class GrpcInstrumentorClient(BaseInstrumentor):
             if kwargs.get(ctype, True):
                 types.append(ctype)
 
-        return types
+        return tuple(types)
 
     def _instrument(self, **kwargs):
         exporter = kwargs.get("exporter", None)

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -184,14 +184,14 @@ class OpenTelemetryClientInterceptor(
 
                 try:
                     result = invoker(request, metadata)
-                except grpc.RpcError as e:
+                except grpc.RpcError as err:
                     guarded_span.generated_span.set_status(
                         Status(StatusCode.ERROR)
                     )
                     guarded_span.generated_span.set_attribute(
-                        "rpc.grpc.status_code", e.code().value[0]
+                        "rpc.grpc.status_code", err.code().value[0]
                     )
-                    raise e
+                    raise err
 
                 return self._trace_result(
                     guarded_span, rpc_info, result, client_info
@@ -242,12 +242,12 @@ class OpenTelemetryClientInterceptor(
                                 response.ByteSize(), client_info.full_method
                             )
                         yield response
-                except grpc.RpcError as e:
+                except grpc.RpcError as err:
                     span.set_status(Status(StatusCode.ERROR))
                     span.set_attribute(
-                        "rpc.grpc.status_code", e.code().value[0]
+                        "rpc.grpc.status_code", err.code().value[0]
                     )
-                    raise e
+                    raise err
 
     def intercept_stream(
         self, request_or_iterator, metadata, client_info, invoker
@@ -283,14 +283,14 @@ class OpenTelemetryClientInterceptor(
 
                 try:
                     result = invoker(request_or_iterator, metadata)
-                except grpc.RpcError as e:
+                except grpc.RpcError as err:
                     guarded_span.generated_span.set_status(
                         Status(StatusCode.ERROR)
                     )
                     guarded_span.generated_span.set_attribute(
-                        "rpc.grpc.status_code", e.code().value[0],
+                        "rpc.grpc.status_code", err.code().value[0],
                     )
-                    raise e
+                    raise err
 
                 return self._trace_result(
                     guarded_span, rpc_info, result, client_info

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -188,7 +188,10 @@ class OpenTelemetryClientInterceptor(
                     guarded_span.generated_span.set_status(
                         Status(StatusCode.ERROR)
                     )
-                    guarded_span.set_attribute("rpc.grpc.status_code", e.code().value[0])
+                    guarded_span.generated_span.set_attribute(
+                        "rpc.grpc.status_code",
+                        e.code().value[0]
+                    )
                     raise e
 
                 return self._trace_result(
@@ -242,7 +245,7 @@ class OpenTelemetryClientInterceptor(
                         yield response
                 except grpc.RpcError as e:
                     span.set_status(Status(StatusCode.ERROR))
-                    guarded_span.set_attribute("rpc.grpc.status_code", e.code().value[0])
+                    span.set_attribute("rpc.grpc.status_code", e.code().value[0])
                     raise e
 
     def intercept_stream(
@@ -283,7 +286,10 @@ class OpenTelemetryClientInterceptor(
                     guarded_span.generated_span.set_status(
                         Status(StatusCode.ERROR)
                     )
-                    guarded_span.set_attribute("rpc.grpc.status_code", e.code().value[0])
+                    guarded_span.generated_span.set_attribute(
+                        "rpc.grpc.status_code",
+                        e.code().value[0],
+                    )
                     raise e
 
                 return self._trace_result(

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -189,8 +189,7 @@ class OpenTelemetryClientInterceptor(
                         Status(StatusCode.ERROR)
                     )
                     guarded_span.generated_span.set_attribute(
-                        "rpc.grpc.status_code",
-                        e.code().value[0]
+                        "rpc.grpc.status_code", e.code().value[0]
                     )
                     raise e
 
@@ -245,7 +244,9 @@ class OpenTelemetryClientInterceptor(
                         yield response
                 except grpc.RpcError as e:
                     span.set_status(Status(StatusCode.ERROR))
-                    span.set_attribute("rpc.grpc.status_code", e.code().value[0])
+                    span.set_attribute(
+                        "rpc.grpc.status_code", e.code().value[0]
+                    )
                     raise e
 
     def intercept_stream(
@@ -287,8 +288,7 @@ class OpenTelemetryClientInterceptor(
                         Status(StatusCode.ERROR)
                     )
                     guarded_span.generated_span.set_attribute(
-                        "rpc.grpc.status_code",
-                        e.code().value[0],
+                        "rpc.grpc.status_code", e.code().value[0],
                     )
                     raise e
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_utilities.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_utilities.py
@@ -84,16 +84,16 @@ class TimedMetricRecorder:
     def record_latency(self, method):
         start_time = time()
         labels = {
+            "rpc.method": method,
             "rpc.system": "grpc",
-            "rpc.grpc.method": method,
-            "rpc.status_code": grpc.StatusCode.OK.name,
+            "rpc.grpc.status_code": grpc.StatusCode.OK.name,
         }
         try:
             yield labels
         except grpc.RpcError as exc:  # pylint:disable=no-member
             if self._meter:
                 # pylint: disable=no-member
-                labels["rpc.status_code"] = exc.code().name
+                labels["rpc.grpc.status_code"] = exc.code().name
                 self._error_count.add(1, labels)
                 labels["error"] = "true"
             raise

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_utilities.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_utilities.py
@@ -72,33 +72,32 @@ class TimedMetricRecorder:
 
     def record_bytes_in(self, bytes_in, method):
         if self._meter:
-            labels = {"method": method}
+            labels = {"rpc.method": method}
             self._bytes_in.add(bytes_in, labels)
 
     def record_bytes_out(self, bytes_out, method):
         if self._meter:
-            labels = {"method": method}
+            labels = {"rpc.method": method}
             self._bytes_out.add(bytes_out, labels)
 
     @contextmanager
     def record_latency(self, method):
         start_time = time()
         labels = {
-            "method": method,
-            "status_code": grpc.StatusCode.OK,  # pylint:disable=no-member
+            "rpc.system": "grpc",
+            "rpc.grpc.method": method,
+            "rpc.status_code": grpc.StatusCode.OK.name,
         }
         try:
             yield labels
         except grpc.RpcError as exc:  # pylint:disable=no-member
             if self._meter:
                 # pylint: disable=no-member
-                labels["status_code"] = exc.code()
+                labels["rpc.status_code"] = exc.code().name
                 self._error_count.add(1, labels)
-                labels["error"] = True
+                labels["error"] = "true"
             raise
         finally:
             if self._meter:
-                if "error" not in labels:
-                    labels["error"] = False
                 elapsed_time = (time() - start_time) * 1000
                 self._duration.record(elapsed_time, labels)

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -116,6 +116,16 @@ class TestClientProto(TestBase):
 
         self._verify_success_records(8, 8, "/GRPCTestServer/SimpleMethod")
 
+        self.assert_span_has_attributes(
+            span,
+            {
+                "rpc.method": "SimpleMethod",
+                "rpc.service": "GRPCTestServer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
+        )
+
     def test_unary_stream(self):
         server_streaming_method(self._stub)
         spans = self.memory_exporter.get_finished_spans()
@@ -132,6 +142,16 @@ class TestClientProto(TestBase):
 
         self._verify_success_records(
             8, 40, "/GRPCTestServer/ServerStreamingMethod"
+        )
+
+        self.assert_span_has_attributes(
+            span,
+            {
+                "rpc.method": "ServerStreamingMethod",
+                "rpc.service": "GRPCTestServer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
         )
 
     def test_stream_unary(self):
@@ -152,6 +172,16 @@ class TestClientProto(TestBase):
             40, 8, "/GRPCTestServer/ClientStreamingMethod"
         )
 
+        self.assert_span_has_attributes(
+            span,
+            {
+                "rpc.method": "ClientStreamingMethod",
+                "rpc.service": "GRPCTestServer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
+        )
+
     def test_stream_stream(self):
         bidirectional_streaming_method(self._stub)
         spans = self.memory_exporter.get_finished_spans()
@@ -170,6 +200,16 @@ class TestClientProto(TestBase):
 
         self._verify_success_records(
             40, 40, "/GRPCTestServer/BidirectionalStreamingMethod"
+        )
+
+        self.assert_span_has_attributes(
+            span,
+            {
+                "rpc.method": "BidirectionalStreamingMethod",
+                "rpc.service": "GRPCTestServer",
+                "rpc.system": "grpc",
+                "rpc.grpc.status_code": grpc.StatusCode.OK.value[0],
+            },
         )
 
     def _verify_error_records(self, method):

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -237,22 +237,32 @@ class TestClientProto(TestBase):
         self.assertEqual(errors.instrument.name, "grpcio/client/errors")
         self.assertSequenceEqual(
             sorted(errors.labels),
-            sorted((
-                ("rpc.grpc.status_code", grpc.StatusCode.INVALID_ARGUMENT.name),
-                ("rpc.method", method),
-                ("rpc.system", "grpc"),
-            )),
+            sorted(
+                (
+                    (
+                        "rpc.grpc.status_code",
+                        grpc.StatusCode.INVALID_ARGUMENT.name,
+                    ),
+                    ("rpc.method", method),
+                    ("rpc.system", "grpc"),
+                )
+            ),
         )
         self.assertEqual(errors.aggregator.checkpoint, 1)
 
         self.assertSequenceEqual(
             sorted(duration.labels),
-            sorted((
-                ("error", "true"),
-                ("rpc.method", method),
-                ("rpc.system", "grpc"),
-                ("rpc.grpc.status_code", grpc.StatusCode.INVALID_ARGUMENT.name),
-            )),
+            sorted(
+                (
+                    ("error", "true"),
+                    ("rpc.method", method),
+                    ("rpc.system", "grpc"),
+                    (
+                        "rpc.grpc.status_code",
+                        grpc.StatusCode.INVALID_ARGUMENT.name,
+                    ),
+                )
+            ),
         )
 
     def test_error_simple(self):


### PR DESCRIPTION
# Description

Updates the gRPC client instrumentation:

* Add additional attributes to span described in the spec but not previously added
* fix example in docs that didn't work #256
* rework the instrumentation call so both secure and insecure connections are instrumented by default - otherwise there's no way to handle both
* properly capture and record RPC errors
* change all metrics labels recorded to be strings
* change metrics labels to be namespaced like the span attributes are, this seems to be a convention when looking at other client instrumentation (i.e. requests)

Re: the instrumentation call - I preserved the existing parameter so as to not break changes, but we may wish to mark that as deprecated, I don't know the convention with this library on how to do that.

Fixes #256 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I've added new checks in the existing tests to make sure the attributes 

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
