### PR TITLE
use StatusCode from trace instead of trace.status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: ddff32ac77e2e22b3193b71f1e71a590a99d1eda
+  CORE_REPO_SHA: 10dc3a8bc031d5b355f62a698094a03eedb2a8ee
 
 jobs:
   build:

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -31,7 +31,7 @@ from opentelemetry.instrumentation.aiohttp_client import (
     AioHttpClientInstrumentor,
 )
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 
 def run_with_test_server(

--- a/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
@@ -268,9 +268,7 @@ class TestAiopgIntegration(TestBase):
         self.assertEqual(span.attributes["db.user"], "testuser")
         self.assertEqual(span.attributes["net.peer.name"], "testhost")
         self.assertEqual(span.attributes["net.peer.port"], 123)
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.UNSET
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.UNSET)
 
     def test_span_not_recording(self):
         connection_props = {
@@ -317,9 +315,7 @@ class TestAiopgIntegration(TestBase):
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
         self.assertEqual(span.attributes["db.statement"], "Test query")
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.ERROR
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.ERROR)
         self.assertEqual(span.status.description, "Exception: Test Exception")
 
     def test_executemany(self):

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -136,7 +136,7 @@ class TestBotocoreInstrumentor(TestBase):
             },
         )
         self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.ERROR,
+            span.status.status_code, trace_api.StatusCode.ERROR,
         )
 
     # Comment test for issue 1088

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -60,9 +60,7 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(span.attributes["db.user"], "testuser")
         self.assertEqual(span.attributes["net.peer.name"], "testhost")
         self.assertEqual(span.attributes["net.peer.port"], 123)
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.UNSET
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.UNSET)
 
     def test_span_name(self):
         db_integration = dbapi.DatabaseApiIntegration(
@@ -125,9 +123,7 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(span.attributes["db.user"], "testuser")
         self.assertEqual(span.attributes["net.peer.name"], "testhost")
         self.assertEqual(span.attributes["net.peer.port"], 123)
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.UNSET
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.UNSET)
 
     def test_span_not_recording(self):
         connection_props = {
@@ -174,9 +170,7 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
         self.assertEqual(span.attributes["db.statement"], "Test query")
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.ERROR
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.ERROR)
         self.assertEqual(span.status.description, "Exception: Test Exception")
 
     def test_executemany(self):

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -24,8 +24,7 @@ from django.test.utils import setup_test_environment, teardown_test_environment
 from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.test.wsgitestutil import WsgiTestBase
-from opentelemetry.trace import SpanKind
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import SpanKind, StatusCode
 from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
 # pylint: disable=import-error

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -28,7 +28,7 @@ from opentelemetry.instrumentation.elasticsearch import (
     ElasticsearchInstrumentor,
 )
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 major_version = elasticsearch.VERSION[0]
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -18,7 +18,7 @@ from falcon import testing
 
 from opentelemetry.instrumentation.falcon import FalconInstrumentor
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
 from .app import make_app

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -152,7 +152,7 @@ class TestClientProto(TestBase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
 
     def test_error_stream_unary(self):
@@ -163,7 +163,7 @@ class TestClientProto(TestBase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
 
     def test_error_unary_stream(self):
@@ -174,7 +174,7 @@ class TestClientProto(TestBase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
 
     def test_error_stream_stream(self):
@@ -185,5 +185,5 @@ class TestClientProto(TestBase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -28,7 +28,7 @@ from opentelemetry.instrumentation.grpc import (
 )
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 from .protobuf.test_server_pb2 import Request, Response
 from .protobuf.test_server_pb2_grpc import (

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -66,9 +66,7 @@ class TestPymongo(TestBase):
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
-        self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.UNSET
-        )
+        self.assertIs(span.status.status_code, trace_api.StatusCode.UNSET)
         self.assertIsNotNone(span.end_time)
 
     def test_not_recording(self):
@@ -96,7 +94,7 @@ class TestPymongo(TestBase):
         span = spans_list[0]
 
         self.assertIs(
-            span.status.status_code, trace_api.status.StatusCode.ERROR,
+            span.status.status_code, trace_api.StatusCode.ERROR,
         )
         self.assertEqual(span.status.description, "failure")
         self.assertIsNotNone(span.end_time)
@@ -116,10 +114,10 @@ class TestPymongo(TestBase):
         second_span = spans_list[1]
 
         self.assertIs(
-            first_span.status.status_code, trace_api.status.StatusCode.UNSET,
+            first_span.status.status_code, trace_api.StatusCode.UNSET,
         )
         self.assertIs(
-            second_span.status.status_code, trace_api.status.StatusCode.ERROR,
+            second_span.status.status_code, trace_api.StatusCode.ERROR,
         )
 
     def test_int_command(self):

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -25,7 +25,7 @@ from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.sdk import resources
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 
 class InvalidResponseObjectException(Exception):
@@ -86,7 +86,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             },
         )
 
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
 
         self.check_span_instrumentation_info(
             span, opentelemetry.instrumentation.requests
@@ -130,7 +130,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
 
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
 
     def test_uninstrument(self):

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -32,7 +32,7 @@ from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.sdk import resources
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 
 class RequestsIntegrationTestBase(abc.ABC):
@@ -111,7 +111,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             },
         )
 
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
 
         self.check_span_instrumentation_info(
             span, opentelemetry.instrumentation.urllib
@@ -161,7 +161,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
 
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
 
     def test_uninstrument(self):

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -21,7 +21,7 @@ from urllib.parse import urlsplit
 import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import trace as trace_api
 from opentelemetry.test.wsgitestutil import WsgiTestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 
 class Response:

--- a/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
@@ -5,7 +5,7 @@ import asyncpg
 
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 POSTGRES_HOST = os.getenv("POSTGRESQL_HOST", "localhost")
 POSTGRES_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))

