### PR TITLE
Fix Xray ID Generator Format Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#392](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/39))
 - Publish `opentelemetry-propagator-ot-trace` package as a part of the release process
   ([#387](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/387))
+- Fixed `AwsXRayIdGenerator()` class to provide correct Xray Format as Per AWS Documentations. 
+  ([#398](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/398))
 
 ### Added
 - `opentelemetry-instrumentation-urllib3` Add urllib3 instrumentation

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,8 +8,12 @@ sphinx~=2.1
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
 pytest!=5.2.3
+pytest-benchmark>=3.2.3
+tox>=3.23.0
 pytest-cov>=2.8
 readme-renderer~=24.0
 grpcio-tools==1.29.0
 mypy-protobuf>=1.23
 protobuf>=3.13.0
+
+setuptools~=54.2.0

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/aws_xray_id_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/aws_xray_id_generator.py
@@ -56,9 +56,8 @@ API
 .. _trace ID format: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
 """
 
-import binascii
-import os
 import time
+import random
 
 
 class AwsXRayIdGenerator():
@@ -67,14 +66,15 @@ class AwsXRayIdGenerator():
     See Same implementation in Javascript: https://github.com/aws-observability/aws-otel-js/tree/main/packages/opentelemetry-id-generator-aws-xray
     """
     TIME = time
+    TRACE_ID_LENGTH = 32
+    SPAN_ID_LENGTH = 16
 
     # Ex: 0c6d1c759808e783
-    @staticmethod
-    def generate_span_id() -> str:
-        return binascii.b2a_hex(os.urandom(8)).decode()
+    def generate_span_id(self) -> str:
+        return (hex(random.getrandbits(88))[2:])[:self.SPAN_ID_LENGTH]
 
     # Ex: 6068d890e80ef8ae6323f667558381bd
     def generate_trace_id(self) -> str:
-        hexa = hex(int(self.TIME.time()))[2:]
-        bina = binascii.b2a_hex(os.urandom(12)).decode()
-        return hexa + bina
+        stamp8 = hex(int(self.TIME.time()))[2:]
+        random24 = hex(random.getrandbits(116))[2:]
+        return (stamp8 + random24)[:self.TRACE_ID_LENGTH]

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/performance/benchmarks/trace/test_benchmark_aws_xray_ids_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/performance/benchmarks/trace/test_benchmark_aws_xray_ids_generator.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import sys
+
+_src_folder_path = os.path.dirname(__file__).split('/')[0:-4]
+_aws_xray_file = os.path.join('/'.join(_src_folder_path), 'src')
+sys.path.append(_aws_xray_file)
 
 from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
@@ -28,7 +28,7 @@ from opentelemetry.trace.span import INVALID_TRACE_ID
 
 
 class AwsXRayIdGeneratorTest(unittest.TestCase):
-    def test_ids_are_valid(self):
+    def test_trace_ids_are_valid(self):
         id_generator = AwsXRayIdGenerator()
         for _ in range(1000):
             trace_id = id_generator.generate_trace_id()
@@ -36,7 +36,7 @@ class AwsXRayIdGeneratorTest(unittest.TestCase):
             span_id = id_generator.generate_span_id()
             self.assertTrue(span_id != INVALID_TRACE_ID)
 
-    def test_id_timestamps_are_acceptable_for_xray(self):
+    def test_trace_id_timestamps_are_acceptable_for_xray(self):
         id_generator = AwsXRayIdGenerator()
         for _ in range(1000):
             trace_id = id_generator.generate_trace_id()
@@ -47,3 +47,11 @@ class AwsXRayIdGeneratorTest(unittest.TestCase):
                 (datetime.datetime.now() - datetime.timedelta(30)).timestamp()
             )
             self.assertGreater(trace_id_time, one_month_ago_time)
+
+    def test_trace_id_length_is_correct(self):
+        trace_id = AwsXRayIdGenerator().generate_trace_id()
+        self.assertEqual(len(trace_id), 32)
+
+    def test_span_id_length_is_correct(self):
+        span_id = AwsXRayIdGenerator().generate_span_id()
+        self.assertEqual(len(span_id), 16)

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
@@ -18,13 +18,14 @@ import unittest
 import sys
 import os
 
+from opentelemetry.trace.span import INVALID_TRACE_ID
+
 # Make sure we import local file instead of /site-packages
 _src_folder_path = os.path.dirname(__file__).split('/')[0:-2]
 _aws_xray_file = os.path.join('/'.join(_src_folder_path), 'src')
 sys.path.append(_aws_xray_file)
 
 from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
-from opentelemetry.trace.span import INVALID_TRACE_ID
 
 
 class AwsXRayIdGeneratorTest(unittest.TestCase):
@@ -49,9 +50,11 @@ class AwsXRayIdGeneratorTest(unittest.TestCase):
             self.assertGreater(trace_id_time, one_month_ago_time)
 
     def test_trace_id_length_is_correct(self):
-        trace_id = AwsXRayIdGenerator().generate_trace_id()
-        self.assertEqual(len(trace_id), 32)
+        for _ in range(1000000):
+            trace_id = AwsXRayIdGenerator().generate_trace_id()
+            self.assertEqual(len(trace_id), 32)
 
     def test_span_id_length_is_correct(self):
-        span_id = AwsXRayIdGenerator().generate_span_id()
-        self.assertEqual(len(span_id), 16)
+        for _ in range(1000000):
+            span_id = AwsXRayIdGenerator().generate_span_id()
+            self.assertEqual(len(span_id), 16)

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/trace/test_aws_xray_ids_generator.py
@@ -15,6 +15,13 @@
 import datetime
 import time
 import unittest
+import sys
+import os
+
+# Make sure we import local file instead of /site-packages
+_src_folder_path = os.path.dirname(__file__).split('/')[0:-2]
+_aws_xray_file = os.path.join('/'.join(_src_folder_path), 'src')
+sys.path.append(_aws_xray_file)
 
 from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
 from opentelemetry.trace.span import INVALID_TRACE_ID
@@ -33,7 +40,7 @@ class AwsXRayIdGeneratorTest(unittest.TestCase):
         id_generator = AwsXRayIdGenerator()
         for _ in range(1000):
             trace_id = id_generator.generate_trace_id()
-            trace_id_time = trace_id >> 96
+            trace_id_time = int(trace_id[:8], 16)
             current_time = int(time.time())
             self.assertLessEqual(trace_id_time, current_time)
             one_month_ago_time = int(

--- a/tox.ini
+++ b/tox.ini
@@ -319,7 +319,7 @@ commands =
 
 [testenv:lint]
 basepython: python3.8
-recreate = False 
+recreate = False
 deps =
   -c dev-requirements.txt
   flaky


### PR DESCRIPTION
# Description

Upon using the SDK class AwsXRayIdGenerator(), I found that the trace_id and span_id generated is in completely wrong format although a correct Xray Documentation was pasted in the python class. A sample implementation in Javascript is here: https://github.com/aws-observability/aws-otel-js/tree/main/packages/opentelemetry-id-generator-aws-xray 

Before: 
trace_id and span_id gave random numbers 

After: 
trace_id is a combination of a 8 hexadecimal digits created from timestamp and 24 random hexadecimal digit as per [aws documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids)

span_id is equivalent to [xray segment id](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html) which is 16 random hexadecimal digits 

Fixes # (issue)
Fixed format for generating trace id and span id created by AwsXRayIdGenerator()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] For trace Id, modified test to reconvert the portion of trace_id timestamp from hexadecimal back to int. The rest of the trace_id and span_ids are completely randomized, as such no longer need any specific tests except length. 
- [x] Added test to assert trace id and span id length

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
