### PR TITLE
botocore: Fix uninstrument to also unpatch header injection on Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.5.0-0.24b0...HEAD)
 
+### Changed
+- `opentelemetry-instrumentation-botocore` Unpatch botocore Endpoint.prepare_request on uninstrument
+  ([#664](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/664))
+
 ## [1.5.0-0.24b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0-0.24b0) - 2021-08-26
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -51,6 +51,7 @@ import logging
 from typing import Collection
 
 from botocore.client import BaseClient
+from botocore.endpoint import Endpoint
 from botocore.exceptions import ClientError
 from wrapt import wrap_function_wrapper
 
@@ -114,6 +115,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
     def _uninstrument(self, **kwargs):
         unwrap(BaseClient, "_make_api_call")
+        unwrap(Endpoint, "prepare_request")
 
     @staticmethod
     def _is_lambda_invoke(service_name, operation_name, api_params):

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -61,6 +61,7 @@ def lambda_handler(event, context):
     return pfunc
 
 
+# pylint:disable=too-many-public-methods
 class TestBotocoreInstrumentor(TestBase):
     """Botocore integration testsuite"""
 
@@ -321,6 +322,31 @@ class TestBotocoreInstrumentor(TestBase):
         kinesis.list_streams()
         spans = self.memory_exporter.get_finished_spans()
         assert not spans, spans
+
+    @mock_ec2
+    def test_uninstrument_does_not_inject_headers(self):
+        headers = {}
+        previous_propagator = get_global_textmap()
+        try:
+            set_global_textmap(MockTextMapPropagator())
+
+            def intercept_headers(**kwargs):
+                headers.update(kwargs["request"].headers)
+
+            ec2 = self.session.create_client("ec2", region_name="us-west-2")
+
+            BotocoreInstrumentor().uninstrument()
+
+            ec2.meta.events.register_first(
+                "before-send.ec2.DescribeInstances", intercept_headers
+            )
+            with self.tracer_provider.get_tracer("test").start_span("parent"):
+                ec2.describe_instances()
+
+            self.assertNotIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
+            self.assertNotIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
+        finally:
+            set_global_textmap(previous_propagator)
 
     @mock_sqs
     def test_double_patch(self):


### PR DESCRIPTION
# Description

botocore instrumentor is patching `botocore.endpoint.Endpoint.prepare_reqyest` in the instrument method but did not unpatch it in the uninstrument method.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Additional unit test was added

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
