### PR TITLE
[instrumentation/pyramid] Conditionally create SERVER spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.8.0-0.27b0...HEAD)
 
 ### Added
-
+- `opentelemetry-instrumentation-pyramid` Pyramid: Conditionally create SERVER spans
+  ([#865](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/865))
 - `opentelemetry-instrumentation-asgi` now returns a `traceresponse` response header.
   ([#817](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/817))
 - `opentelemetry-instrumentation-kafka-python` added kafka-python module instrumentation.


### PR DESCRIPTION
# Description

This code change resolves the conditional span creation for pyramid framework in case of other framework is used as well. This fix will use the existing span and make the new span its child and create a parent child relation which is the right behavior

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/449

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have added the unit test cases in test_automatic.py for this code change where I have added a span in current context and send a request using test client which will create the child span and I have checked that parent.id of the newly created span is equal to the id of the existing span.

# Does This PR Require a Core Repo Change?
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
