### PR TITLE
Make propagators conform to spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#472](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/472))
 - Set the `traced_request_attrs` of FalconInstrumentor by an argument correctly.
   ([#473](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/473))
+- Propagators use the root context as default for `extract` and do not modify
+  the context if extracting from carrier does not work.
+  ([#488](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/488))
 
 ### Added
 - Move `opentelemetry-instrumentation` from core repository

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -42,6 +42,9 @@ class DatadogFormat(TextMapPropagator):
         context: typing.Optional[Context] = None,
         getter: Getter = default_getter,
     ) -> Context:
+        if context is None:
+            context = Context()
+
         trace_id = extract_first_element(
             getter.get(carrier, self.TRACE_ID_KEY)
         )
@@ -64,7 +67,7 @@ class DatadogFormat(TextMapPropagator):
             trace_flags = trace.TraceFlags(trace.TraceFlags.SAMPLED)
 
         if trace_id is None or span_id is None:
-            return set_span_in_context(trace.INVALID_SPAN, context)
+            return context
 
         trace_state = []
         if origin is not None:

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from re import compile as re_compile
+import re
 from typing import Any, Iterable, Optional
 
 from opentelemetry.baggage import get_all, set_baggage
@@ -40,10 +40,10 @@ OT_SPAN_ID_HEADER = "ot-tracer-spanid"
 OT_SAMPLED_HEADER = "ot-tracer-sampled"
 OT_BAGGAGE_PREFIX = "ot-baggage-"
 
-_valid_header_name = re_compile(r"[\w_^`!#$%&'*+.|~]+")
-_valid_header_value = re_compile(r"[\t\x20-\x7e\x80-\xff]+")
-_valid_extract_traceid = re_compile(r"[0-9a-f]{1,32}")
-_valid_extract_spanid = re_compile(r"[0-9a-f]{1,16}")
+_valid_header_name = re.compile(r"[\w_^`!#$%&'*+.|~]+")
+_valid_header_value = re.compile(r"[\t\x20-\x7e\x80-\xff]+")
+_valid_extract_traceid = re.compile(r"[0-9a-f]{1,32}")
+_valid_extract_spanid = re.compile(r"[0-9a-f]{1,16}")
 
 
 class OTTracePropagator(TextMapPropagator):
@@ -55,13 +55,19 @@ class OTTracePropagator(TextMapPropagator):
         context: Optional[Context] = None,
         getter: Getter = default_getter,
     ) -> Context:
+        if context is None:
+            context = Context()
 
-        traceid = _extract_first_element(
-            getter.get(carrier, OT_TRACE_ID_HEADER), INVALID_TRACE_ID
+        traceid = _extract_identifier(
+            getter.get(carrier, OT_TRACE_ID_HEADER),
+            _valid_extract_traceid,
+            INVALID_TRACE_ID,
         )
 
-        spanid = _extract_first_element(
-            getter.get(carrier, OT_SPAN_ID_HEADER), INVALID_SPAN_ID
+        spanid = _extract_identifier(
+            getter.get(carrier, OT_SPAN_ID_HEADER),
+            _valid_extract_spanid,
+            INVALID_SPAN_ID,
         )
 
         sampled = _extract_first_element(
@@ -73,17 +79,12 @@ class OTTracePropagator(TextMapPropagator):
         else:
             traceflags = TraceFlags.DEFAULT
 
-        if (
-            traceid != INVALID_TRACE_ID
-            and _valid_extract_traceid.fullmatch(traceid) is not None
-            and spanid != INVALID_SPAN_ID
-            and _valid_extract_spanid.fullmatch(spanid) is not None
-        ):
+        if traceid != INVALID_TRACE_ID and spanid != INVALID_SPAN_ID:
             context = set_span_in_context(
                 NonRecordingSpan(
                     SpanContext(
-                        trace_id=int(traceid, 16),
-                        span_id=int(spanid, 16),
+                        trace_id=traceid,
+                        span_id=spanid,
                         is_remote=True,
                         trace_flags=TraceFlags(traceflags),
                     )
@@ -172,3 +173,16 @@ def _extract_first_element(
     if items is None:
         return default
     return next(iter(items), None)
+
+
+def _extract_identifier(
+    items: Iterable[CarrierT], validator: re.Pattern, default: int
+) -> int:
+    header = _extract_first_element(items)
+    if header is None or validator.fullmatch(header) is None:
+        return default
+
+    try:
+        return int(header, 16)
+    except ValueError:
+        return default

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
+from re import compile as re_compile
 from typing import Any, Iterable, Optional
 
 from opentelemetry.baggage import get_all, set_baggage
@@ -40,10 +40,10 @@ OT_SPAN_ID_HEADER = "ot-tracer-spanid"
 OT_SAMPLED_HEADER = "ot-tracer-sampled"
 OT_BAGGAGE_PREFIX = "ot-baggage-"
 
-_valid_header_name = re.compile(r"[\w_^`!#$%&'*+.|~]+")
-_valid_header_value = re.compile(r"[\t\x20-\x7e\x80-\xff]+")
-_valid_extract_traceid = re.compile(r"[0-9a-f]{1,32}")
-_valid_extract_spanid = re.compile(r"[0-9a-f]{1,16}")
+_valid_header_name = re_compile(r"[\w_^`!#$%&'*+.|~]+")
+_valid_header_value = re_compile(r"[\t\x20-\x7e\x80-\xff]+")
+_valid_extract_traceid = re_compile(r"[0-9a-f]{1,32}")
+_valid_extract_spanid = re_compile(r"[0-9a-f]{1,16}")
 
 
 class OTTracePropagator(TextMapPropagator):
@@ -176,10 +176,10 @@ def _extract_first_element(
 
 
 def _extract_identifier(
-    items: Iterable[CarrierT], validator: re.Pattern, default: int
+    items: Iterable[CarrierT], validator_pattern, default: int
 ) -> int:
     header = _extract_first_element(items)
-    if header is None or validator.fullmatch(header) is None:
+    if header is None or validator_pattern.fullmatch(header) is None:
         return default
 
     try:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
@@ -106,19 +106,18 @@ class AwsXRayFormat(TextMapPropagator):
         context: typing.Optional[Context] = None,
         getter: Getter = default_getter,
     ) -> Context:
+        if context is None:
+            context = Context()
+
         trace_header_list = getter.get(carrier, TRACE_HEADER_KEY)
 
         if not trace_header_list or len(trace_header_list) != 1:
-            return trace.set_span_in_context(
-                trace.INVALID_SPAN, context=context
-            )
+            return context
 
         trace_header = trace_header_list[0]
 
         if not trace_header:
-            return trace.set_span_in_context(
-                trace.INVALID_SPAN, context=context
-            )
+            return context
 
         try:
             (
@@ -128,9 +127,7 @@ class AwsXRayFormat(TextMapPropagator):
             ) = AwsXRayFormat._extract_span_properties(trace_header)
         except AwsParseTraceHeaderError as err:
             _logger.debug(err.message)
-            return trace.set_span_in_context(
-                trace.INVALID_SPAN, context=context
-            )
+            return context
 
         options = 0
         if sampled:
@@ -148,9 +145,7 @@ class AwsXRayFormat(TextMapPropagator):
             _logger.debug(
                 "Invalid Span Extracted. Insertting INVALID span into provided context."
             )
-            return trace.set_span_in_context(
-                trace.INVALID_SPAN, context=context
-            )
+            return context
 
         return trace.set_span_in_context(
             trace.NonRecordingSpan(span_context), context=context


### PR DESCRIPTION
# Description

Propagators use the root context as default value for the extract operation. Additionally avoid modifying the context in case there is nothing to extract or the carrier does not hold valid data.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1765

Fixes also an issue in the `ot-trace` propagator where trace/span id validity was comparing str with int values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
unit tests have been added/adapted

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
