### PR TITLE
Added new opentelemetry-contrib-instrumentations meta package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-aws-lambda` `SpanKind.SERVER` by default, add more cases for `SpanKind.CONSUMER` services. ([#926](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/926))
 - `opentelemetry-instrumentation-sqlalchemy` added experimental sql commenter capability
    ([#924](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/924))
+- `opentelemetry-contrib-instrumentations` added new meta-package that installs all contrib instrumentations.
+  ([#681](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/681))
 - `opentelemetry-instrumentation-dbapi` add experimental sql commenter capability
   ([#908](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/908))
 - `opentelemetry-instrumentation-requests` make span attribute available to samplers

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -37,5 +37,7 @@ sqlalchemy>=1.0
 tornado>=5.1.1
 ddtrace>=0.34.0
 httpx>=0.18.0
+
+# indirect dependency pins
 markupsafe==2.0.1
 itsdangerous==2.0.1

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -41,6 +41,7 @@ packages=
     opentelemetry-semantic-conventions
     opentelemetry-test-utils
     opentelemetry-instrumentation
+    opentelemetry-contrib-instrumentations
     opentelemetry-distro
 
 [exclude_release]

--- a/opentelemetry-contrib-instrumentations/LICENSE
+++ b/opentelemetry-contrib-instrumentations/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/opentelemetry-contrib-instrumentations/MANIFEST.in
+++ b/opentelemetry-contrib-instrumentations/MANIFEST.in
@@ -1,0 +1,8 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/opentelemetry-contrib-instrumentations/README.rst
+++ b/opentelemetry-contrib-instrumentations/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry Instrumentation
+=============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-contrib-instrumentations.svg
+   :target: https://pypi.org/project/opentelemetry-contrib-instrumentations/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-contrib-instrumentations
+
+
+This package installs all instrumentation packages hosted by the OpenTelemetry Python Coontrib repository.
+The list of packages can be found (here)[https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation]
+
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/opentelemetry-contrib-instrumentations/setup.cfg
+++ b/opentelemetry-contrib-instrumentations/setup.cfg
@@ -1,0 +1,73 @@
+[metadata]
+name = opentelemetry-contrib-instrumentations
+description = OpenTelemetry Contrib Instrumentation Packages
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-contrib-instrumentations
+platforms = any
+license = Apache-2.0
+classifiers = 
+	Development Status :: 4 - Beta
+	Intended Audience :: Developers
+	License :: OSI Approved :: Apache Software License
+	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
+
+[options]
+python_requires = >=3.6
+package_dir = 
+	=src
+packages = find_namespace:
+zip_safe = False
+include_package_data = True
+install_requires = 
+	opentelemetry-instrumentation-aiohttp-client==0.29b0
+	opentelemetry-instrumentation-aiopg==0.29b0
+	opentelemetry-instrumentation-asgi==0.29b0
+	opentelemetry-instrumentation-asyncpg==0.29b0
+	opentelemetry-instrumentation-aws-lambda==0.29b0
+	opentelemetry-instrumentation-boto==0.29b0
+	opentelemetry-instrumentation-botocore==0.29b0
+	opentelemetry-instrumentation-celery==0.29b0
+	opentelemetry-instrumentation-dbapi==0.29b0
+	opentelemetry-instrumentation-django==0.29b0
+	opentelemetry-instrumentation-elasticsearch==0.29b0
+	opentelemetry-instrumentation-falcon==0.29b0
+	opentelemetry-instrumentation-fastapi==0.29b0
+	opentelemetry-instrumentation-flask==0.29b0
+	opentelemetry-instrumentation-grpc==0.29b0
+	opentelemetry-instrumentation-httpx==0.29b0
+	opentelemetry-instrumentation-jinja2==0.29b0
+	opentelemetry-instrumentation-kafka-python==0.29b0
+	opentelemetry-instrumentation-logging==0.29b0
+	opentelemetry-instrumentation-mysql==0.29b0
+	opentelemetry-instrumentation-pika==0.29b0
+	opentelemetry-instrumentation-psycopg2==0.29b0
+	opentelemetry-instrumentation-pymemcache==0.29b0
+	opentelemetry-instrumentation-pymongo==0.29b0
+	opentelemetry-instrumentation-pymysql==0.29b0
+	opentelemetry-instrumentation-pyramid==0.29b0
+	opentelemetry-instrumentation-redis==0.29b0
+	opentelemetry-instrumentation-requests==0.29b0
+	opentelemetry-instrumentation-sklearn==0.29b0
+	opentelemetry-instrumentation-sqlalchemy==0.29b0
+	opentelemetry-instrumentation-sqlite3==0.29b0
+	opentelemetry-instrumentation-starlette==0.29b0
+	opentelemetry-instrumentation-tornado==0.29b0
+	opentelemetry-instrumentation-urllib==0.29b0
+	opentelemetry-instrumentation-urllib3==0.29b0
+	opentelemetry-instrumentation-wsgi==0.29b0
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test = 
+

--- a/opentelemetry-contrib-instrumentations/setup.py
+++ b/opentelemetry-contrib-instrumentations/setup.py
@@ -1,0 +1,29 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "contrib-instrumentations", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME, encoding="utf-8") as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(
+    version=PACKAGE_INFO["__version__"],
+)

--- a/opentelemetry-contrib-instrumentations/src/opentelemetry/contrib-instrumentations/version.py
+++ b/opentelemetry-contrib-instrumentations/src/opentelemetry/contrib-instrumentations/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.28b1"

--- a/scripts/generate_instrumentation_metapackage.py
+++ b/scripts/generate_instrumentation_metapackage.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from configparser import ConfigParser
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("instrumentation_metapackage_generator")
+
+_prefix = "opentelemetry-instrumentation-"
+
+
+root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+base_instrumentation_path = os.path.join(root_path, "instrumentation")
+
+
+def get_instrumentation_packages():
+    for instrumentation in sorted(os.listdir(base_instrumentation_path)):
+        instrumentation_path = os.path.join(
+            base_instrumentation_path, instrumentation
+        )
+        if not os.path.isdir(
+            instrumentation_path
+        ) or not instrumentation.startswith(_prefix):
+            continue
+
+        src_dir = os.path.join(
+            instrumentation_path, "src", "opentelemetry", "instrumentation"
+        )
+        src_pkgs = [
+            f
+            for f in os.listdir(src_dir)
+            if os.path.isdir(os.path.join(src_dir, f))
+        ]
+        assert len(src_pkgs) == 1
+        name = src_pkgs[0]
+
+        pkg_info = {}
+        version_filename = os.path.join(
+            src_dir,
+            name,
+            "version.py",
+        )
+        with open(version_filename, encoding="utf-8") as fh:
+            exec(fh.read(), pkg_info)
+
+        version = pkg_info["__version__"]
+        yield (instrumentation, version)
+
+
+def main():
+    dependencies = get_instrumentation_packages()
+
+    setup_cfg_path = os.path.join(
+        root_path, "opentelemetry-contrib-instrumentations", "setup.cfg"
+    )
+    config = ConfigParser()
+    config.read(setup_cfg_path)
+
+    deps = "\n".join(f"{pkg}=={version}" for pkg, version in dependencies)
+
+    config["options"]["install_requires"] = "\n" + deps
+    with open(setup_cfg_path, "w", encoding="utf-8") as fh:
+        config.write(fh)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -529,3 +529,4 @@ commands =
   {toxinidir}/scripts/generate_setup.py
   {toxinidir}/scripts/generate_instrumentation_bootstrap.py
   {toxinidir}/scripts/generate_instrumentation_readme.py
+  {toxinidir}/scripts/generate_instrumentation_metapackage.py


### PR DESCRIPTION
# Description

This package does not contain any features on its own but serves is a
convenient way to install all supported instrumentations at once.

Also pins `markupsafe` to `2.0.1` in tests as `2.1.1` adding some breaking changes.

## Type of change

Please delete options that are not relevant.

- [x] New package
- [x] Packaging fix 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
