### PR TITLE
Replaced Tracer.use_span() with opentelemetry.trace.use_span()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: 9bf28fb451a85fd9e9a4f2276c3eebd484e55d02
+  CORE_REPO_SHA: ddff32ac77e2e22b3193b71f1e71a590a99d1eda
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.18b0...HEAD)
+- Updated instrumentations to use `opentelemetry.trace.use_span` instead of `Tracer.use_span()`
+  ([#364](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/364))
 
 ### Changed
 - Rename `IdsGenerator` to `IdGenerator`

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -8,7 +8,6 @@ from opentelemetry.instrumentation.dbapi import (
     DatabaseApiIntegration,
 )
 from opentelemetry.trace import SpanKind
-from opentelemetry.trace.status import Status, StatusCode
 
 
 # pylint: disable=abstract-method
@@ -117,13 +116,7 @@ class AsyncCursorTracer(CursorTracer):
             name, kind=SpanKind.CLIENT
         ) as span:
             self._populate_span(span, cursor, *args)
-            try:
-                result = await query_method(*args, **kwargs)
-                return result
-            except Exception as ex:  # pylint: disable=broad-except
-                if span.is_recording():
-                    span.set_status(Status(StatusCode.ERROR, str(ex)))
-                raise ex
+            return await query_method(*args, **kwargs)
 
 
 def get_traced_cursor_proxy(cursor, db_api_integration, *args, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
@@ -289,8 +289,6 @@ class TestAiopgIntegration(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         db_integration = AiopgIntegration(
             mock_tracer, "testcomponent", connection_attributes
         )
@@ -322,7 +320,7 @@ class TestAiopgIntegration(TestBase):
         self.assertIs(
             span.status.status_code, trace_api.status.StatusCode.ERROR
         )
-        self.assertEqual(span.status.description, "Test Exception")
+        self.assertEqual(span.status.description, "Exception: Test Exception")
 
     def test_executemany(self):
         db_integration = AiopgIntegration(self.tracer, "testcomponent")

--- a/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
@@ -82,8 +82,6 @@ class TestBotoInstrumentor(TestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             ec2 = boto.ec2.connect_to_region("us-west-2")

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -81,8 +81,6 @@ class TestBotocoreInstrumentor(TestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             ec2 = self.session.create_client("ec2", region_name="us-west-2")

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -137,8 +137,8 @@ class CeleryInstrumentor(BaseInstrumentor):
             operation_name, context=tracectx, kind=trace.SpanKind.CONSUMER
         )
 
-        activation = self._tracer.use_span(span, end_on_exit=True)
-        activation.__enter__()
+        activation = trace.use_span(span, end_on_exit=True)
+        activation.__enter__()  # pylint: disable=E1101
         utils.attach_span(task, task_id, (span, activation))
 
     @staticmethod
@@ -186,8 +186,9 @@ class CeleryInstrumentor(BaseInstrumentor):
             span.set_attribute(_TASK_NAME_KEY, task.name)
             utils.set_attributes_from_context(span, kwargs)
 
-        activation = self._tracer.use_span(span, end_on_exit=True)
-        activation.__enter__()
+        activation = trace.use_span(span, end_on_exit=True)
+        activation.__enter__()  # pylint: disable=E1101
+
         utils.attach_span(task, task_id, (span, activation), is_publish=True)
 
         headers = kwargs.get("headers")
@@ -208,7 +209,7 @@ class CeleryInstrumentor(BaseInstrumentor):
             logger.warning("no existing span found for task_id=%s", task_id)
             return
 
-        activation.__exit__(None, None, None)
+        activation.__exit__(None, None, None)  # pylint: disable=E1101
         utils.detach_span(task, task_id, is_publish=True)
 
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -371,13 +371,7 @@ class CursorTracer:
             name, kind=SpanKind.CLIENT
         ) as span:
             self._populate_span(span, cursor, *args)
-            try:
-                result = query_method(*args, **kwargs)
-                return result
-            except Exception as ex:  # pylint: disable=broad-except
-                if span.is_recording():
-                    span.set_status(Status(StatusCode.ERROR, str(ex)))
-                raise ex
+            return query_method(*args, **kwargs)
 
 
 def get_traced_cursor_proxy(cursor, db_api_integration, *args, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -146,8 +146,6 @@ class TestDBApiIntegration(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         db_integration = dbapi.DatabaseApiIntegration(
             mock_tracer, "testcomponent", connection_attributes
         )
@@ -179,7 +177,7 @@ class TestDBApiIntegration(TestBase):
         self.assertIs(
             span.status.status_code, trace_api.status.StatusCode.ERROR
         )
-        self.assertEqual(span.status.description, "Test Exception")
+        self.assertEqual(span.status.description, "Exception: Test Exception")
 
     def test_executemany(self):
         db_integration = dbapi.DatabaseApiIntegration(

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -24,7 +24,7 @@ from opentelemetry.instrumentation.wsgi import (
     collect_request_attributes,
 )
 from opentelemetry.propagate import extract
-from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.trace import SpanKind, get_tracer, use_span
 from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
 try:
@@ -118,8 +118,8 @@ class _DjangoMiddleware(MiddlewareMixin):
             for key, value in attributes.items():
                 span.set_attribute(key, value)
 
-        activation = tracer.use_span(span, end_on_exit=True)
-        activation.__enter__()
+        activation = use_span(span, end_on_exit=True)
+        activation.__enter__()  # pylint: disable=E1101
 
         request.META[self._environ_activation_key] = activation
         request.META[self._environ_span_key] = span

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -146,8 +146,6 @@ class TestMiddleware(TestBase, WsgiTestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             Client().get("/traced/")

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -136,19 +136,15 @@ def _wrap_perform_request(tracer, span_name_prefix):
                     attributes["elasticsearch.params"] = str(params)
                 for key, value in attributes.items():
                     span.set_attribute(key, value)
-            try:
-                rv = wrapped(*args, **kwargs)
-                if isinstance(rv, dict) and span.is_recording():
-                    for member in _ATTRIBUTES_FROM_RESULT:
-                        if member in rv:
-                            span.set_attribute(
-                                "elasticsearch.{0}".format(member),
-                                str(rv[member]),
-                            )
-                return rv
-            except Exception as ex:  # pylint: disable=broad-except
-                if span.is_recording():
-                    span.set_status(Status(StatusCode.ERROR, str(ex)))
-                raise ex
+
+            rv = wrapped(*args, **kwargs)
+            if isinstance(rv, dict) and span.is_recording():
+                for member in _ATTRIBUTES_FROM_RESULT:
+                    if member in rv:
+                        span.set_attribute(
+                            "elasticsearch.{0}".format(member),
+                            str(rv[member]),
+                        )
+            return rv
 
     return wrapper

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -104,6 +104,7 @@ class _InstrumentedFalconAPI(falcon.API):
         super().__init__(*args, **kwargs)
 
     def __call__(self, env, start_response):
+        # pylint: disable=E1101
         if _excluded_urls.url_disabled(env.get("PATH_INFO", "/")):
             return super().__call__(env, start_response)
 
@@ -120,7 +121,7 @@ class _InstrumentedFalconAPI(falcon.API):
             for key, value in attributes.items():
                 span.set_attribute(key, value)
 
-        activation = self._tracer.use_span(span, end_on_exit=True)
+        activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()
         env[_ENVIRON_SPAN_KEY] = span
         env[_ENVIRON_ACTIVATION_KEY] = activation

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -199,8 +199,6 @@ class TestFalconInstrumentation(TestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = mock_span
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             self.client().simulate_get(path="/hello?q=abc")

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -138,8 +138,8 @@ def _wrapped_before_request(name_callback):
             for key, value in attributes.items():
                 span.set_attribute(key, value)
 
-        activation = tracer.use_span(span, end_on_exit=True)
-        activation.__enter__()
+        activation = trace.use_span(span, end_on_exit=True)
+        activation.__enter__()  # pylint: disable=E1101
         flask_request_environ[_ENVIRON_ACTIVATION_KEY] = activation
         flask_request_environ[_ENVIRON_SPAN_KEY] = span
         flask_request_environ[_ENVIRON_TOKEN] = token
@@ -148,6 +148,7 @@ def _wrapped_before_request(name_callback):
 
 
 def _teardown_request(exc):
+    # pylint: disable=E1101
     if _excluded_urls.url_disabled(flask.request.url):
         return
 

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -125,8 +125,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = mock_span
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             self.client.get("/hello/123")

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -191,7 +191,9 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
         else:
             yield
 
-    def _start_span(self, handler_call_details, context):
+    def _start_span(
+        self, handler_call_details, context, set_status_on_exception=False
+    ):
 
         # standard attributes
         attributes = {
@@ -234,6 +236,7 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
             name=handler_call_details.method,
             kind=trace.SpanKind.SERVER,
             attributes=attributes,
+            set_status_on_exception=set_status_on_exception,
         )
 
     def intercept_service(self, continuation, handler_call_details):
@@ -251,7 +254,9 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
                 with self._set_remote_context(context):
                     with self._start_span(
-                        handler_call_details, context
+                        handler_call_details,
+                        context,
+                        set_status_on_exception=False,
                     ) as span:
                         # wrap the context
                         context = _OpenTelemetryServicerContext(context, span)
@@ -283,7 +288,9 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
     ):
 
         with self._set_remote_context(context):
-            with self._start_span(handler_call_details, context) as span:
+            with self._start_span(
+                handler_call_details, context, set_status_on_exception=False
+            ) as span:
                 context = _OpenTelemetryServicerContext(context, span)
 
                 try:

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -59,8 +59,6 @@ class TestJinja2Instrumentor(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = mock_span
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             jinja2.environment.Template("Hello {{name}}!")

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -121,8 +121,6 @@ class TestPostgresqlIntegration(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         Psycopg2Instrumentor().instrument()
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/tests/test_pymemcache.py
@@ -84,8 +84,6 @@ class PymemcacheClientTestCase(
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             client = self.make_client([b"STORED\r\n"])

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -76,8 +76,6 @@ class TestPymongo(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         mock_event = MockEvent({})
         command_tracer = CommandTracer(mock_tracer)
         command_tracer.started(event=mock_event)

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -83,8 +83,8 @@ def _before_traversal(event):
         for key, value in attributes.items():
             span.set_attribute(key, value)
 
-    activation = tracer.use_span(span, end_on_exit=True)
-    activation.__enter__()
+    activation = trace.use_span(span, end_on_exit=True)
+    activation.__enter__()  # pylint: disable=E1101
     request_environ[_ENVIRON_ACTIVATION_KEY] = activation
     request_environ[_ENVIRON_SPAN_KEY] = span
     request_environ[_ENVIRON_TOKEN] = token
@@ -105,6 +105,7 @@ def trace_tween_factory(handler, registry):
 
     # make a request tracing function
     def trace_tween(request):
+        # pylint: disable=E1101
         if _excluded_urls.url_disabled(request.url):
             request.environ[_ENVIRON_ENABLED_KEY] = False
             # short-circuit when we don't want to trace anything

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
@@ -104,8 +104,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with patch("opentelemetry.trace.get_tracer"):
             self.client.get("/hello/123")
             span_list = self.memory_exporter.get_finished_spans()

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -42,8 +42,6 @@ class TestRedis(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             with mock.patch.object(redis_client, "connection"):
                 tracer.return_value = mock_tracer

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -98,7 +98,7 @@ class EngineTracer:
             self._operation_name(db_name, statement),
             kind=trace.SpanKind.CLIENT,
         )
-        with self.tracer.use_span(self.current_span, end_on_exit=False):
+        with trace.use_span(self.current_span, end_on_exit=False):
             if self.current_span.is_recording():
                 self.current_span.set_attribute(_STMT, statement)
                 self.current_span.set_attribute("db.system", self.vendor)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -43,8 +43,6 @@ class TestSqlalchemyInstrumentation(TestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             engine = create_engine("sqlite:///:memory:")

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -208,8 +208,8 @@ def _start_span(tracer, handler, start_time) -> _TraceContext:
         for key, value in attributes.items():
             span.set_attribute(key, value)
 
-    activation = tracer.use_span(span, end_on_exit=True)
-    activation.__enter__()
+    activation = trace.use_span(span, end_on_exit=True)
+    activation.__enter__()  # pylint: disable=E1101
     ctx = _TraceContext(activation, span, token)
     setattr(handler, _HANDLER_CONTEXT_KEY, ctx)
     return ctx
@@ -249,6 +249,6 @@ def _finish_span(tracer, handler, error=None):
             )
         )
 
-    ctx.activation.__exit__(*finish_args)
+    ctx.activation.__exit__(*finish_args)  # pylint: disable=E1101
     context.detach(ctx.token)
     delattr(handler, _HANDLER_CONTEXT_KEY)

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
@@ -64,7 +64,7 @@ def fetch_async(tracer, func, _, args, kwargs):
         for key, value in attributes.items():
             span.set_attribute(key, value)
 
-    with tracer.use_span(span):
+    with trace.use_span(span):
         inject(type(request.headers).__setitem__, request.headers)
         future = func(*args, **kwargs)
         future.add_done_callback(

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -157,8 +157,6 @@ class TestTornadoInstrumentation(TornadoTest):
         mock_span = Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = True
         with patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             self.fetch("/")

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -218,7 +218,7 @@ class OpenTelemetryMiddleware:
         )
 
         try:
-            with self.tracer.use_span(span):
+            with trace.use_span(span):
                 start_response = self._create_start_response(
                     span, start_response
                 )
@@ -239,7 +239,7 @@ class OpenTelemetryMiddleware:
 # behavior as little as possible).
 def _end_span_after_iterating(iterable, span, tracer, token):
     try:
-        with tracer.use_span(span):
+        with trace.use_span(span):
             for yielded in iterable:
                 yield yielded
     finally:

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -129,8 +129,6 @@ class TestWsgiApplication(WsgiTestBase):
         mock_span = mock.Mock()
         mock_span.is_recording.return_value = False
         mock_tracer.start_span.return_value = mock_span
-        mock_tracer.use_span.return_value.__enter__ = mock_span
-        mock_tracer.use_span.return_value.__exit__ = mock_span
         with mock.patch("opentelemetry.trace.get_tracer") as tracer:
             tracer.return_value = mock_tracer
             app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)


### PR DESCRIPTION
# Description

Replaces `Tracer.use_span()` with `opentelemetry.trace.use_span()`.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1630

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Updated existing tests

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/1668
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
