### PR TITLE
Remove unnecessary deps on test pkgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.6.0-0.25b0...HEAD)
+- `opentelemetry-sdk-extension-aws` & `opentelemetry-propagator-aws` Remove unnecessary dependencies on `opentelemetry-test`
+([#752](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/752))
 
 ### Changed
 - `opentelemetry-util-http` no longer contains an instrumentation entrypoint and will not be loaded

--- a/propagator/opentelemetry-propagator-aws-xray/setup.cfg
+++ b/propagator/opentelemetry-propagator-aws-xray/setup.cfg
@@ -47,7 +47,6 @@ opentelemetry_propagator =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.25b0
 
 [options.packages.find]
 where = src

--- a/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/setup.cfg
@@ -47,7 +47,6 @@ opentelemetry_id_generator =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.25b0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
# Description

We just found out that the `opentelemetry-sdk-extension-aws` and `opentelemetry-propagator-aws-xray` packages do not need to depend on the `opentelemetry-test` package.

We remove their dependencies in this PR.

Since it is _removing_ a dependency and not _adding_ one, we can release these packages as _patch` updates.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Made a new virtual environment
- Cloned the contrib repo
- Removed the dependencies on `opentelemetry-test`
- Ran both `tox -e test-sdkextensionaws` and `tox -e test-propagator-aws`
- Saw that they both ran successfully

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [] Unit tests have been added~
- [x] Documentation has been updated
