### PR TITLE
EKS Detector should return empty string, not resource if env var missing

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
@@ -74,7 +74,7 @@ def _get_cluster_info(cred_value):
     )
 
 
-def _get_cluster_name(cred_value):
+def _get_cluster_name(cred_value) -> str:
     cluster_info = json.loads(_get_cluster_info(cred_value))
     cluster_name = ""
     try:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
@@ -74,11 +74,7 @@ def _get_cluster_info(cred_value):
     )
 
 
-def _get_cluster_name():
-    cred_value = _get_k8s_cred_value()
-    if not _is_eks(cred_value):
-        return Resource.get_empty()
-
+def _get_cluster_name(cred_value):
     cluster_info = json.loads(_get_cluster_info(cred_value))
     cluster_name = ""
     try:
@@ -110,7 +106,14 @@ class AwsEksResourceDetector(ResourceDetector):
 
     def detect(self) -> "Resource":
         try:
-            cluster_name = _get_cluster_name()
+            cred_value = _get_k8s_cred_value()
+
+            if not _is_eks(cred_value):
+                raise RuntimeError(
+                    "Could not confirm process is running on EKS."
+                )
+
+            cluster_name = _get_cluster_name(cred_value)
             container_id = _get_container_id()
 
             if not container_id and not cluster_name:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
@@ -33,6 +33,14 @@ MockEksResourceAttributes = {
 
 class AwsEksResourceDetectorTest(unittest.TestCase):
     @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._get_k8s_cred_value",
+        return_value="MOCK_TOKEN",
+    )
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_eks",
+        return_value=True,
+    )
+    @patch(
         "opentelemetry.sdk.extension.aws.resource.eks._get_cluster_info",
         return_value=f"""{{
   "kind": "ConfigMap",
@@ -56,14 +64,6 @@ class AwsEksResourceDetectorTest(unittest.TestCase):
 """,
     )
     @patch(
-        "opentelemetry.sdk.extension.aws.resource.eks._is_eks",
-        return_value=True,
-    )
-    @patch(
-        "opentelemetry.sdk.extension.aws.resource.eks._get_k8s_cred_value",
-        return_value="MOCK_TOKEN",
-    )
-    @patch(
         "builtins.open",
         new_callable=mock_open,
         read_data=f"""14:name=systemd:/docker/{MockEksResourceAttributes[ResourceAttributes.CONTAINER_ID]}
@@ -85,11 +85,25 @@ class AwsEksResourceDetectorTest(unittest.TestCase):
     def test_simple_create(
         self,
         mock_open_function,
-        mock_get_k8_cred_value,
-        mock_is_eks,
         mock_get_cluster_info,
+        mock_is_eks,
+        mock_get_k8_cred_value,
     ):
         actual = AwsEksResourceDetector().detect()
         self.assertDictEqual(
             actual.attributes.copy(), OrderedDict(MockEksResourceAttributes)
         )
+
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._get_k8s_cred_value",
+        return_value="MOCK_TOKEN",
+    )
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_eks",
+        return_value=False,
+    )
+    def test_if_no_eks_env_var_and_should_raise(
+        self, mock_is_eks, mock_get_k8_cred_value
+    ):
+        with self.assertRaises(RuntimeError):
+            AwsEksResourceDetector(raise_on_error=True).detect()


### PR DESCRIPTION
# Description

We noticed a logic mistake in the "bad" path of the EKS detector. Instead of returning `Resource.get_empty()`, we should return the empty string `""` if the process can't be verified to be running on EKS.

This check was probably moved by me when I was setting up the tests. I've added a unit test for it now.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a unit test to make sure this code path raises an exception.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~ Should not need a CHANGELOG if we merge before the next release
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
