### PR TITLE
Prototype retry/redirect logic for urllib3 instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/814))
 - `opentelemetry-instrumentation-falcon` Falcon: Conditionally create SERVER spans
   ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/867))
+- `opentelemetry-instrumentation-urllib3` implements automatic retry/redirect to comply
+  with http semantic conventions.
+  ([#817](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/817))
+
 ### Fixed
 
 - `opentelemetry-instrumentation-django` Django: Conditionally create SERVER spans

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -160,6 +160,8 @@ class URLLib3Instrumentor(BaseInstrumentor):
         _uninstrument()
 
 
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-branches
 def _instrument(
     tracer,
     request_hook: _RequestHookT = None,

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -98,3 +98,6 @@ def remove_url_credentials(url: str) -> str:
     except ValueError:  # an unparseable url was passed
         pass
     return url
+
+def is_redirect(status: int) -> bool:
+    return status in (301, 302, 303, 307, 308)

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -99,5 +99,6 @@ def remove_url_credentials(url: str) -> str:
         pass
     return url
 
+
 def is_redirect(status: int) -> bool:
     return status in (301, 302, 303, 307, 308)


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-python-contrib/issues/862

As part of an effort to push http semantic conventions to stable, this [otep](https://github.com/open-telemetry/oteps/pull/174) covers the outstanding http topics that are still being discussed and in scope for 1.0 release of http semantic conventions. The most notable topic is supporting creation of spans upon automatic redirect/retry for instrumentations that support them (for instrumentations that do not support automatic retry/redirect, our guidance to users is that the feature is not supported and they would have to add "semantic convention related attributes/spans" manually). Hence the "SHOULD key words in the specs (this was discussed in the instrumentation SIG).

This PR is a prototype implementation for the urllib3 library to make the instrumentation comply with the spec [pr](https://github.com/open-telemetry/opentelemetry-specification/pull/2078). Note a couple of things with urllib3:

1. Users can use [urllib3.PoolManager](https://urllib3.readthedocs.io/en/latest/reference/urllib3.poolmanager.html) or [urllib3.ConnectionPool](https://urllib3.readthedocs.io/en/latest/reference/urllib3.connectionpool.html#urllib3.HTTPConnectionPool) to make their requests. This implementation works for both ways.
2. redirects are essentially retries, but the code path for retries is done RECURSIVELY, whereas redirects are handled separately AFTER the initial response returns a 3XX. 
3. EDIT: From the [discussion](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/883#discussion_r796036493), all created redirect/retry spans will be siblings of the original span of the request. They will be correlated purely with LINKs.
4. This will be complicated if users want to use a higher level library such as `requests` that builds on top of urllib3 (as the implementation exists within urllib3 instrumentation and not requests instrumentation). In the future if this is implemented for requests, the logic will probably have to be duplicated, and suppression would probably have to be used in the underlying urllib3 library in the case both instrumentations are used.

Since this is a prototype, I am open to alternative suggestions in how to implement this. :)

Example cases exported to Jaeger:

Redirect scenario:
![image](https://user-images.githubusercontent.com/11580155/152442641-6d548673-556e-46c5-989e-bc61cd4ed61c.png)

Retry scenario:
![image](https://user-images.githubusercontent.com/11580155/152442878-c87a31d1-77e6-442b-a8ac-1a32941abb32.png)