### PR TITLE
Update AWS entry points to match spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.3.0-0.22b0...HEAD)
+- `opentelemetry-sdk-extension-aws` Update AWS entry points to match spec
+  ([#566](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/566))
 - Include Flask 2.0 as compatible with existing flask instrumentation
   ([#545](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/545))
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
@@ -53,7 +53,7 @@ This can be done by either setting this environment variable:
 
 ::
 
-    export OTEL_PROPAGATORS = aws_xray
+    export OTEL_PROPAGATORS = xray
 
 
 Or by setting this propagator in your instrumented application:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
@@ -42,9 +42,9 @@ install_requires =
 
 [options.entry_points]
 opentelemetry_propagator =
-    aws_xray = opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format:AwsXRayFormat
+    xray = opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format:AwsXRayFormat
 opentelemetry_id_generator =
-    aws_xray = opentelemetry.sdk.extension.aws.trace.aws_xray_id_generator:AwsXRayIdGenerator
+    xray = opentelemetry.sdk.extension.aws.trace.aws_xray_id_generator:AwsXRayIdGenerator
 
 [options.extras_require]
 test =

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
@@ -31,7 +31,7 @@ This can be done by either setting this environment variable:
 
 ::
 
-    export OTEL_PROPAGATORS = aws_xray
+    export OTEL_PROPAGATORS = xray
 
 
 Or by setting this propagator in your instrumented application:


### PR DESCRIPTION
# Description

Quick PR to change the name of the entry points for the `opentelemetry-sdk-extension-aws` package. They have been updated to be `xray` instead of `aws_xray` so we make this change just for consistency with other languages.

Fixes #565 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Should not need more tests since it doesn't change any code, only changes how the package is used.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~
- [x] Documentation has been updated
