### PR TITLE
chore: Set SDK Ext AWS to 1.1.0dev0

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.1"
+__version__ = "1.1.0dev0"


### PR DESCRIPTION
# Description

Following #672, we set the version of the AWS SDK so that development can be done on this package in foresight of a `1.1.0` release.

If however, a path would be needed, that PR could simply change the version to the path number needed, with a follow up PR to set it back to this `dev0` state if needed.
