### PR TITLE
Fix Django 1.9 issue preventing use of MIDDLEWARE_CLASSES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-asgi` ASGI: Conditionally create SERVER spans
   ([#843](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/843))
 
+- `opentelemetry-instrumentation-django` Django: fix issue preventing detection of MIDDLEWARE_CLASSES
 
 ## [1.8.0-0.27b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.8.0-0.27b0) - 2021-12-17
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -105,7 +105,7 @@ def _get_django_middleware_setting() -> str:
     # In Django versions 1.x, setting MIDDLEWARE_CLASSES can be used as a legacy
     # alternative to MIDDLEWARE. This is the case when `settings.MIDDLEWARE` has
     # its default value (`None`).
-    if not DJANGO_2_0 and getattr(settings, "MIDDLEWARE", []) is None:
+    if not DJANGO_2_0 and getattr(settings, "MIDDLEWARE", None) is None:
         return "MIDDLEWARE_CLASSES"
     return "MIDDLEWARE"
 


### PR DESCRIPTION
# Description

Previous implementation would never use MIDDLEWARE_CLASSES as the default value in the getattr [] would not match the None


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
