### PR TITLE
Enforce one distro is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.3.0-0.22b0...HEAD)
+- `opentelemetry-instrumentation` Enforce 1 distro+configurator for auto instrumentation
+  ([#571](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/571))
 - `opentelemetry-sdk-extension-aws` Update AWS entry points to match spec
   ([#566](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/566))
 - Include Flask 2.0 as compatible with existing flask instrumentation

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -38,6 +38,11 @@ opentelemetry-instrument
 
     opentelemetry-instrument python program.py
 
+**NOTE:** `opentelemetry-instrument` will check for compatible "distros" (like `opentelemetry-distro`)
+when automatically instrumenting. If multiple distros are found, instrumentation will fail. Check out
+`Github Issue #551 <https://github.com/open-telemetry/opentelemetry-python-contrib/issues/551>`_ for
+more.
+
 The instrument command will try to automatically detect packages used by your python program
 and when possible, apply automatic tracing instrumentation on them. This means your program
 will get automatic distributed tracing for free without having to make any code changes

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -39,9 +39,11 @@ opentelemetry-instrument
     opentelemetry-instrument python program.py
 
 **NOTE:** `opentelemetry-instrument` will check for compatible "distros" (like `opentelemetry-distro`)
-when automatically instrumenting. If multiple distros are found, instrumentation will fail. Check out
+when automatically instrumenting. A "distro" is defined as a class that successfully inherits from the
+[BaseDistro](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py#L30).
+If multiple distros are found, auto-instrumentation will fail. Check out
 `Github Issue #551 <https://github.com/open-telemetry/opentelemetry-python-contrib/issues/551>`_ for
-more.
+more details.
 
 The instrument command will try to automatically detect packages used by your python program
 and when possible, apply automatic tracing instrumentation on them. This means your program

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -40,21 +40,24 @@ def _load_distros() -> BaseDistro:
 
         if more_distros:
             logger.error(
-                    "Multiple distros were found: (%s). Only one should be installed.",
-                    ",".join([first_distro.module_name] + more_distros),
-                )
-            raise RuntimeError("Cannot Auto Instrument with multiple distros installed.")
+                "Multiple distros were found: (%s). Only one should be installed.",
+                ",".join([first_distro.module_name] + more_distros),
+            )
+            raise RuntimeError(
+                "Cannot Auto Instrument with multiple distros installed."
+            )
 
         return first_distro.load()()
     except StopIteration:
-        logger.warning("Initializing Auto Instrumentation without using a distro.")
+        logger.warning(
+            "Initializing Auto Instrumentation without using a distro."
+        )
+        return DefaultDistro()
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(
             "Distribution %s configuration failed", first_distro.module_name
         )
         raise exc
-    logger.warning("Initializing Auto Instrumentation without using a distro.")
-    return DefaultDistro()
 
 
 def _load_instrumentors(distro):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -35,7 +35,7 @@ logger = getLogger(__file__)
 def _load_distros() -> BaseDistro:
     entry_points = iter_entry_points("opentelemetry_distro")
     try:
-        first_distro = entry_points[0]
+        first_distro = next(entry_points)
 
         more_distros = [ep.module_name for ep in entry_points]
 
@@ -49,14 +49,14 @@ def _load_distros() -> BaseDistro:
         loaded_distro = first_distro.load()()
         if isinstance(loaded_distro, BaseDistro):
             logger.debug(
-                "Distribution %s will be configured", loaded_distro.module_name
+                "Distribution %s will be configured", first_distro.module_name
             )
             return loaded_distro
     except IndexError:
         logger.warning("Initializing Auto Instrumentation without using a distro.")
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(
-            "Distribution %s configuration failed", loaded_distro.module_name
+            "Distribution %s configuration failed", first_distro.module_name
         )
         raise exc
     logger.warning("Initializing Auto Instrumentation without using a distro.")

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -45,12 +45,7 @@ def _load_distros() -> BaseDistro:
                 )
             raise RuntimeError("Cannot Auto Instrument with multiple distros installed.")
 
-        loaded_distro = first_distro.load()()
-        if isinstance(loaded_distro, BaseDistro):
-            logger.debug(
-                "Distribution %s will be configured", first_distro.module_name
-            )
-            return loaded_distro
+        return first_distro.load()()
     except IndexError:
         logger.warning("Initializing Auto Instrumentation without using a distro.")
     except Exception as exc:  # pylint: disable=broad-except

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -46,7 +46,7 @@ def _load_distros() -> BaseDistro:
             raise RuntimeError("Cannot Auto Instrument with multiple distros installed.")
 
         return first_distro.load()()
-    except IndexError:
+    except StopIteration:
         logger.warning("Initializing Auto Instrumentation without using a distro.")
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -23,7 +23,6 @@ from pkg_resources import iter_entry_points
 from opentelemetry.environment_variables import (
     OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
-from opentelemetry.instrumentation.configurator import BaseConfigurator
 from opentelemetry.instrumentation.dependencies import (
     get_dist_dependency_conflicts,
 )


### PR DESCRIPTION
# Description

Small PR to enforce that only one distro be installed when trying to run auto instrumentation.

Additionally, checks that the `Configurator` that is loaded automatically is a derived class of `BaseConfigurator`. The idea is that `Configurator`s should come from distros and every distro should provide one. (Even if they just subclass the `opentelemetry-sdk` package Configurator which does a pretty good configuration).

Follow up to: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/551

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unfortunately I can't add unit tests because if you import functions from `sitecustomize.py` it will try to run the whole file and auto instrument which we can't do in a testing environment for now...

But I did confirm locally that an error is thrown _only_ if multiple distros are installed:

```
$ OTEL_RESOURCE_ATTRIBUTES=service.name=my_auto_app \
OTEL_EXPORTER_OTLP_INSECURE=True \
OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
LISTEN_ADDRESS=127.0.0.1:8080 \
opentelemetry-instrument python3 auto-instrumentation/flask/application.py

Multiple distros were found: (opentelemetry.distro,opentelemetry.distro_aws,opentelemetry.distro_test). Only one should be installed.
Failed to auto initialize opentelemetry
Traceback (most recent call last):
  File "/Users/enowell/git/opentelemetry-python-contrib/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 132, in initialize
    distro = _load_distros()
  File "/Users/enowell/git/opentelemetry-python-contrib/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 45, in _load_distros
    raise RuntimeError("Cannot Auto Instrument with multiple distros installed.")
RuntimeError: Cannot Auto Instrument with multiple distros installed.
 * Serving Flask app "create_flask_app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://127.0.0.1:8080/ (Press CTRL+C to quit)
```

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~ See comment about testing above.
- [x] Documentation has been updated
