### PR TITLE
Potential fix for flaky celery test

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/celery/conftest.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/conftest.py
@@ -70,7 +70,7 @@ def instrument(tracer_provider, memory_exporter):
     CeleryInstrumentor().uninstrument()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def tracer_provider(memory_exporter):
     original_tracer_provider = trace_api.get_tracer_provider()
 
@@ -86,7 +86,7 @@ def tracer_provider(memory_exporter):
     trace_api.set_tracer_provider(original_tracer_provider)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def memory_exporter():
     memory_exporter = InMemorySpanExporter()
     return memory_exporter


### PR DESCRIPTION
# Description

It seems the same in memory span exporter was being reused by multiple
tests. This change _should_ create a new instance of memeory exporter
per test/function.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2067 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Existing tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
