### PR TITLE
code changes to resolve conditional server span creation for WSGI and adding 'attributes' parameter to util function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.9.1-0.28b1...HEAD)
 
+- `opentelemetry-instrumentation-wsgi` WSGI: Conditionally create SERVER spans
+  ([#903](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/903))
+
 ### Fixed
 
 - `opentelemetry-instrumentation-logging` retrieves service name defensively.
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-pika` requires `packaging` dependency
 
 - `opentelemetry-instrumentation-tornado` Tornado: Conditionally create SERVER spans
-  ([#867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/889))
+  ([#889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/889))
 
 ## [1.9.0-0.28b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.0-0.28b0) - 2022-01-26
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -280,11 +280,17 @@ class OpenTelemetryMiddleware:
             start_response: The WSGI start_response callable.
         """
 
-        token = context.attach(extract(environ, getter=wsgi_getter))
+        token = ctx = None
+        span_kind = trace.SpanKind.INTERNAL
+        if trace.get_current_span() is trace.INVALID_SPAN:
+            ctx = extract(environ, getter=wsgi_getter)
+            token = context.attach(ctx)
+            span_kind = trace.SpanKind.SERVER
 
         span = self.tracer.start_span(
             get_default_span_name(environ),
-            kind=trace.SpanKind.SERVER,
+            context=ctx,
+            kind=span_kind,
             attributes=collect_request_attributes(environ),
         )
 
@@ -308,7 +314,8 @@ class OpenTelemetryMiddleware:
             if span.is_recording():
                 span.set_status(Status(StatusCode.ERROR, str(ex)))
             span.end()
-            context.detach(token)
+            if token is not None:
+                context.detach(token)
             raise
 
 
@@ -324,7 +331,8 @@ def _end_span_after_iterating(iterable, span, tracer, token):
         if close:
             close()
         span.end()
-        context.detach(token)
+        if token is not None:
+            context.detach(token)
 
 
 # TODO: inherit from opentelemetry.instrumentation.propagators.Setter

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -110,11 +110,10 @@ import wsgiref.util as wsgiref_util
 
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import (
+    _start_internal_or_server_span,
     http_status_to_status_code,
-    _start_internal_or_server_span
 )
 from opentelemetry.instrumentation.wsgi.version import __version__
-from opentelemetry.propagate import extract
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
@@ -288,7 +287,7 @@ class OpenTelemetryMiddleware:
             start_time=None,
             context_carrier=environ,
             context_getter=wsgi_getter,
-            attributes=collect_request_attributes(environ)
+            attributes=collect_request_attributes(environ),
         )
 
         if self.request_hook:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -76,7 +76,7 @@ def unwrap(obj, attr: str):
 
 
 def _start_internal_or_server_span(
-    tracer, span_name, start_time, context_carrier, context_getter
+    tracer, span_name, start_time, context_carrier, context_getter, attributes=None
 ):
     """Returns internal or server span along with the token which can be used by caller to reset context
 
@@ -107,5 +107,6 @@ def _start_internal_or_server_span(
         context=ctx,
         kind=span_kind,
         start_time=start_time,
+        attributes=attributes
     )
     return span, token

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -76,7 +76,12 @@ def unwrap(obj, attr: str):
 
 
 def _start_internal_or_server_span(
-    tracer, span_name, start_time, context_carrier, context_getter, attributes=None
+    tracer,
+    span_name,
+    start_time,
+    context_carrier,
+    context_getter,
+    attributes=None,
 ):
     """Returns internal or server span along with the token which can be used by caller to reset context
 
@@ -107,6 +112,6 @@ def _start_internal_or_server_span(
         context=ctx,
         kind=span_kind,
         start_time=start_time,
-        attributes=attributes
+        attributes=attributes,
     )
     return span, token


### PR DESCRIPTION
…tps://github.com/open-telemetry/opentelemetry-python-contrib/issues/454)

# Description

This PR contains code changes for conditional server span creation for WSGI framework in case of another framework is present and it has already created SERVER span. In that case WSGI instrumentation will create a span of kind INTERNAL and make it a child of the SERVER span mentioned above.
Also I have added 'attributes' parameter to a util function _start_internal_or_server_span() util function to make it more compatible with multiple frameworks

Fixes # ([issue](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/454))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A: Provide an unit test where a SERVER span was already exists in the context and check if the newly created span is of kind INTERNAL and is it a child of SERVER span mentioned before.

# Does This PR Require a Core Repo Change?
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
