### PR TITLE
Conditionally create server spans for tornado and refactoring other frameworks to use utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-pika` requires `packaging` dependency
 
+- `opentelemetry-instrumentation-tornado` Tornado: Conditionally create SERVER spans
+  ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/889))
 
 ## [1.9.0-0.28b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.0-0.28b0) - 2022-01-26
 


### PR DESCRIPTION
# Description

- Adds support to make spans as INTERNAL if a span is already present in current context in tornado.
- Refactoring code in Django, Pyramid, Flask to use the utility funciton i.e. _start_internal_or_server_span

Fixes #450 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Currently falcon only makes SERVER spans. With this PR it can make INTERNAL spans in presence of a span in current context.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Does This PR Require a Core Repo Change?
 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
