### PR TITLE
datadog-apm: deprecate datadog exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-requests` make span attribute available to samplers
   ([#931](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/931))
 
+- `opentelemetry-datadog-exporter` add deprecation note to example.
+  ([#900](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/900))
+
 ### Fixed
 
 - `opentelemetry-instrumentation-logging` retrieves service name defensively.

--- a/exporter/opentelemetry-exporter-datadog/README.rst
+++ b/exporter/opentelemetry-exporter-datadog/README.rst
@@ -1,4 +1,4 @@
-OpenTelemetry Datadog Exporter
+OpenTelemetry Datadog Span Exporter
 ==============================
 
 |pypi|
@@ -12,7 +12,7 @@ supported.
 
 Deprecated
 ------------
-This exporter has been deprecated. To export your OpenTelemetry traces to Datadog please refer to `Datadog Python Open Standards <https://docs.datadoghq.com/tracing/setup_overview/open_standards/python/#opentelemetry>`_ .
+This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
 
 
 Installation

--- a/exporter/opentelemetry-exporter-datadog/README.rst
+++ b/exporter/opentelemetry-exporter-datadog/README.rst
@@ -10,9 +10,7 @@ This library allows to export tracing data to `Datadog
 <https://www.datadoghq.com/>`_. OpenTelemetry span event and links are not
 supported.
 
-Deprecated
-------------
-This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
+.. warning:: This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
 
 
 Installation

--- a/exporter/opentelemetry-exporter-datadog/README.rst
+++ b/exporter/opentelemetry-exporter-datadog/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Datadog Span Exporter
-==============================
+===================================
 
 |pypi|
 

--- a/exporter/opentelemetry-exporter-datadog/README.rst
+++ b/exporter/opentelemetry-exporter-datadog/README.rst
@@ -10,6 +10,11 @@ This library allows to export tracing data to `Datadog
 <https://www.datadoghq.com/>`_. OpenTelemetry span event and links are not
 supported.
 
+Deprecated
+------------
+This exporter has been deprecated. To export your OpenTelemetry tracer to datadog please refer to [Datadog Python Open Standards](https://docs.datadoghq.com/tracing/setup_overview/open_standards/python/#opentelemetry).
+
+
 Installation
 ------------
 

--- a/exporter/opentelemetry-exporter-datadog/README.rst
+++ b/exporter/opentelemetry-exporter-datadog/README.rst
@@ -12,7 +12,7 @@ supported.
 
 Deprecated
 ------------
-This exporter has been deprecated. To export your OpenTelemetry tracer to datadog please refer to [Datadog Python Open Standards](https://docs.datadoghq.com/tracing/setup_overview/open_standards/python/#opentelemetry).
+This exporter has been deprecated. To export your OpenTelemetry traces to Datadog please refer to `Datadog Python Open Standards <https://docs.datadoghq.com/tracing/setup_overview/open_standards/python/#opentelemetry>`_ .
 
 
 Installation


### PR DESCRIPTION
# Description

Adds deprecation note to the Datadog Span Exporter.

## Type of change

Updates Readme

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
