### PR TITLE
Respect suppress instrumentation key in gRPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updating dependency for opentelemetry api/sdk packages to support major version instead
   of pinning to specific versions.
   ([#567](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/567))
+- `opentelemetry-instrumentation-grpc` Respect the suppress instrumentation in gRPC client instrumentor
+  ([#559](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/559))
 
 ### Added
 - `opentelemetry-instrumentation-httpx` Add `httpx` instrumentation

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -123,7 +123,7 @@ class OpenTelemetryClientInterceptor(
         return _GuardedSpan(self._start_span(*args, **kwargs))
 
     def intercept_unary(self, request, metadata, client_info, invoker):
-        if context.get_value( _SUPPRESS_INSTRUMENTATION_KEY):
+        if context.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return invoker(request, metadata)
 
         if not metadata:
@@ -193,7 +193,7 @@ class OpenTelemetryClientInterceptor(
     def intercept_stream(
         self, request_or_iterator, metadata, client_info, invoker
     ):
-        if context.get_value( _SUPPRESS_INSTRUMENTATION_KEY):
+        if context.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return invoker(request_or_iterator, metadata)
 
         if client_info.is_server_stream:

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -18,7 +18,7 @@ from tests.protobuf import (  # pylint: disable=no-name-in-module
 )
 
 import opentelemetry.instrumentation.grpc
-from opentelemetry import trace
+from opentelemetry import context, trace
 from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
 from opentelemetry.instrumentation.grpc._client import (
     OpenTelemetryClientInterceptor,
@@ -26,6 +26,7 @@ from opentelemetry.instrumentation.grpc._client import (
 from opentelemetry.instrumentation.grpc.grpcext._interceptor import (
     _UnaryClientInfo,
 )
+from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
@@ -178,6 +179,7 @@ class TestClientProto(TestBase):
             },
         )
 
+
     def test_stream_stream(self):
         bidirectional_streaming_method(self._stub)
         spans = self.memory_exporter.get_finished_spans()
@@ -286,3 +288,47 @@ class TestClientProto(TestBase):
 
         finally:
             set_global_textmap(previous_propagator)
+
+    def test_unary_unary_with_suppress_key(self):
+        token = context.attach(
+            context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            simple_method(self._stub)
+            spans = self.memory_exporter.get_finished_spans()
+        finally:
+            context.detach(token)
+        self.assertEqual(len(spans), 0)
+
+    def test_unary_stream_with_suppress_key(self):
+        token = context.attach(
+            context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            server_streaming_method(self._stub)
+            spans = self.memory_exporter.get_finished_spans()
+        finally:
+            context.detach(token)
+        self.assertEqual(len(spans), 0)
+
+    def test_stream_unary_with_suppress_key(self):
+        token = context.attach(
+            context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            client_streaming_method(self._stub)
+            spans = self.memory_exporter.get_finished_spans()
+        finally:
+            context.detach(token)
+        self.assertEqual(len(spans), 0)
+
+    def test_stream_stream_with_suppress_key(self):
+        token = context.attach(
+            context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            bidirectional_streaming_method(self._stub)
+            spans = self.memory_exporter.get_finished_spans()
+        finally:
+            context.detach(token)
+        self.assertEqual(len(spans), 0)

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -179,7 +179,6 @@ class TestClientProto(TestBase):
             },
         )
 
-
     def test_stream_stream(self):
         bidirectional_streaming_method(self._stub)
         spans = self.memory_exporter.get_finished_spans()


### PR DESCRIPTION
# Description

Make gRPC client instrumentor respect `_SUPPRESS_INSTRUMENTATION_KEY`

Fixes # (issue)
#476 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit Test added

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this projects
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
