### PR TITLE
Update Doc for aws propagator default sampling behavior

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
@@ -65,6 +65,11 @@ Or by setting this propagator in your instrumented application:
 
     set_global_textmap(AwsXRayFormat())
 
+**NOTE**: Because the parent context parsed from the `X-Amzn-Trace-Id` header
+assumes the context is _not_ sampled by default, users should make sure to add
+`Sampled=1` to their `X-Amzn-Trace-Id` headers so that the child spans are
+sampled.
+
 Usage (AWS Resource Detectors)
 ------------------------------
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
@@ -46,6 +46,11 @@ Next, use the provided `AwsXRayIdGenerator` to initialize the `TracerProvider`.
 Usage (AWS X-Ray Propagator)
 ----------------------------
 
+**NOTE**: Because the parent context extracted from the `X-Amzn-Trace-Id` header
+assumes the context is _not_ sampled by default, users should make sure to add
+`Sampled=1` to their `X-Amzn-Trace-Id` headers so that the child spans are
+sampled.
+
 Use the provided AWS X-Ray Propagator to inject the necessary context into
 traces sent to external systems.
 
@@ -64,11 +69,6 @@ Or by setting this propagator in your instrumented application:
     from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import AwsXRayFormat
 
     set_global_textmap(AwsXRayFormat())
-
-**NOTE**: Because the parent context parsed from the `X-Amzn-Trace-Id` header
-assumes the context is _not_ sampled by default, users should make sure to add
-`Sampled=1` to their `X-Amzn-Trace-Id` headers so that the child spans are
-sampled.
 
 Usage (AWS Resource Detectors)
 ------------------------------

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
@@ -18,8 +18,16 @@ AWS X-Ray Propagator
 
 The **AWS X-Ray Propagator** provides a propagator that when used, adds a `trace
 header`_ to outgoing traces that is compatible with the AWS X-Ray backend service.
-This allows the trace context to be propagated when a trace span multiple AWS
+This allows the trace context to be propagated when a trace spans multiple AWS
 services.
+
+The same propagator setup is used to extract a context sent by external systems
+so that child span have the correct parent context.
+
+**NOTE**: Because the parent context parsed from the ``X-Amzn-Trace-Id`` header
+assumes the context is _not_ sampled by default, users should make sure to add
+``Sampled=1`` to their ``X-Amzn-Trace-Id`` headers so that the child spans are
+sampled.
 
 Usage
 -----
@@ -42,11 +50,6 @@ Or by setting this propagator in your instrumented application:
     from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import AwsXRayFormat
 
     set_global_textmap(AwsXRayFormat())
-
-**NOTE**: Because the parent context parsed from the `X-Amzn-Trace-Id` header
-assumes the context is _not_ sampled by default, users should make sure to add
-`Sampled=1` to their `X-Amzn-Trace-Id` headers so that the child spans are
-sampled.
 
 API
 ---

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/trace/propagation/aws_xray_format.py
@@ -43,6 +43,11 @@ Or by setting this propagator in your instrumented application:
 
     set_global_textmap(AwsXRayFormat())
 
+**NOTE**: Because the parent context parsed from the `X-Amzn-Trace-Id` header
+assumes the context is _not_ sampled by default, users should make sure to add
+`Sampled=1` to their `X-Amzn-Trace-Id` headers so that the child spans are
+sampled.
+
 API
 ---
 .. _trace header: https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader


### PR DESCRIPTION
# Description

By default the `TraceProvider` uses a Sampler which respects the Parent Sampling decision. If the user does not provide `Sampled=1;` into their `X-Amzn-Trace-Id` header when using the `AwsXrayFormat` propagator, the parent context (and all subsequent child spans) are assumed to be `sampled=false` by default.

This PR updates the docs to warn users about that.

Fixes #649

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
- [x] Documentation has been updated
