### PR TITLE
disable elasticcachesearch7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,8 @@ envlist =
     pypy3-test-instrumentation-boto
 
     ; opentelemetry-instrumentation-elasticsearch
-    py3{6,7,8,9}-test-instrumentation-elasticsearch{2,5,6,7}
-    pypy3-test-instrumentation-elasticsearch{2,5,6,7}
+    py3{6,7,8,9}-test-instrumentation-elasticsearch{2,5,6}
+    pypy3-test-instrumentation-elasticsearch{2,5,6}
 
     ; opentelemetry-instrumentation-falcon
     py3{4,5,6,7,8,9}-test-instrumentation-falcon
@@ -171,8 +171,8 @@ deps =
   elasticsearch5: elasticsearch>=5.0,<6.0
   elasticsearch6: elasticsearch-dsl>=6.0,<7.0
   elasticsearch6: elasticsearch>=6.0,<7.0
-  elasticsearch7: elasticsearch-dsl>=7.0,<8.0
-  elasticsearch7: elasticsearch>=7.0,<8.0
+  ; elasticsearch7: elasticsearch-dsl>=7.0,<8.0
+  ; elasticsearch7: elasticsearch>=7.0,<8.0
   sqlalchemy11: sqlalchemy>=1.1,<1.2
   sqlalchemy14: aiosqlite
   sqlalchemy14: sqlalchemy~=1.4
@@ -190,7 +190,7 @@ changedir =
   test-instrumentation-celery: instrumentation/opentelemetry-instrumentation-celery/tests
   test-instrumentation-dbapi: instrumentation/opentelemetry-instrumentation-dbapi/tests
   test-instrumentation-django: instrumentation/opentelemetry-instrumentation-django/tests
-  test-instrumentation-elasticsearch{2,5,6,7}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
+  test-instrumentation-elasticsearch{2,5,6}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
   test-instrumentation-falcon: instrumentation/opentelemetry-instrumentation-falcon/tests
   test-instrumentation-fastapi: instrumentation/opentelemetry-instrumentation-fastapi/tests
   test-instrumentation-flask: instrumentation/opentelemetry-instrumentation-flask/tests
@@ -295,7 +295,7 @@ commands_pre =
 
   sqlalchemy{11,14}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy[test]
 
-  elasticsearch{2,5,6,7}: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-instrumentation {toxinidir}/instrumentation/opentelemetry-instrumentation-elasticsearch[test]
+  elasticsearch{2,5,6}: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-instrumentation {toxinidir}/instrumentation/opentelemetry-instrumentation-elasticsearch[test]
 
   httpx: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-httpx[test]
 


### PR DESCRIPTION
this tox task appears to be hanging. This is what I saw when I ran it locally:

```

test_elasticsearch.py::TestElasticsearchIntegration::test_dsl_create FAILED                                                                        [  8%]
test_elasticsearch.py::TestElasticsearchIntegration::test_dsl_index FAILED                                                                         [ 16%]
test_elasticsearch.py::TestElasticsearchIntegration::test_dsl_search FAILED                                                                        [ 25%]
test_elasticsearch.py::TestElasticsearchIntegration::test_instrumentor FAILED                                                                      [ 33%]
test_elasticsearch.py::TestElasticsearchIntegration::test_multithread 
```