### PR TITLE
implements context propagation for lambda invoke + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+### Added
+- `opentelemetry-instrumentation-botocore` now supports
+  context propagation for lambda invoke via Payload embedded headers. 
+  ([#458](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/458))
+  
 ## [0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 ### Changed
 

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
 [options.extras_require]
 test =
     boto~=2.0
-    moto~=1.0
+    moto~=2.0
     opentelemetry-test == 0.22.dev0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    moto ~= 1.0
+    moto[all] ~= 2.0
     opentelemetry-test == 0.22.dev0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -46,6 +46,7 @@ API
 ---
 """
 
+import json
 import logging
 
 from botocore.client import BaseClient
@@ -99,6 +100,27 @@ class BotocoreInstrumentor(BaseInstrumentor):
     def _uninstrument(self, **kwargs):
         unwrap(BaseClient, "_make_api_call")
 
+    @staticmethod
+    def _is_lambda_invoke(service_name, operation_name, api_params):
+        return (
+            service_name == "lambda"
+            and operation_name == "Invoke"
+            and isinstance(api_params, dict)
+            and "Payload" in api_params
+        )
+
+    @staticmethod
+    def _patch_lambda_invoke(api_params):
+        try:
+            payload_str = api_params["Payload"]
+            payload = json.loads(payload_str)
+            headers = payload.get("headers", {})
+            inject(headers)
+            payload["headers"] = headers
+            api_params["Payload"] = json.dumps(payload)
+        except ValueError:
+            pass
+
     # pylint: disable=too-many-branches
     def _patched_api_call(self, original_func, instance, args, kwargs):
         if context_api.get_value("suppress_instrumentation"):
@@ -110,6 +132,12 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
         error = None
         result = None
+
+        # inject trace context into payload headers for lambda Invoke
+        if BotocoreInstrumentor._is_lambda_invoke(
+            service_name, operation_name, api_params
+        ):
+            BotocoreInstrumentor._patch_lambda_invoke(api_params)
 
         with self._tracer.start_as_current_span(
             "{}".format(service_name), kind=SpanKind.CLIENT,


### PR DESCRIPTION
# Description

Implements context propagation for lambda invoke (botocore) which needs to have the headers as a part of the payload.
Adds tests.
Bumps moto to ~2.0 - previous version had issues preventing lambda tests.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Automated test with moto

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
