### PR TITLE
Logging: Defensively access provider resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.9.1-0.28b1...HEAD)
 
+### Fixed
+
+- `opentelemetry-instrumentation-logging` retrieves service name defensively.
+  ([#890](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/890))
+
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 
 


### PR DESCRIPTION
# Description

Now service name is extracted from the provider defensively and lazily.
This accounts for an SDK that does not provide access to "resource" via
TracerProviders and for lazy initialization of TracerProviders.

Fixes #810


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new test to cover use case
- [x] Manually

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
