### PR TITLE
adding response_hook to redis instrumentor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.5.0-0.24b0...HEAD)
 
+### Added
+- `opentelemetry-instrumentation-redis` added response_hook callback passed as an argument to the instrument method.
+  ([#669](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/669))
+
 ### Changed
 - `opentelemetry-instrumentation-botocore` Unpatch botocore Endpoint.prepare_request on uninstrument
   ([#664](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/664))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.5.0-0.24b0...HEAD)
 
 ### Added
-- `opentelemetry-instrumentation-redis` added response_hook callback passed as an argument to the instrument method.
+- `opentelemetry-instrumentation-redis` added request_hook and response_hook callbacks passed as arguments to the instrument method.
   ([#669](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/669))
 
 ### Changed

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -41,8 +41,8 @@ Usage
 API
 ---
 """
-
-from typing import Collection
+import typing
+from typing import Any, Collection
 
 import redis
 from wrapt import wrap_function_wrapper
@@ -57,8 +57,13 @@ from opentelemetry.instrumentation.redis.util import (
 from opentelemetry.instrumentation.redis.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import Span
 
 _DEFAULT_SERVICE = "redis"
+
+_ResponseHookT = typing.Optional[
+    typing.Callable[[Span, redis.connection.Connection, Any], None]
+]
 
 
 def _set_connection_attributes(span, conn):
@@ -70,42 +75,64 @@ def _set_connection_attributes(span, conn):
         span.set_attribute(key, value)
 
 
-def _traced_execute_command(func, instance, args, kwargs):
-    tracer = getattr(redis, "_opentelemetry_tracer")
-    query = _format_command_args(args)
-    name = ""
-    if len(args) > 0 and args[0]:
-        name = args[0]
-    else:
-        name = instance.connection_pool.connection_kwargs.get("db", 0)
-    with tracer.start_as_current_span(
-        name, kind=trace.SpanKind.CLIENT
-    ) as span:
-        if span.is_recording():
-            span.set_attribute(SpanAttributes.DB_STATEMENT, query)
-            _set_connection_attributes(span, instance)
-            span.set_attribute("db.redis.args_length", len(args))
-        return func(*args, **kwargs)
+def _instrument(
+    tracer, response_hook: _ResponseHookT = None,
+):
+    def _traced_execute_command(func, instance, args, kwargs):
+        query = _format_command_args(args)
+        name = ""
+        if len(args) > 0 and args[0]:
+            name = args[0]
+        else:
+            name = instance.connection_pool.connection_kwargs.get("db", 0)
+        with tracer.start_as_current_span(
+            name, kind=trace.SpanKind.CLIENT
+        ) as span:
+            if span.is_recording():
+                span.set_attribute(SpanAttributes.DB_STATEMENT, query)
+                _set_connection_attributes(span, instance)
+                span.set_attribute("db.redis.args_length", len(args))
+            response = func(*args, **kwargs)
+            if callable(response_hook):
+                response_hook(span, instance, response)
+            return response
 
+    def _traced_execute_pipeline(func, instance, args, kwargs):
+        cmds = [_format_command_args(c) for c, _ in instance.command_stack]
+        resource = "\n".join(cmds)
 
-def _traced_execute_pipeline(func, instance, args, kwargs):
-    tracer = getattr(redis, "_opentelemetry_tracer")
+        span_name = " ".join([args[0] for args, _ in instance.command_stack])
 
-    cmds = [_format_command_args(c) for c, _ in instance.command_stack]
-    resource = "\n".join(cmds)
+        with tracer.start_as_current_span(
+            span_name, kind=trace.SpanKind.CLIENT
+        ) as span:
+            if span.is_recording():
+                span.set_attribute(SpanAttributes.DB_STATEMENT, resource)
+                _set_connection_attributes(span, instance)
+                span.set_attribute(
+                    "db.redis.pipeline_length", len(instance.command_stack)
+                )
+            response = func(*args, **kwargs)
+            if callable(response_hook):
+                response_hook(span, instance, response)
+            return response
 
-    span_name = " ".join([args[0] for args, _ in instance.command_stack])
+    pipeline_class = (
+        "BasePipeline" if redis.VERSION < (3, 0, 0) else "Pipeline"
+    )
+    redis_class = "StrictRedis" if redis.VERSION < (3, 0, 0) else "Redis"
 
-    with tracer.start_as_current_span(
-        span_name, kind=trace.SpanKind.CLIENT
-    ) as span:
-        if span.is_recording():
-            span.set_attribute(SpanAttributes.DB_STATEMENT, resource)
-            _set_connection_attributes(span, instance)
-            span.set_attribute(
-                "db.redis.pipeline_length", len(instance.command_stack)
-            )
-        return func(*args, **kwargs)
+    wrap_function_wrapper(
+        "redis", f"{redis_class}.execute_command", _traced_execute_command
+    )
+    wrap_function_wrapper(
+        "redis.client", f"{pipeline_class}.execute", _traced_execute_pipeline,
+    )
+    wrap_function_wrapper(
+        "redis.client",
+        f"{pipeline_class}.immediate_execute_command",
+        _traced_execute_command,
+    )
 
 
 class RedisInstrumentor(BaseInstrumentor):
@@ -117,41 +144,18 @@ class RedisInstrumentor(BaseInstrumentor):
         return _instruments
 
     def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        setattr(
-            redis,
-            "_opentelemetry_tracer",
-            trace.get_tracer(
-                __name__, __version__, tracer_provider=tracer_provider,
-            ),
-        )
+        """Instruments the redis module
 
-        if redis.VERSION < (3, 0, 0):
-            wrap_function_wrapper(
-                "redis", "StrictRedis.execute_command", _traced_execute_command
-            )
-            wrap_function_wrapper(
-                "redis.client",
-                "BasePipeline.execute",
-                _traced_execute_pipeline,
-            )
-            wrap_function_wrapper(
-                "redis.client",
-                "BasePipeline.immediate_execute_command",
-                _traced_execute_command,
-            )
-        else:
-            wrap_function_wrapper(
-                "redis", "Redis.execute_command", _traced_execute_command
-            )
-            wrap_function_wrapper(
-                "redis.client", "Pipeline.execute", _traced_execute_pipeline
-            )
-            wrap_function_wrapper(
-                "redis.client",
-                "Pipeline.immediate_execute_command",
-                _traced_execute_command,
-            )
+        Args:
+            **kwargs: Optional arguments
+                ``tracer_provider``: a TracerProvider, defaults to global.
+                ``response_hook``: An optional callback which is invoked right before the span is finished processing a response.
+        """
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = trace.get_tracer(
+            __name__, __version__, tracer_provider=tracer_provider
+        )
+        _instrument(tracer, response_hook=kwargs.get("response_hook"))
 
     def _uninstrument(self, **kwargs):
         if redis.VERSION < (3, 0, 0):

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -111,3 +111,33 @@ class TestRedis(TestBase):
         self.assertEqual(
             span.attributes.get(response_attribute_name), test_value
         )
+
+    def test_request_hook(self):
+        redis_client = redis.Redis()
+        connection = redis.connection.Connection()
+        redis_client.connection = connection
+
+        custom_attribute_name = "my.request.attribute"
+
+        def request_hook(span, conn, args, kwargs):
+            if span and span.is_recording():
+                span.set_attribute(custom_attribute_name, args[0])
+
+        RedisInstrumentor().uninstrument()
+        RedisInstrumentor().instrument(
+            tracer_provider=self.tracer_provider, request_hook=request_hook
+        )
+
+        test_value = "test_value"
+
+        with mock.patch.object(connection, "send_command"):
+            with mock.patch.object(
+                redis_client, "parse_response", return_value=test_value
+            ):
+                redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assertEqual(span.attributes.get(custom_attribute_name), "GET")

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -80,3 +80,34 @@ class TestRedis(TestBase):
 
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
+
+    def test_response_hook(self):
+        redis_client = redis.Redis()
+        connection = redis.connection.Connection()
+        redis_client.connection = connection
+
+        response_attribute_name = "db.redis.response"
+
+        def response_hook(span, conn, response):
+            span.set_attribute(response_attribute_name, response)
+
+        RedisInstrumentor().uninstrument()
+        RedisInstrumentor().instrument(
+            tracer_provider=self.tracer_provider, response_hook=response_hook
+        )
+
+        test_value = "test_value"
+
+        with mock.patch.object(connection, "send_command"):
+            with mock.patch.object(
+                redis_client, "parse_response", return_value=test_value
+            ):
+                redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assertEqual(
+            span.attributes.get(response_attribute_name), test_value
+        )


### PR DESCRIPTION
# Description

`opentelemetry-instrumentation-redis`: added response_hook callback passed as an argument to the instrument method, enabling the users to add data from the response to the span attributes

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] `test_response_hook` -  a new unit test testing the hook activation

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
