### PR TITLE
`falcon`: Drop support for Python 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#765](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/765))
 - `opentelemetry-instrumentation-pika` now propagates context to basic_consume callback
   ([#766](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/766))
+- `opentelemetry-instrumentation-falcon` Dropped broken support for Python 3.4.
+  ([#774](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/774))
 
 ## [1.6.2-0.25b2](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2-0.25b2) - 2021-10-19
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.6
 package_dir=
     =src
 packages=find_namespace:

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ envlist =
     pypy3-test-instrumentation-elasticsearch{2,5,6}
 
     ; opentelemetry-instrumentation-falcon
-    py3{4,5,6,7,8,9}-test-instrumentation-falcon{2,3}
+    py3{6,7,8,9}-test-instrumentation-falcon{2,3}
     pypy3-test-instrumentation-falcon{2,3}
 
     ; opentelemetry-instrumentation-fastapi
@@ -258,7 +258,7 @@ commands_pre =
   test: pip install "opentelemetry-semantic-conventions[test] @ {env:CORE_REPO}#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions"
   test: pip install "opentelemetry-sdk[test] @ {env:CORE_REPO}#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk"
   test: pip install "opentelemetry-test[test] @ {env:CORE_REPO}#egg=opentelemetry-test&subdirectory=tests/util"
-  test: pip install {toxinidir}/opentelemetry-instrumentation 
+  test: pip install {toxinidir}/opentelemetry-instrumentation
 
   distro: pip install {toxinidir}/opentelemetry-distro
 


### PR DESCRIPTION
# Description

Remove unwanted support for Python versions <3.6. This integration mistakenly lists Python 3.4 support, because it was merged in https://github.com/open-telemetry/opentelemetry-python/pull/1039, after the merge of https://github.com/open-telemetry/opentelemetry-python/pull/1099, so the latter didn't consider `falcon`.

Python 3.4 is broken nevertheless, as this integration already includes f-strings and other `opentelemetry` dependencies, which require Python 3.6.

Fixes #772.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
