### PR TITLE
Reimplement the keys method in WSGI CarrierGetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.18b0...HEAD)
 - Updated instrumentations to use `opentelemetry.trace.use_span` instead of `Tracer.use_span()`
   ([#364](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/364))
+- `opentelemetry-instrumentation-wsgi` Reimplement `keys` method to return actual keys from the carrier instead of an empty list.
+  ([#379](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/379))
 
 ### Changed
 - Rename `IdsGenerator` to `IdGenerator`

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -66,6 +66,8 @@ from opentelemetry.propagators.textmap import DictGetter
 from opentelemetry.trace.status import Status, StatusCode
 
 _HTTP_VERSION_PREFIX = "HTTP/"
+_CARRIER_KEY_PREFIX = "HTTP_"
+_CARRIER_KEY_PREFIX_LEN = len(_CARRIER_KEY_PREFIX)
 
 
 class CarrierGetter(DictGetter):
@@ -89,7 +91,11 @@ class CarrierGetter(DictGetter):
         return None
 
     def keys(self, carrier):
-        return []
+        return [
+            key[_CARRIER_KEY_PREFIX_LEN:].lower().replace("_", "-")
+            for key in carrier
+            if key.startswith(_CARRIER_KEY_PREFIX)
+        ]
 
 
 carrier_getter = CarrierGetter()

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_getter.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_getter.py
@@ -22,15 +22,30 @@ class TestCarrierGetter(TestCase):
         getter = CarrierGetter()
         carrier = {}
         val = getter.get(carrier, "test")
+
         self.assertIsNone(val)
 
-    def test_get_(self):
+    def test_get(self):
         getter = CarrierGetter()
         carrier = {"HTTP_TEST_KEY": "val"}
         val = getter.get(carrier, "test-key")
+
         self.assertEqual(val, ["val"])
 
     def test_keys(self):
         getter = CarrierGetter()
+        keys = getter.keys(
+            {
+                "HTTP_TEST_KEY": "val",
+                "HTTP_OTHER_KEY": 42,
+                "NON_HTTP_KEY": "val",
+            }
+        )
+
+        self.assertEqual(keys, ["test-key", "other-key"])
+
+    def test_keys_empty(self):
+        getter = CarrierGetter()
         keys = getter.keys({})
+
         self.assertEqual(keys, [])


### PR DESCRIPTION
# Description

Implements keys method in WSGI CarrierGetter (previously a static, empty list was returned)

Fixes #376 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See the unit test added in this PR.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
