### PR TITLE
Fix tornado instrumentation's usage of Span Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
 - Fixed cases where description was used with non-error status code when creating Status objects.
-  ([#503](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/503))
+  ([#504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/504))
 
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+- Fixed cases where description was used with non-error status code when creating Status objects.
+  ([#503](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/503))
+
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports
   context propagation for lambda invoke via Payload embedded headers. 

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -301,7 +301,7 @@ def _finish_span(tracer, handler, error=None):
         ctx.span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, status_code)
         otel_status_code = http_status_to_status_code(status_code)
         otel_status_description = None
-        if otel_status_code == StatusCode.ERROR:
+        if otel_status_code is StatusCode.ERROR:
             otel_status_description = reason
         ctx.span.set_status(
             Status(

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -95,7 +95,7 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagate import extract
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace.status import Status
+from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util._time import _time_ns
 from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
@@ -299,10 +299,14 @@ def _finish_span(tracer, handler, error=None):
 
     if ctx.span.is_recording():
         ctx.span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, status_code)
+        otel_status_code = http_status_to_status_code(status_code)
+        otel_status_description = None
+        if otel_status_code == StatusCode.ERROR:
+            otel_status_description = reason
         ctx.span.set_status(
             Status(
-                status_code=http_status_to_status_code(status_code),
-                description=reason,
+                status_code=otel_status_code,
+                description=otel_status_description,
             )
         )
 


### PR DESCRIPTION

# Description

Tornado will only set Status description if the accompanying status_code
is an error status.

Fixes: #500 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
