### PR TITLE
Update bootstrap gen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,3 +97,6 @@ jobs:
           key: v4-misc-tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt', 'gen-requirements.txt', 'docs-requirements.txt') }}
       - name: run tox
         run: tox -e ${{ matrix.tox-environment }}
+      - name: Ensure generated code is up to date
+        if: matrix.tox-environment == 'generate'
+        run: git diff --exit-code || (echo 'Generated code is out of date, please run "tox -e generate" and commit the changes in this PR.' && exit 1)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -18,111 +18,111 @@
 libraries = {
     "aiohttp": {
         "library": "aiohttp ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.25b1",
     },
     "aiopg": {
         "library": "aiopg >= 0.13.0, < 1.3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiopg==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-aiopg==0.25b1",
     },
     "asgiref": {
         "library": "asgiref ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-asgi==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-asgi==0.25b1",
     },
     "asyncpg": {
         "library": "asyncpg >= 0.12.0",
-        "instrumentation": "opentelemetry-instrumentation-asyncpg==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-asyncpg==0.25b1",
     },
     "boto": {
         "library": "boto~=2.0",
-        "instrumentation": "opentelemetry-instrumentation-boto==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-boto==0.25b1",
     },
     "botocore": {
         "library": "botocore ~= 1.0",
-        "instrumentation": "opentelemetry-instrumentation-botocore==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-botocore==0.25b1",
     },
     "celery": {
         "library": "celery >= 4.0, < 6.0",
-        "instrumentation": "opentelemetry-instrumentation-celery==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-celery==0.25b1",
     },
     "django": {
         "library": "django >= 1.10",
-        "instrumentation": "opentelemetry-instrumentation-django==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-django==0.25b1",
     },
     "elasticsearch": {
         "library": "elasticsearch >= 2.0",
-        "instrumentation": "opentelemetry-instrumentation-elasticsearch==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-elasticsearch==0.25b1",
     },
     "falcon": {
         "library": "falcon >= 2.0.0, < 4.0.0",
-        "instrumentation": "opentelemetry-instrumentation-falcon==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-falcon==0.25b1",
     },
     "fastapi": {
         "library": "fastapi ~= 0.58",
-        "instrumentation": "opentelemetry-instrumentation-fastapi==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-fastapi==0.25b1",
     },
     "flask": {
         "library": "flask >= 1.0, < 3.0",
-        "instrumentation": "opentelemetry-instrumentation-flask==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-flask==0.25b1",
     },
     "grpcio": {
         "library": "grpcio ~= 1.27",
-        "instrumentation": "opentelemetry-instrumentation-grpc==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-grpc==0.25b1",
     },
     "httpx": {
         "library": "httpx >= 0.18.0, < 0.19.0",
-        "instrumentation": "opentelemetry-instrumentation-httpx==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-httpx==0.25b1",
     },
     "jinja2": {
         "library": "jinja2 >= 2.7, < 4.0",
-        "instrumentation": "opentelemetry-instrumentation-jinja2==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-jinja2==0.25b1",
     },
     "mysql-connector-python": {
         "library": "mysql-connector-python ~= 8.0",
-        "instrumentation": "opentelemetry-instrumentation-mysql==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-mysql==0.25b1",
     },
     "pika": {
         "library": "pika >= 1.1.0",
-        "instrumentation": "opentelemetry-instrumentation-pika==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-pika==0.25b1",
     },
     "psycopg2": {
         "library": "psycopg2 >= 2.7.3.1",
-        "instrumentation": "opentelemetry-instrumentation-psycopg2==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-psycopg2==0.25b1",
     },
     "pymemcache": {
         "library": "pymemcache ~= 1.3",
-        "instrumentation": "opentelemetry-instrumentation-pymemcache==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-pymemcache==0.25b1",
     },
     "pymongo": {
         "library": "pymongo ~= 3.1",
-        "instrumentation": "opentelemetry-instrumentation-pymongo==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-pymongo==0.25b1",
     },
     "PyMySQL": {
         "library": "PyMySQL ~= 0.10.1",
-        "instrumentation": "opentelemetry-instrumentation-pymysql==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-pymysql==0.25b1",
     },
     "pyramid": {
         "library": "pyramid >= 1.7",
-        "instrumentation": "opentelemetry-instrumentation-pyramid==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-pyramid==0.25b1",
     },
     "redis": {
         "library": "redis >= 2.6",
-        "instrumentation": "opentelemetry-instrumentation-redis==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-redis==0.25b1",
     },
     "requests": {
         "library": "requests ~= 2.0",
-        "instrumentation": "opentelemetry-instrumentation-requests==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-requests==0.25b1",
     },
     "scikit-learn": {
         "library": "scikit-learn ~= 0.24.0",
-        "instrumentation": "opentelemetry-instrumentation-sklearn==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-sklearn==0.25b1",
     },
     "sqlalchemy": {
         "library": "sqlalchemy",
-        "instrumentation": "opentelemetry-instrumentation-sqlalchemy==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-sqlalchemy==0.25b1",
     },
     "starlette": {
         "library": "starlette ~= 0.13.0",
-        "instrumentation": "opentelemetry-instrumentation-starlette==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-starlette==0.25b1",
     },
     "tornado": {
         "library": "tornado >= 6.0",
@@ -130,13 +130,13 @@ libraries = {
     },
     "urllib3": {
         "library": "urllib3 >= 1.0.0, < 2.0.0",
-        "instrumentation": "opentelemetry-instrumentation-urllib3==0.25b0",
+        "instrumentation": "opentelemetry-instrumentation-urllib3==0.25b1",
     },
 }
 default_instrumentations = [
-    "opentelemetry-instrumentation-dbapi==0.25b0",
-    "opentelemetry-instrumentation-logging==0.25b0",
-    "opentelemetry-instrumentation-sqlite3==0.25b0",
-    "opentelemetry-instrumentation-urllib==0.25b0",
-    "opentelemetry-instrumentation-wsgi==0.25b0",
+    "opentelemetry-instrumentation-dbapi==0.25b1",
+    "opentelemetry-instrumentation-logging==0.25b1",
+    "opentelemetry-instrumentation-sqlite3==0.25b1",
+    "opentelemetry-instrumentation-urllib==0.25b1",
+    "opentelemetry-instrumentation-wsgi==0.25b1",
 ]


### PR DESCRIPTION
## Description

Global generate check was removed from CI workflow and a specific check was added to generate bootstrap script in this commit:
https://github.com/open-telemetry/opentelemetry-python-contrib/commit/d2984f5242ed2250ad1c11b6164e2e8e11e2a804#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L112-L114
https://github.com/open-telemetry/opentelemetry-python-contrib/commit/d2984f5242ed2250ad1c11b6164e2e8e11e2a804#diff-0b911e478cf36c1398ccb7c6b5a371bc2fb5b7a962f897ae28acd3027fe1cecdR109-R120

However, it prevented the checks to actually run for code generation scripts other than genertate_instrumentation_bootstrap.py. At this point we had generate check only working for generate_instrumentation_bootstrap.py in CI.

Next change was migration of opentelemetry-instrumentation to contrib which included removal of the bootstap specific check here: https://github.com/open-telemetry/opentelemetry-python-contrib/commit/7cf3cb42cf42c3cb9781ed219a8edff0f57302e4#diff-0b911e478cf36c1398ccb7c6b5a371bc2fb5b7a962f897ae28acd3027fe1cecdL109-L120

Since that commit, we haven't had generate checks run in CI for any script.

This PR adds the generate checks back. 

As a direct result of this, our latest release is somewhat broken. Installing `opentelemetry-instrumentation==0.25b1` install a bootstrap command which forces a downgrade to `0.25b0` of all instrumentation packages.

## Effect

Check is working as expected now:
<img width="933" alt="image" src="https://user-images.githubusercontent.com/46186/137867138-09ad1338-a4f8-41e7-94e9-23f0f0c7c939.png">


## Type of change

Please delete options that are not relevant.

- [x] Dev/tooling enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
