### PR TITLE
Fix ids_generator references from moving from api to sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: master
+  CORE_REPO_SHA: 2b188b9a43dfaa74c1a0a4514b91d1cb07d3075d
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#261](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/261))
 - `opentelemetry-instrumentation-aiopg` Fix AttributeError `__aexit__` when `aiopg.connect` and `aio[g].create_pool` used with async context manager
   ([#235](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/235))
+- `opentelemetry-exporter-datadog` `opentelemetry-sdk-extension-aws` Fix reference to ids_generator in sdk
+  ([#235](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/235))
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.16b1) - 2020-11-26
 

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.datadog import constants, propagator
 from opentelemetry.sdk import trace
+from opentelemetry.sdk.ids_generator import RandomIdsGenerator
 from opentelemetry.trace import get_current_span, set_span_in_context
 from opentelemetry.trace.propagation.textmap import DictGetter
 
@@ -29,7 +30,7 @@ carrier_getter = DictGetter()
 class TestDatadogFormat(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ids_generator = trace_api.RandomIdsGenerator()
+        ids_generator = RandomIdsGenerator()
         cls.serialized_trace_id = propagator.format_trace_id(
             ids_generator.generate_trace_id()
         )

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, patch
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.datadog import constants, propagator
 from opentelemetry.sdk import trace
-from opentelemetry.sdk.ids_generator import RandomIdsGenerator
+from opentelemetry.sdk.trace.ids_generator import RandomIdsGenerator
 from opentelemetry.trace import get_current_span, set_span_in_context
 from opentelemetry.trace.propagation.textmap import DictGetter
 
@@ -108,7 +108,7 @@ class TestDatadogFormat(unittest.TestCase):
             "child",
             trace_api.SpanContext(
                 parent_span_context.trace_id,
-                trace_api.RandomIdsGenerator().generate_span_id(),
+                RandomIdsGenerator().generate_span_id(),
                 is_remote=False,
                 trace_flags=parent_span_context.trace_flags,
                 trace_state=parent_span_context.trace_state,
@@ -155,7 +155,7 @@ class TestDatadogFormat(unittest.TestCase):
             "child",
             trace_api.SpanContext(
                 parent_span_context.trace_id,
-                trace_api.RandomIdsGenerator().generate_span_id(),
+                RandomIdsGenerator().generate_span_id(),
                 is_remote=False,
                 trace_flags=parent_span_context.trace_flags,
                 trace_state=parent_span_context.trace_state,

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/aws_xray_ids_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/aws_xray_ids_generator.py
@@ -15,10 +15,13 @@
 import random
 import time
 
-from opentelemetry import trace
+from opentelemetry.sdk.trace.ids_generator import (
+    IdsGenerator,
+    RandomIdsGenerator,
+)
 
 
-class AwsXRayIdsGenerator(trace.IdsGenerator):
+class AwsXRayIdsGenerator(IdsGenerator):
     """Generates tracing IDs compatible with the AWS X-Ray tracing service. In
     the X-Ray system, the first 32 bits of the `TraceId` are the Unix epoch time
     in seconds. Since spans (AWS calls them segments) with an embedded timestamp
@@ -28,7 +31,7 @@ class AwsXRayIdsGenerator(trace.IdsGenerator):
     See: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
     """
 
-    random_ids_generator = trace.RandomIdsGenerator()
+    random_ids_generator = RandomIdsGenerator()
 
     def generate_span_id(self) -> int:
         return self.random_ids_generator.generate_span_id()


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-python/pull/1514