### PR TITLE
Add SQLAlchemy multithreading test

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import contextlib
+import logging
+import threading
 
-from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy import Column, Integer, String, create_engine, insert
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import close_all_sessions, scoped_session, sessionmaker
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -199,3 +201,47 @@ class SQLAlchemyTestMixin(TestBase):
         self.assertEqual(parent_span.instrumentation_info.name, "sqlalch_svc")
 
         self.assertEqual(child_span.name, "SELECT " + self.SQL_DB)
+
+    def test_multithreading(self):
+        """Ensure spans are captured correctly in a multithreading scenario
+
+        We also expect no logged warnings about calling end() on an ended span.
+        """
+
+        def insert_player(session):
+            _session = session()
+            player = Player(name="Player")
+            _session.add(player)
+            _session.commit()
+            _session.query(Player).all()
+
+        def insert_players(session):
+            _session = session()
+            players = []
+            for player_number in range(3):
+                players.append(Player(name=f"Player {player_number}"))
+            _session.add_all(players)
+            _session.commit()
+
+        session_factory = sessionmaker(bind=self.engine)
+        # pylint: disable=invalid-name
+        Session = scoped_session(session_factory)
+        thread_one = threading.Thread(target=insert_player, args=(Session,))
+        thread_two = threading.Thread(target=insert_players, args=(Session,))
+
+        logger = logging.getLogger("opentelemetry.sdk.trace")
+        with self.assertLogs(logger, level="WARNING") as cm:
+            # Dummy warning so test doesn't fail on no logs
+            logger.warning("Dummy warning")
+            thread_one.start()
+            thread_two.start()
+            thread_one.join()
+            thread_two.join()
+            close_all_sessions()
+
+            self.assertEqual(
+                cm.output, ["WARNING:opentelemetry.sdk.trace:Dummy warning"]
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 5)

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
@@ -59,7 +59,3 @@ class SQLiteTestCase(SQLAlchemyTestMixin):
         self.assertEqual(
             span.status.description, "no such table: a_wrong_table"
         )
-
-    def test_multithreading(self):
-        # Overriding instead of skipping based on DB name in mixin
-        pass

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_sqlite.py
@@ -59,3 +59,7 @@ class SQLiteTestCase(SQLAlchemyTestMixin):
         self.assertEqual(
             span.status.description, "no such table: a_wrong_table"
         )
+
+    def test_multithreading(self):
+        # Overriding instead of skipping based on DB name in mixin
+        pass


### PR DESCRIPTION
# Description

I was able to get the test to fail reliably for PostgreSQL by reverting
back the behavior before #315. When going back to the current behavior,
the test passes fine.

Should more be done to try to trigger the others
to also log the warning?

Resolves #383 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Docker SQLAlchemy test added

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
