### PR TITLE
Added `eachdist.py format` command

### DIFF
--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -237,6 +237,16 @@ def parse_args(args=None):
         "releaseargs", nargs=argparse.REMAINDER, help=extraargs_help("pytest")
     )
 
+    fmtparser = subparsers.add_parser(
+        "format", help="Formats all source code with black and isort.",
+    )
+    fmtparser.set_defaults(func=format_args)
+    fmtparser.add_argument(
+        "--path",
+        required=False,
+        help="Format only this path instead of entire repository",
+    )
+
     return parser.parse_args(args)
 
 
@@ -641,6 +651,22 @@ def test_args(args):
                 "testroots",
             ),
         )
+    )
+
+
+def format_args(args):
+    format_dir = str(find_projectroot())
+    if args.path:
+        format_dir = os.path.join(format_dir, args.path)
+
+    runsubprocess(
+        args.dry_run, ("black", "."), cwd=format_dir, check=True,
+    )
+    runsubprocess(
+        args.dry_run,
+        ("isort", "--profile", "black", "."),
+        cwd=format_dir,
+        check=True,
     )
 
 


### PR DESCRIPTION
# Description

Added `format` command to eachdist.py script. This just run black and isort over the entire repository or the provided path via `--path` option.

Usage:

```
./scripts/eachdist.py format
```

or

```
./scripts/eachdist.py format --path instrumentation/opentelemetry-instrumentation-dbapi
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tooling enhancement

# How Has This Been Tested?

- [x] Tested manually

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
