### PR TITLE
default value is invalid, was renamed

### DIFF
--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -31,4 +31,4 @@ class OpenTelemetryDistro(BaseDistro):
 
     # pylint: disable=no-self-use
     def _configure(self, **kwargs):
-        os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc_span")
+        os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc")

--- a/opentelemetry-distro/tests/test_distro.py
+++ b/opentelemetry-distro/tests/test_distro.py
@@ -34,5 +34,5 @@ class TestDistribution(TestCase):
         self.assertIsNone(os.environ.get(OTEL_TRACES_EXPORTER))
         distro.configure()
         self.assertEqual(
-            "otlp_proto_grpc_span", os.environ.get(OTEL_TRACES_EXPORTER)
+            "otlp_proto_grpc", os.environ.get(OTEL_TRACES_EXPORTER)
         )

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -72,12 +72,12 @@ Well known trace exporter names:
     - jaeger_thrift
     - opencensus
     - otlp
-    - otlp_proto_grpc_span
-    - otlp_proto_http_span
+    - otlp_proto_grpc
+    - otlp_proto_http
     - zipkin_json
     - zipkin_proto
 
-``otlp`` is an alias for ``otlp_proto_grpc_span``.
+``otlp`` is an alias for ``otlp_proto_grpc``.
 
 * ``--id-generator`` or ``OTEL_PYTHON_ID_GENERATOR``
 


### PR DESCRIPTION
The entry point was renamed to remove the `_span` suffix but the values configured in the distro were not.