### PR TITLE
Falcon: handle env vars locally vs globally

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -26,7 +26,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import StatusCode, format_span_id, format_trace_id
-from opentelemetry.util.http import get_excluded_urls, get_traced_request_attrs
 
 from .app import make_app
 
@@ -34,12 +33,6 @@ from .app import make_app
 class TestFalconBase(TestBase):
     def setUp(self):
         super().setUp()
-        FalconInstrumentor().instrument(
-            request_hook=getattr(self, "request_hook", None),
-            response_hook=getattr(self, "response_hook", None),
-        )
-        self.app = make_app()
-        # pylint: disable=protected-access
         self.env_patch = patch.dict(
             "os.environ",
             {
@@ -48,20 +41,12 @@ class TestFalconBase(TestBase):
             },
         )
         self.env_patch.start()
-        self.exclude_patch = patch(
-            "opentelemetry.instrumentation.falcon._excluded_urls",
-            get_excluded_urls("FALCON"),
+
+        FalconInstrumentor().instrument(
+            request_hook=getattr(self, "request_hook", None),
+            response_hook=getattr(self, "response_hook", None),
         )
-        middleware = self.app._middleware[0][  # pylint:disable=W0212
-            0
-        ].__self__
-        self.traced_patch = patch.object(
-            middleware,
-            "_traced_request_attrs",
-            get_traced_request_attrs("FALCON"),
-        )
-        self.exclude_patch.start()
-        self.traced_patch.start()
+        self.app = make_app()
 
     def client(self):
         return testing.TestClient(self.app)
@@ -71,8 +56,6 @@ class TestFalconBase(TestBase):
         with self.disable_logging():
             FalconInstrumentor().uninstrument()
         self.env_patch.stop()
-        self.exclude_patch.stop()
-        self.traced_patch.stop()
 
 
 class TestFalconInstrumentation(TestFalconBase):


### PR DESCRIPTION
All instrumentations read most env vars today at module level. This has
a few disadvantages.

- harder to test.
- code executed on import even if instrumentation is not used.
- forces to use global vars.

This commit fixes the Falcon instrumentation to handle env vars locally
during instrumentor initialization and considerably simplifies testing.
Other instrumentations should receive similar treatment.

## Type of change

Please delete options that are not relevant.

- [x] Code/Tooling enhancement (non-breaking change which fixes an issue)


# How Has This Been Tested?


- [x] Existing tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
