### PR TITLE
Release AWS Python SDK Extension as 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.5.0-0.24b0...HEAD)
+- `opentelemetry-sdk-extension-aws` Release AWS Python SDK Extension as 1.0.0
+  ([#667](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/667))
 
 ### Changed
 - `opentelemetry-instrumentation-botocore` Unpatch botocore Endpoint.prepare_request on uninstrument

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.24b0"
+__version__ = "1.0.0"


### PR DESCRIPTION
# Description

With #596 and #598 merged we completed the major tasks we wanted to release packages from Contrib as 1.0 Instrumentation API is not stable so they cannot be released as 1.0, but packages that the maintainers feel comfortable to release _can_ be released as 1.0.

With that said, I became the CODEOWNER for the `sdk-extension/opentelemetry-sdk-extension-aws` package in #655 , and after bringing it up at the SIG meeting got the go-ahead to release this package as 1.0!

The `sdk-extension/opentelemetry-sdk-extension-aws` package only depends on `opentelemetry-sdk`, which is 1.0 stable as well so it should give us confidence the APIs needed for this `sdk-extension` package are also stable.

See:

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/704f1d9cfdd59f84162885bfc611f416ba37f0c7/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg#L40-L41

Once we merge this, we can try the changes from #598 to _release from a tag_. (e.g. `opentelemetry-sdk-extension-aws==1.0.0`)

## Type of change

Individual Contrib package release.

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
