### PR TITLE
Conditionally create server spans for falcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#817](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/817))
 - `opentelemetry-instrumentation-kafka-python` added kafka-python module instrumentation.
   ([#814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/814))
-
+- `opentelemetry-instrumentation-falcon` Falcon: Conditionally create SERVER spans
+  ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/867))
 ### Fixed
 
 - `opentelemetry-instrumentation-django` Django: Conditionally create SERVER spans

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -108,10 +108,9 @@ from opentelemetry.instrumentation.propagators import (
 )
 from opentelemetry.instrumentation.utils import (
     extract_attributes_from_object,
+    get_token_context_span_kind,
     http_status_to_status_code,
-    get_token_context_span_kind
 )
-from opentelemetry.propagate import extract
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status
 from opentelemetry.util._time import _time_ns
@@ -196,8 +195,10 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
 
         start_time = _time_ns()
 
-        token, ctx, span_kind = get_token_context_span_kind(env, getter=otel_wsgi.wsgi_getter)
-  
+        token, ctx, span_kind = get_token_context_span_kind(
+            env, getter=otel_wsgi.wsgi_getter
+        )
+
         span = self._tracer.start_span(
             otel_wsgi.get_default_span_name(env),
             context=ctx,

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -107,9 +107,9 @@ from opentelemetry.instrumentation.propagators import (
     get_global_response_propagator,
 )
 from opentelemetry.instrumentation.utils import (
+    _start_internal_or_server_span,
     extract_attributes_from_object,
     http_status_to_status_code,
-    start_internal_or_server_span,
 )
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status
@@ -195,11 +195,11 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
 
         start_time = _time_ns()
 
-        span, token = start_internal_or_server_span(
+        span, token = _start_internal_or_server_span(
             tracer=self._tracer,
             span_name=otel_wsgi.get_default_span_name(env),
             start_time=start_time,
-            env=env,
+            context_carrier=env,
             context_getter=otel_wsgi.wsgi_getter,
         )
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -204,7 +204,7 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
         else:
             ctx = context.get_current()
             span_kind = trace.SpanKind.INTERNAL
-  
+
         span = self._tracer.start_span(
             otel_wsgi.get_default_span_name(env),
             context=ctx,

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock, patch
 
 from falcon import testing
 
+from opentelemetry import trace
 from opentelemetry.instrumentation.falcon import FalconInstrumentor
 from opentelemetry.instrumentation.propagators import (
     TraceResponsePropagator,
@@ -27,7 +28,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 from opentelemetry.trace import StatusCode
-from opentelemetry import trace
+
 from .app import make_app
 
 
@@ -265,6 +266,7 @@ class TestFalconInstrumentationHooks(TestFalconBase):
             span.attributes["request_hook_attr"], "value from hook"
         )
 
+
 class TestFalconInstrumentationWrappedWithOtherFramework(TestFalconBase):
     def test_mark_span_internal_in_presence_of_span_from_other_framework(self):
         tracer = trace.get_tracer(__name__)
@@ -275,6 +277,6 @@ class TestFalconInstrumentationWrappedWithOtherFramework(TestFalconBase):
             span = self.memory_exporter.get_finished_spans()[0]
             assert span.status.is_ok
             self.assertEqual(trace.SpanKind.INTERNAL, span.kind)
-            self.assertEqual(span.parent.span_id, parent_span.get_span_context().span_id)
-        
-       
+            self.assertEqual(
+                span.parent.span_id, parent_span.get_span_context().span_id
+            )

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -92,7 +92,6 @@ def start_internal_or_server_span(
     """
 
     token = ctx = span_kind = None
-
     if trace.get_current_span() is trace.INVALID_SPAN:
         ctx = extract(env, getter=context_getter)
         token = context.attach(ctx)
@@ -100,12 +99,10 @@ def start_internal_or_server_span(
     else:
         ctx = context.get_current()
         span_kind = trace.SpanKind.INTERNAL
-
     span = tracer.start_span(
         name=span_name,
         context=ctx,
         kind=span_kind,
         start_time=start_time,
     )
-
     return span, token

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -72,8 +72,8 @@ def unwrap(obj, attr: str):
         setattr(obj, attr, func.__wrapped__)
 
 
-def start_internal_or_server_span(
-    tracer, span_name, start_time, env, context_getter
+def _start_internal_or_server_span(
+    tracer, span_name, start_time, context_carrier, context_getter
 ):
     """Returns internal or server span along with the token which can be used by caller to reset context
 
@@ -82,7 +82,7 @@ def start_internal_or_server_span(
         tracer : tracer in use by given instrumentation library
         name (string): name of the span
         start_time : start time of the span
-        env : object which contains values that are
+        context_carrier : object which contains values that are
             used to construct a Context. This object
             must be paired with an appropriate getter
             which understands how to extract a value from it.
@@ -93,7 +93,7 @@ def start_internal_or_server_span(
 
     token = ctx = span_kind = None
     if trace.get_current_span() is trace.INVALID_SPAN:
-        ctx = extract(env, getter=context_getter)
+        ctx = extract(context_carrier, getter=context_getter)
         token = context.attach(ctx)
         span_kind = trace.SpanKind.SERVER
     else:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -14,14 +14,15 @@
 
 from typing import Dict, Sequence
 
-from opentelemetry import context, trace
 from wrapt import ObjectProxy
+
+from opentelemetry import context, trace
 
 # pylint: disable=unused-import
 # pylint: disable=E0611
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY  # noqa: F401
-from opentelemetry.trace import StatusCode
 from opentelemetry.propagate import extract
+from opentelemetry.trace import StatusCode
 
 
 def extract_attributes_from_object(
@@ -72,7 +73,7 @@ def unwrap(obj, attr: str):
 
 
 def get_token_context_span_kind(env, getter):
-    """Based on presence of active span, extracts context and initializes token and span_kind 
+    """Based on presence of active span, extracts context and initializes token and span_kind
 
     Args:
         env : object which contains values that are
@@ -81,7 +82,7 @@ def get_token_context_span_kind(env, getter):
             which understands how to extract a value from it.
         getter : an object which contains a get function that can retrieve zero
             or more values from the carrier and a keys function that can get all the keys
-            from carrier. 
+            from carrier.
     """
 
     token = ctx = span_kind = None


### PR DESCRIPTION
# Description

Adds support to make spans as INTERNAL if a span is already present in current context in falcon.

Fixes #447

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    Currently falcon only makes SERVER spans. With this PR it can make INTERNAL spans in presence of a span in current context.

# How Has This Been Tested?

Added unit test for the changes.
Manually tested the scenario.
To reproduce the issue: Add two instrumentors i.e. FalconInstrumentor and OpenTelemetryMiddleware in the same app. This creates two separate traces instead of one.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
