### PR TITLE
Fix failing aiopg tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: 09b010cfcc85e2aa07326e9204541b80a7dd52f0
+  CORE_REPO_SHA: main
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: main
+  CORE_REPO_SHA: 48efb9737b037b7fb85ecafdf0f3dccd45d96af8
 
 jobs:
   build:

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
@@ -22,7 +22,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.aiopg import AiopgInstrumentor
 from opentelemetry.test.test_base import TestBase
 
-POSTGRES_HOST = os.getenv("POSTGRESQL_HOST", "localhost")
+POSTGRES_HOST = os.getenv("POSTGRESQL_HOST", "127.0.0.1")
 POSTGRES_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
 POSTGRES_DB_NAME = os.getenv("POSTGRESQL_DB_NAME", "opentelemetry-tests")
 POSTGRES_PASSWORD = os.getenv("POSTGRESQL_PASSWORD", "testpassword")


### PR DESCRIPTION
# Description

The aiopg builds were hanging. Found a bug reported that aiopg [connections hang](https://github.com/aio-libs/aiopg/issues/275) when failing to resolve localhost, updated the host to 127.0.0.1 instead

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/1578
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project