### PR TITLE
Fix the empty headers use case for OTTracePropagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.18b0...HEAD)
 - Updated instrumentations to use `opentelemetry.trace.use_span` instead of `Tracer.use_span()`
   ([#364](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/364))
+- `opentelemetry-propagator-ot-trace` Do not throw an exception when headers are not present
+  ([#378](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/378))
 
 ### Changed
 - Rename `IdsGenerator` to `IdGenerator`

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -121,9 +121,7 @@ class OTTracePropagator(TextMapPropagator):
             carrier, OT_TRACE_ID_HEADER, hex(span_context.trace_id)[2:][-16:]
         )
         set_in_carrier(
-            carrier,
-            OT_SPAN_ID_HEADER,
-            hex(span_context.span_id)[2:][-16:],
+            carrier, OT_SPAN_ID_HEADER, hex(span_context.span_id)[2:][-16:],
         )
 
         if span_context.trace_flags == TraceFlags.SAMPLED:
@@ -167,8 +165,7 @@ class OTTracePropagator(TextMapPropagator):
 
 
 def _extract_first_element(
-    items: Iterable[TextMapPropagatorT],
-    default: Any = None,
+    items: Iterable[TextMapPropagatorT], default: Any = None,
 ) -> Optional[TextMapPropagatorT]:
     if items is None:
         return default

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from re import compile as re_compile
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from opentelemetry.baggage import get_all, set_baggage
 from opentelemetry.context import Context
@@ -55,10 +55,10 @@ class OTTracePropagator(TextMapPropagator):
     ) -> Context:
 
         traceid = _extract_first_element(
-            getter.get(carrier, OT_TRACE_ID_HEADER)
+            getter.get(carrier, OT_TRACE_ID_HEADER), INVALID_TRACE_ID
         )
 
-        spanid = _extract_first_element(getter.get(carrier, OT_SPAN_ID_HEADER))
+        spanid = _extract_first_element(getter.get(carrier, OT_SPAN_ID_HEADER), INVALID_SPAN_ID)
 
         sampled = _extract_first_element(
             getter.get(carrier, OT_SAMPLED_HEADER)
@@ -164,7 +164,8 @@ class OTTracePropagator(TextMapPropagator):
 
 def _extract_first_element(
     items: Iterable[TextMapPropagatorT],
+    default: Any = None,
 ) -> Optional[TextMapPropagatorT]:
     if items is None:
-        return None
+        return default
     return next(iter(items), None)

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -58,7 +58,9 @@ class OTTracePropagator(TextMapPropagator):
             getter.get(carrier, OT_TRACE_ID_HEADER), INVALID_TRACE_ID
         )
 
-        spanid = _extract_first_element(getter.get(carrier, OT_SPAN_ID_HEADER), INVALID_SPAN_ID)
+        spanid = _extract_first_element(
+            getter.get(carrier, OT_SPAN_ID_HEADER), INVALID_SPAN_ID
+        )
 
         sampled = _extract_first_element(
             getter.get(carrier, OT_SAMPLED_HEADER)
@@ -119,7 +121,9 @@ class OTTracePropagator(TextMapPropagator):
             carrier, OT_TRACE_ID_HEADER, hex(span_context.trace_id)[2:][-16:]
         )
         set_in_carrier(
-            carrier, OT_SPAN_ID_HEADER, hex(span_context.span_id)[2:][-16:],
+            carrier,
+            OT_SPAN_ID_HEADER,
+            hex(span_context.span_id)[2:][-16:],
         )
 
         if span_context.trace_flags == TraceFlags.SAMPLED:

--- a/propagator/opentelemetry-propagator-ot-trace/tests/test_ot_trace_propagator.py
+++ b/propagator/opentelemetry-propagator-ot-trace/tests/test_ot_trace_propagator.py
@@ -366,3 +366,12 @@ class TestOTTracePropagator(TestCase):
 
         self.assertEqual(baggage["abc"], "abc")
         self.assertEqual(baggage["def"], "def")
+
+    def test_extract_empty(self):
+        "Test extraction when no headers are present"
+
+        span_context = get_current_span(
+            self.ot_trace_propagator.extract(carrier_getter, {})
+        ).get_span_context()
+
+        self.assertEqual(span_context, INVALID_SPAN_CONTEXT)


### PR DESCRIPTION
# Description
Fix the empty headers use case (ignore instead of throwing an exception) for `OTTracePropagator`.
See more details in the issue below.

Fixes #377 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See added unit test in this PR.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
