### PR TITLE
Fix ASGI instrumentation default span name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Fixed cases where description was used with non-
   error status code when creating Status objects.
   ([#504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/504))
-- Fix ASGI instrumentation default span name.
+- `opentelemetry-instrumentation-asgi` Fix instrumentation default span name.
   ([#418](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/418))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Fixed cases where description was used with non-
   error status code when creating Status objects.
   ([#504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/504))
+- Fix ASGI instrumentation default span name.
+  ([#418](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/418))
 
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports
-  context propagation for lambda invoke via Payload embedded headers. 
+  context propagation for lambda invoke via Payload embedded headers.
   ([#458](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/458))
-  
+
 ## [0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 
 ### Changed
@@ -81,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#436](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/436))
 - `opentelemetry-instrumentation-grpc` Keep client interceptor in sync with grpc client interceptors.
   ([#442](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/442))
-  
+
 ### Removed
 - Remove `http.status_text` from span attributes
   ([#406](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/406))

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -217,7 +217,7 @@ class OpenTelemetryMiddleware:
                 @wraps(receive)
                 async def wrapped_receive():
                     with self.tracer.start_as_current_span(
-                        span_name + " " + scope["type"] + ".receive"
+                        " ".join((span_name, scope["type"], "receive"))
                     ) as receive_span:
                         message = await receive()
                         if receive_span.is_recording():
@@ -229,7 +229,7 @@ class OpenTelemetryMiddleware:
                 @wraps(send)
                 async def wrapped_send(message):
                     with self.tracer.start_as_current_span(
-                        span_name + " " + scope["type"] + ".send"
+                        " ".join((span_name, scope["type"], "send"))
                     ) as send_span:
                         if send_span.is_recording():
                             if message["type"] == "http.response.start":

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -147,12 +147,12 @@ def get_default_span_details(scope: dict) -> Tuple[str, dict]:
         scope: the asgi scope dictionary
 
     Returns:
-        a tuple of the span, and any attributes to attach to the
-        span.
+        a tuple of the span name, and any attributes to attach to the span.
     """
     method_or_path = scope.get("method") or scope.get("path")
+    span_name = "HTTP {}".format(method_or_path.strip())
 
-    return method_or_path, {}
+    return span_name, {}
 
 
 class OpenTelemetryMiddleware:
@@ -205,7 +205,7 @@ class OpenTelemetryMiddleware:
 
         try:
             with self.tracer.start_as_current_span(
-                span_name + " asgi", kind=trace.SpanKind.SERVER,
+                span_name, kind=trace.SpanKind.SERVER,
             ) as span:
                 if span.is_recording():
                     attributes = collect_request_attributes(scope)

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -149,8 +149,7 @@ def get_default_span_details(scope: dict) -> Tuple[str, dict]:
     Returns:
         a tuple of the span name, and any attributes to attach to the span.
     """
-    method_or_path = scope.get("method") or scope.get("path")
-    span_name = "HTTP {}".format(method_or_path.strip())
+    span_name = scope.get("path") or "HTTP {}".format(scope.get("method", "").strip())
 
     return span_name, {}
 
@@ -216,7 +215,7 @@ class OpenTelemetryMiddleware:
                 @wraps(receive)
                 async def wrapped_receive():
                     with self.tracer.start_as_current_span(
-                        span_name + " asgi." + scope["type"] + ".receive"
+                        span_name + " " + scope["type"] + ".receive"
                     ) as receive_span:
                         message = await receive()
                         if receive_span.is_recording():
@@ -228,7 +227,7 @@ class OpenTelemetryMiddleware:
                 @wraps(send)
                 async def wrapped_send(message):
                     with self.tracer.start_as_current_span(
-                        span_name + " asgi." + scope["type"] + ".send"
+                        span_name + " " + scope["type"] + ".send"
                     ) as send_span:
                         if send_span.is_recording():
                             if message["type"] == "http.response.start":

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -149,7 +149,9 @@ def get_default_span_details(scope: dict) -> Tuple[str, dict]:
     Returns:
         a tuple of the span name, and any attributes to attach to the span.
     """
-    span_name = scope.get("path") or "HTTP {}".format(scope.get("method", "").strip())
+    span_name = scope.get("path", "").strip() or "HTTP {}".format(
+        scope.get("method", "").strip()
+    )
 
     return span_name, {}
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -116,12 +116,12 @@ class TestAsgiApplication(AsgiTestBase):
         self.assertEqual(len(span_list), 4)
         expected = [
             {
-                "name": "GET asgi.http.receive",
+                "name": "HTTP GET asgi.http.receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.request"},
             },
             {
-                "name": "GET asgi.http.send",
+                "name": "HTTP GET asgi.http.send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     SpanAttributes.HTTP_STATUS_CODE: 200,
@@ -129,12 +129,12 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "GET asgi.http.send",
+                "name": "HTTP GET asgi.http.send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.response.body"},
             },
             {
-                "name": "GET asgi",
+                "name": "HTTP GET",
                 "kind": trace_api.SpanKind.SERVER,
                 "attributes": {
                     SpanAttributes.HTTP_METHOD: "GET",
@@ -201,9 +201,12 @@ class TestAsgiApplication(AsgiTestBase):
 
         def update_expected_span_name(expected):
             for entry in expected:
-                entry["name"] = " ".join(
-                    [span_name] + entry["name"].split(" ")[-1:]
-                )
+                if entry["kind"] == trace_api.SpanKind.SERVER:
+                    entry["name"] = span_name
+                else:
+                    entry["name"] = " ".join(
+                        [span_name] + entry["name"].split(" ")[-1:]
+                    )
             return expected
 
         app = otel_asgi.OpenTelemetryMiddleware(
@@ -305,17 +308,17 @@ class TestAsgiApplication(AsgiTestBase):
         self.assertEqual(len(span_list), 6)
         expected = [
             {
-                "name": "/ asgi.websocket.receive",
+                "name": "/ asgi.websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.connect"},
             },
             {
-                "name": "/ asgi.websocket.send",
+                "name": "/ asgi.websocket send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.accept"},
             },
             {
-                "name": "/ asgi.websocket.receive",
+                "name": "/ asgi.websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     "type": "websocket.receive",
@@ -323,7 +326,7 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "/ asgi.websocket.send",
+                "name": "/ asgi.websocket send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     "type": "websocket.send",
@@ -331,7 +334,7 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "/ asgi.websocket.receive",
+                "name": "/ asgi.websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.disconnect"},
             },

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -116,12 +116,12 @@ class TestAsgiApplication(AsgiTestBase):
         self.assertEqual(len(span_list), 4)
         expected = [
             {
-                "name": "HTTP GET asgi.http.receive",
+                "name": "/ http.receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.request"},
             },
             {
-                "name": "HTTP GET asgi.http.send",
+                "name": "/ http.send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     SpanAttributes.HTTP_STATUS_CODE: 200,
@@ -129,12 +129,12 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "HTTP GET asgi.http.send",
+                "name": "/ http.send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.response.body"},
             },
             {
-                "name": "HTTP GET",
+                "name": "/",
                 "kind": trace_api.SpanKind.SERVER,
                 "attributes": {
                     SpanAttributes.HTTP_METHOD: "GET",
@@ -308,17 +308,17 @@ class TestAsgiApplication(AsgiTestBase):
         self.assertEqual(len(span_list), 6)
         expected = [
             {
-                "name": "/ asgi.websocket receive",
+                "name": "/ websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.connect"},
             },
             {
-                "name": "/ asgi.websocket send",
+                "name": "/ websocket send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.accept"},
             },
             {
-                "name": "/ asgi.websocket receive",
+                "name": "/ websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     "type": "websocket.receive",
@@ -326,7 +326,7 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "/ asgi.websocket send",
+                "name": "/ websocket send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     "type": "websocket.send",
@@ -334,12 +334,12 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "/ asgi.websocket receive",
+                "name": "/ websocket receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "websocket.disconnect"},
             },
             {
-                "name": "/ asgi",
+                "name": "/",
                 "kind": trace_api.SpanKind.SERVER,
                 "attributes": {
                     SpanAttributes.HTTP_SCHEME: self.scope["scheme"],

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -116,12 +116,12 @@ class TestAsgiApplication(AsgiTestBase):
         self.assertEqual(len(span_list), 4)
         expected = [
             {
-                "name": "/ http.receive",
+                "name": "/ http receive",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.request"},
             },
             {
-                "name": "/ http.send",
+                "name": "/ http send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {
                     SpanAttributes.HTTP_STATUS_CODE: 200,
@@ -129,7 +129,7 @@ class TestAsgiApplication(AsgiTestBase):
                 },
             },
             {
-                "name": "/ http.send",
+                "name": "/ http send",
                 "kind": trace_api.SpanKind.INTERNAL,
                 "attributes": {"type": "http.response.body"},
             },
@@ -205,7 +205,7 @@ class TestAsgiApplication(AsgiTestBase):
                     entry["name"] = span_name
                 else:
                     entry["name"] = " ".join(
-                        [span_name] + entry["name"].split(" ")[-1:]
+                        [span_name] + entry["name"].split(" ")[1:]
                     )
             return expected
 


### PR DESCRIPTION
# Description

Fixes ASGI default span name for SERVER spans, to be `HTTP <method>`.

Fixes #146.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated unit tests, executed with `tox -e test-instrumentation-asgi`.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
