### PR TITLE
fix route does not exists in ResolverMatch before Django 2.2

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -171,7 +171,7 @@ class _DjangoMiddleware(MiddlewareMixin):
             if span.is_recording():
                 match = getattr(request, "resolver_match")
                 if match:
-                    route = getattr(match, "route")
+                    route = getattr(match, "route", None)
                     if route:
                         span.set_attribute(SpanAttributes.HTTP_ROUTE, route)
 


### PR DESCRIPTION
# Description

https://docs.djangoproject.com/en/2.2/ref/urlresolvers/#django.urls.ResolverMatch.route

"route" does not exists in ResolverMatch before Django 2.2

Fixes #512 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] it can work in my Django 1.11 project

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
