### PR TITLE
Fix inject method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#315](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/315))
 - Make getters and setters optional
   ([#372](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/372))
+- Fixed metadata injection in a client gRPC interceptor.
+  ([#388](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/388)
 
 ### Removed
 - Removing support for Python 3.5

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -52,17 +52,6 @@ class _GuardedSpan:
         return self.span
 
 
-def _inject_span_context(metadata: MutableMapping[str, str]) -> None:
-    # pylint:disable=unused-argument
-    def append_metadata(
-        carrier: MutableMapping[str, str], key: str, value: str
-    ):
-        metadata[key] = value
-
-    # Inject current active span from the context
-    inject(append_metadata, metadata)
-
-
 def _make_future_done_callback(span, rpc_info):
     def callback(response_future):
         with span:
@@ -125,7 +114,7 @@ class OpenTelemetryClientInterceptor(
             mutable_metadata = OrderedDict(metadata)
 
         with self._start_guarded_span(client_info.full_method) as guarded_span:
-            _inject_span_context(mutable_metadata)
+            inject(mutable_metadata)
             metadata = tuple(mutable_metadata.items())
 
             rpc_info = RpcInfo(
@@ -160,7 +149,7 @@ class OpenTelemetryClientInterceptor(
             mutable_metadata = OrderedDict(metadata)
 
         with self._start_span(client_info.full_method) as span:
-            _inject_span_context(mutable_metadata)
+            inject(mutable_metadata)
             metadata = tuple(mutable_metadata.items())
             rpc_info = RpcInfo(
                 full_method=client_info.full_method,
@@ -195,7 +184,7 @@ class OpenTelemetryClientInterceptor(
             mutable_metadata = OrderedDict(metadata)
 
         with self._start_guarded_span(client_info.full_method) as guarded_span:
-            _inject_span_context(mutable_metadata)
+            inject(mutable_metadata)
             metadata = tuple(mutable_metadata.items())
             rpc_info = RpcInfo(
                 full_method=client_info.full_method,

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -20,7 +20,6 @@
 """Implementation of the invocation-side open-telemetry interceptor."""
 
 from collections import OrderedDict
-from typing import MutableMapping
 
 import grpc
 


### PR DESCRIPTION
# Description

As the opentelemtry-api has a breaking change in the arguments of the `inject` method, we need to adopt it.

https://github.com/open-telemetry/opentelemetry-python/commit/25edfefd70f2d2fd8f6c6a90293d598a358fbb96#diff-b0320c590cdc029baa73878aad144c5ba225caf819db268eecfbbf13b6bfbb1a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I tested it by installing it locally.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
