### PR TITLE
(instrumentation-sqlite3): trace connections made with `dbapi2.connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-django` Django: fix issue preventing detection of MIDDLEWARE_CLASSES
 
+- `opentelemetry-instrumentation-sqlite3` Instrumentation now works with `dbapi2.connect`
+
 ## [1.8.0-0.27b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.8.0-0.27b0) - 2021-12-17
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -39,6 +39,7 @@ API
 ---
 """
 
+import sqlite3
 from sqlite3 import dbapi2
 from typing import Collection
 
@@ -54,6 +55,8 @@ _DATABASE_SYSTEM = "sqlite"
 
 
 class SQLite3Instrumentor(BaseInstrumentor):
+    _TO_WRAP = [sqlite3, dbapi2]
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
@@ -63,19 +66,21 @@ class SQLite3Instrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
 
-        dbapi.wrap_connect(
-            __name__,
-            dbapi2,
-            "connect",
-            _DATABASE_SYSTEM,
-            _CONNECTION_ATTRIBUTES,
-            version=__version__,
-            tracer_provider=tracer_provider,
-        )
+        for module in self._TO_WRAP:
+            dbapi.wrap_connect(
+                __name__,
+                module,
+                "connect",
+                _DATABASE_SYSTEM,
+                _CONNECTION_ATTRIBUTES,
+                version=__version__,
+                tracer_provider=tracer_provider,
+            )
 
     def _uninstrument(self, **kwargs):
         """ "Disable SQLite3 instrumentation"""
-        dbapi.unwrap_connect(dbapi2, "connect")
+        for module in self._TO_WRAP:
+            dbapi.unwrap_connect(module, "connect")
 
     @staticmethod
     def instrument_connection(connection, tracer_provider=None):

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -39,7 +39,7 @@ API
 ---
 """
 
-import sqlite3
+from sqlite3 import dbapi2
 from typing import Collection
 
 from opentelemetry.instrumentation import dbapi
@@ -65,7 +65,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
 
         dbapi.wrap_connect(
             __name__,
-            sqlite3,
+            dbapi2,
             "connect",
             _DATABASE_SYSTEM,
             _CONNECTION_ATTRIBUTES,
@@ -75,7 +75,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
 
     def _uninstrument(self, **kwargs):
         """ "Disable SQLite3 instrumentation"""
-        dbapi.unwrap_connect(sqlite3, "connect")
+        dbapi.unwrap_connect(dbapi2, "connect")
 
     @staticmethod
     def instrument_connection(connection, tracer_provider=None):


### PR DESCRIPTION
# Description

Django basic app auto instrumentation with sqlite3 as a backend didn't produce the db spans. Digging further I realised it uses the `dbapi2.connect` (which is same as `sqlite3.connect`) for historical reasons. This updates to instrument both.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e test-instruementation-sqlite3`

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