--- a/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
@@ -22,7 +22,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.sdk.trace import TracerProvider, export
-from opentelemetry.trace.status import StatusCode
+from opentelemetry.trace import StatusCode
 
 # set a high timeout for async executions due to issues in CI
 ASYNC_GET_TIMEOUT = 120

--- a/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
@@ -36,7 +36,7 @@ class TestRedisInstrument(TestBase):
     def _check_span(self, span, name):
         self.assertEqual(span.attributes["service"], self.test_service)
         self.assertEqual(span.name, name)
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
         self.assertEqual(span.attributes.get("db.name"), 0)
         self.assertEqual(span.attributes["net.peer.name"], "localhost")
         self.assertEqual(span.attributes["net.peer.ip"], 6379)
@@ -130,7 +130,7 @@ class TestRedisDBIndexInstrument(TestBase):
 
     def _check_span(self, span, name):
         self.assertEqual(span.name, name)
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
         self.assertEqual(span.attributes["net.peer.name"], "localhost")
         self.assertEqual(span.attributes["net.peer.ip"], 6379)
         self.assertEqual(span.attributes["db.redis.database_index"], 10)

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
@@ -114,7 +114,7 @@ class SQLAlchemyTestMixin(TestBase):
             name = "{0} {1}".format(name, self.SQL_DB)
         self.assertEqual(span.name, name)
         self.assertEqual(span.attributes.get(_DB), self.SQL_DB)
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
         self.assertGreater((span.end_time - span.start_time), 0)
 
     def test_orm_insert(self):

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_instrument.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_instrument.py
@@ -65,5 +65,5 @@ class SQLAlchemyInstrumentTestCase(TestBase):
         span = traces[0]
         # check subset of span fields
         self.assertEqual(span.name, "SELECT opentelemetry-tests")
-        self.assertIs(span.status.status_code, trace.status.StatusCode.UNSET)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
         self.assertGreater((span.end_time - span.start_time), 0)

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mysql.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mysql.py
@@ -76,6 +76,6 @@ class MysqlConnectorTestCase(SQLAlchemyTestMixin):
         self.assertTrue(span.end_time - span.start_time > 0)
         # check the error
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
         self.assertIn("a_wrong_table", span.status.description)

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_postgres.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_postgres.py
@@ -74,7 +74,7 @@ class PostgresTestCase(SQLAlchemyTestMixin):
         self.assertTrue(span.end_time - span.start_time > 0)
         # check the error
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
         self.assertIn("a_wrong_table", span.status.description)
 

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
@@ -51,7 +51,7 @@ class SQLiteTestCase(SQLAlchemyTestMixin):
         self.assertTrue((span.end_time - span.start_time) > 0)
         # check the error
         self.assertIs(
-            span.status.status_code, trace.status.StatusCode.ERROR,
+            span.status.status_code, trace.StatusCode.ERROR,
         )
         self.assertEqual(
             span.status.description, "no such table: a_wrong_table"


### PR DESCRIPTION
# Description

Updating reference to `StatusCode` to use the simpler path.

Related to: https://github.com/open-telemetry/opentelemetry-python/issues/1619

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/1681

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated
