### PR TITLE
Aiohttp instrumentation readme

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
@@ -33,26 +33,26 @@ Example
    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
 
-   jaeger_exporter = jaeger.JaegerSpanExporter(
-      service_name="xxx",
+   _JAEGER_EXPORTER = jaeger.JaegerSpanExporter(
+      service_name="example-xxx",
       agent_host_name="localhost",
       agent_port=6831,
    )
 
    _TRACE_PROVIDER = TracerProvider()
-   _TRACE_PROVIDER.add_span_processor(BatchExportSpanProcessor(jaeger_exporter))
+   _TRACE_PROVIDER.add_span_processor(BatchExportSpanProcessor(_JAEGER_EXPORTER))
    trace.set_tracer_provider(_TRACE_PROVIDER)
 
    AioHttpClientInstrumentor().instrument()
 
 
-   async def span_emmitter():
+   async def span_emitter():
       async with aiohttp.ClientSession() as session:
          async with session.get("https://example.com") as resp:
                print(resp.status)
 
 
-   asyncio.run(span_emmitter())
+   asyncio.run(span_emitter())
 
 
 References

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/README.rst
@@ -17,6 +17,44 @@ Installation
      pip install opentelemetry-instrumentation-aiohttp-client
 
 
+Example
+-------
+
+.. code:: python
+
+   import asyncio
+   
+   import aiohttp
+
+   from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+   from opentelemetry import trace
+   from opentelemetry.exporter import jaeger
+   from opentelemetry.sdk.trace import TracerProvider
+   from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+
+   jaeger_exporter = jaeger.JaegerSpanExporter(
+      service_name="xxx",
+      agent_host_name="localhost",
+      agent_port=6831,
+   )
+
+   _TRACE_PROVIDER = TracerProvider()
+   _TRACE_PROVIDER.add_span_processor(BatchExportSpanProcessor(jaeger_exporter))
+   trace.set_tracer_provider(_TRACE_PROVIDER)
+
+   AioHttpClientInstrumentor().instrument()
+
+
+   async def span_emmitter():
+      async with aiohttp.ClientSession() as session:
+         async with session.get("https://example.com") as resp:
+               print(resp.status)
+
+
+   asyncio.run(span_emmitter())
+
+
 References
 ----------
 


### PR DESCRIPTION
# Description

Improved documentation with a minimal viable example for aiohttp instrumentation. There is currently not a clear example of this anywhere in the wild, nor is there much in the way of documentation explaining what glue is required between instrumentation and jaeger / opentelemetry layers. Now there is.

Fixes # (issue)

## Type of change

Small docs change.

# How Has This Been Tested?

You can take a look at the well rendered example here: https://github.com/theelous3/opentelemetry-python-contrib/tree/aiohttp-instrumentation-readme/instrumentation/opentelemetry-instrumentation-aiohttp-client

Run the code in the example yourself if you like. Should be self explanatory.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

N/A
