### PR TITLE
botocore: Introduce instrumentation extensions

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/__init__.py
@@ -1,0 +1,35 @@
+import importlib
+import logging
+
+from opentelemetry.instrumentation.botocore.extensions.types import (
+    _AwsSdkCallContext,
+    _AwsSdkExtension,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def _lazy_load(module, cls):
+    def loader():
+        imported_mod = importlib.import_module(module, __name__)
+        return getattr(imported_mod, cls, None)
+
+    return loader
+
+
+_KNOWN_EXTENSIONS = {
+    "sqs": _lazy_load(".sqs", "_SqsExtension"),
+}
+
+
+def _find_extension(call_context: _AwsSdkCallContext) -> _AwsSdkExtension:
+    try:
+        loader = _KNOWN_EXTENSIONS.get(call_context.service)
+        if loader is None:
+            return _AwsSdkExtension(call_context)
+
+        extension_cls = loader()
+        return extension_cls(call_context)
+    except Exception as ex:  # pylint: disable=broad-except
+        _logger.error("Error when loading extension: %s", ex)
+        return _AwsSdkExtension(call_context)

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
@@ -1,0 +1,12 @@
+from opentelemetry.instrumentation.botocore.extensions.types import (
+    _AttributeMapT,
+    _AwsSdkExtension,
+)
+
+
+class _SqsExtension(_AwsSdkExtension):
+    def extract_attributes(self, attributes: _AttributeMapT):
+        queue_url = self._call_context.params.get("QueueUrl")
+        if queue_url:
+            # TODO: update when semantic conventions exist
+            attributes["aws.queue_url"] = queue_url


### PR DESCRIPTION
# Description

Adds an extension mechanism that allows enriching the botocore span with additional request/response attributes. An extension is specific to the called AWS service (e.g. 'lambda', 'sqs', 'dynamodb', ...) and provides callbacks that get invoked before and after the actual AWS service call is made.
As the initial part SQS specifics are moved to a dedicated extension. Extensions for 'dynamodb' and 'lambda' will be added in followup PRs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

covered by existing tests

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
