### PR TITLE
fix instrumentation of connection when pool.acquire was called multip…

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -86,9 +86,11 @@ def get_traced_pool_proxy(pool, db_api_integration, *args, **kwargs):
         async def _acquire(self):
             # pylint: disable=protected-access
             connection = await self.__wrapped__._acquire()
-            return get_traced_connection_proxy(
-                connection, db_api_integration, *args, **kwargs
-            )
+            if not hasattr(connection, "__wrapped__"):
+                connection = get_traced_connection_proxy(
+                    connection, db_api_integration, *args, **kwargs
+                )
+            return connection
 
     return TracedPoolProxy(pool, *args, **kwargs)
 

--- a/tests/opentelemetry-docker-tests/tests/aiopg/test_aiopg_funcitonal.py
+++ b/tests/opentelemetry-docker-tests/tests/aiopg/test_aiopg_funcitonal.py
@@ -1,0 +1,52 @@
+import asyncio
+import os
+
+import aiopg
+
+from opentelemetry.instrumentation.aiopg import AiopgInstrumentor
+from opentelemetry.test.test_base import TestBase
+
+POSTGRES_HOST = os.getenv("POSTGRESQL_HOST", "localhost")
+POSTGRES_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
+POSTGRES_DB_NAME = os.getenv("POSTGRESQL_DB_NAME", "opentelemetry-tests")
+POSTGRES_PASSWORD = os.getenv("POSTGRESQL_PASSWORD", "testpassword")
+POSTGRES_USER = os.getenv("POSTGRESQL_USER", "testuser")
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+class TestFunctionalAsyncPG(TestBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._connection = None
+        cls._cursor = None
+        cls._tracer = cls.tracer_provider.get_tracer(__name__)
+        AiopgInstrumentor().instrument(tracer_provider=cls.tracer_provider)
+        cls._dsn = (
+            f"dbname='{POSTGRES_DB_NAME}' user='{POSTGRES_USER}' password='{POSTGRES_PASSWORD}'"
+            f" host='{POSTGRES_HOST}' port='{POSTGRES_PORT}'"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        AiopgInstrumentor().uninstrument()
+
+    def test_instrumented_pool_with_multiple_acquires(self, *_, **__):
+        async def double_asquire():
+            pool = await aiopg.create_pool(dsn=self._dsn)
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    query = "SELECT 1"
+                    await cursor.execute(query)
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    query = "SELECT 1"
+                    await cursor.execute(query)
+
+        async_call(double_asquire())
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)


### PR DESCRIPTION
…le times

# Description

Fix appearing multiple nested spans when instumented `aiopg.pool` was used. The reason of the bug was that `pool.acquire` instrumented connection every time. But pool reuses old connections which had already been instrumented. This fix addes checking connection. Instrumenting connection only if it was not instrumented.

Fixes #372

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See added integration test in this PR.

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
