### PR TITLE
Safer patching for Falcon API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-logging` retrieves service name defensively.
   ([#890](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/890))
-
 - `opentelemetry-instrumentation-wsgi` WSGI: Conditionally create SERVER spans
   ([#903](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/903))
+- `opentelemetry-instrumentation-falcon` Safer patching mechanism
+  ([#895](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/895))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
-
-
 
 ### Fixed
 


### PR DESCRIPTION
# Description

We replace Falcon API class with a partial callable. It is safer to
replace it with a sub-class of the base falcon.API class so any other
systems making assumptions about falcon don't fail.

Fixes #894 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Existing tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
