### PR TITLE
aiohttp-client async response hook

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -85,6 +85,7 @@ API
 ---
 """
 
+import asyncio
 import types
 import typing
 from typing import Collection
@@ -121,7 +122,7 @@ _ResponseHookT = typing.Optional[
                 aiohttp.TraceRequestExceptionParams,
             ],
         ],
-        None,
+        typing.Awaitable[None],
     ]
 ]
 
@@ -235,7 +236,10 @@ def create_trace_config(
             return
 
         if callable(response_hook):
-            response_hook(trace_config_ctx.span, params)
+            if asyncio.iscoroutinefunction(response_hook):
+                await response_hook(trace_config_ctx.span, params)
+            else:
+                response_hook(trace_config_ctx.span, params)
 
         if trace_config_ctx.span.is_recording():
             trace_config_ctx.span.set_status(
@@ -255,7 +259,10 @@ def create_trace_config(
             return
 
         if callable(response_hook):
-            response_hook(trace_config_ctx.span, params)
+            if asyncio.iscoroutinefunction(response_hook):
+                await response_hook(trace_config_ctx.span, params)
+            else:
+                response_hook(trace_config_ctx.span, params)
 
         if trace_config_ctx.span.is_recording() and params.exception:
             trace_config_ctx.span.set_status(Status(StatusCode.ERROR))


### PR DESCRIPTION
# Description

Using the `aiohttp-client` instrument I would like to be able to add extra context from the http request object to the current span. Currently the `response_hook` callable does not support coroutines but this is required in order to access certain http response data, e.g. `await response.text()`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Test
- [x] Manual Test

Manual test can be achieved using the following setup:
```python
async def response_hook(span, params):
     content = await params.response.text()
     span.set_attribute("http.content", content)

trace_config = aiohttp_client.create_trace_config(response_hook=response_hook)
url = 'https://jsonplaceholder.typicode.com/todos/1'

async with aiohttp.ClientSession(trace_configs=[trace_config]) as session:
   await session.request(method="GET", url=url)
```

I have added a new unit test but having trouble running the test suite locally:

```sh
> tox -e test-instrumentation-aiohttp-client

test-instrumentation-aiohttp-client run-test-pre: commands[3] | pip install 'opentelemetry-test[test] @ git+https://github.com/open-telemetry/opentelemetry-python.git@main#egg=opentelemetry-test&subdirectory=tests/opentelemetry-tests'
Collecting opentelemetry-test[test]@ git+https://github.com/open-telemetry/opentelemetry-python.git@main#egg=opentelemetry-test&subdirectory=tests/opentelemetry-tests
  Cloning https://github.com/open-telemetry/opentelemetry-python.git (to revision main) to /private/var/folders/c8/gp1k0qt51_v3yxbtmt2vk33m0000gn/T/pip-install-78r42ydg/opentelemetry-test_73ed373c76fe4dfaa4bcc3166a343246
  Running command git clone -q https://github.com/open-telemetry/opentelemetry-python.git /private/var/folders/c8/gp1k0qt51_v3yxbtmt2vk33m0000gn/T/pip-install-78r42ydg/opentelemetry-test_73ed373c76fe4dfaa4bcc3166a343246
  Resolved https://github.com/open-telemetry/opentelemetry-python.git to commit 9ed60ea600cd0ffda6b614fc30b62117a84aeea7
ERROR: File "setup.py" not found for legacy project opentelemetry-test[test]@ git+https://github.com/open-telemetry/opentelemetry-python.git@main#egg=opentelemetry-test&subdirectory=tests/opentelemetry-tests from git+https://github.com/open-telemetry/opentelemetry-python.git@main#egg=opentelemetry-test&subdirectory=tests/opentelemetry-tests.
WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
You should consider upgrading via the '/Users/me/Projects/opentelemetry-python-contrib/.tox/test-instrumentation-aiohttp-client/bin/python -m pip install --upgrade pip' command.
ERROR: InvocationError for command /Users/me/Projects/opentelemetry-python-contrib/.tox/test-instrumentation-aiohttp-client/bin/pip install 'opentelemetry-test[test] @ git+https://github.com/open-telemetry/opentelemetry-python.git@main#egg=opentelemetry-test&subdirectory=tests/opentelemetry-tests' (exited with code 1)
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
