### PR TITLE
Bump core repo SHA reference to get latest Semantic Conventions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: c4cdffd0c8bd47b2e5c4f4a823722ca514f10db3
+  CORE_REPO_SHA: bb41b81093d4010dadb233f146e8ba04973ec5a3
 
 jobs:
   build:


### PR DESCRIPTION
# Description

An important change that went into Core was the update to the semantic conventions https://github.com/open-telemetry/opentelemetry-python/pull/1946. Instrumentations usually rely on it indirectly through the `opentelemetry-sdk`, so to continue passing the CI in Contrib we need to bump the version.

Pointing to this commit: https://github.com/open-telemetry/opentelemetry-python/tree/bb41b81093d4010dadb233f146e8ba04973ec5a3

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- CI tests will show it works

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
