### PR TITLE
Fix mssql docker tests v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,13 +84,6 @@ jobs:
           python-version: 3.9
       - name: Install tox
         run: pip install -U tox
-      - name: Prep mssql driver
-        if: ${{ matrix.tox-environment == 'docker-tests' }}
-        run: | 
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          sudo sh -c "echo 'deb [arch=amd64,armhf,arm64] https://packages.microsoft.com/ubuntu/20.04/prod focal main' >  /etc/apt/sources.list.d/mssql-release.list"
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17
       - name: Install libsnappy-dev
         if: ${{ matrix.tox-environment == 'lint' }}
         run: sudo apt-get install -y libsnappy-dev

--- a/tests/opentelemetry-docker-tests/tests/docker-compose.yml
+++ b/tests/opentelemetry-docker-tests/tests/docker-compose.yml
@@ -46,4 +46,4 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: "yourStrong(!)Password"
-    command: /bin/sh -c "sleep 10s && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P yourStrong\(!\)Password -d master -Q 'CREATE DATABASE [opentelemetry-tests]' & /opt/mssql/bin/sqlservr"
+    command: /opt/mssql/bin/sqlservr


### PR DESCRIPTION
# Description

We were giving mssql server 10 seconds to start before creating the test
database. It now takes Github CI more than 10 seconds to start the mssql
server. Instead of increasing the leeway with guesses, this commit moves
the creation of test database from docker compose to the python test suite.
This allows the docker image to come up first and then create the DB
inside the test suite with proper retry mechanism that is already in
place.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
