### PR TITLE
Fix datadog exporter test

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -550,18 +550,28 @@ class TestDatadogSpanExporter(unittest.TestCase):
         )
 
     def test_origin(self):
-        context = trace_api.SpanContext(
-            trace_id=0x000000000000000000000000DEADBEEF,
-            span_id=trace_api.INVALID_SPAN,
-            is_remote=True,
-            trace_state=trace_api.TraceState(
-                [(datadog.constants.DD_ORIGIN, "origin-service")]
-            ),
+        trace_id = 0x000000000000000000000000DEADBEEF
+        trace_state = trace_api.TraceState(
+            [(datadog.constants.DD_ORIGIN, "origin-service")]
+        )
+        parent_span_ctx = trace_api.SpanContext(
+            trace_id=trace_id,
+            span_id=0x1,
+            is_remote=False,
+            trace_state=trace_state,
+        )
+        child_span_ctx = trace_api.SpanContext(
+            trace_id=trace_id,
+            span_id=0x2,
+            is_remote=False,
+            trace_state=trace_state,
         )
 
-        root_span = trace._Span(name="root", context=context, parent=None)
+        root_span = trace._Span(
+            name="root", context=parent_span_ctx, parent=None
+        )
         child_span = trace._Span(
-            name="child", context=context, parent=root_span
+            name="child", context=child_span_ctx, parent=parent_span_ctx
         )
         root_span.start()
         child_span.start()


### PR DESCRIPTION
Fixes the test setup for `test_datadog_exporter.test_origin`. The test manually creates the spans and used the `INVALID_SPAN` was used as span ID. So instead of an expected `int` value, a whole `NonRecordingSpan` was used. 
