### PR TITLE
Do not fail tests if component owners workflow fails

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -10,5 +10,8 @@ jobs:
   run_self:
     runs-on: ubuntu-latest
     name: Auto Assign Owners
+    # Don't fail tests if this workflow fails. Some pending issues:
+    # - https://github.com/dyladan/component-owners/issues/8
+    continue-on-error: true
     steps:
       - uses: dyladan/component-owners@main


### PR DESCRIPTION
# Description

Follow up to #659, #656 revealed that the Component Owners action can fail if users send a `git commit --amend` instead of pushing a new commit. It's not ideal, but we can ignore this failure and let the PR pass if any errors occur with this action because it is supposed to just be a convenience for assigning respective CODEOWNERs.

Approvers can always assign reviewers directly.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
