### PR TITLE
Fix AttributeError: `ResolverMatch` object has no attribute `route`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#567](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/567))
 - `opentelemetry-instrumentation-grpc` Fixed asynchonous unary call traces
   ([#536](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/536))
+- `opentelemetry-instrumentation-django` Fix AttributeError: ResolverMatch object has no attribute route
+  ([#581](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/581))
 
 ### Added
 - `opentelemetry-instrumentation-httpx` Add `httpx` instrumentation

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -191,9 +191,9 @@ class _DjangoMiddleware(MiddlewareMixin):
             span = request.META[self._environ_span_key]
 
             if span.is_recording():
-                match = getattr(request, "resolver_match")
+                match = getattr(request, "resolver_match", None)
                 if match:
-                    route = getattr(match, "route")
+                    route = getattr(match, "route", None)
                     if route:
                         span.set_attribute(SpanAttributes.HTTP_ROUTE, route)
 


### PR DESCRIPTION
# Description
`getattr` throws `AttributeError` if named attribute doesn't exist. 

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1948

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually tested with Django 2.1
