### PR TITLE
Merge parallel benchmarks + include propagator + latest GH action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,15 +47,15 @@ jobs:
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
         # TODO: Add at least one benchmark to every package type to remove this (#249)
-        if: matrix.package == 'sdkextension'
+        if: matrix.package == 'sdkextension' || matrix.package == 'propagator'
         run: >-
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
           **/**/tests/*${{ matrix.package }}*-benchmark.json > output.json
       - name: Report on benchmark results
         # TODO: Add at least one benchmark to every package type to remove this (#249)
-        if: matrix.package == 'sdkextension'
-        uses: rhysd/github-action-benchmark@v1
+        if: matrix.package == 'sdkextension' || matrix.package == 'propagator'
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}
           tool: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,16 +45,39 @@ jobs:
           key: v4-build-tox-cache-${{ env.RUN_MATRIX_COMBINATION }}-${{ hashFiles('tox.ini', 'gen-requirements.txt', 'dev-requirements.txt') }}
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
-      - name: Find and merge benchmarks
+      - name: Find and merge ${{ matrix.package }} benchmarks
         # TODO: Add at least one benchmark to every package type to remove this (#249)
         if: matrix.package == 'sdkextension' || matrix.package == 'propagator'
         run: >-
+          mkdir -p benchmarks;
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
-          **/**/tests/*${{ matrix.package }}*-benchmark.json > output.json
+          **/**/tests/*${{ matrix.package }}*-benchmark.json > benchmarks/output_${{ matrix.package }}.json
+      - name: Upload all benchmarks under same key as an artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmarks
+          path: benchmarks/output_${{ matrix.package }}.json
+  combine-benchmarks:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ always() }}
+    name: Combine benchmarks from previous build job
+    steps:
+      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v2
+      - name: Download all benchmarks as artifact using key
+        uses: actions/download-artifact@v2
+        with:
+          name: benchmarks
+          path: benchmarks
+      - name: Find and merge all benchmarks
+        run: >-
+          jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
+          | if .[0].benchmarks == null then null else .[0] end'
+          benchmarks/output_*.json > output.json;
       - name: Report on benchmark results
-        # TODO: Add at least one benchmark to every package type to remove this (#249)
-        if: matrix.package == 'sdkextension' || matrix.package == 'propagator'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}


### PR DESCRIPTION
# Description

* When we moved the aws-xray propagator in #720, we needed to update the benchmark step of the workflow
* Additionally, the GH action has evolved since we added benchmarks so we should use the latest version
* Now that different jobs create benchmarks, we added a way to wait for them all to finish and merge them at the end

~NOTE: Because the test run in parallel, there is a chance there is a race condition between the tests as they fight to lock the `gh-pages` branch and publish the benchmarks. This will cause the test to fail. We should come up with  a way to have all the jobs upload the benchmarks as artifacts and then combine them in a later job.~ I decided to add the separate job in this PR, please let me know what you all think!

Fixes: N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The test worked before, this just includes them again now that they are in a new package.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
