### PR TITLE
Add support instrumentation for Tornado 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.7.0-0.26b0...HEAD)
-
+- `opentelemetry-instrumentation-tornado` Add support instrumentation for Tornado 5.1.1
+  ([#812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/812))
+  
 ## [1.7.1-0.26b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.7.0-0.26b0) - 2021-11-11
 
 - `opentelemetry-instrumentation-aws-lambda` Add instrumentation for AWS Lambda Service - pkg metadata files (Part 1/2)

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -34,6 +34,6 @@ PyMySQL~=0.9.3
 pyramid>=1.7
 redis>=2.6
 sqlalchemy>=1.0
-tornado>=6.0
+tornado>=5.1.1
 ddtrace>=0.34.0
 httpx~=0.18.0

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -32,7 +32,7 @@
 | [opentelemetry-instrumentation-sqlalchemy](./opentelemetry-instrumentation-sqlalchemy) | sqlalchemy |
 | [opentelemetry-instrumentation-sqlite3](./opentelemetry-instrumentation-sqlite3) | sqlite3 |
 | [opentelemetry-instrumentation-starlette](./opentelemetry-instrumentation-starlette) | starlette ~= 0.13.0 |
-| [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 6.0 |
+| [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 |
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib |
 | [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 2.0.0 |
 | [opentelemetry-instrumentation-wsgi](./opentelemetry-instrumentation-wsgi) | wsgi |

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("tornado >= 6.0",)
+_instruments = ("tornado >= 5.1.1",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -125,7 +125,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-starlette==0.26b1",
     },
     "tornado": {
-        "library": "tornado >= 6.0",
+        "library": "tornado >= 5.1.1",
         "instrumentation": "opentelemetry-instrumentation-tornado==0.26b1",
     },
     "urllib3": {


### PR DESCRIPTION
# Description

Now tornado-instrumentaion support only Tornado version more than 6.0, but in instrumentation code not anything specifics for Tornado 6 there are. There is [release note](https://www.tornadoweb.org/en/stable/releases/v6.0.0.html#backwards-incompatible-changes) for Tornado 6.0, and noone backwards-incompatible changes using in actual implementation of instumentation. I've tested Tornado instrumentation for last 5s version (5.1.1) in my highload project for this version and it works for me. Alternative way, using opentracing instead of opentelemetry, is not quite good, because a lot of part of microserfices may using opentelemetry for Java, Go and different languages. For more complecevity good reason for using opentelemetry for old tornado version. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Run current tests for Tornado 5.1.1 on Python 3.8.10. Start up on highload service (8000 rps) on pythonv 3.8.10. Check generated span and send throgh OTL. As a result - see span on Jaeger.


# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [ ] Unit tests have been added. Not reasons for add new tests
- [X] Documentation has been updated
