### PR TITLE
Instrumentation runtime checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          key: tox-cache-${{ env.RUN_MATRIX_COMBINATION }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}
+          key: v2-build-tox-cache-${{ env.RUN_MATRIX_COMBINATION }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
@@ -99,6 +99,6 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          key: v2-tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt', 'docs-requirements.txt') }}
+          key: v2-misc-tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt', 'docs-requirements.txt') }}
       - name: run tox
         run: tox -e ${{ matrix.tox-environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 
 ### Changed
+- Instrumentation packages don't specify the libraries they instrument as dependencies
+  anymore. Instead, they verify the correct version of libraries are installed at runtime.
+  ([#475](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/475))
 - `opentelemetry-propagator-ot-trace` Use `TraceFlags` object in `extract`
   ([#472](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/472))
 - Set the `traced_request_attrs` of FalconInstrumentor by an argument correctly.

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
@@ -186,7 +186,7 @@ class DatadogExportSpanProcessor(SpanProcessor):
                 self.flush_condition.notify()
 
     def _drain_queue(self):
-        """ "Export all elements until queue is empty.
+        """Export all elements until queue is empty.
 
         Can only be called from the worker thread context because it invokes
         `export` that is not thread safe.

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
@@ -186,7 +186,7 @@ class DatadogExportSpanProcessor(SpanProcessor):
                 self.flush_condition.notify()
 
     def _drain_queue(self):
-        """"Export all elements until queue is empty.
+        """ "Export all elements until queue is empty.
 
         Can only be called from the worker thread context because it invokes
         `export` that is not thread safe.

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    aiohttp ~= 3.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "aiohttp_client",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "aiohttp_client",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -64,12 +64,14 @@ API
 
 import types
 import typing
+from typing import Collection
 
 import aiohttp
 import wrapt
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
+from opentelemetry.instrumentation.aiohttp_client.package import _instruments
 from opentelemetry.instrumentation.aiohttp_client.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import (
@@ -287,6 +289,9 @@ class AioHttpClientInstrumentor(BaseInstrumentor):
 
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Instruments aiohttp ClientSession

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/package.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/package.py
@@ -1,0 +1,16 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("aiohttp ~= 3.0",)

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation-dbapi == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    aiopg >= 0.13.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "aiopg", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "aiopg", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
@@ -45,7 +45,10 @@ API
 ---
 """
 
+from typing import Collection
+
 from opentelemetry.instrumentation.aiopg import wrappers
+from opentelemetry.instrumentation.aiopg.package import _instruments
 from opentelemetry.instrumentation.aiopg.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 
@@ -59,6 +62,9 @@ class AiopgInstrumentor(BaseInstrumentor):
     }
 
     _DATABASE_SYSTEM = "postgresql"
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Integrate with PostgreSQL aiopg library.

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/package.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("aiopg >= 0.13.0",)

--- a/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    asgiref ~= 3.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-asgi/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "asgi", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "asgi", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -112,8 +112,7 @@ def collect_request_attributes(scope):
 
 
 def get_host_port_url_tuple(scope):
-    """Returns (host, port, full_url) tuple.
-    """
+    """Returns (host, port, full_url) tuple."""
     server = scope.get("server") or ["0.0.0.0", 80]
     port = server[1]
     server_host = server[0] + (":" + str(port) if port != 80 else "")

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("asgiref ~= 3.0",)

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    asyncpg >= 0.12.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "asyncpg",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "asyncpg",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -34,11 +34,14 @@ API
 ---
 """
 
+from typing import Collection
+
 import asyncpg
 import wrapt
 from asyncpg import exceptions
 
 from opentelemetry import trace
+from opentelemetry.instrumentation.asyncpg.package import _instruments
 from opentelemetry.instrumentation.asyncpg.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -97,6 +100,9 @@ class AsyncPGInstrumentor(BaseInstrumentor):
         super().__init__()
         self.capture_parameters = capture_parameters
         self._tracer = None
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/package.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("asyncpg >= 0.12.0",)

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    boto ~= 2.0
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
@@ -46,7 +45,6 @@ install_requires =
 
 [options.extras_require]
 test =
-    boto~=2.0
     moto~=2.0
     opentelemetry-test == 0.22.dev0
 

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "boto", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "boto", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -43,10 +43,12 @@ API
 
 import logging
 from inspect import currentframe
+from typing import Collection
 
 from boto.connection import AWSAuthConnection, AWSQueryConnection
 from wrapt import wrap_function_wrapper
 
+from opentelemetry.instrumentation.boto.package import _instruments
 from opentelemetry.instrumentation.boto.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -78,6 +80,9 @@ class BotoInstrumentor(BaseInstrumentor):
     def __init__(self):
         super().__init__()
         self._original_boto = None
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         # AWSQueryConnection and AWSAuthConnection are two different classes

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/package.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("boto~=2.0",)

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    botocore ~= 1.0
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "botocore",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "botocore",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -48,12 +48,14 @@ API
 
 import json
 import logging
+from typing import Collection
 
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 from wrapt import wrap_function_wrapper
 
 from opentelemetry import context as context_api
+from opentelemetry.instrumentation.botocore.package import _instruments
 from opentelemetry.instrumentation.botocore.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -77,6 +79,9 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/package.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("botocore ~= 1.0",)

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    celery >= 4.0, < 6.0
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
@@ -46,7 +45,6 @@ install_requires =
 [options.extras_require]
 test =
     pytest
-    celery >= 4.0, < 6.0
     opentelemetry-test == 0.22.dev0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "celery", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "celery", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -52,12 +52,13 @@ API
 """
 
 import logging
-from collections.abc import Iterable
+from typing import Collection, Iterable
 
 from celery import signals  # pylint: disable=no-name-in-module
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.celery import utils
+from opentelemetry.instrumentation.celery.package import _instruments
 from opentelemetry.instrumentation.celery.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.propagate import extract, inject
@@ -95,6 +96,9 @@ celery_getter = CeleryGetter()
 
 
 class CeleryInstrumentor(BaseInstrumentor):
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/package.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("celery >= 4.0, < 6.0",)

--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "dbapi", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "dbapi", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 __version__ = "0.22.dev0"
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    django >= 1.10
     opentelemetry-util-http == 0.22.dev0
     opentelemetry-instrumentation-wsgi == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0

--- a/instrumentation/opentelemetry-instrumentation-django/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "django", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "django", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -75,6 +75,7 @@ and right before the span is finished while processing a response. The hooks can
 
 from logging import getLogger
 from os import environ
+from typing import Collection
 
 from django.conf import settings
 
@@ -82,6 +83,7 @@ from opentelemetry.instrumentation.django.environment_variables import (
     OTEL_PYTHON_DJANGO_INSTRUMENT,
 )
 from opentelemetry.instrumentation.django.middleware import _DjangoMiddleware
+from opentelemetry.instrumentation.django.package import _instruments
 from opentelemetry.instrumentation.django.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.trace import get_tracer
@@ -98,6 +100,9 @@ class DjangoInstrumentor(BaseInstrumentor):
     _opentelemetry_middleware = ".".join(
         [_DjangoMiddleware.__module__, _DjangoMiddleware.__qualname__]
     )
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/package.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("django >= 1.10",)

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
     wrapt >= 1.0.0, < 2.0.0
-    elasticsearch >= 2.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "elasticsearch",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "elasticsearch",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -48,11 +48,13 @@ environment variable or by passing the prefix as an argument to the instrumentor
 
 from logging import getLogger
 from os import environ
+from typing import Collection
 
 import elasticsearch
 import elasticsearch.exceptions
 from wrapt import wrap_function_wrapper as _wrap
 
+from opentelemetry.instrumentation.elasticsearch.package import _instruments
 from opentelemetry.instrumentation.elasticsearch.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -86,6 +88,9 @@ class ElasticsearchInstrumentor(BaseInstrumentor):
             )
         self._span_name_prefix = span_name_prefix.strip()
         super().__init__()
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("elasticsearch >= 2.0",)

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -39,7 +39,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    falcon ~= 2.0
     opentelemetry-instrumentation-wsgi == 0.22.dev0
     opentelemetry-util-http == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
@@ -48,7 +47,6 @@ install_requires =
 
 [options.extras_require]
 test =
-    falcon ~= 2.0
     opentelemetry-test == 0.22.dev0
     parameterized == 0.7.4
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "falcon", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "falcon", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -92,11 +92,13 @@ API
 from functools import partial
 from logging import getLogger
 from sys import exc_info
+from typing import Collection
 
 import falcon
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import context, trace
+from opentelemetry.instrumentation.falcon.package import _instruments
 from opentelemetry.instrumentation.falcon.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.propagators import (
@@ -133,6 +135,9 @@ class FalconInstrumentor(BaseInstrumentor):
 
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         self._original_falcon_api = falcon.API

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/package.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("falcon ~= 2.0",)

--- a/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
@@ -51,7 +51,6 @@ opentelemetry_instrumentor =
 [options.extras_require]
 test =
     opentelemetry-test == 0.22.dev0
-    fastapi ~= 0.58.1
     requests ~= 2.23.0 # needed for testclient
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-fastapi/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "fastapi",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "fastapi",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Collection
+
 import fastapi
 from starlette.routing import Match
 
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+from opentelemetry.instrumentation.asgi.package import _instruments
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.util.http import get_excluded_urls
@@ -33,8 +36,7 @@ class FastAPIInstrumentor(BaseInstrumentor):
 
     @staticmethod
     def instrument_app(app: fastapi.FastAPI, tracer_provider=None):
-        """Instrument an uninstrumented FastAPI application.
-        """
+        """Instrument an uninstrumented FastAPI application."""
         if not getattr(app, "is_instrumented_by_opentelemetry", False):
             app.add_middleware(
                 OpenTelemetryMiddleware,
@@ -43,6 +45,9 @@ class FastAPIInstrumentor(BaseInstrumentor):
                 tracer_provider=tracer_provider,
             )
             app.is_instrumented_by_opentelemetry = True
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         self._original_fastapi = fastapi.FastAPI

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("fastapi ~= 0.58.1",)

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    flask ~= 1.0
     opentelemetry-util-http == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
     opentelemetry-instrumentation-wsgi == 0.22.dev0
@@ -47,7 +46,6 @@ install_requires =
 
 [options.extras_require]
 test =
-    flask~=1.0
     opentelemetry-test == 0.22.dev0
 
 [options.entry_points]

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "flask", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "flask", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -48,11 +48,13 @@ API
 """
 
 from logging import getLogger
+from typing import Collection
 
 import flask
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import context, trace
+from opentelemetry.instrumentation.flask.package import _instruments
 from opentelemetry.instrumentation.flask.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.propagators import (
@@ -208,6 +210,9 @@ class FlaskInstrumentor(BaseInstrumentor):
 
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         self._original_flask = flask.Flask

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/package.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("flask ~= 1.0",)

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     opentelemetry-sdk == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    grpcio ~= 1.27
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "grpc", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "grpc", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -118,11 +118,14 @@ You can also add the instrumentor manually, rather than using
                          interceptors = [server_interceptor()])
 
 """
+from typing import Collection
+
 import grpc  # pylint:disable=import-self
 from wrapt import wrap_function_wrapper as _wrap
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.grpc.grpcext import intercept_channel
+from opentelemetry.instrumentation.grpc.package import _instruments
 from opentelemetry.instrumentation.grpc.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -144,6 +147,9 @@ class GrpcInstrumentorServer(BaseInstrumentor):
     """
 
     # pylint:disable=attribute-defined-outside-init, redefined-outer-name
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         self._original_func = grpc.server
@@ -193,6 +199,9 @@ class GrpcInstrumentorClient(BaseInstrumentor):
                 types.append(ctype)
 
         return tuple(types)
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         for ctype in self._which_channel(kwargs):

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/package.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("grpcio ~= 1.27",)

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -39,7 +39,6 @@ packages=find_namespace:
 install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    jinja2~=2.7
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "jinja2", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "jinja2", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/__init__.py
@@ -40,12 +40,14 @@ API
 # pylint: disable=no-value-for-parameter
 
 import logging
+from typing import Collection
 
 import jinja2
 from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _wrap
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.jinja2.package import _instruments
 from opentelemetry.instrumentation.jinja2.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import SpanKind, get_tracer
@@ -58,8 +60,7 @@ DEFAULT_TEMPLATE_NAME = "<memory>"
 
 
 def _with_tracer_wrapper(func):
-    """Helper for providing tracer for wrapper functions.
-    """
+    """Helper for providing tracer for wrapper functions."""
 
     def _with_tracer(tracer):
         def wrapper(wrapped, instance, args, kwargs):
@@ -72,8 +73,7 @@ def _with_tracer_wrapper(func):
 
 @_with_tracer_wrapper
 def _wrap_render(tracer, wrapped, instance, args, kwargs):
-    """Wrap `Template.render()` or `Template.generate()`
-    """
+    """Wrap `Template.render()` or `Template.generate()`"""
     with tracer.start_as_current_span(
         "jinja2.render", kind=SpanKind.INTERNAL,
     ) as span:
@@ -122,6 +122,9 @@ class Jinja2Instrumentor(BaseInstrumentor):
 
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")

--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/package.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("jinja2~=2.7",)

--- a/instrumentation/opentelemetry-instrumentation-logging/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "logging",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "logging",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -16,7 +16,7 @@
 
 import logging  # pylint: disable=import-self
 from os import environ
-from typing import Callable
+from typing import Collection
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.logging.constants import (
@@ -28,6 +28,7 @@ from opentelemetry.instrumentation.logging.environment_variables import (
     OTEL_PYTHON_LOG_FORMAT,
     OTEL_PYTHON_LOG_LEVEL,
 )
+from opentelemetry.instrumentation.logging.package import _instruments
 from opentelemetry.trace import (
     INVALID_SPAN,
     INVALID_SPAN_CONTEXT,
@@ -72,6 +73,9 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
     )
 
     _old_factory = None
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         service_name = ""

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/package.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/version.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/version.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 __version__ = "0.22.dev0"
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-instrumentation-dbapi == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    mysql-connector-python ~= 8.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "mysql", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "mysql", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -38,10 +38,13 @@ API
 ---
 """
 
+from typing import Collection
+
 import mysql.connector
 
 from opentelemetry.instrumentation import dbapi
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.mysql.package import _instruments
 from opentelemetry.instrumentation.mysql.version import __version__
 from opentelemetry.trace import get_tracer
 
@@ -55,6 +58,9 @@ class MySQLInstrumentor(BaseInstrumentor):
     }
 
     _DATABASE_SYSTEM = "mysql"
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Integrate with MySQL Connector/Python library.

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/package.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("mysql-connector-python ~= 8.0",)

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-instrumentation-dbapi == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "psycopg2",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "psycopg2",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -40,6 +40,7 @@ API
 """
 
 import typing
+from typing import Collection
 
 import psycopg2
 from psycopg2.extensions import (
@@ -49,6 +50,7 @@ from psycopg2.sql import Composed  # pylint: disable=no-name-in-module
 
 from opentelemetry.instrumentation import dbapi
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.psycopg2.package import _instruments
 from opentelemetry.instrumentation.psycopg2.version import __version__
 
 _OTEL_CURSOR_FACTORY_KEY = "_otel_orig_cursor_factory"
@@ -64,9 +66,12 @@ class Psycopg2Instrumentor(BaseInstrumentor):
 
     _DATABASE_SYSTEM = "postgresql"
 
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
     def _instrument(self, **kwargs):
         """Integrate with PostgreSQL Psycopg library.
-           Psycopg: http://initd.org/psycopg/
+        Psycopg: http://initd.org/psycopg/
         """
         tracer_provider = kwargs.get("tracer_provider")
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/package.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("psycopg2-binary >= 2.7.3.1",)

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    pymemcache ~= 1.3
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "pymemcache",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymemcache",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
@@ -38,12 +38,14 @@ API
 # pylint: disable=no-value-for-parameter
 
 import logging
+from typing import Collection
 
 import pymemcache
 from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _wrap
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pymemcache.package import _instruments
 from opentelemetry.instrumentation.pymemcache.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv.trace import (
@@ -180,6 +182,9 @@ def _get_address_attributes(instance):
 
 class PymemcacheInstrumentor(BaseInstrumentor):
     """An instrumentor for pymemcache See `BaseInstrumentor`"""
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("pymemcache ~= 1.3",)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    pymongo ~= 3.1
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "pymongo",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymongo",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -37,10 +37,13 @@ API
 ---
 """
 
+from typing import Collection
+
 from pymongo import monitoring
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pymongo.package import _instruments
 from opentelemetry.instrumentation.pymongo.version import __version__
 from opentelemetry.semconv.trace import DbSystemValues, SpanAttributes
 from opentelemetry.trace import SpanKind, get_tracer
@@ -126,6 +129,9 @@ class PymongoInstrumentor(BaseInstrumentor):
     # an unregister API. In order to provide a mechanishm to disable
     # instrumentation an enabled flag is implemented in CommandTracer,
     # it's checked in the different listeners.
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Integrate with pymongo to trace it using event listener.

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("pymongo ~= 3.1",)

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-instrumentation-dbapi == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    PyMySQL ~=  0.10.1
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "pymysql",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pymysql",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -40,10 +40,13 @@ API
 ---
 """
 
+from typing import Collection
+
 import pymysql
 
 from opentelemetry.instrumentation import dbapi
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.pymysql.package import _instruments
 from opentelemetry.instrumentation.pymysql.version import __version__
 
 
@@ -56,6 +59,9 @@ class PyMySQLInstrumentor(BaseInstrumentor):
     }
 
     _DATABASE_SYSTEM = "mysql"
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Integrate with the PyMySQL library.

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("PyMySQL ~= 0.10.1",)

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    pyramid >= 1.7
     opentelemetry-instrumentation == 0.22.dev0
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "pyramid",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "pyramid",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
@@ -79,6 +79,7 @@ API
 """
 
 import typing
+from typing import Collection
 
 from pyramid.config import Configurator
 from pyramid.path import caller_package
@@ -92,6 +93,7 @@ from opentelemetry.instrumentation.pyramid.callbacks import (
     TWEEN_NAME,
     trace_tween_factory,
 )
+from opentelemetry.instrumentation.pyramid.package import _instruments
 from opentelemetry.instrumentation.pyramid.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import TracerProvider, get_tracer
@@ -125,6 +127,9 @@ def _traced_init(wrapped, instance, args, kwargs):
 
 
 class PyramidInstrumentor(BaseInstrumentor):
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
     def _instrument(self, **kwargs):
         """Integrate with Pyramid Python library.
         https://docs.pylonsproject.org/projects/pyramid/en/latest/

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("pyramid >= 1.7",)

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    redis >= 2.6
     wrapt >= 1.12.1
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "redis", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "redis", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -42,11 +42,14 @@ API
 ---
 """
 
+from typing import Collection
+
 import redis
 from wrapt import ObjectProxy, wrap_function_wrapper
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.redis.package import _instruments
 from opentelemetry.instrumentation.redis.util import (
     _extract_conn_attributes,
     _format_command_args,
@@ -109,6 +112,9 @@ class RedisInstrumentor(BaseInstrumentor):
     """An instrumentor for Redis
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/package.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("redis >= 2.6",)

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    requests ~= 2.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "requests",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "requests",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -35,6 +35,7 @@ API
 
 import functools
 import types
+from typing import Collection
 
 from requests.models import Response
 from requests.sessions import Session
@@ -42,6 +43,7 @@ from requests.structures import CaseInsensitiveDict
 
 from opentelemetry import context
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.requests.package import _instruments
 from opentelemetry.instrumentation.requests.version import __version__
 from opentelemetry.instrumentation.utils import http_status_to_status_code
 from opentelemetry.propagate import inject
@@ -212,6 +214,9 @@ class RequestsInstrumentor(BaseInstrumentor):
     """An instrumentor for requests
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Instruments requests module

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/package.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("requests ~= 2.0",)

--- a/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
@@ -40,7 +40,6 @@ packages=find_namespace:
 install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    scikit-learn ~= 0.22.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-sklearn/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "sklearn",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "sklearn",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/__init__.py
@@ -65,7 +65,16 @@ from functools import wraps
 from importlib import import_module
 from inspect import isclass
 from pkgutil import iter_modules
-from typing import Callable, Dict, List, MutableMapping, Sequence, Type, Union
+from typing import (
+    Callable,
+    Collection,
+    Dict,
+    List,
+    MutableMapping,
+    Sequence,
+    Type,
+    Union,
+)
 
 from sklearn.base import BaseEstimator
 from sklearn.pipeline import FeatureUnion, Pipeline
@@ -73,6 +82,7 @@ from sklearn.tree import BaseDecisionTree
 from sklearn.utils.metaestimators import _IffHasAttrDescriptor
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.sklearn.package import _instruments
 from opentelemetry.instrumentation.sklearn.version import __version__
 from opentelemetry.trace import get_tracer
 from opentelemetry.util.types import Attributes
@@ -361,6 +371,9 @@ class SklearnInstrumentor(BaseInstrumentor):
         else:
             self.exclude_classes = tuple(exclude_classes)
 
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
     def _instrument(self, **kwargs):
         """Instrument the library, and any additional specified on init."""
         klasses = get_base_estimators(packages=self.packages)
@@ -496,7 +509,7 @@ class SklearnInstrumentor(BaseInstrumentor):
               estimator.
             method_name (str): The method name of the estimator on which to
               apply a span.
-       """
+        """
         orig_method_name = "_otel_original_" + method_name
         if isclass(estimator):
             qualname = estimator.__qualname__
@@ -540,7 +553,7 @@ class SklearnInstrumentor(BaseInstrumentor):
               estimator.
             method_name (str): The method name of the estimator on which to
               apply a span.
-       """
+        """
         orig_method_name = "_otel_original_" + method_name
         if isclass(estimator):
             qualname = estimator.__qualname__

--- a/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/package.py
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/package.py
@@ -1,0 +1,16 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("scikit-learn ~= 0.22.0",)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
     wrapt >= 1.11.2
-    sqlalchemy
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "sqlalchemy",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "sqlalchemy",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -39,8 +39,9 @@ Usage
 API
 ---
 """
+from typing import Collection
+
 import sqlalchemy
-import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -49,6 +50,7 @@ from opentelemetry.instrumentation.sqlalchemy.engine import (
     _get_tracer,
     _wrap_create_engine,
 )
+from opentelemetry.instrumentation.sqlalchemy.package import _instruments
 from opentelemetry.instrumentation.utils import unwrap
 
 
@@ -56,6 +58,9 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
     """An instrumentor for SQLAlchemy
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Instruments SQLAlchemy engine creation methods and the engine

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/package.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("sqlalchemy",)

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "sqlite3",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "sqlite3",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -40,9 +40,11 @@ API
 """
 
 import sqlite3
+from typing import Collection
 
 from opentelemetry.instrumentation import dbapi
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.sqlite3.package import _instruments
 from opentelemetry.instrumentation.sqlite3.version import __version__
 from opentelemetry.trace import get_tracer
 
@@ -52,6 +54,9 @@ class SQLite3Instrumentor(BaseInstrumentor):
     _CONNECTION_ATTRIBUTES = {}
 
     _DATABASE_SYSTEM = "sqlite"
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Integrate with SQLite3 Python library.

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/package.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 __version__ = "0.22.dev0"
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
@@ -51,7 +51,6 @@ opentelemetry_instrumentor =
 [options.extras_require]
 test =
     opentelemetry-test == 0.22.dev0
-    starlette ~= 0.13.0
     requests ~= 2.23.0 # needed for testclient
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "starlette",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "starlette",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Collection
+
 from starlette import applications
 from starlette.routing import Match
 
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+from opentelemetry.instrumentation.asgi.package import _instruments
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.util.http import get_excluded_urls
@@ -33,8 +36,7 @@ class StarletteInstrumentor(BaseInstrumentor):
 
     @staticmethod
     def instrument_app(app: applications.Starlette, tracer_provider=None):
-        """Instrument an uninstrumented Starlette application.
-        """
+        """Instrument an uninstrumented Starlette application."""
         if not getattr(app, "is_instrumented_by_opentelemetry", False):
             app.add_middleware(
                 OpenTelemetryMiddleware,
@@ -43,6 +45,9 @@ class StarletteInstrumentor(BaseInstrumentor):
                 tracer_provider=tracer_provider,
             )
             app.is_instrumented_by_opentelemetry = True
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         self._original_starlette = applications.Starlette

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("starlette ~= 0.13.0",)

--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
@@ -37,7 +37,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    tornado >= 6.0
     opentelemetry-instrumentation == 0.22.dev0
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
@@ -45,7 +44,6 @@ install_requires =
 
 [options.extras_require]
 test =
-    tornado >= 6.0
     opentelemetry-test == 0.22.dev0
 
 [options.entry_points]

--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "tornado",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "tornado",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -76,6 +76,7 @@ API
 from collections import namedtuple
 from functools import partial
 from logging import getLogger
+from typing import Collection
 
 import tornado.web
 import wrapt
@@ -87,6 +88,7 @@ from opentelemetry.instrumentation.propagators import (
     FuncSetter,
     get_global_response_propagator,
 )
+from opentelemetry.instrumentation.tornado.package import _instruments
 from opentelemetry.instrumentation.tornado.version import __version__
 from opentelemetry.instrumentation.utils import (
     extract_attributes_from_object,
@@ -116,6 +118,9 @@ response_propagation_setter = FuncSetter(tornado.web.RequestHandler.add_header)
 class TornadoInstrumentor(BaseInstrumentor):
     patched_handlers = []
     original_handler_new = None
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("tornado >= 6.0",)

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -38,6 +38,7 @@ API
 
 import functools
 import types
+from typing import Collection
 from urllib.request import (  # pylint: disable=no-name-in-module,import-error
     OpenerDirector,
     Request,
@@ -45,9 +46,8 @@ from urllib.request import (  # pylint: disable=no-name-in-module,import-error
 
 from opentelemetry import context
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.urllib.version import (  # pylint: disable=no-name-in-module,import-error
-    __version__,
-)
+from opentelemetry.instrumentation.urllib.package import _instruments
+from opentelemetry.instrumentation.urllib.version import __version__
 from opentelemetry.instrumentation.utils import http_status_to_status_code
 from opentelemetry.propagate import inject
 from opentelemetry.semconv.trace import SpanAttributes
@@ -62,6 +62,9 @@ class URLLibInstrumentor(BaseInstrumentor):
     """An instrumentor for urllib
     See `BaseInstrumentor`
     """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
 
     def _instrument(self, **kwargs):
         """Instruments urllib module

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/package.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/version.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/version.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 __version__ = "0.22.dev0"
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-urllib3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api == 1.3.0.dev0
     opentelemetry-semantic-conventions == 0.22.dev0
     opentelemetry-instrumentation == 0.22.dev0
-    urllib3 >= 1.0.0, < 2.0.0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.extras_require]

--- a/instrumentation/opentelemetry-instrumentation-urllib3/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/setup.py
@@ -18,10 +18,24 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR,
     "src",
@@ -30,8 +44,28 @@ VERSION_FILENAME = os.path.join(
     "urllib3",
     "version.py",
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR,
+    "src",
+    "opentelemetry",
+    "instrumentation",
+    "urllib3",
+    "package.py",
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -46,12 +46,14 @@ API
 
 import contextlib
 import typing
+from typing import Collection
 
 import urllib3.connectionpool
 import wrapt
 
 from opentelemetry import context
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.urllib3.package import _instruments
 from opentelemetry.instrumentation.urllib3.version import __version__
 from opentelemetry.instrumentation.utils import (
     http_status_to_status_code,
@@ -59,7 +61,7 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagate import inject
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer
+from opentelemetry.trace import Span, SpanKind, get_tracer
 from opentelemetry.trace.status import Status
 
 _SUPPRESS_HTTP_INSTRUMENTATION_KEY = "suppress_http_instrumentation"
@@ -76,6 +78,9 @@ _URL_OPEN_ARG_TO_INDEX_MAPPING = {
 
 
 class URLLib3Instrumentor(BaseInstrumentor):
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
     def _instrument(self, **kwargs):
         """Instruments the urllib3 module
 

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("urllib3 >= 1.0.0, < 2.0.0",)

--- a/instrumentation/opentelemetry-instrumentation-wsgi/setup.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/setup.py
@@ -18,15 +18,44 @@
 
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read("setup.cfg")
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if "options.extras_require" in config:
+    for key, value in config["options.extras_require"].items():
+        extras_require[key] = [v for v in value.split("\n") if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
+PACKAGE_INFO = {}
+
 VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "wsgi", "version.py"
 )
-PACKAGE_INFO = {}
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "wsgi", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well.
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"], extras_require=extras_require
+)

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = tuple()

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 __version__ = "0.22.dev0"
+
+_instruments = tuple()

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -1,0 +1,46 @@
+from typing import Collection, Optional
+
+from pkg_resources import (
+    Distribution,
+    DistributionNotFound,
+    VersionConflict,
+    get_distribution,
+)
+
+
+class DependencyConflict:
+    required: str = None
+    found: Optional[str] = None
+
+    def __init__(self, required, found=None):
+        self.required = required
+        self.found = found
+
+    def __str__(self):
+        return 'DependencyConflict: requested: "{0}" but found: "{1}"'.format(
+            self.required, self.found
+        )
+
+
+def get_dist_dependency_conflicts(
+    dist: Distribution,
+) -> Optional[DependencyConflict]:
+    deps = [
+        dep
+        for dep in dist.requires(("instruments",))
+        if dep not in dist.requires()
+    ]
+    return get_dependency_conflicts(deps)
+
+
+def get_dependency_conflicts(
+    deps: Collection[str],
+) -> Optional[DependencyConflict]:
+    for dep in deps:
+        try:
+            get_distribution(str(dep))
+        except VersionConflict as exc:
+            return DependencyConflict(dep, exc.dist)
+        except DistributionNotFound:
+            return DependencyConflict(dep)
+    return None

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
@@ -48,7 +48,7 @@ class BaseDistro(ABC):
         self._configure(**kwargs)
 
     def load_instrumentor(  # pylint: disable=no-self-use
-        self, entry_point: EntryPoint
+        self, entry_point: EntryPoint, **kwargs
     ):
         """Takes a collection of instrumentation entry points
         and activates them by instantiating and calling instrument()
@@ -60,7 +60,7 @@ class BaseDistro(ABC):
         skip loading entirely, etc.
         """
         instrumentor: BaseInstrumentor = entry_point.load()
-        instrumentor().instrument()
+        instrumentor().instrument(**kwargs)
 
 
 class DefaultDistro(BaseDistro):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -19,9 +19,12 @@ OpenTelemetry Base Instrumentor
 
 from abc import ABC, abstractmethod
 from logging import getLogger
-from typing import Collection
+from typing import Collection, Optional
 
-from opentelemetry.instrumentation.dependencies import get_dependency_conflicts
+from opentelemetry.instrumentation.dependencies import (
+    DependencyConflict,
+    get_dependency_conflicts,
+)
 
 _LOG = getLogger(__name__)
 
@@ -72,7 +75,7 @@ class BaseInstrumentor(ABC):
     def _uninstrument(self, **kwargs):
         """Uninstrument the library"""
 
-    def _check_dependency_conflicts(self) -> bool:
+    def _check_dependency_conflicts(self) -> Optional[DependencyConflict]:
         dependencies = self.instrumentation_dependencies()
         return get_dependency_conflicts(dependencies)
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -19,6 +19,9 @@ OpenTelemetry Base Instrumentor
 
 from abc import ABC, abstractmethod
 from logging import getLogger
+from typing import Collection
+
+from opentelemetry.instrumentation.dependencies import get_dependency_conflicts
 
 _LOG = getLogger(__name__)
 
@@ -47,12 +50,31 @@ class BaseInstrumentor(ABC):
         return cls._instance
 
     @abstractmethod
+    def instrumentation_dependencies(self) -> Collection[str]:
+        """Return a list of python packages with versions that the will be instrumented.
+
+        The format should be the same as used in requirements.txt or setup.py.
+
+        For example, if an instrumentation instruments requests 1.x, this method should look
+        like:
+
+            def instrumentation_dependencies(self) -> Collection[str]:
+                return ['requests ~= 1.0']
+
+        This will ensure that the instrumentation will only be used when the specified library
+        is present in the environment.
+        """
+
     def _instrument(self, **kwargs):
         """Instrument the library"""
 
     @abstractmethod
     def _uninstrument(self, **kwargs):
         """Uninstrument the library"""
+
+    def _check_dependency_conflicts(self) -> bool:
+        dependencies = self.instrumentation_dependencies()
+        return get_dependency_conflicts(dependencies)
 
     def instrument(self, **kwargs):
         """Instrument the library
@@ -65,14 +87,23 @@ class BaseInstrumentor(ABC):
         ``opentelemetry-instrument`` command does.
         """
 
-        if not self._is_instrumented:
-            result = self._instrument(**kwargs)
-            self._is_instrumented = True
-            return result
+        if self._is_instrumented:
+            _LOG.warning("Attempting to instrument while already instrumented")
+            return None
 
-        _LOG.warning("Attempting to instrument while already instrumented")
+        # check if instrumentor has any missing or conflicting dependencies
+        skip_dep_check = kwargs.pop("skip_dep_check", False)
+        if not skip_dep_check:
+            conflict = self._check_dependency_conflicts()
+            if conflict:
+                _LOG.warning(conflict)
+                return None
 
-        return None
+        result = self._instrument(  # pylint: disable=assignment-from-no-return
+            **kwargs
+        )
+        self._is_instrumented = True
+        return result
 
     def uninstrument(self, **kwargs):
         """Uninstrument the library

--- a/opentelemetry-instrumentation/tests/test_dependencies.py
+++ b/opentelemetry-instrumentation/tests/test_dependencies.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=protected-access
+
+import pytest
+
+from opentelemetry.instrumentation.dependencies import (
+    DependencyConflict,
+    get_dependency_conflicts,
+)
+from opentelemetry.test.test_base import TestBase
+
+
+class TestDependencyConflicts(TestBase):
+    def setUp(self):
+        pass
+
+    def test_get_dependency_conflicts_empty(self):
+        self.assertIsNone(get_dependency_conflicts([]))
+
+    def test_get_dependency_conflicts_no_conflict(self):
+        self.assertIsNone(get_dependency_conflicts(["pytest"]))
+
+    def test_get_dependency_conflicts_not_installed(self):
+        conflict = get_dependency_conflicts(["this-package-does-not-exist"])
+        self.assertTrue(conflict is not None)
+        self.assertTrue(isinstance(conflict, DependencyConflict))
+        print(conflict)
+        self.assertEqual(
+            str(conflict),
+            'DependencyConflict: requested: "this-package-does-not-exist" but found: "None"',
+        )
+
+    def test_get_dependency_conflicts_mismatched_version(self):
+        conflict = get_dependency_conflicts(["pytest == 5000"])
+        self.assertTrue(conflict is not None)
+        self.assertTrue(isinstance(conflict, DependencyConflict))
+        print(conflict)
+        self.assertEqual(
+            str(conflict),
+            'DependencyConflict: requested: "pytest == 5000" but found: "pytest {0}"'.format(
+                pytest.__version__
+            ),
+        )

--- a/opentelemetry-instrumentation/tests/test_distro.py
+++ b/opentelemetry-instrumentation/tests/test_distro.py
@@ -22,6 +22,9 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 
 
 class MockInstrumetor(BaseInstrumentor):
+    def instrumentation_dependencies(self):
+        return []
+
     def _instrument(self, **kwargs):
         pass
 

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -27,6 +27,9 @@ class TestInstrumentor(TestCase):
         def _uninstrument(self, **kwargs):
             return "uninstrumented"
 
+        def instrumentation_dependencies(self):
+            return []
+
     def test_protect(self):
         instrumentor = self.Instrumentor()
 

--- a/scripts/generate_setup.py
+++ b/scripts/generate_setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/templates/instrumentation_setup.py.txt
+++ b/templates/instrumentation_setup.py.txt
@@ -17,20 +17,45 @@
 {{ auto_generation_msg }}
 
 import os
+from configparser import ConfigParser
 
 import setuptools
 
+config = ConfigParser()
+config.read('setup.cfg')
+
+# We provide extras_require parameter to setuptools.setup later which
+# overwrites the extra_require section from setup.cfg. To support extra_require
+# secion in setup.cfg, we load it here and merge it with the extra_require param.
+extras_require = {}
+if 'options.extras_require' in config:
+    for key, value in config['options.extras_require'].items():
+        extras_require[key] = [v for v in value.split('\n') if v.strip()]
+
 BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "instrumentation",
-    "{{ name }}",
-    "version.py"
-)
 PACKAGE_INFO = {}
+
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "{{ name }}", "version.py"
+)
 with open(VERSION_FILENAME) as f:
     exec(f.read(), PACKAGE_INFO)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+PACKAGE_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "instrumentation", "{{ name }}", "package.py"
+)
+with open(PACKAGE_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+# Mark any instruments/runtime dependencies as test dependencies as well. 
+extras_require["instruments"] = PACKAGE_INFO["_instruments"]
+test_deps = extras_require.get("test", [])
+for dep in extras_require["instruments"]:
+    test_deps.append(dep)
+
+extras_require["test"] = test_deps
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"],
+    extras_require=extras_require
+)

--- a/tox.ini
+++ b/tox.ini
@@ -220,22 +220,22 @@ commands_pre =
   py3{6,7,8,9}: python -m pip install -U pip setuptools wheel
 ; Install common packages for all the tests. These are not needed in all the
 ; cases but it saves a lot of boilerplate in this file.
-  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-api
-  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-semantic-conventions
-  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-sdk
-  test: pip install {toxinidir}/opentelemetry-python-core/tests/util
+  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-api[test]
+  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-semantic-conventions[test]
+  test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-sdk[test]
+  test: pip install {toxinidir}/opentelemetry-python-core/tests/util[test]
 
-  test: pip install {toxinidir}/opentelemetry-instrumentation
+  test: pip install {toxinidir}/opentelemetry-instrumentation[test]
 
   celery: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-celery[test]
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon,flask,django,pyramid,tornado,starlette,fastapi: pip install {toxinidir}/util/opentelemetry-util-http
-  wsgi,falcon,flask,django,pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi
-  asgi,starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi
+  falcon,flask,django,pyramid,tornado,starlette,fastapi: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  wsgi,falcon,flask,django,pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
+  asgi,starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 
-  asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg
+  asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg[test]
 
   boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
   boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-boto[test]
@@ -276,27 +276,27 @@ commands_pre =
 
   starlette: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-starlette[test]
 
-  tornado: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-tornado
+  tornado: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-tornado[test]
 
   jinja2: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-jinja2[test]
 
-  logging: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-logging
+  logging: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-logging[test]
 
-  aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client
+  aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
 
   aiopg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg[test]
 
-  datadog: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-datadog
+  datadog: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
 
   sklearn: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sklearn[test]
 
-  sqlalchemy: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy
+  sqlalchemy: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy[test]
 
   elasticsearch{2,5,6,7}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-elasticsearch[test]
 
-  aws: pip install requests {toxinidir}/sdk-extension/opentelemetry-sdk-extension-aws
+  aws: pip install requests {toxinidir}/sdk-extension/opentelemetry-sdk-extension-aws[test]
 
-  http: pip install {toxinidir}/util/opentelemetry-util-http
+  http: pip install {toxinidir}/util/opentelemetry-util-http[test]
 ; In order to get a health coverage report,
   propagator-ot-trace: pip install {toxinidir}/propagator/opentelemetry-propagator-ot-trace[test]
 
@@ -395,7 +395,7 @@ deps =
   docker-compose >= 1.25.2
   mysql-connector-python ~=  8.0
   pymongo ~= 3.1
-  pymysql ~= 0.9.3
+  PyMySQL ~= 0.10.1
   psycopg2-binary ~= 2.8.4
   aiopg >= 0.13.0
   sqlalchemy ~= 1.3.16


### PR DESCRIPTION
# Description

This change updates instrumentations to remove the instrumented libraries as install time dependencies. It also adds runtime checks to instrumentations so they don't try to instrument unsupported versions of a library. 

Effectively this means installing instrumentations will not automatically install the instrumented libraries. For example:

- Installing `opentelemetry-instrumentation-requests` will not install `requests`.

### Manual instrumentation
- If requests is not installed and a user still attempts to manually instrument requests in code, it'll result in `ImportError`.
- If a version of requests is installed that is not supported by the instrumenation, the instrumentation will be a noop and will log a debug message.

### Auto instrumentation (via opentelemetry-instrument command)
- If requests is not installed or an incompatible version is installed, the instrumentation will not be used. In fact it won't be imported at all. No errors are raised for missing or incompatible instrumentations when auto-instrumenting.

Updated logic is mostly contained in the opentelemetry-instrumentation package. Look at `instrumentors.BaseInsrumentor` and `sitecustomize._load_instrumentors`. Rest of the changes are just about updating packaging/layout for all instrumentations.

Implements a solution for: https://github.com/open-telemetry/opentelemetry-python/discussions/1729

Includes changes from #474. Will get simpler once that is merged.

Blocks #514 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
