### PR TITLE
[WIP] Conditionally create server spans for flask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-tornado` Add support instrumentation for Tornado 5.1.1
   ([#812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/812))
+
+- `opentelemetry-instrumentation-flask` Flask: Conditionally create SERVER spans
+  ([#826](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/826))
   
 ## [1.7.1-0.26b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.7.0-0.26b0) - 2021-11-11
 
@@ -62,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#759](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/759))
 - Consolidate instrumentation documentation in docstrings
   ([#754](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/754))
-- Flask: Conditionally create SERVER spans
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#759](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/759))
 - Consolidate instrumentation documentation in docstrings
   ([#754](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/754))
+- Flask: Conditionally create SERVER spans
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -58,7 +58,6 @@ if DJANGO_2_0:
             response = self.get_response(request)
             return self.process_response(request, response)
 
-
 else:
     # Django versions 1.x can use `settings.MIDDLEWARE_CLASSES` and expect
     # old-style middlewares, which are created by inheriting from

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -176,15 +176,23 @@ def _wrapped_before_request(
             return
         flask_request_environ = flask.request.environ
         span_name = get_default_span_name()
-        token = context.attach(
-            extract(flask_request_environ, getter=otel_wsgi.wsgi_getter)
-        )
+
+        token = ctx = None
+        span_kind = trace.SpanKind.INTERNAL
+        
+        if trace.get_current_span() is trace.INVALID_SPAN:
+            ctx = extract(flask_request_environ, getter=otel_wsgi.wsgi_getter)
+            print(ctx)
+            token = context.attach(ctx)
+            span_kind = trace.SpanKind.SERVER
 
         span = tracer.start_span(
             span_name,
-            kind=trace.SpanKind.SERVER,
+            ctx,
+            kind=span_kind,
             start_time=flask_request_environ.get(_ENVIRON_STARTTIME_KEY),
         )
+
         if request_hook:
             request_hook(span, flask_request_environ)
 
@@ -229,7 +237,9 @@ def _wrapped_teardown_request(excluded_urls=None):
             activation.__exit__(
                 type(exc), exc, getattr(exc, "__traceback__", None)
             )
-        context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+
+        if flask.request.environ.get(_ENVIRON_TOKEN, None) is not None:
+            context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
 
     return _teardown_request
 

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -179,7 +179,7 @@ def _wrapped_before_request(
 
         token = ctx = None
         span_kind = trace.SpanKind.INTERNAL
-        
+
         if trace.get_current_span() is trace.INVALID_SPAN:
             ctx = extract(flask_request_environ, getter=otel_wsgi.wsgi_getter)
             print(ctx)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -439,4 +439,6 @@ class TestProgrammaticWrappedWithOtherFramework(
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(trace.SpanKind.INTERNAL, span_list[0].kind)
         self.assertEqual(trace.SpanKind.SERVER, span_list[1].kind)
-        self.assertEqual(span_list[0].parent.span_id, span_list[1].context.span_id)
+        self.assertEqual(
+            span_list[0].parent.span_id, span_list[1].context.span_id
+        )

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -18,12 +18,12 @@ from flask import Flask, request
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
-from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
 from opentelemetry.instrumentation.propagators import (
     TraceResponsePropagator,
     get_global_response_propagator,
     set_global_response_propagator,
 )
+from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
@@ -415,7 +415,10 @@ class TestProgrammaticCustomTracerProviderWithoutApp(
             "flask-api-no-app",
         )
 
-class TestProgrammaticWrappedWithOtherFramework(InstrumentationTest, TestBase, WsgiTestBase):
+
+class TestProgrammaticWrappedWithOtherFramework(
+    InstrumentationTest, TestBase, WsgiTestBase
+):
     def setUp(self):
         super().setUp()
 
@@ -423,7 +426,7 @@ class TestProgrammaticWrappedWithOtherFramework(InstrumentationTest, TestBase, W
         self.app.wsgi_app = OpenTelemetryMiddleware(self.app.wsgi_app)
         FlaskInstrumentor().instrument_app(self.app)
         self._common_initialization()
-        
+
     def tearDown(self) -> None:
         super().tearDown()
         with self.disable_logging():
@@ -436,4 +439,4 @@ class TestProgrammaticWrappedWithOtherFramework(InstrumentationTest, TestBase, W
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(trace.SpanKind.INTERNAL, span_list[0].kind)
         self.assertEqual(trace.SpanKind.SERVER, span_list[1].kind)
-        print(span_list[0].parent.span_id == span_list[1].context.span_id)
+        self.assertEqual(span_list[0].parent.span_id, span_list[1].context.span_id)


### PR DESCRIPTION
# Description

Adds support to make spans as INTERNAL if a span is already present in current context in flask. 

Fixes 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Currently flask only makes SERVER spans. With this PR it can make INTERNAL spans in presence of a span in current context.

# How Has This Been Tested?

Added unit test for the changes.
Manually tested the scenario.
To reproduce: Add two instrumentors i.e. FlaskInstrumentor and  OpenTelemetryMiddleware in the same app. This creates two separate traces instead of one.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
