### PR TITLE
SDK extension does not need to depend on API directly

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
@@ -38,7 +38,6 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
 
 [options.entry_points]


### PR DESCRIPTION
# Description

Quick PR to remove `opentelemetry-api` as a dependency for the SDK extension because it should already get that dependency through` opentelemetry-sdk`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [] Changelogs have been updated~ Hopefully we can skip this for such a minor change?
~- [] Unit tests have been added~
~- [ ] Documentation has been updated~
