### PR TITLE
prepare_release script to ignore some packages/files

### DIFF
--- a/eachdist.ini
+++ b/eachdist.ini
@@ -41,6 +41,12 @@ packages=
     opentelemetry-semantic-conventions
     opentelemetry-test-utils
     opentelemetry-instrumentation
+    opentelemetry-distro
+
+[exclude_release]
+packages=
+    opentelemetry-sdk-extension-aws
+    opentelemetry-propagator-aws-xray
 
 [lintroots]
 extraroots=examples/*,scripts/


### PR DESCRIPTION
# Description

- Will not ignore files from build/dist directories. The script was picking up version.py files from these directories and updating them instead of the real version.py files.
- Will ignore packages that are released independently of the contrib release process.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev/Tooling update.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual verification

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
