### PR TITLE
Use instanceof to check if responses are valid Response objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#227](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/227]))
 - `opentelemetry-instrumentation-botocore` Adds a field to report the number of retries it take to complete an API call
   ([#275](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/275))
+- `opentelemetry-instrumentation-requests` Use instanceof to check if responses are valid Response objects
+  ([#273](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/273))
 
 ### Changed
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-wsgi` Return `None` for `CarrierGetter` if key not found

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -38,6 +38,7 @@ import types
 
 from requests import Timeout, URLRequired
 from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema
+from requests.models import Response
 from requests.sessions import Session
 from requests.structures import CaseInsensitiveDict
 
@@ -158,7 +159,7 @@ def _instrument(tracer_provider=None, span_callback=None, name_callback=None):
                 finally:
                     context.detach(token)
 
-                if result is not None:
+                if isinstance(result, Response):
                     if span.is_recording():
                         span.set_attribute(
                             "http.status_code", result.status_code


### PR DESCRIPTION
There are some exception types that set the response attribute to a
non-Response type, e.g. "AttributeError: 'dict' object has no attribute
'status_code'"

# Description

At $WORK, we have an integration with a vendor (i.e. POST calls via `requests`) that will fail once-in-a-while with an exception where the `response` attribute on the exception is a dictionary instead of a `Response` object. Because the instrumentation doesn't have a type check, it tries to get the `status_code` attribute from the dictionary and fails with an `AttributeError`. Since it swallows the exception thrown from `requests`, we can't easily debug it (vendor issue is not easily reproducible). This change will allow the instrumentation to work in this edge case.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added unit tests

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/master/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
