### PR TITLE
Release Botocore Instrumentation as 0.28b0

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.27b0"
+__version__ = "0.28b0"

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -38,7 +38,7 @@ libraries = {
     },
     "botocore": {
         "library": "botocore ~= 1.0",
-        "instrumentation": "opentelemetry-instrumentation-botocore==0.27b0",
+        "instrumentation": "opentelemetry-instrumentation-botocore==0.28b0",
     },
     "celery": {
         "library": "celery >= 4.0, < 6.0",


### PR DESCRIPTION
# Description

Follow up to #875, where we released the instrumentations as `0.28b0`. We also want to release the `botocore` instrumentation because it needs to have the same dependencies as the other instrumentations.

## Type of change

Please delete options that are not relevant.

- [ ] New Release

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
