### PR TITLE
Keep client interceptors in sync with grpc client interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#436](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/436))
 - `opentelemetry-instrumenation-flask` now supports trace response headers.
   ([#436](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/436))
-
+- `opentelemetry-instrumentation-grpc` Keep client interceptor in sync with grpc client interceptors.
+  ([#442](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/442))
+  
 ### Removed
 - Remove `http.status_text` from span attributes
   ([#406](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/406))

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/grpcext/_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/grpcext/_interceptor.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 # pylint:disable=relative-beyond-top-level
-# pylint:disable=arguments-differ
 # pylint:disable=no-member
-# pylint:disable=signature-differs
 
 """Implementation of gRPC Python interceptors."""
 
@@ -48,21 +46,23 @@ class _InterceptorUnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         self._base_callable = base_callable
         self._interceptor = interceptor
 
-    def __call__(self, request, timeout=None, metadata=None, credentials=None):
-        def invoker(request, metadata):
-            return self._base_callable(request, timeout, metadata, credentials)
-
-        client_info = _UnaryClientInfo(self._method, timeout)
-        return self._interceptor.intercept_unary(
-            request, metadata, client_info, invoker
-        )
-
-    def with_call(
-        self, request, timeout=None, metadata=None, credentials=None
+    def __call__(
+        self,
+        request,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
     ):
         def invoker(request, metadata):
-            return self._base_callable.with_call(
-                request, timeout, metadata, credentials
+            return self._base_callable(
+                request,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _UnaryClientInfo(self._method, timeout)
@@ -70,10 +70,47 @@ class _InterceptorUnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
             request, metadata, client_info, invoker
         )
 
-    def future(self, request, timeout=None, metadata=None, credentials=None):
+    def with_call(
+        self,
+        request,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    ):
+        def invoker(request, metadata):
+            return self._base_callable.with_call(
+                request,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
+            )
+
+        client_info = _UnaryClientInfo(self._method, timeout)
+        return self._interceptor.intercept_unary(
+            request, metadata, client_info, invoker
+        )
+
+    def future(
+        self,
+        request,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    ):
         def invoker(request, metadata):
             return self._base_callable.future(
-                request, timeout, metadata, credentials
+                request,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _UnaryClientInfo(self._method, timeout)
@@ -88,9 +125,24 @@ class _InterceptorUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
         self._base_callable = base_callable
         self._interceptor = interceptor
 
-    def __call__(self, request, timeout=None, metadata=None, credentials=None):
+    def __call__(
+        self,
+        request,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    ):
         def invoker(request, metadata):
-            return self._base_callable(request, timeout, metadata, credentials)
+            return self._base_callable(
+                request,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
+            )
 
         client_info = _StreamClientInfo(self._method, False, True, timeout)
         return self._interceptor.intercept_stream(
@@ -105,11 +157,22 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         self._interceptor = interceptor
 
     def __call__(
-        self, request_iterator, timeout=None, metadata=None, credentials=None
+        self,
+        request_iterator,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
     ):
         def invoker(request_iterator, metadata):
             return self._base_callable(
-                request_iterator, timeout, metadata, credentials
+                request_iterator,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _StreamClientInfo(self._method, True, False, timeout)
@@ -118,11 +181,22 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         )
 
     def with_call(
-        self, request_iterator, timeout=None, metadata=None, credentials=None
+        self,
+        request_iterator,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
     ):
         def invoker(request_iterator, metadata):
             return self._base_callable.with_call(
-                request_iterator, timeout, metadata, credentials
+                request_iterator,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _StreamClientInfo(self._method, True, False, timeout)
@@ -131,11 +205,22 @@ class _InterceptorStreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         )
 
     def future(
-        self, request_iterator, timeout=None, metadata=None, credentials=None
+        self,
+        request_iterator,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
     ):
         def invoker(request_iterator, metadata):
             return self._base_callable.future(
-                request_iterator, timeout, metadata, credentials
+                request_iterator,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _StreamClientInfo(self._method, True, False, timeout)
@@ -151,11 +236,22 @@ class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
         self._interceptor = interceptor
 
     def __call__(
-        self, request_iterator, timeout=None, metadata=None, credentials=None
+        self,
+        request_iterator,
+        timeout=None,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
     ):
         def invoker(request_iterator, metadata):
             return self._base_callable(
-                request_iterator, timeout, metadata, credentials
+                request_iterator,
+                timeout,
+                metadata,
+                credentials,
+                wait_for_ready,
+                compression,
             )
 
         client_info = _StreamClientInfo(self._method, True, True, timeout)


### PR DESCRIPTION
# Description
Keep the opentelemetry interceptors in sync with grpc interceptors

Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/320
The discussion on this issue states a more serious refactoring is needed. This fix is to get people unblocked.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Yes. Updated test cases

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:
- [x] Unit tests have been added
