### PR TITLE
Fix build script to not release stable pkgs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,11 +31,14 @@ DISTDIR=dist
  (
    cd $DISTDIR
    for x in *.tar.gz ; do
-    if [[ $x =~ ^opentelemetry-.*-1\.[0-9]+.*\.tar\.gz$ ]]; then
-      echo "Skipping $x because it is >=1.0 and should be released using a tag."
-      continue
+    # NOTE: We filter beta vs 1.0 package at this point because we can read the
+    # version directly from the .tar.gz file.
+    if (echo "$x" | grep -Eq ^opentelemetry-.*-0\..*\.tar\.gz$); then
+      pip wheel --no-deps $x
+    else
+      echo "Skipping $x because it is not in pre-1.0 state and should be released using a tag."
+      rm $x
     fi
-     pip wheel --no-deps $x
    done
  )
 )


### PR DESCRIPTION
# Description

In #598 we modified the release skip to not release packages that have hit `1.0.0` because they should be released using a pushed `tag`.

After the latest release however, `1.0.0`+ packages [were released together](https://github.com/open-telemetry/opentelemetry-python-contrib/runs/3888307687?check_suite_focus=true#step:7:419) with the beta packages when using this script. They should not have been. The problem was that we were using Double Square brackets `[[` to do a "bash" test but this is not available on GitHub's shell environment and so [the check was being ignored](https://github.com/open-telemetry/opentelemetry-python-contrib/runs/3888307687?check_suite_focus=true#step:4:2450)

This PR fixes this by using a test method for the regex match that should [work for any POSIX compliant shell](https://stackoverflow.com/a/21112809/7460739).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- It works locally when I run `./scripts/build.sh` because I don't see the `1.0.0`+ components.
- It also works on GitHub runners because I pushed the change to my fork and I can confirm [that the 1.0.0 packages get skipped](https://github.com/NathanielRN/opentelemetry-python-contrib-1/runs/3900444665?check_suite_focus=true#step:4:2418)
- In that same workflow, you can see that no wheel is generated for the `1.0.0` packages.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
