### PR TITLE
Fix documentation for MySQL instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -30,7 +30,7 @@ Usage
 
     cnx = mysql.connector.connect(database="MySQL_Database")
     cursor = cnx.cursor()
-    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cursor.execute("INSERT INTO test (testField) VALUES (123)")
     cursor.close()
     cnx.close()
 


### PR DESCRIPTION
Add closing parenthesis to documentation example.
