### PR TITLE
Use Py Version and Package matrix to distinguish benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
     if: ${{ always() }}
     name: Combine benchmarks from previous build job
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         python-version: [ py36, py37, py38, py39, py310, pypy3 ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,37 +52,38 @@ jobs:
           mkdir -p benchmarks;
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
-          **/**/tests/*${{ matrix.package }}*-benchmark.json > benchmarks/output_${{ matrix.package }}.json
-      - name: Upload all benchmarks under same key as an artifact
+          **/**/tests/*${{ matrix.package }}*-benchmark.json > output_${{ matrix.python-version }}_${{ matrix.package }}.json
+      - name: Upload benchmarks using (${{ matrix.python-version }}, ${{ matrix.package }}) key
         if: ${{ success() }}
         uses: actions/upload-artifact@v2
         with:
-          name: benchmarks
-          path: benchmarks/output_${{ matrix.package }}.json
+          name: benchmarks_${{ matrix.python-version }}_${{ matrix.package }}
+          path: output_${{ matrix.python-version }}_${{ matrix.package }}.json
   combine-benchmarks:
     runs-on: ubuntu-latest
     needs: build
     if: ${{ always() }}
     name: Combine benchmarks from previous build job
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [ py36, py37, py38, py39, py310, pypy3 ]
+        # TODO: Add "instrumentation", "distro", "exporter", when they have benchmarks
+        package: ["sdkextension", "propagator"]
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v2
-      - name: Download all benchmarks as artifact using key
+      - name: Download benchmarks using (${{ matrix.python-version }}, ${{ matrix.package }}) key
         uses: actions/download-artifact@v2
         with:
-          name: benchmarks
-          path: benchmarks
-      - name: Find and merge all benchmarks
-        run: >-
-          jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
-          | if .[0].benchmarks == null then null else .[0] end'
-          benchmarks/output_*.json > output.json;
+          name: benchmarks_${{ matrix.python-version }}_${{ matrix.package }}
+          path: output_${{ matrix.python-version }}_${{ matrix.package }}.json
       - name: Report on benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}
           tool: pytest
-          output-file-path: output.json
+          output-file-path: output_${{ matrix.python-version }}_${{ matrix.package }}.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           max-items-in-chart: 100
           # Alert with a commit comment on possible performance regression


### PR DESCRIPTION
# Description

Follow up to #838, the benchmark-action requires you provide the `name` under which all the benchmarks should be uploaded. Because we merged all the benchmarks into one, it was combining all the benchmarks under the same name instead of distinguishing by `matrix.python-version` and `matrix.package`.

i.e.

`py7 - sdkextension`
`py8 - sdkextension`
`py7 - propagator`

were all going under the same name, with the last `{pyversion} - {package}` overwriting the previous one.

To fix this we upload files that use `matrix.python-version` and `matrix.package` as the key for file naming.

NOTE: This means we will have **MANY more jobs** because there will be a job for every `(matrix.python-version, matrix.package)` permutation.

QUESTION: Should we just combine everything under the same name (i.e. `OpenTelemetry Python Contrib Benchmarks`) so we can do it all in one job?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Didn't have a chance to run on my fork, but this is all on the `gh-pages` branch which should be easy to clean up.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
~- [] Changelogs have been updated~
~- [] Unit tests have been added~
~- [] Documentation has been updated~
