### PR TITLE
Respect provided tracer provider when instrumenting SQLAlchemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#713](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/713))
 - `opentelemetry-sdk-extension-aws` Move AWS X-Ray Propagator into its own `opentelemetry-propagators-aws` package
   ([#720](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/720))
+- `opentelemetry-instrumentation-sqlalchemy` Respect provided tracer provider when instrumenting SQLAlchemy
+  ([#728](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/728))
 
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -88,13 +88,13 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
         Returns:
             An instrumented engine if passed in as an argument, None otherwise.
         """
-        _w("sqlalchemy", "create_engine", _wrap_create_engine)
-        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine)
+        _w("sqlalchemy", "create_engine", _wrap_create_engine(kwargs))
+        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine(kwargs))
         if parse_version(sqlalchemy.__version__).release >= (1, 4):
             _w(
                 "sqlalchemy.ext.asyncio",
                 "create_async_engine",
-                _wrap_create_async_engine,
+                _wrap_create_async_engine(kwargs),
             )
 
         if kwargs.get("engine") is not None:

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -90,7 +90,11 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
         _w("sqlalchemy", "create_engine", _wrap_create_engine(tracer_provider))
-        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine(tracer_provider))
+        _w(
+            "sqlalchemy.engine",
+            "create_engine",
+            _wrap_create_engine(tracer_provider),
+        )
         if parse_version(sqlalchemy.__version__).release >= (1, 4):
             _w(
                 "sqlalchemy.ext.asyncio",
@@ -100,9 +104,7 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
 
         if kwargs.get("engine") is not None:
             return EngineTracer(
-                _get_tracer(
-                    kwargs.get("engine"), tracer_provider
-                ),
+                _get_tracer(kwargs.get("engine"), tracer_provider),
                 kwargs.get("engine"),
             )
         return None

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -88,19 +88,20 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
         Returns:
             An instrumented engine if passed in as an argument, None otherwise.
         """
-        _w("sqlalchemy", "create_engine", _wrap_create_engine(kwargs))
-        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine(kwargs))
+        tracer_provider = kwargs.get("tracer_provider")
+        _w("sqlalchemy", "create_engine", _wrap_create_engine(tracer_provider))
+        _w("sqlalchemy.engine", "create_engine", _wrap_create_engine(tracer_provider))
         if parse_version(sqlalchemy.__version__).release >= (1, 4):
             _w(
                 "sqlalchemy.ext.asyncio",
                 "create_async_engine",
-                _wrap_create_async_engine(kwargs),
+                _wrap_create_async_engine(tracer_provider),
             )
 
         if kwargs.get("engine") is not None:
             return EngineTracer(
                 _get_tracer(
-                    kwargs.get("engine"), kwargs.get("tracer_provider")
+                    kwargs.get("engine"), tracer_provider
                 ),
                 kwargs.get("engine"),
             )

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -42,8 +42,8 @@ def _get_tracer(engine, tracer_provider=None):
     )
 
 
-# pylint: disable=unused-argument
 def _wrap_create_async_engine(tracer_provider=None):
+    # pylint: disable=unused-argument
     def _wrap_create_async_engine_internal(func, module, args, kwargs):
         """Trace the SQLAlchemy engine, creating an `EngineTracer`
         object that will listen to SQLAlchemy events.
@@ -55,8 +55,8 @@ def _wrap_create_async_engine(tracer_provider=None):
     return _wrap_create_async_engine_internal
 
 
-# pylint: disable=unused-argument
 def _wrap_create_engine(tracer_provider=None):
+    # pylint: disable=unused-argument
     def _wrap_create_engine_internal(func, module, args, kwargs):
         """Trace the SQLAlchemy engine, creating an `EngineTracer`
         object that will listen to SQLAlchemy events.

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -43,23 +43,33 @@ def _get_tracer(engine, tracer_provider=None):
 
 
 # pylint: disable=unused-argument
-def _wrap_create_async_engine(func, module, args, kwargs):
-    """Trace the SQLAlchemy engine, creating an `EngineTracer`
-    object that will listen to SQLAlchemy events.
-    """
-    engine = func(*args, **kwargs)
-    EngineTracer(_get_tracer(engine), engine.sync_engine)
-    return engine
+def _wrap_create_async_engine(kwargs):
+    tracer_provider = kwargs.get("tracer_provider")
+
+    def _wrap_create_async_engine_internal(func, module, args, kwargs):
+        """Trace the SQLAlchemy engine, creating an `EngineTracer`
+        object that will listen to SQLAlchemy events.
+        """
+        engine = func(*args, **kwargs)
+        EngineTracer(_get_tracer(engine, tracer_provider), engine.sync_engine)
+        return engine
+
+    return _wrap_create_async_engine_internal
 
 
 # pylint: disable=unused-argument
-def _wrap_create_engine(func, module, args, kwargs):
-    """Trace the SQLAlchemy engine, creating an `EngineTracer`
-    object that will listen to SQLAlchemy events.
-    """
-    engine = func(*args, **kwargs)
-    EngineTracer(_get_tracer(engine), engine)
-    return engine
+def _wrap_create_engine(kwargs):
+    tracer_provider = kwargs.get("tracer_provider")
+
+    def _wrap_create_engine_internal(func, module, args, kwargs):
+        """Trace the SQLAlchemy engine, creating an `EngineTracer`
+        object that will listen to SQLAlchemy events.
+        """
+        engine = func(*args, **kwargs)
+        EngineTracer(_get_tracer(engine, tracer_provider), engine)
+        return engine
+
+    return _wrap_create_engine_internal
 
 
 class EngineTracer:

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -43,9 +43,7 @@ def _get_tracer(engine, tracer_provider=None):
 
 
 # pylint: disable=unused-argument
-def _wrap_create_async_engine(kwargs):
-    tracer_provider = kwargs.get("tracer_provider")
-
+def _wrap_create_async_engine(tracer_provider=None):
     def _wrap_create_async_engine_internal(func, module, args, kwargs):
         """Trace the SQLAlchemy engine, creating an `EngineTracer`
         object that will listen to SQLAlchemy events.
@@ -58,9 +56,7 @@ def _wrap_create_async_engine(kwargs):
 
 
 # pylint: disable=unused-argument
-def _wrap_create_engine(kwargs):
-    tracer_provider = kwargs.get("tracer_provider")
-
+def _wrap_create_engine(tracer_provider=None):
     def _wrap_create_engine_internal(func, module, args, kwargs):
         """Trace the SQLAlchemy engine, creating an `EngineTracer`
         object that will listen to SQLAlchemy events.

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -19,9 +19,9 @@ import sqlalchemy
 from sqlalchemy import create_engine
 
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider, export
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.test.test_base import TestBase
 
 
@@ -100,10 +100,16 @@ class TestSqlalchemyInstrumentation(TestBase):
     def test_custom_tracer_provider(self):
         provider = TracerProvider(
             resource=Resource.create(
-                {"service.name": "test", "deployment.environment": "env", "service.version": "1234"},
+                {
+                    "service.name": "test",
+                    "deployment.environment": "env",
+                    "service.version": "1234",
+                },
             ),
         )
-        provider.add_span_processor(export.SimpleSpanProcessor(self.memory_exporter))
+        provider.add_span_processor(
+            export.SimpleSpanProcessor(self.memory_exporter)
+        )
 
         SQLAlchemyInstrumentor().instrument(tracer_provider=provider)
         from sqlalchemy import create_engine  # pylint: disable-all
@@ -115,9 +121,12 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         self.assertEqual(len(spans), 1)
         self.assertEqual(spans[0].resource.attributes["service.name"], "test")
-        self.assertEqual(spans[0].resource.attributes["deployment.environment"], "env")
-        self.assertEqual(spans[0].resource.attributes["service.version"], "1234")
-
+        self.assertEqual(
+            spans[0].resource.attributes["deployment.environment"], "env"
+        )
+        self.assertEqual(
+            spans[0].resource.attributes["service.version"], "1234"
+        )
 
     @pytest.mark.skipif(
         not sqlalchemy.__version__.startswith("1.4"),

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -19,6 +19,8 @@ import sqlalchemy
 from sqlalchemy import create_engine
 
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.test.test_base import TestBase
 
@@ -94,6 +96,28 @@ class TestSqlalchemyInstrumentation(TestBase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(spans[0].name, "SELECT :memory:")
         self.assertEqual(spans[0].kind, trace.SpanKind.CLIENT)
+
+    def test_custom_tracer_provider(self):
+        provider = TracerProvider(
+            resource=Resource.create(
+                {"service.name": "test", "deployment.environment": "env", "service.version": "1234"},
+            ),
+        )
+        provider.add_span_processor(export.SimpleSpanProcessor(self.memory_exporter))
+
+        SQLAlchemyInstrumentor().instrument(tracer_provider=provider)
+        from sqlalchemy import create_engine  # pylint: disable-all
+
+        engine = create_engine("sqlite:///:memory:")
+        cnx = engine.connect()
+        cnx.execute("SELECT	1 + 1;").fetchall()
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].resource.attributes["service.name"], "test")
+        self.assertEqual(spans[0].resource.attributes["deployment.environment"], "env")
+        self.assertEqual(spans[0].resource.attributes["service.version"], "1234")
+
 
     @pytest.mark.skipif(
         not sqlalchemy.__version__.startswith("1.4"),


### PR DESCRIPTION
# Description

This change updates the SQLALchemyInstrumentor to respect the tracer provider that is passed in through the kwargs when patching the `create_engine` functionality provided by SQLAlchemy. Previously, it would default to the global tracer provider.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tested and tested in a real environment.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
