### PR TITLE
Update gRPCContext wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#387](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/387))
 - Update redis instrumentation to follow semantic conventions
   ([#403](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/403))
+- Update gRPC instrumentation to better wrap server context
+  ([xxx]((https://github.com/open-telemetry/opentelemetry-python-contrib/pull/xxx))
 
 ### Added
 - `opentelemetry-instrumentation-urllib3` Add urllib3 instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update redis instrumentation to follow semantic conventions
   ([#403](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/403))
 - Update gRPC instrumentation to better wrap server context
-  ([xxx]((https://github.com/open-telemetry/opentelemetry-python-contrib/pull/xxx))
+  ([#420](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/420))
 
 ### Added
 - `opentelemetry-instrumentation-urllib3` Add urllib3 instrumentation

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -71,29 +71,8 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.details = None
         super().__init__()
 
-    @property
-    def _state(self):
-        return self._servicer_context._state
-
-    @_state.setter
-    def _state(self, value):
-        self._servicer_context._state = value
-
-    @property
-    def _rpc_event(self):
-        return self._servicer_context._rpc_event
-
-    @_rpc_event.setter
-    def _rpc_event(self, value):
-        self._servicer_context._rpc_event = value
-
-    @property
-    def _request_deserializer(self):
-        return self._servicer_context._request_deserializer
-
-    @_request_deserializer.setter
-    def _request_deserializer(self, value):
-        self._servicer_context._request_deserializer = value
+    def __getattr__(self, attr):
+        return getattr(self._servicer_context, attr)
 
     def is_active(self, *args, **kwargs):
         return self._servicer_context.is_active(*args, **kwargs)

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -71,6 +71,30 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.details = None
         super().__init__()
 
+    @property
+    def _state(self):
+        return self._servicer_context._state
+
+    @_state.setter
+    def _state(self, value):
+        self._servicer_context._state = value
+
+    @property
+    def _rpc_event(self):
+        return self._servicer_context._rpc_event
+
+    @_rpc_event.setter
+    def _rpc_event(self, value):
+        self._servicer_context._rpc_event = value
+
+    @property
+    def _request_deserializer(self):
+        return self._servicer_context._request_deserializer
+
+    @_request_deserializer.setter
+    def _request_deserializer(self, value):
+        self._servicer_context._request_deserializer = value
+
     def is_active(self, *args, **kwargs):
         return self._servicer_context.is_active(*args, **kwargs)
 


### PR DESCRIPTION
# Description

There are a few cases where one needs to dig into `grpc.ServicerContext` objects, and these fields were missing from our wrapper, which can cause issues with implmementation.

Yes, they're private attributes, but there's no way to get the data they hold otherwise, so we should properly map them so our wrapper Context behaves like a real one does.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

There don't seem to be any test cases which cover this - I only noticed because I have an interceptor that reports exceptions  to Sentry, and so it has to dig into the `grpc.ServicerContext` object for details, rather than wrapping it like we do here.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
