### PR TITLE
Fix generate_instrumentation_bootstrap script on windows 🤞 

### DIFF
--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -18,6 +18,7 @@ import ast
 import logging
 import os
 import subprocess
+import sys
 
 import astor
 import pkg_resources
@@ -91,7 +92,18 @@ def main():
     with open(gen_path, "w") as gen_file:
         gen_file.write(source)
 
-    subprocess.run(["black", "-q", gen_path], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/eachdist.py",
+            "format",
+            "--path",
+            "opentelemetry-instrumentation",
+        ],
+        check=True,
+    )
+
+    logger.info("generated %s", gen_path)
 
 
 if __name__ == "__main__":

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -27,12 +27,13 @@ def get_instrumentation_packages():
         if not os.path.isdir(pkg_path):
             continue
 
-        out = str(
-            subprocess.check_output(
-                "python setup.py meta", shell=True, cwd=pkg_path
-            )
+        out = subprocess.check_output(
+            "python setup.py meta",
+            shell=True,
+            cwd=pkg_path,
+            universal_newlines=True,
         )
-        instrumentation = json.loads(out.split("\\n")[1])
+        instrumentation = json.loads(out.splitlines()[1])
         instrumentation["requirement"] = "==".join(
             (instrumentation["name"], instrumentation["version"],)
         )


### PR DESCRIPTION
# Description

This should fix the generate scripts on windows.

Also running `eachdist format` instead of `black` to format files post-generation.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tooling enchancement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
