### PR TITLE
fix celery spankind to server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-tornado` Add support instrumentation for Tornado 5.1.1
   ([#812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/812))
+
+- `opentelemetry-instrumentation-celery` Fixed SpanKind and add documentation(related issue #609)
+  ([#819](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/819))
   
 ## [1.7.1-0.26b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.7.0-0.26b0) - 2021-11-11
 

--- a/instrumentation/opentelemetry-instrumentation-celery/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-celery/README.rst
@@ -22,3 +22,16 @@ References
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_
 
+Note - Keeping Published Tasks Span
+-----------------------------------
+In the case where Celery Worker "**A**" publishes a Task ``b.ping`` to Celery Worker "**B**".
+
+Let's say Worker "**A**" receives a Task ``a.ping`` which publishes a Task ``b.ping``
+::
+
+    ==>a.ping
+       ==>b.ping
+
+to keep the span relations, the task ``b.ping`` should be added to the Celery Worker "**A**" tasks registry.
+otherwise, the process span would not reside at the original parent task Trace.
+

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -146,7 +146,7 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         operation_name = f"{_TASK_RUN}/{task.name}"
         span = self._tracer.start_span(
-            operation_name, context=tracectx, kind=trace.SpanKind.CONSUMER
+            operation_name, context=tracectx, kind=trace.SpanKind.SERVER
         )
 
         activation = trace.use_span(span, end_on_exit=True)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -49,7 +49,7 @@ class TestCeleryInstrumentation(TestBase):
         consumer, producer = spans
 
         self.assertEqual(consumer.name, "run/tests.celery_test_tasks.task_add")
-        self.assertEqual(consumer.kind, SpanKind.CONSUMER)
+        self.assertEqual(consumer.kind, SpanKind.SERVER)
         self.assertSpanHasAttributes(
             consumer,
             {


### PR DESCRIPTION
# Description

Celery worker Pipeline Service Map (Grafana Node Map)does not reflect the real nodes in the system.
When we have a Celery worker "A" which publishes a Task for Celery worker "B" the Service Map will not show the Service "B" and it would all be contained under a node "celery"

Code change:

In function `_trace_prerun`, just change the `SpanKind=CONSUMER` to `SpanKind=SERVER`
Fixes # (issue)
It also pertained to issue #609 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A
Existing Test at
`instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py`
was changed to assert the `SpanKind=SERVER`

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Documentation has been updated
