### PR TITLE
Release AWS Python SDK Extension as 2.0.1 and AWS Propagator as 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.6.1-0.25b1...HEAD)
+- `opentelemetry-sdk-extension-aws` & `opentelemetry-propagator-aws` Release AWS Python SDK Extension as 2.0.1 and AWS Propagator as 1.0.1
+  ([#753](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/753))
 
 ## [1.6.1-0.25b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.1-0.25b1) - 2021-10-18
 

--- a/propagator/opentelemetry-propagator-aws-xray/src/opentelemetry/propagators/aws/version.py
+++ b/propagator/opentelemetry-propagator-aws-xray/src/opentelemetry/propagators/aws/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
# Description

This PR is part of continuous updates and releases to the packages which makes OpenTelemetry compatible with AWS.

In this release:

`opentelemetry-sdk-extension-aws==2.0.1`
* Removed an unnecessary dependency on `opentelemetry-test`

`opentelemetry-propagator-aws==2.0.1`
* Removed an unnecessary dependency on `opentelemetry-test`

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
