### PR TITLE
[tests] use _NoOpTracer and _NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -278,7 +278,7 @@ class TestClientProto(TestBase):
         try:
             set_global_textmap(MockTextMapPropagator())
             interceptor = OpenTelemetryClientInterceptor(
-                trace._DefaultTracer()
+                trace._NoOpTracer()
             )
 
             carrier = tuple()

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -277,9 +277,7 @@ class TestClientProto(TestBase):
         previous_propagator = get_global_textmap()
         try:
             set_global_textmap(MockTextMapPropagator())
-            interceptor = OpenTelemetryClientInterceptor(
-                trace._NoOpTracer()
-            )
+            interceptor = OpenTelemetryClientInterceptor(trace.NoOpTracer())
 
             carrier = tuple()
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -359,7 +359,7 @@ class BaseTestCases:
         def test_not_recording(self):
             with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
                 transport = self.create_transport(
-                    tracer_provider=trace._DefaultTracerProvider()
+                    tracer_provider=trace._NoOpTracerProvider()
                 )
                 client = self.create_client(transport)
                 mock_span.is_recording.return_value = False
@@ -454,7 +454,7 @@ class BaseTestCases:
         def test_not_recording(self):
             with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
                 HTTPXClientInstrumentor().instrument(
-                    tracer_provider=trace._DefaultTracerProvider()
+                    tracer_provider=trace._NoOpTracerProvider()
                 )
                 client = self.create_client()
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -359,7 +359,7 @@ class BaseTestCases:
         def test_not_recording(self):
             with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
                 transport = self.create_transport(
-                    tracer_provider=trace._NoOpTracerProvider()
+                    tracer_provider=trace.NoOpTracerProvider()
                 )
                 client = self.create_client(transport)
                 mock_span.is_recording.return_value = False
@@ -454,7 +454,7 @@ class BaseTestCases:
         def test_not_recording(self):
             with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
                 HTTPXClientInstrumentor().instrument(
-                    tracer_provider=trace._NoOpTracerProvider()
+                    tracer_provider=trace.NoOpTracerProvider()
                 )
                 client = self.create_client()
 

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -250,7 +250,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             RequestsInstrumentor().uninstrument()
             RequestsInstrumentor().instrument(
-                tracer_provider=trace._NoOpTracerProvider()
+                tracer_provider=trace.NoOpTracerProvider()
             )
             mock_span.is_recording.return_value = False
             result = self.perform_request(self.URL)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -250,7 +250,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             RequestsInstrumentor().uninstrument()
             RequestsInstrumentor().instrument(
-                tracer_provider=trace._DefaultTracerProvider()
+                tracer_provider=trace._NoOpTracerProvider()
             )
             mock_span.is_recording.return_value = False
             result = self.perform_request(self.URL)

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -192,7 +192,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             URLLibInstrumentor().uninstrument()
             URLLibInstrumentor().instrument(
-                tracer_provider=trace._NoOpTracerProvider()
+                tracer_provider=trace.NoOpTracerProvider()
             )
             mock_span.is_recording.return_value = False
             result = self.perform_request(self.URL)

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -192,7 +192,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             URLLibInstrumentor().uninstrument()
             URLLibInstrumentor().instrument(
-                tracer_provider=trace._DefaultTracerProvider()
+                tracer_provider=trace._NoOpTracerProvider()
             )
             mock_span.is_recording.return_value = False
             result = self.perform_request(self.URL)


### PR DESCRIPTION
# Description

Follow up to https://github.com/open-telemetry/opentelemetry-python/pull/2363, not necessary for that change, but removes deprecation warnings.
