### PR TITLE
adding missing python 3.9 classifier

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6.3

--- a/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.4

--- a/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 package_dir=

--- a/instrumentation/opentelemetry-instrumentation-logging/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-logging/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 package_dir=

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-pika/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pika/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-starlette/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-tornado/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-urllib/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-urllib/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-urllib3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/propagator/opentelemetry-propagator-aws-xray/setup.cfg
+++ b/propagator/opentelemetry-propagator-aws-xray/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/propagator/opentelemetry-propagator-ot-trace/setup.cfg
+++ b/propagator/opentelemetry-propagator-ot-trace/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6

--- a/util/opentelemetry-util-http/setup.cfg
+++ b/util/opentelemetry-util-http/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
Some setup.cfg files were missing the 3.9 classifier, this PR fixes that.