### PR TITLE
Case insensitive header key retrieval for asgi instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `opentelemetry-instrumentation-aiopg`, `opentelemetry-instrumentation-dbapi` Remove unused `database_type` parameter from `trace_integration` function.
   ([#301](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/301))
 - `opentelemetry-instrumentation-asgi` Return header values using case insensitive keys
+  ([#308](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/308))
 
 ## [0.17b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.17b0) - 2021-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `component` span attribute in instrumentations. 
   `opentelemetry-instrumentation-aiopg`, `opentelemetry-instrumentation-dbapi` Remove unused `database_type` parameter from `trace_integration` function.
   ([#301](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/301))
+- `opentelemetry-instrumentation-asgi` Return header values using case insensitive keys
 
 ## [0.17b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.17b0) - 2021-01-20
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -48,6 +48,11 @@ class CarrierGetter(DictGetter):
                 else None.
         """
         headers = carrier.get("headers")
+        if not headers:
+            return None
+
+        # asgi header keys are in lower case
+        key = key.lower()
         decoded = [
             _value.decode("utf8")
             for (_key, _value) in headers

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_getter.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_getter.py
@@ -28,9 +28,21 @@ class TestCarrierGetter(TestCase):
         getter = CarrierGetter()
         carrier = {"headers": [(b"test-key", b"val")]}
         expected_val = ["val"]
-        self.assertEqual(getter.get(carrier, "Test-Key"), expected_val, "Should be case insensitive")
-        self.assertEqual(getter.get(carrier, "test-key"), expected_val, "Should be case insensitive")
-        self.assertEqual(getter.get(carrier, "TEST-KEY"), expected_val, "Should be case insensitive")
+        self.assertEqual(
+            getter.get(carrier, "Test-Key"),
+            expected_val,
+            "Should be case insensitive",
+        )
+        self.assertEqual(
+            getter.get(carrier, "test-key"),
+            expected_val,
+            "Should be case insensitive",
+        )
+        self.assertEqual(
+            getter.get(carrier, "TEST-KEY"),
+            expected_val,
+            "Should be case insensitive",
+        )
 
     def test_keys(self):
         getter = CarrierGetter()

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_getter.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_getter.py
@@ -1,0 +1,38 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from opentelemetry.instrumentation.asgi import CarrierGetter
+
+
+class TestCarrierGetter(TestCase):
+    def test_get_none(self):
+        getter = CarrierGetter()
+        carrier = {}
+        val = getter.get(carrier, "test")
+        self.assertIsNone(val)
+
+    def test_get_(self):
+        getter = CarrierGetter()
+        carrier = {"headers": [(b"test-key", b"val")]}
+        expected_val = ["val"]
+        self.assertEqual(getter.get(carrier, "Test-Key"), expected_val, "Should be case insensitive")
+        self.assertEqual(getter.get(carrier, "test-key"), expected_val, "Should be case insensitive")
+        self.assertEqual(getter.get(carrier, "TEST-KEY"), expected_val, "Should be case insensitive")
+
+    def test_keys(self):
+        getter = CarrierGetter()
+        keys = getter.keys({})
+        self.assertEqual(keys, [])


### PR DESCRIPTION
# Description

Made Asgi Instrumentor retrieve header keys in lower case.

Fixes #307 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tox -e test-instrumentation-asgi

Added new test cases in test_getter.py

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
