### PR TITLE
removing toumorokoshi from approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Approvers ([@open-telemetry/python-approvers](https://github.com/orgs/open-telem
 - [Diego Hurtado](https://github.com/ocelotl)
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Owais Lone](https://github.com/owais), Splunk
-- [Yusuke Tsutsumi](https://github.com/toumorokoshi), Google
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 


### PR DESCRIPTION
officially removing toumorokoshi from approvers.

See https://github.com/open-telemetry/opentelemetry-python/pull/1744.

Upon merge of this PR, I will remove myself from the GitHub group.

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/1744