### PR TITLE
Expand allowed versions for jinja2 instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/package.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("jinja2~=2.7",)
+_instruments = ("jinja2>=2.7",)


### PR DESCRIPTION
# Description

The Jinja2 API hasn't changed the functions that have been wrapped in at least 8 years.
The version supported should be much more broad.

Specifically, 
`
jinja2.environment.Template.render
jinja2.Template.generate
jinja2.Environment.compile
jinja2.Environment._load_template
`
which are the only wrapped functions seem to be appropriate for the instrumentation wrappers without further changes.

I'm not a jinja2 expert, so it's possible I'm missing something. Happy to help with changes if it seems that I am.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change produces useful traces in our system.

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
