### PR TITLE
Check Request ID format on S3 call for botocore instrumentation tests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    moto[all] ~= 2.0
+    moto[all] ~= 2.2.6
     opentelemetry-test == 0.25b1
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -178,15 +178,17 @@ class TestBotocoreInstrumentor(TestBase):
 
         location = {"LocationConstraint": "us-west-2"}
         s3.create_bucket(Bucket="mybucket", CreateBucketConfiguration=location)
-        self.assert_span("S3", "CreateBucket")
+        self.assert_span(
+            "S3", "CreateBucket", request_id=_REQUEST_ID_REGEX_MATCH
+        )
         self.memory_exporter.clear()
 
         s3.put_object(Key="foo", Bucket="mybucket", Body=b"bar")
-        self.assert_span("S3", "PutObject")
+        self.assert_span("S3", "PutObject", request_id=_REQUEST_ID_REGEX_MATCH)
         self.memory_exporter.clear()
 
         s3.get_object(Bucket="mybucket", Key="foo")
-        self.assert_span("S3", "GetObject")
+        self.assert_span("S3", "GetObject", request_id=_REQUEST_ID_REGEX_MATCH)
 
     @mock_sqs
     def test_sqs_client(self):


### PR DESCRIPTION
# Description

A while ago I said we could not check the request ID on S3 tests [because moto did not have this feature](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/150/files?authenticity_token=Z%2BviMS6g0n3M5x%2BSwN97WQ%2FrS7OIjIXqV5yB6pA%2BO8xfyHtSvPeb75k1PGoNFPNiJd34JDcmCSkOEouKDO4ykQ%3D%3D&file-filters%5B%5D=.py#r519485813) for its mock of the AWS service.

Recently I noticed that `moto` [fixed this](https://github.com/spulec/moto/pull/3836) as of their `2.2.6` release so I updated it to that version and added the check so there is consistency with the other tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests are still passing with this restriction on a _test_ dependency.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
