### PR TITLE
disable pylint for file is causing pylint 2.11.0 to hang

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -15,6 +15,8 @@
 # Note: This package is not named "flask" because of
 # https://github.com/PyCQA/pylint/issues/2648
 
+# pylint: skip-file
+
 """
 This library builds on the OpenTelemetry WSGI middleware to track web requests
 in Flask applications. In addition to opentelemetry-util-http, it


### PR DESCRIPTION
# Description

This file is causing pylint >2.9.6 to hang, disabling pylint for this file to allow us to move forward w/ the rest of the code.

Fixes #690 
