### PR TITLE
Fix DataDog trace exporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: f556d1418c8015b71ec2e16b4ba2b76efdd3804f
+  CORE_REPO_SHA: 7054b534404fc69199e368cbe62a4e7570cc46ea
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.19b0...HEAD)
 
 ### Changed
+- Downgrade DataDog exporter's `ddtrace` dependency so the exporter continues to work.
+  ([#400](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/400))
 - GRPC instrumentation now correctly injects trace context into outgoing requests.
   ([#392](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/39))
 - Publish `opentelemetry-propagator-ot-trace` package as a part of the release process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python-contrib/compare/v0.19b0...HEAD)
 
 ### Changed
-- Downgrade DataDog exporter's `ddtrace` dependency so the exporter continues to work.
+- Restrict DataDog exporter's `ddtrace` dependency to known working versions.
   ([#400](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/400))
 - GRPC instrumentation now correctly injects trace context into outgoing requests.
   ([#392](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/39))

--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -38,7 +38,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    ddtrace>=0.34.0
+    ddtrace>=0.34.0,<0.47.0
     opentelemetry-api == 1.0.0
     opentelemetry-sdk == 1.0.0
 


### PR DESCRIPTION
# Description

Fixed DataDog trace exporter

`ddtrace` package introduced some breaking changes that break the
DataDog trace exporter. This commit downgrades the dependency to last
know working version to fix the exporter.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
