### PR TITLE
Remove http.status_text from span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-urllib3` Add urllib3 instrumentation
   ([#299](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/299))
 
+### Removed
+- Remove `http.status_text` from span attributes
+  ([#406](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/406))
+
 ## [0.19b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.19b0) - 2021-03-26
 
 ### Changed

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -198,9 +198,6 @@ def create_trace_config(
             trace_config_ctx.span.set_attribute(
                 "http.status_code", params.response.status
             )
-            trace_config_ctx.span.set_attribute(
-                "http.status_text", params.response.reason
-            )
         _end_trace(trace_config_ctx)
 
     async def on_request_exception(

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -134,7 +134,6 @@ class TestAioHttpIntegration(TestBase):
                                     host, port
                                 ),
                                 "http.status_code": int(status_code),
-                                "http.status_text": status_code.phrase,
                             },
                         )
                     ]
@@ -191,7 +190,6 @@ class TestAioHttpIntegration(TestBase):
                                     host, port, path
                                 ),
                                 "http.status_code": int(HTTPStatus.OK),
-                                "http.status_text": HTTPStatus.OK.phrase,
                             },
                         )
                     ]
@@ -222,7 +220,6 @@ class TestAioHttpIntegration(TestBase):
                             host, port
                         ),
                         "http.status_code": int(HTTPStatus.OK),
-                        "http.status_text": HTTPStatus.OK.phrase,
                     },
                 )
             ]
@@ -361,7 +358,6 @@ class TestAioHttpClientInstrumentor(TestBase):
             span.attributes["http.url"],
         )
         self.assertEqual(200, span.attributes["http.status_code"])
-        self.assertEqual("OK", span.attributes["http.status_text"])
 
     def test_instrument_with_existing_trace_config(self):
         trace_config = aiohttp.TraceConfig()

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -116,7 +116,6 @@ class TestMiddleware(TestBase, WsgiTestBase):
         )
         self.assertEqual(span.attributes["http.scheme"], "http")
         self.assertEqual(span.attributes["http.status_code"], 200)
-        self.assertEqual(span.attributes["http.status_text"], "OK")
 
     def test_traced_get(self):
         Client().get("/traced/")
@@ -138,7 +137,6 @@ class TestMiddleware(TestBase, WsgiTestBase):
         self.assertEqual(span.attributes["http.route"], "^traced/")
         self.assertEqual(span.attributes["http.scheme"], "http")
         self.assertEqual(span.attributes["http.status_code"], 200)
-        self.assertEqual(span.attributes["http.status_text"], "OK")
 
     def test_not_recording(self):
         mock_tracer = Mock()
@@ -173,7 +171,6 @@ class TestMiddleware(TestBase, WsgiTestBase):
         self.assertEqual(span.attributes["http.route"], "^traced/")
         self.assertEqual(span.attributes["http.scheme"], "http")
         self.assertEqual(span.attributes["http.status_code"], 200)
-        self.assertEqual(span.attributes["http.status_text"], "OK")
 
     def test_error(self):
         with self.assertRaises(ValueError):

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -104,7 +104,6 @@ class TestFalconInstrumentation(TestBase):
                 "net.peer.port": "65133",
                 "http.flavor": "1.1",
                 "falcon.resource": "HelloWorldResource",
-                "http.status_text": "Created",
                 "http.status_code": 201,
             },
         )
@@ -129,7 +128,6 @@ class TestFalconInstrumentation(TestBase):
                 "net.peer.ip": "127.0.0.1",
                 "net.peer.port": "65133",
                 "http.flavor": "1.1",
-                "http.status_text": "Not Found",
                 "http.status_code": 404,
             },
         )

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -35,7 +35,6 @@ def expected_attributes(override_attributes):
         "http.host": "localhost",
         "http.target": "/",
         "http.flavor": "1.1",
-        "http.status_text": "OK",
         "http.status_code": 200,
     }
     for key, val in override_attributes.items():
@@ -138,7 +137,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
             {
                 "http.method": "POST",
                 "http.target": "/bye",
-                "http.status_text": "NOT FOUND",
                 "http.status_code": 404,
             }
         )
@@ -157,7 +155,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
             {
                 "http.target": "/hello/500",
                 "http.route": "/hello/<int:helloid>",
-                "http.status_text": "INTERNAL SERVER ERROR",
                 "http.status_code": 500,
             }
         )

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_programmatic.py
@@ -35,7 +35,6 @@ def expected_attributes(override_attributes):
         "http.host": "localhost",
         "http.target": "/",
         "http.flavor": "1.1",
-        "http.status_text": "OK",
         "http.status_code": 200,
     }
     for key, val in override_attributes.items():
@@ -118,7 +117,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
             {
                 "http.method": "POST",
                 "http.target": "/bye",
-                "http.status_text": "Not Found",
                 "http.status_code": 404,
             }
         )
@@ -137,7 +135,6 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
             {
                 "http.target": "/hello/500",
                 "http.route": "/hello/{helloid}",
-                "http.status_text": "Internal Server Error",
                 "http.status_code": 500,
             }
         )

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -150,7 +150,6 @@ def _instrument(tracer_provider=None, span_callback=None, name_callback=None):
             if isinstance(result, Response):
                 if span.is_recording():
                     span.set_attribute("http.status_code", result.status_code)
-                    span.set_attribute("http.status_text", result.reason)
                     span.set_status(
                         Status(http_status_to_status_code(result.status_code))
                     )

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -82,7 +82,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": self.URL,
                 "http.status_code": 200,
-                "http.status_text": "OK",
             },
         )
 
@@ -127,7 +126,6 @@ class RequestsIntegrationTestBase(abc.ABC):
         span = self.assert_span()
 
         self.assertEqual(span.attributes.get("http.status_code"), 404)
-        self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
 
         self.assertIs(
             span.status.status_code, trace.StatusCode.ERROR,
@@ -237,7 +235,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": self.URL,
                 "http.status_code": 200,
-                "http.status_text": "OK",
                 "http.response.body": "Hello!",
             },
         )
@@ -306,7 +303,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": self.URL,
                 "http.status_code": 500,
-                "http.status_text": "Internal Server Error",
             },
         )
         self.assertEqual(span.status.status_code, StatusCode.ERROR)

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -238,8 +238,6 @@ def _finish_span(tracer, handler, error=None):
         return
 
     if ctx.span.is_recording():
-        if reason:
-            ctx.span.set_attribute("http.status_text", reason)
         ctx.span.set_attribute("http.status_code", status_code)
         ctx.span.set_status(
             Status(

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -132,7 +132,6 @@ class TestTornadoInstrumentation(TornadoTest):
                 "http.host": "127.0.0.1:" + str(self.get_http_port()),
                 "http.target": "/",
                 "net.peer.ip": "127.0.0.1",
-                "http.status_text": "Created",
                 "http.status_code": 201,
             },
         )
@@ -205,7 +204,6 @@ class TestTornadoInstrumentation(TornadoTest):
                 "http.host": "127.0.0.1:" + str(self.get_http_port()),
                 "http.target": url,
                 "net.peer.ip": "127.0.0.1",
-                "http.status_text": "Created",
                 "http.status_code": 201,
             },
         )
@@ -274,7 +272,6 @@ class TestTornadoInstrumentation(TornadoTest):
                 "http.host": "127.0.0.1:" + str(self.get_http_port()),
                 "http.target": "/missing-url",
                 "net.peer.ip": "127.0.0.1",
-                "http.status_text": "Not Found",
                 "http.status_code": 404,
             },
         )
@@ -318,7 +315,6 @@ class TestTornadoInstrumentation(TornadoTest):
                 "http.host": "127.0.0.1:" + str(self.get_http_port()),
                 "http.target": "/dyna",
                 "net.peer.ip": "127.0.0.1",
-                "http.status_text": "Accepted",
                 "http.status_code": 202,
             },
         )

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -171,7 +171,6 @@ def _instrument(tracer_provider=None, span_callback=None, name_callback=None):
 
                 if span.is_recording():
                     span.set_attribute("http.status_code", code_)
-                    span.set_attribute("http.status_text", result.reason)
                     span.set_status(Status(http_status_to_status_code(code_)))
 
                 ver_ = str(getattr(result, "version", ""))

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -107,7 +107,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": self.URL,
                 "http.status_code": 200,
-                "http.status_text": "OK",
             },
         )
 
@@ -158,7 +157,6 @@ class RequestsIntegrationTestBase(abc.ABC):
         span = self.assert_span()
 
         self.assertEqual(span.attributes.get("http.status_code"), 404)
-        self.assertEqual(span.attributes.get("http.status_text"), "Not Found")
 
         self.assertIs(
             span.status.status_code, trace.StatusCode.ERROR,
@@ -271,7 +269,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": self.URL,
                 "http.status_code": 200,
-                "http.status_text": "OK",
                 "http.response.body": "Hello!",
             },
         )
@@ -301,7 +298,6 @@ class RequestsIntegrationTestBase(abc.ABC):
                 "http.method": "GET",
                 "http.url": "http://httpbin.org/status/500",
                 "http.status_code": 500,
-                "http.status_text": "Internal Server Error",
             },
         )
         self.assertEqual(span.status.status_code, StatusCode.ERROR)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -203,7 +203,6 @@ def _apply_response(span: Span, response: urllib3.response.HTTPResponse):
         return
 
     span.set_attribute("http.status_code", response.status)
-    span.set_attribute("http.status_text", response.reason)
     span.set_status(Status(http_status_to_status_code(response.status)))
 
 

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -72,7 +72,6 @@ class TestURLLib3Instrumentor(TestBase):
             "http.method": "GET",
             "http.url": url,
             "http.status_code": 200,
-            "http.status_text": "OK",
         }
         self.assertEqual(attributes, span.attributes)
 
@@ -127,7 +126,6 @@ class TestURLLib3Instrumentor(TestBase):
 
         span = self.assert_span()
         self.assertEqual(404, span.attributes.get("http.status_code"))
-        self.assertEqual("Not Found", span.attributes.get("http.status_text"))
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     def test_basic_http_non_default_port(self):

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -157,8 +157,7 @@ def add_response_attributes(
     passed to a PEP3333-conforming start_response callable."""
     if not span.is_recording():
         return
-    status_code, status_text = start_response_status.split(" ", 1)
-    span.set_attribute("http.status_text", status_text)
+    status_code, _ = start_response_status.split(" ", 1)
 
     try:
         status_code = int(status_code)

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -112,7 +112,6 @@ class TestWsgiApplication(WsgiTestBase):
             "http.host": "127.0.0.1",
             "http.flavor": "1.0",
             "http.url": "http://127.0.0.1/",
-            "http.status_text": "OK",
             "http.status_code": 200,
         }
         if http_method is not None:
@@ -339,7 +338,6 @@ class TestWsgiAttributes(unittest.TestCase):
         otel_wsgi.add_response_attributes(self.span, "404 Not Found", {})
         expected = (
             mock.call("http.status_code", 404),
-            mock.call("http.status_text", "Not Found"),
         )
         self.assertEqual(self.span.set_attribute.call_count, len(expected))
         self.span.set_attribute.assert_has_calls(expected, any_order=True)
@@ -347,9 +345,6 @@ class TestWsgiAttributes(unittest.TestCase):
     def test_response_attributes_invalid_status_code(self):
         otel_wsgi.add_response_attributes(self.span, "Invalid Status Code", {})
         self.assertEqual(self.span.set_attribute.call_count, 1)
-        self.span.set_attribute.assert_called_with(
-            "http.status_text", "Status Code"
-        )
 
 
 if __name__ == "__main__":

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -336,9 +336,7 @@ class TestWsgiAttributes(unittest.TestCase):
 
     def test_response_attributes(self):
         otel_wsgi.add_response_attributes(self.span, "404 Not Found", {})
-        expected = (
-            mock.call("http.status_code", 404),
-        )
+        expected = (mock.call("http.status_code", 404),)
         self.assertEqual(self.span.set_attribute.call_count, len(expected))
         self.span.set_attribute.assert_has_calls(expected, any_order=True)
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -342,10 +342,6 @@ class TestWsgiAttributes(unittest.TestCase):
         self.assertEqual(self.span.set_attribute.call_count, len(expected))
         self.span.set_attribute.assert_has_calls(expected, any_order=True)
 
-    def test_response_attributes_invalid_status_code(self):
-        otel_wsgi.add_response_attributes(self.span, "Invalid Status Code", {})
-        self.assertEqual(self.span.set_attribute.call_count, 1)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description

`http.status_text` was removed in this spec pr https://github.com/open-telemetry/opentelemetry-specification/pull/972

