### PR TITLE
Fix flaky celery docker test

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
@@ -15,7 +15,6 @@
 
 import celery
 from celery.exceptions import Retry
-from flaky import flaky
 from pytest import mark
 
 import opentelemetry.instrumentation.celery
@@ -559,8 +558,6 @@ def test_apply_async_previous_style_tasks(
     ) == async_run_span.attributes.get(SpanAttributes.MESSAGING_MESSAGE_ID)
 
 
-# FIXME find a permanent solution for the flakiness of this test
-@flaky
 def test_custom_tracer_provider(celery_app, memory_exporter):
     @celery_app.task
     def fn_task():
@@ -576,7 +573,7 @@ def test_custom_tracer_provider(celery_app, memory_exporter):
     CeleryInstrumentor().uninstrument()
     CeleryInstrumentor().instrument(tracer_provider=tracer_provider)
 
-    fn_task.delay()
+    fn_task.apply()
 
     spans_list = memory_exporter.get_finished_spans()
     assert len(spans_list) == 1


### PR DESCRIPTION
Fixes #638

# Description

The test was actually generating 2 spans but on very fast systems we
only saw one as the test ran faster than the message would travel
through the broker, trigger a task and generate 2nd span.

Switched from .delay() to .apply() so only one span is generated which
is enough for the test in question.

## Type of change

Please delete options that are not relevant.

- [x] Dev/Tooling enhancement
 
# How Has This Been Tested?

- [x] Unit Tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
