### PR TITLE
Fix RequestsInstrumentor for custom transport adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#543](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/543))
 - Require aiopg to be less than 1.3.0
   ([#560](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/560))
+- `opentelemetry-instrumentation-requests` Fix potential `AttributeError` when `requests`
+  is used with a custom transport adapter.
+  ([#562](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/562))
 
 ### Added
 - `opentelemetry-instrumentation-httpx` Add `httpx` instrumentation

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -131,10 +131,6 @@ def _instrument(tracer, span_callback=None, name_callback=None):
 
         url = remove_url_credentials(url)
 
-        labels = {}
-        labels[SpanAttributes.HTTP_METHOD] = method
-        labels[SpanAttributes.HTTP_URL] = url
-
         with tracer.start_as_current_span(
             span_name, kind=SpanKind.CLIENT
         ) as span:
@@ -164,15 +160,6 @@ def _instrument(tracer, span_callback=None, name_callback=None):
                     )
                     span.set_status(
                         Status(http_status_to_status_code(result.status_code))
-                    )
-                labels[SpanAttributes.HTTP_STATUS_CODE] = str(
-                    result.status_code
-                )
-                if result.raw and result.raw.version:
-                    labels[SpanAttributes.HTTP_FLAVOR] = (
-                        str(result.raw.version)[:1]
-                        + "."
-                        + str(result.raw.version)[:-1]
                     )
             if span_callback is not None:
                 span_callback(span, result)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -356,7 +356,6 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
     def test_adapter_with_custom_response(self):
-        # See ONE-56722
         response = Response()
         response.status_code = 210
         response.reason = "hello adapter"

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -17,6 +17,8 @@ from unittest import mock
 
 import httpretty
 import requests
+from requests.adapters import BaseAdapter
+from requests.models import Response
 
 import opentelemetry.instrumentation.requests
 from opentelemetry import context, trace
@@ -30,6 +32,23 @@ from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import StatusCode
 
 
+class TransportMock:
+    def read(self, *args, **kwargs):
+        pass
+
+
+class MyAdapter(BaseAdapter):
+    def __init__(self, response):
+        super().__init__()
+        self._response = response
+
+    def send(self, *args, **kwargs):  # pylint:disable=signature-differs
+        return self._response
+
+    def close(self):
+        pass
+
+
 class InvalidResponseObjectException(Exception):
     def __init__(self):
         super().__init__()
@@ -38,6 +57,7 @@ class InvalidResponseObjectException(Exception):
 
 class RequestsIntegrationTestBase(abc.ABC):
     # pylint: disable=no-member
+    # pylint: disable=too-many-public-methods
 
     URL = "http://httpbin.org/status/200"
 
@@ -334,6 +354,27 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         span = self.assert_span()
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
+
+    def test_adapter_with_custom_response(self):
+        # See ONE-56722
+        response = Response()
+        response.status_code = 210
+        response.reason = "hello adapter"
+        response.raw = TransportMock()
+
+        session = requests.Session()
+        session.mount(self.URL, MyAdapter(response))
+
+        self.perform_request(self.URL, session)
+        span = self.assert_span()
+        self.assertEqual(
+            span.attributes,
+            {
+                "http.method": "GET",
+                "http.url": self.URL,
+                "http.status_code": 210,
+            },
+        )
 
 
 class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):


### PR DESCRIPTION
The `RequestsInstrumentor` contained some dead code from an early metrics implementation that in certain situations failed with an `AttributeError`. The `AttributeError` happened when trying to determine the HTTP flavor from the `raw.version` attribute on the returned `Response` object. 
By default, the `raw` attribute is an `urllib3` response that has the `version` attribute. However, `requests` allows mounting custom [transport adapters](https://docs.python-requests.org/en/master/user/advanced/#transport-adapters) for certain URLs. 
A custom adapter can return a `Response` where the `raw` object isn't an `urllib3` response and the version attribute might not be present. Thus, the `RequestsInstrumentor` could run into an `AttributeError`.

This change removes the dead metrics code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Additional unit test to verify that the `RequestsInstrumentor` works with custom transport adapters.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
