### PR TITLE
Provide excluded_urls argument to Flask instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.4.0-0.23b0...HEAD)
 
 ### Changed
-- Enable explicit excluded\_urls argument in `opentelemetry-instrumentation-flask`
+- Enable explicit `excluded_urls` argument in `opentelemetry-instrumentation-flask`
   ([#604](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/604))
 
 ## [1.4.0-0.23b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.4.0-0.23b0) - 2021-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.4.0-0.23b0...HEAD)
 
 ### Changed
-- Enable explicit excluded\_urls `opentelemetry-instrumentation-flask`
+- Enable explicit excluded\_urls argument in `opentelemetry-instrumentation-flask`
   ([#604](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/604))
 
 ## [1.4.0-0.23b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.4.0-0.23b0) - 2021-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.4.0-0.23b0...HEAD)
 
+### Changed
+- Enable explicit excluded\_urls `opentelemetry-instrumentation-flask`
+  ([#604](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/604))
+
 ## [1.4.0-0.23b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.4.0-0.23b0) - 2021-07-21
 
 ### Removed

--- a/instrumentation/opentelemetry-instrumentation-flask/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-flask/README.rst
@@ -31,6 +31,12 @@ For example,
 
 will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
 
+You can also pass the comma delimited regexes to the ``instrument_app`` method directly:
+
+.. code-block:: python
+
+    FlaskInstrumentor().instrument_app(app, excluded_urls="client/.*/info,healthcheck")
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -63,7 +63,7 @@ from opentelemetry.instrumentation.propagators import (
 from opentelemetry.propagate import extract
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.util._time import _time_ns
-from opentelemetry.util.http import get_excluded_urls
+from opentelemetry.util.http import get_excluded_urls, parse_excluded_urls
 
 _logger = getLogger(__name__)
 
@@ -73,7 +73,7 @@ _ENVIRON_ACTIVATION_KEY = "opentelemetry-flask.activation_key"
 _ENVIRON_TOKEN = "opentelemetry-flask.token"
 
 
-_excluded_urls = get_excluded_urls("FLASK")
+_excluded_urls_from_env = get_excluded_urls("FLASK")
 
 
 def get_default_span_name():
@@ -85,7 +85,7 @@ def get_default_span_name():
     return span_name
 
 
-def _rewrapped_app(wsgi_app, response_hook=None):
+def _rewrapped_app(wsgi_app, response_hook=None, excluded_urls=None):
     def _wrapped_app(wrapped_app_environ, start_response):
         # We want to measure the time for route matching, etc.
         # In theory, we could start the span here and use
@@ -94,7 +94,9 @@ def _rewrapped_app(wsgi_app, response_hook=None):
         wrapped_app_environ[_ENVIRON_STARTTIME_KEY] = _time_ns()
 
         def _start_response(status, response_headers, *args, **kwargs):
-            if not _excluded_urls.url_disabled(flask.request.url):
+            if excluded_urls is None or not excluded_urls.url_disabled(
+                flask.request.url
+            ):
                 span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
 
                 propagator = get_global_response_propagator()
@@ -123,9 +125,11 @@ def _rewrapped_app(wsgi_app, response_hook=None):
     return _wrapped_app
 
 
-def _wrapped_before_request(request_hook=None, tracer=None):
+def _wrapped_before_request(
+    request_hook=None, tracer=None, excluded_urls=None
+):
     def _before_request():
-        if _excluded_urls.url_disabled(flask.request.url):
+        if excluded_urls and excluded_urls.url_disabled(flask.request.url):
             return
         flask_request_environ = flask.request.environ
         span_name = get_default_span_name()
@@ -163,29 +167,33 @@ def _wrapped_before_request(request_hook=None, tracer=None):
     return _before_request
 
 
-def _teardown_request(exc):
-    # pylint: disable=E1101
-    if _excluded_urls.url_disabled(flask.request.url):
-        return
+def _wrapped_teardown_request(excluded_urls=None):
+    def _teardown_request(exc):
+        # pylint: disable=E1101
+        if excluded_urls and excluded_urls.url_disabled(flask.request.url):
+            return
 
-    activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
-    if not activation:
-        # This request didn't start a span, maybe because it was created in a
-        # way that doesn't run `before_request`, like when it is created with
-        # `app.test_request_context`.
-        return
+        activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
+        if not activation:
+            # This request didn't start a span, maybe because it was created in
+            # a way that doesn't run `before_request`, like when it is created
+            # with `app.test_request_context`.
+            return
 
-    if exc is None:
-        activation.__exit__(None, None, None)
-    else:
-        activation.__exit__(
-            type(exc), exc, getattr(exc, "__traceback__", None)
-        )
-    context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+        if exc is None:
+            activation.__exit__(None, None, None)
+        else:
+            activation.__exit__(
+                type(exc), exc, getattr(exc, "__traceback__", None)
+            )
+        context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+
+    return _teardown_request
 
 
 class _InstrumentedFlask(flask.Flask):
 
+    _excluded_urls = None
     _tracer_provider = None
     _request_hook = None
     _response_hook = None
@@ -209,6 +217,10 @@ class _InstrumentedFlask(flask.Flask):
         )
         self._before_request = _before_request
         self.before_request(_before_request)
+
+        _teardown_request = _wrapped_teardown_request(
+            excluded_urls=_InstrumentedFlask._excluded_urls,
+        )
         self.teardown_request(_teardown_request)
 
 
@@ -232,6 +244,12 @@ class FlaskInstrumentor(BaseInstrumentor):
             _InstrumentedFlask._response_hook = response_hook
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedFlask._tracer_provider = tracer_provider
+        excluded_urls = kwargs.get("excluded_urls")
+        _InstrumentedFlask._excluded_urls = (
+            _excluded_urls_from_env
+            if excluded_urls is None
+            else parse_excluded_urls(excluded_urls)
+        )
         flask.Flask = _InstrumentedFlask
 
     def _uninstrument(self, **kwargs):
@@ -239,20 +257,36 @@ class FlaskInstrumentor(BaseInstrumentor):
 
     @staticmethod
     def instrument_app(
-        app, request_hook=None, response_hook=None, tracer_provider=None
+        app,
+        request_hook=None,
+        response_hook=None,
+        tracer_provider=None,
+        excluded_urls=None,
     ):
         if not hasattr(app, "_is_instrumented_by_opentelemetry"):
             app._is_instrumented_by_opentelemetry = False
 
         if not app._is_instrumented_by_opentelemetry:
+            excluded_urls = (
+                parse_excluded_urls(excluded_urls)
+                if excluded_urls is not None
+                else _excluded_urls_from_env
+            )
             app._original_wsgi_app = app.wsgi_app
             app.wsgi_app = _rewrapped_app(app.wsgi_app, response_hook)
 
             tracer = trace.get_tracer(__name__, __version__, tracer_provider)
 
-            _before_request = _wrapped_before_request(request_hook, tracer)
+            _before_request = _wrapped_before_request(
+                request_hook, tracer, excluded_urls=excluded_urls,
+            )
             app._before_request = _before_request
             app.before_request(_before_request)
+
+            _teardown_request = _wrapped_teardown_request(
+                excluded_urls=excluded_urls,
+            )
+            app._teardown_request = _teardown_request
             app.teardown_request(_teardown_request)
             app._is_instrumented_by_opentelemetry = True
         else:
@@ -267,7 +301,7 @@ class FlaskInstrumentor(BaseInstrumentor):
 
             # FIXME add support for other Flask blueprints that are not None
             app.before_request_funcs[None].remove(app._before_request)
-            app.teardown_request_funcs[None].remove(_teardown_request)
+            app.teardown_request_funcs[None].remove(app._teardown_request)
             del app._original_wsgi_app
             app._is_instrumented_by_opentelemetry = False
         else:

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -205,7 +205,9 @@ class _InstrumentedFlask(flask.Flask):
         self._is_instrumented_by_opentelemetry = True
 
         self.wsgi_app = _rewrapped_app(
-            self.wsgi_app, _InstrumentedFlask._response_hook
+            self.wsgi_app,
+            _InstrumentedFlask._response_hook,
+            excluded_urls=_InstrumentedFlask._excluded_urls,
         )
 
         tracer = trace.get_tracer(
@@ -213,7 +215,9 @@ class _InstrumentedFlask(flask.Flask):
         )
 
         _before_request = _wrapped_before_request(
-            _InstrumentedFlask._request_hook, tracer,
+            _InstrumentedFlask._request_hook,
+            tracer,
+            excluded_urls=_InstrumentedFlask._excluded_urls,
         )
         self._before_request = _before_request
         self.before_request(_before_request)
@@ -273,7 +277,9 @@ class FlaskInstrumentor(BaseInstrumentor):
                 else _excluded_urls_from_env
             )
             app._original_wsgi_app = app.wsgi_app
-            app.wsgi_app = _rewrapped_app(app.wsgi_app, response_hook)
+            app.wsgi_app = _rewrapped_app(
+                app.wsgi_app, response_hook, excluded_urls=excluded_urls
+            )
 
             tracer = trace.get_tracer(__name__, __version__, tracer_provider)
 

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
@@ -59,3 +59,23 @@ class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
         self.assertEqual([b"Hello: 123"], list(resp.response))
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
+
+    def test_exluded_urls_explicit(self):
+        FlaskInstrumentor().uninstrument()
+        FlaskInstrumentor().instrument(excluded_urls="/hello/456")
+
+        self.app = flask.Flask(__name__)
+        self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        client = Client(self.app, BaseResponse)
+
+        resp = client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 123"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        resp = client.get("/hello/456")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello: 456"], list(resp.response))
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)


### PR DESCRIPTION
# Description

Proposal to solve #375 for the `FlaskInstrumentor`, based on the `FastAPIInstrumentor` solution in #486.
This PR allows users to pass an explicit `excluded_urls` argument during instrumentation.
The explicit argument will override values set via environment variable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: The `test_programmatic` module was modified to test both environment-based and explicit exclusions.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated