### PR TITLE
datadog: do not add None tracestate value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rename `IdsGenerator` to `IdGenerator`
   ([#350](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/350))
+- `opentelemetry-exporter-datadog` Fix warning when DatadogFormat encounters a request with
+  no DD_ORIGIN headers ([#368](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/368)).
 
 ## [0.18b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.18b0) - 2021-02-16
 
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#345](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/345))
 
 ### Removed
-- Remove `component` span attribute in instrumentations. 
+- Remove `component` span attribute in instrumentations.
   `opentelemetry-instrumentation-aiopg`, `opentelemetry-instrumentation-dbapi` Remove unused `database_type` parameter from `trace_integration` function.
   ([#301](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/301))
 - `opentelemetry-instrumentation-asgi` Return header values using case insensitive keys

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -91,9 +91,7 @@ class DatadogFormat(TextMapPropagator):
             return
         sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0
         set_in_carrier(
-            carrier,
-            self.TRACE_ID_KEY,
-            format_trace_id(span.context.trace_id),
+            carrier, self.TRACE_ID_KEY, format_trace_id(span.context.trace_id),
         )
         set_in_carrier(
             carrier, self.PARENT_ID_KEY, format_span_id(span.context.span_id)


### PR DESCRIPTION
# Description

The datadog exporter sometimes attempts to add a "None" value to the TraceState, if the
datadog origin header doesn't exist.

This does not cause runtime errors in the most recent opentelemetry
release (tracestate protects against an invalid value), but does cause warnings:

WARNING  opentelemetry.trace.span:span.py:230 Invalid key/value pair (dd_origin, None) found.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/262#issuecomment-788969716

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The existing tests suffice to verify my change didn't affect behavior, aside from the warning.

I was thinking of adding a log.capture test, but thought it would be overkill.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
