### PR TITLE
Tornado attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -249,6 +249,11 @@ def _get_operation_name(handler, request):
     return f"{class_name}.{request.method.lower()}"
 
 
+def _get_full_handler_name(handler):
+    klass = type(handler)
+    return f"{klass.__module__}.{klass.__qualname__}"
+
+
 def _start_span(tracer, handler, start_time) -> _TraceContext:
     token = context.attach(extract(handler.request.headers))
 
@@ -261,6 +266,7 @@ def _start_span(tracer, handler, start_time) -> _TraceContext:
         attributes = _get_attributes_from_request(handler.request)
         for key, value in attributes.items():
             span.set_attribute(key, value)
+        span.set_attribute("handler", _get_full_handler_name(handler))
 
     activation = trace.use_span(span, end_on_exit=True)
     activation.__enter__()  # pylint: disable=E1101

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -235,9 +235,6 @@ def _get_attributes_from_request(request):
         SpanAttributes.HTTP_TARGET: request.path,
     }
 
-    if request.host:
-        attrs[SpanAttributes.HTTP_HOST] = request.host
-
     if request.remote_ip:
         attrs[SpanAttributes.NET_PEER_IP] = request.remote_ip
 

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -236,7 +236,7 @@ def _get_attributes_from_request(request):
     }
 
     if request.remote_ip:
-        attrs[SpanAttributes.NET_PEER_IP] = request.remote_ip
+        attrs[SpanAttributes.HTTP_CLIENT_IP] = request.remote_ip
 
     return extract_attributes_from_object(
         request, _traced_request_attrs, attrs

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -143,7 +143,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: "/",
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 201,
             },
         )
@@ -220,7 +220,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: url,
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 201,
             },
         )
@@ -258,7 +258,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: "/error",
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 500,
             },
         )
@@ -292,7 +292,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: "/missing-url",
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 404,
             },
         )
@@ -336,7 +336,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: "/dyna",
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 202,
             },
         )
@@ -377,7 +377,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_HOST: "127.0.0.1:"
                 + str(self.get_http_port()),
                 SpanAttributes.HTTP_TARGET: "/on_finish",
-                SpanAttributes.NET_PEER_IP: "127.0.0.1",
+                SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 200,
             },
         )

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -145,6 +145,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_TARGET: "/",
                 SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 201,
+                "handler": "tests.tornado_test_app.MainHandler",
             },
         )
 
@@ -260,6 +261,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_TARGET: "/error",
                 SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 500,
+                "handler": "tests.tornado_test_app.BadHandler",
             },
         )
 
@@ -294,6 +296,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_TARGET: "/missing-url",
                 SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 404,
+                "handler": "tornado.web.ErrorHandler",
             },
         )
 
@@ -338,6 +341,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_TARGET: "/dyna",
                 SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 202,
+                "handler": "tests.tornado_test_app.DynamicHandler",
             },
         )
 
@@ -379,6 +383,7 @@ class TestTornadoInstrumentation(TornadoTest):
                 SpanAttributes.HTTP_TARGET: "/on_finish",
                 SpanAttributes.HTTP_CLIENT_IP: "127.0.0.1",
                 SpanAttributes.HTTP_STATUS_CODE: 200,
+                "handler": "tests.tornado_test_app.FinishedHandler",
             },
         )
 


### PR DESCRIPTION
# Description

* Set `http.client_ip` instead of `net.peer.ip`: the value is changed by Tornado to `X-Forwarded-For` or `X-Real-IP`, see [Tornado code](https://github.com/tornadoweb/tornado/blob/790715ae0f0a30b9ee830bfee75bb7fa4c4ec2f6/tornado/httpserver.py#L332-L352), see [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/b46bcab5fb709381f1fd52096a19541370c7d1b3/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions)
    * The actual `net.peer.ip` is in `_orig_remote_ip`, however I thought it best not to read a private field. Let me know if it's ok.
* Set `handler` to the fully-qualified name of the request handler class
    * The Tornado instrumentation does not provide any route information, such as `http.route`, only the base handler class's name as the span name. I didn't find an easy way to read the route pattern, the name of the handler seems like the next best thing

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e py38-test-instrumentation-tornado` (`TestTornadoInstrumentation` updated)

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated