### PR TITLE
feat: support pymongo v4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/814))
 - `opentelemetry-instrumentation-falcon` Falcon: Conditionally create SERVER spans
   ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/867))
+- `opentelemetry-instrumentation-pymongo` now supports `pymongo v4`
+  ([#876](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/876))
 
 ### Fixed
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -24,7 +24,7 @@
 | [opentelemetry-instrumentation-pika](./opentelemetry-instrumentation-pika) | pika >= 0.12.0 |
 | [opentelemetry-instrumentation-psycopg2](./opentelemetry-instrumentation-psycopg2) | psycopg2 >= 2.7.3.1 |
 | [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache ~= 1.3 |
-| [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo ~= 3.1 |
+| [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 |
 | [opentelemetry-instrumentation-pymysql](./opentelemetry-instrumentation-pymysql) | PyMySQL < 2 |
 | [opentelemetry-instrumentation-pyramid](./opentelemetry-instrumentation-pyramid) | pyramid >= 1.7 |
 | [opentelemetry-instrumentation-redis](./opentelemetry-instrumentation-redis) | redis >= 2.6 |

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("pymongo ~= 3.1",)
+_instruments = ("pymongo >= 3.1, < 5.0",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -97,7 +97,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-pymemcache==0.28b1",
     },
     "pymongo": {
-        "library": "pymongo ~= 3.1",
+        "library": "pymongo >= 3.1, < 5.0",
         "instrumentation": "opentelemetry-instrumentation-pymongo==0.28b1",
     },
     "PyMySQL": {

--- a/tox.ini
+++ b/tox.ini
@@ -474,7 +474,7 @@ deps =
   asyncpg==0.20.1
   docker-compose >= 1.25.2
   mysql-connector-python ~=  8.0
-  pymongo ~= 3.1
+  pymongo >= 3.1, < 5.0
   PyMySQL ~= 0.10.1
   psycopg2 ~= 2.8.4
   aiopg >= 0.13.0, < 1.3.0


### PR DESCRIPTION
# Description

pymongo instrumentation already supported the latest releases (v4.0), I just needed to enable that configuration.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Running the same unit tests on the newer pymongo version

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
