### PR TITLE
Django trace response headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: cad261e5dae1fe986c87e6965664b45cc9ab73c3
+  CORE_REPO_SHA: 7b11971c504387341df0c38f5a34d7d1293c7e4f
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#299](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/299))
 - `opentelemetry-instrumenation-django` now supports request and response hooks.
   ([#407](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/407))
+- Add trace response header support for Django.
+  ([#395](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/395))
 
 ### Removed
 - Remove `http.status_text` from span attributes

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -20,6 +20,9 @@ from django.http import HttpRequest, HttpResponse
 
 from opentelemetry.context import attach, detach
 from opentelemetry.instrumentation.django.version import __version__
+from opentelemetry.instrumentation.propagators import (
+    get_global_back_propagator,
+)
 from opentelemetry.instrumentation.utils import extract_attributes_from_object
 from opentelemetry.instrumentation.wsgi import (
     add_response_attributes,
@@ -179,6 +182,11 @@ class _DjangoMiddleware(MiddlewareMixin):
                 response,
             )
 
+            propagator = get_global_back_propagator()
+            if propagator:
+                propagator.inject(response)
+
+            # record any exceptions raised while processing the request
             exception = request.META.pop(self._environ_exception_key, None)
             if _DjangoMiddleware._otel_response_hook:
                 _DjangoMiddleware._otel_response_hook(  # pylint: disable=not-callable

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -26,10 +26,19 @@ from opentelemetry.instrumentation.django import (
     DjangoInstrumentor,
     _DjangoMiddleware,
 )
+from opentelemetry.instrumentation.propagators import (
+    TraceResponsePropagator,
+    set_global_back_propagator,
+)
 from opentelemetry.sdk.trace import Span
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.test.wsgitestutil import WsgiTestBase
-from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.trace import (
+    SpanKind,
+    StatusCode,
+    format_span_id,
+    format_trace_id,
+)
 from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
 # pylint: disable=import-error
@@ -41,6 +50,7 @@ from .views import (
     route_span_name,
     traced,
     traced_template,
+    with_response_header,
 )
 
 DJANGO_2_2 = VERSION >= (2, 2)
@@ -52,6 +62,7 @@ urlpatterns = [
     url(r"^excluded_arg/", excluded),
     url(r"^excluded_noarg/", excluded_noarg),
     url(r"^excluded_noarg2/", excluded_noarg2),
+    url(r"^response_header/", with_response_header),
     url(r"^span_name/([0-9]{4})/$", route_span_name),
 ]
 _django_instrumentor = DjangoInstrumentor()
@@ -309,3 +320,55 @@ class TestMiddleware(TestBase, WsgiTestBase):
         self.assertIsInstance(response_hook_args[1], HttpRequest)
         self.assertIsInstance(response_hook_args[2], HttpResponse)
         self.assertEqual(response_hook_args[2], response)
+
+    def test_trace_response_headers(self):
+        response = Client().get("/span_name/1234/")
+        self.assertNotIn("Server-Timing", response._headers)
+        self.memory_exporter.clear()
+
+        set_global_back_propagator(TraceResponsePropagator())
+
+        response = Client().get("/span_name/1234/")
+        span = self.memory_exporter.get_finished_spans()[0]
+
+        self.assertIn("traceresponse", response._headers)
+        self.assertEqual(
+            response._headers["access-control-expose-headers"][0],
+            "Access-Control-Expose-Headers",
+        )
+        self.assertEqual(
+            response._headers["access-control-expose-headers"][1],
+            "traceresponse",
+        )
+        self.assertEqual(
+            response._headers["traceresponse"][0], "traceresponse"
+        )
+        self.assertEqual(
+            response._headers["traceresponse"][1],
+            "00-{0}-{1}-01".format(
+                format_trace_id(span.get_span_context().trace_id),
+                format_span_id(span.get_span_context().span_id),
+            ),
+        )
+        self.memory_exporter.clear()
+
+    def test_trace_response_header_pre_existing_header(self):
+        set_global_back_propagator(TraceResponsePropagator())
+
+        response = Client().get("/response_header/")
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertIn("traceresponse", response._headers)
+        self.assertEqual(
+            response._headers["access-control-expose-headers"][1],
+            "X-Test-Header, traceresponse",
+        )
+        self.assertEqual(
+            response._headers["traceresponse"][1],
+            "abc; val=1, "
+            + "00-{0}-{1}-01".format(
+                format_trace_id(span.get_span_context().trace_id),
+                format_span_id(span.get_span_context().span_id),
+            ),
+        )
+
+        self.memory_exporter.clear()

--- a/instrumentation/opentelemetry-instrumentation-django/tests/views.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/views.py
@@ -1,5 +1,9 @@
 from django.http import HttpResponse
 
+from opentelemetry.instrumentation.propagators import (
+    _HTTP_HEADER_ACCESS_CONTROL_EXPOSE_HEADERS,
+)
+
 
 def traced(request):  # pylint: disable=unused-argument
     return HttpResponse()
@@ -29,3 +33,10 @@ def route_span_name(
     request, *args, **kwargs
 ):  # pylint: disable=unused-argument
     return HttpResponse()
+
+
+def with_response_header(request):  # pylint: disable=unused-argument
+    response = HttpResponse()
+    response["traceresponse"] = "abc; val=1"
+    response[_HTTP_HEADER_ACCESS_CONTROL_EXPOSE_HEADERS] = "X-Test-Header"
+    return response


### PR DESCRIPTION
# Description

Added opt-in support to return trace response headers from Django.

This allows users to configure their Django apps to inject trace context
as headers in HTTP responses. This is useful when client side apps need
to connect their spans with the server side spans e.g, in RUM products.

Today the most practical way to do this is to use the `Server-Timing`
header but in near future we might use the `traceresponse` header as
described here: https://w3c.github.io/trace-context/#trace-context-http-response-headers-format

As a result the implementation does not use a hard-coded header and
instead let's the users pick one.

This can be done by setting the `OTEL_PYTHON_TRACE_RESPONSE_HEADER` to
the header name that users want to inject in HTTP responses. The option
does not have a default value and the feature is disbaled when a env var
is not set.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested manually
- [x] Added unit tests

# Does This PR Require a Contrib Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/1762
- [ ] No.


# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
