### PR TITLE
Bugfix/set default context in pika

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -41,15 +41,20 @@ def _decorate_callback(
     ) -> Any:
         if not properties:
             properties = BasicProperties()
+        if properties.headers is None:
+            properties.headers = {}
+        ctx = propagate.extract(properties.headers, getter=_pika_getter)
+        if not ctx:
+            ctx = context.get_current()
         span = _get_span(
             tracer,
             channel,
             properties,
             task_name=task_name,
+            ctx=ctx,
             operation=MessagingOperationValues.RECEIVE,
         )
         with trace.use_span(span, end_on_exit=True):
-            propagate.inject(properties.headers)
             retval = callback(channel, method, properties, body)
         return retval
 
@@ -70,11 +75,13 @@ def _decorate_basic_publish(
     ) -> Any:
         if not properties:
             properties = BasicProperties()
+        ctx = context.get_current()
         span = _get_span(
             tracer,
             channel,
             properties,
             task_name="(temporary)",
+            ctx=ctx,
             operation=None,
         )
         if not span:
@@ -97,13 +104,9 @@ def _get_span(
     channel: Channel,
     properties: BasicProperties,
     task_name: str,
+    ctx: context.Context,
     operation: Optional[MessagingOperationValues] = None,
 ) -> Optional[Span]:
-    if properties.headers is None:
-        properties.headers = {}
-    ctx = propagate.extract(properties.headers, getter=_pika_getter)
-    if not ctx:
-        ctx = context.get_current()
     if context.get_value("suppress_instrumentation") or context.get_value(
         _SUPPRESS_INSTRUMENTATION_KEY
     ):


### PR DESCRIPTION
# Description

This PR fixes a bug in the pika instrumentation library. When the propagator could not detect a context from the message headers (for example in the sending action `properties.headers`) the context would be set to `{}` instead of the current context - thus breaking the trace chain.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Maunal Instrumentation test

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
