### PR TITLE
lambda instrumentation - support for flush timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `opentelemetry-instrumentation-aws-lambda` Adds support for configurable flush timeout  via `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` property. ([#825](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/825)) 
+- `opentelemetry-instrumentation-aws-lambda` Adds support for configurable flush timeout  via `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` property. ([#825](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/825))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.7.0-0.26b0...HEAD)
 
+### Added
+
+- `opentelemetry-instrumentation-aws-lambda` Adds support for configurable flush timeout  via `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` property. ([#825](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/825)) 
+
 ### Fixed
 
 - `opentelemetry-exporter-richconsole` Fixed attribute error on parentless spans.

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -248,8 +248,7 @@ class TestAwsLambdaInstrumentor(TestBase):
 
         test_env_patch.stop()
 
-    # test that NO ERROR is thrown
-    def test_lambda_flush_timeout(self):
+    def test_lambda_no_error_with_invalid_flush_timeout(self):
 
         test_env_patch = mock.patch.dict(
             "os.environ",

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -19,6 +19,7 @@ from opentelemetry.environment_variables import OTEL_PROPAGATORS
 from opentelemetry.instrumentation.aws_lambda import (
     _HANDLER,
     _X_AMZN_TRACE_ID,
+    OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT,
     AwsLambdaInstrumentor,
 )
 from opentelemetry.propagate import get_global_textmap
@@ -244,5 +245,33 @@ class TestAwsLambdaInstrumentor(TestBase):
             MOCK_W3C_TRACE_STATE_VALUE,
         )
         self.assertTrue(parent_context.is_remote)
+
+        test_env_patch.stop()
+
+    # test that NO ERROR is thrown
+    def test_lambda_flush_timeout(self):
+
+        test_env_patch = mock.patch.dict(
+            "os.environ",
+            {
+                **os.environ,
+                # NOT Active Tracing
+                _X_AMZN_TRACE_ID: MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED,
+                # NOT using the X-Ray Propagator
+                OTEL_PROPAGATORS: "tracecontext",
+                OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT: "10000",
+            },
+        )
+        test_env_patch.start()
+
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        assert spans
+
+        self.assertEqual(len(spans), 1)
 
         test_env_patch.stop()

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -258,7 +258,7 @@ class TestAwsLambdaInstrumentor(TestBase):
                 _X_AMZN_TRACE_ID: MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED,
                 # NOT using the X-Ray Propagator
                 OTEL_PROPAGATORS: "tracecontext",
-                OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT: "10000",
+                OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT: "invalid-timeout-string",
             },
         )
         test_env_patch.start()

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -58,7 +58,6 @@ if DJANGO_2_0:
             response = self.get_response(request)
             return self.process_response(request, response)
 
-
 else:
     # Django versions 1.x can use `settings.MIDDLEWARE_CLASSES` and expect
     # old-style middlewares, which are created by inheriting from

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=E0611
+
 from sys import modules
 from unittest.mock import Mock, patch
 

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=E0611
+
 from sys import modules
 from unittest.mock import Mock, patch
 


### PR DESCRIPTION
# Description

Adds support for configurable flush timeout to AWS lambda instrumentation. Property name aligned with other implementations (Java).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- unit test
- previously implemented in the otel-lambda module (before instrumentation was moved here)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
