### PR TITLE
Add tests for credentials from HTTPX in http.url

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -31,7 +31,7 @@ from opentelemetry.trace import SpanKind, Tracer, TracerProvider, get_tracer
 from opentelemetry.trace.span import Span
 from opentelemetry.trace.status import Status
 
-URL = typing.Tuple[bytes, bytes, typing.Optional[int], bytes]
+RawURL = typing.Tuple[bytes, bytes, typing.Optional[int], bytes]
 Headers = typing.List[typing.Tuple[bytes, bytes]]
 RequestHook = typing.Callable[[Span, "RequestInfo"], None]
 ResponseHook = typing.Callable[[Span, "RequestInfo", "ResponseInfo"], None]
@@ -45,7 +45,7 @@ AsyncResponseHook = typing.Callable[
 
 class RequestInfo(typing.NamedTuple):
     method: bytes
-    url: URL
+    url: RawURL
     headers: typing.Optional[Headers]
     stream: typing.Optional[
         typing.Union[httpx.SyncByteStream, httpx.AsyncByteStream]
@@ -72,7 +72,7 @@ def _apply_status_code(span: Span, status_code: int) -> None:
     span.set_status(Status(http_status_to_status_code(status_code)))
 
 
-def _prepare_attributes(method: bytes, url: URL) -> typing.Dict[str, str]:
+def _prepare_attributes(method: bytes, url: RawURL) -> typing.Dict[str, str]:
     _method = method.decode().upper()
     _url = str(httpx.URL(url))
     span_attributes = {
@@ -117,7 +117,7 @@ class SyncOpenTelemetryTransport(httpx.BaseTransport):
     def handle_request(
         self,
         method: bytes,
-        url: URL,
+        url: RawURL,
         headers: typing.Optional[Headers] = None,
         stream: typing.Optional[httpx.SyncByteStream] = None,
         extensions: typing.Optional[dict] = None,
@@ -203,7 +203,7 @@ class AsyncOpenTelemetryTransport(httpx.AsyncBaseTransport):
     async def handle_async_request(
         self,
         method: bytes,
-        url: URL,
+        url: RawURL,
         headers: typing.Optional[Headers] = None,
         stream: typing.Optional[httpx.AsyncByteStream] = None,
         extensions: typing.Optional[dict] = None,


### PR DESCRIPTION
# Description

According to the [specs for HTTP spans][1], `http.url` MUST NOT contain credentials. This change adds a test case to ensure that they are not in the URL attribute.

For code clarity we rename the type `RawURL` (a low-level tuple) to avoid confusion with `httpx.URL` (a high-level object). This is the same naming used in httpx internals.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
