### PR TITLE
Adding unit tests for conditional server span creation in starlette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Tornado: Conditionally create SERVER spans
   ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/889))
 
+- `opentelemetry-instrumentation-starlette` Adding unit tests for conditional server span creation
+  ([#897](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/897))
+
 ## [1.9.0-0.28b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.0-0.28b0) - 2022-01-26
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Tornado: Conditionally create SERVER spans
   ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/889))
 
-- `opentelemetry-instrumentation-starlette` Adding unit tests for conditional server span creation
-  ([#897](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/897))
-
 ## [1.9.0-0.28b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.0-0.28b0) - 2022-01-26
 
 

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -229,7 +229,7 @@ class TestAutoInstrumentationLogic(unittest.TestCase):
 
 
 class TestConditonalServerSpanCreation(TestStarletteManualInstrumentation):
-    def test_wrapped_with_server_span(self):
+    def test_mark_span_internal_in_presence_of_another_span(self):
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span(
             "test", kind=SpanKind.SERVER

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -24,6 +24,7 @@ import opentelemetry.instrumentation.starlette as otel_starlette
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind, get_tracer
 from opentelemetry.util.http import get_excluded_urls
 
 
@@ -225,3 +226,21 @@ class TestAutoInstrumentationLogic(unittest.TestCase):
 
         should_be_original = applications.Starlette
         self.assertIs(original, should_be_original)
+
+
+class TestConditonalServerSpanCreation(TestStarletteManualInstrumentation):
+    def test_wrapped_with_server_span(self):
+        tracer = get_tracer(__name__)
+        with tracer.start_as_current_span(
+            "test", kind=SpanKind.SERVER
+        ) as parent_span:
+            self._client.get("/foobar")
+            spans = self.sorted_spans(
+                self.memory_exporter.get_finished_spans()
+            )
+            starlette_span = spans[2]
+            self.assertEqual(SpanKind.INTERNAL, starlette_span.kind)
+            self.assertEqual(SpanKind.SERVER, parent_span.kind)
+            self.assertEqual(
+                parent_span.context.span_id, starlette_span.parent.span_id
+            )


### PR DESCRIPTION
# Description

Adding unit tests in starlette to test if spans are market as INTERNAL in presence of another span

Fixes #452 

## Type of change
Unit test Addition

# How Has This Been Tested?
Added unit test and manually tested the scenario

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
