### PR TITLE
datadog-exporter: don't set tags which are None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,10 +161,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#246](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/246))
 - Update TraceState to adhere to specs
   ([#276](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/276))
+- `opentelemetry-exporter-datadog` Don't allow `NoneType` values in `context.trace_state` fields
+  ([#272](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/272))
 
 ### Removed
 - Remove Configuration
   ([#285](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/285))
+
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.16b1) - 2020-11-26
 

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -103,7 +103,7 @@ class DatadogFormat(TextMapPropagator):
             self.SAMPLING_PRIORITY_KEY,
             str(constants.AUTO_KEEP if sampled else constants.AUTO_REJECT),
         )
-        if constants.DD_ORIGIN in span.context.trace_state:
+        if span.context.trace_state.get(constants.DD_ORIGIN) is not None:
             setter.set(
                 carrier,
                 self.ORIGIN_KEY,

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -198,7 +198,6 @@ class TestDatadogFormat(unittest.TestCase):
 
         self.assertEqual(FORMAT.fields, inject_fields)
 
-
     @patch("opentelemetry.exporter.datadog.propagator.get_current_span")
     def test_trace_state_not_none(self, mock_get_current_span):
         """Make sure the fields attribute returns the fields used in inject"""
@@ -231,6 +230,6 @@ class TestDatadogFormat(unittest.TestCase):
 
         # verify 'x-datadog-origin' is not present, it was None
         expected_fields = FORMAT.fields.copy()
-        expected_fields.discard('x-datadog-origin')
+        expected_fields.discard("x-datadog-origin")
 
         self.assertEqual(expected_fields, inject_fields)

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -197,3 +197,40 @@ class TestDatadogFormat(unittest.TestCase):
             inject_fields.add(call[1][1])
 
         self.assertEqual(FORMAT.fields, inject_fields)
+
+
+    @patch("opentelemetry.exporter.datadog.propagator.get_current_span")
+    def test_trace_state_not_none(self, mock_get_current_span):
+        """Make sure the fields attribute returns the fields used in inject"""
+
+        tracer = trace.TracerProvider().get_tracer("sdk_tracer_provider")
+
+        mock_set_in_carrier = Mock()
+
+        mock_get_current_span.configure_mock(
+            **{
+                "return_value": Mock(
+                    **{
+                        "get_span_context.return_value": None,
+                        "context.trace_flags": 0,
+                        "context.trace_id": 1,
+                        "context.trace_state": {constants.DD_ORIGIN: None},
+                    }
+                )
+            }
+        )
+
+        with tracer.start_as_current_span("parent"):
+            with tracer.start_as_current_span("child"):
+                FORMAT.inject(mock_set_in_carrier, {})
+
+        inject_fields = set()
+
+        for call in mock_set_in_carrier.mock_calls:
+            inject_fields.add(call[1][1])
+
+        # verify 'x-datadog-origin' is not present, it was None
+        expected_fields = FORMAT.fields.copy()
+        expected_fields.discard('x-datadog-origin')
+
+        self.assertEqual(expected_fields, inject_fields)


### PR DESCRIPTION
# Description

This is often `None`, but tags are always strings, and so things get broken when spans get passed along to other client calls.

Fixes #262

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This passes existing tests, and I've added one to verify when the field is set to `None`, it's skipped.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
