### PR TITLE
Release 0.18b0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: 73601dfc0c8ab622fb8a2bfd4c0b1ea6c3f91fa3
+  CORE_REPO_SHA: 39a1f1e81dee33eba60a90463a1452e1c4ea03c7
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.17b0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.18b0...HEAD)
+
+## [0.18b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.18b0) - 2021-02-16
 
 ### Changed
 - Remove `component` span attribute in instrumentations. 

--- a/_template/setup.cfg
+++ b/_template/setup.cfg
@@ -46,7 +46,7 @@ package_dir=
 packages=find_namespace:
 
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/_template/version.py
+++ b/_template/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     ddtrace>=0.34.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     aiohttp ~= 3.0
     wrapt >= 1.0.0, < 2.0.0
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-dbapi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-dbapi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
     aiopg >= 0.13.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     asgiref ~= 3.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     asyncpg >= 0.12.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/version.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -40,15 +40,15 @@ package_dir=
 packages=find_namespace:
 install_requires =
     boto ~= 2.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-instrumentation-botocore == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-instrumentation-botocore == 0.18b0
 
 [options.extras_require]
 test =
     boto~=2.0
     moto~=1.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -40,13 +40,13 @@ package_dir=
 packages=find_namespace:
 install_requires =
     botocore ~= 1.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
 
 [options.extras_require]
 test =
     moto ~= 1.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -40,14 +40,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     celery >= 4.0, < 6.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
 
 [options.extras_require]
 test =
     pytest
     celery >= 4.0, < 6.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -40,14 +40,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     django >= 1.10
-    opentelemetry-util-http == 0.18.dev0
-    opentelemetry-instrumentation-wsgi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-util-http == 0.18b0
+    opentelemetry-instrumentation-wsgi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     wrapt >= 1.0.0, < 2.0.0
     elasticsearch >= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     elasticsearch-dsl >= 2.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -41,15 +41,15 @@ package_dir=
 packages=find_namespace:
 install_requires =
     falcon ~= 2.0
-    opentelemetry-instrumentation-wsgi == 0.18.dev0
-    opentelemetry-util-http == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-instrumentation-wsgi == 0.18b0
+    opentelemetry-util-http == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =
     falcon ~= 2.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     parameterized == 0.7.4
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
@@ -38,9 +38,9 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-asgi == 0.18.dev0
-    opentelemetry-util-http == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-asgi == 0.18b0
+    opentelemetry-util-http == 0.18b0
 
 [options.entry_points]
 opentelemetry_instrumentor =
@@ -48,7 +48,7 @@ opentelemetry_instrumentor =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     fastapi ~= 0.58.1
     requests ~= 2.23.0 # needed for testclient
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -40,15 +40,15 @@ package_dir=
 packages=find_namespace:
 install_requires =
     flask ~= 1.0
-    opentelemetry-util-http == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-instrumentation-wsgi == 0.18.dev0
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-util-http == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-instrumentation-wsgi == 0.18b0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =
     flask~=1.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
     grpcio ~= 1.27
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-test == 0.18b0
+    opentelemetry-sdk == 1.0.0rc1
     protobuf >= 3.13.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/version.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -38,14 +38,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     jinja2~=2.7
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-dbapi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-dbapi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
     mysql-connector-python ~= 8.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/version.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-dbapi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-dbapi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/version.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     pymemcache ~= 1.3
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     pymongo ~= 3.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-dbapi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-dbapi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
     PyMySQL ~=  0.10.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -40,16 +40,16 @@ package_dir=
 packages=find_namespace:
 install_requires =
     pyramid >= 1.7
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-wsgi == 0.18.dev0
-    opentelemetry-util-http == 0.18.dev0
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-wsgi == 0.18b0
+    opentelemetry-util-http == 0.18b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
     werkzeug == 0.16.1
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -39,15 +39,15 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     redis >= 2.6
     wrapt >= 1.12.1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-test == 0.18b0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     requests ~= 2.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     httpretty ~= 1.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     scikit-learn ~= 0.22.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires = 
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     wrapt >= 1.11.2
     sqlalchemy
 
 [options.extras_require]
 test =
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-sdk == 1.0.0rc1
     pytest
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-dbapi == 0.18.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-dbapi == 0.18b0
+    opentelemetry-instrumentation == 0.18b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
@@ -38,9 +38,9 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation-asgi == 0.18.dev0
-    opentelemetry-util-http == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation-asgi == 0.18b0
+    opentelemetry-util-http == 0.18b0
 
 [options.entry_points]
 opentelemetry_instrumentor =
@@ -48,7 +48,7 @@ opentelemetry_instrumentor =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     starlette ~= 0.13.0
     requests ~= 2.23.0 # needed for testclient
 

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
@@ -39,14 +39,14 @@ package_dir=
 packages=find_namespace:
 install_requires =
     tornado >= 6.0
-    opentelemetry-instrumentation == 0.18.dev0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-util-http == 0.18.dev0
+    opentelemetry-instrumentation == 0.18b0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-util-http == 0.18b0
 
 [options.extras_require]
 test =
     tornado >= 6.0
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-urllib/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-urllib/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/version.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
@@ -39,12 +39,12 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.entry_points]
 opentelemetry_propagator =
@@ -49,7 +49,7 @@ opentelemetry_ids_generator =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/util/opentelemetry-util-http/setup.cfg
+++ b/util/opentelemetry-util-http/setup.cfg
@@ -39,13 +39,13 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-instrumentation == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-instrumentation == 0.18b0
     asgiref ~= 3.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
 
 [options.packages.find]
 where = src

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/version.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"


### PR DESCRIPTION
Release 0.18b0 for instrumentations.

Also updates all references to core packages to use rc1 version.

Core release: https://github.com/open-telemetry/opentelemetry-python/pull/1610