### PR TITLE
Changing supported version of tornado to 6.0 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-wsgi` WSGI: Conditionally create SERVER spans
   ([#903](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/903))
 
+- `opentelemetry-instrumentation-tornado` Supported version of tornado changed to 6.0
+  ([#909](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/909))
+
 ### Fixed
 
 - `opentelemetry-instrumentation-logging` retrieves service name defensively.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -34,6 +34,6 @@ PyMySQL~=0.9.3
 pyramid>=1.7
 redis>=2.6
 sqlalchemy>=1.0
-tornado>=5.1.1
+tornado>=6.0
 ddtrace>=0.34.0
 httpx>=0.18.0

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -33,7 +33,7 @@
 | [opentelemetry-instrumentation-sqlalchemy](./opentelemetry-instrumentation-sqlalchemy) | sqlalchemy |
 | [opentelemetry-instrumentation-sqlite3](./opentelemetry-instrumentation-sqlite3) | sqlite3 |
 | [opentelemetry-instrumentation-starlette](./opentelemetry-instrumentation-starlette) | starlette ~= 0.13.0 |
-| [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 |
+| [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 6.0 |
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib |
 | [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 2.0.0 |
 | [opentelemetry-instrumentation-wsgi](./opentelemetry-instrumentation-wsgi) | wsgi |

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("tornado >= 5.1.1",)
+_instruments = ("tornado >= 6.0",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -129,7 +129,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-starlette==0.28b1",
     },
     "tornado": {
-        "library": "tornado >= 5.1.1",
+        "library": "tornado >= 6.0",
         "instrumentation": "opentelemetry-instrumentation-tornado==0.28b1",
     },
     "urllib3": {


### PR DESCRIPTION
# Description
Agent fails to detach context with tornado 5.1.1. The issue comes because `contextvars` does not work perfectly with tornado's `gen.coroutine` as mentioned in this [issue](https://github.com/tornadoweb/tornado/issues/2731). `contextvars` has problems with resetting the context with `gen.coroutine`. The [fix](https://github.com/tornadoweb/tornado/pull/2938) for this is implemented in tornado 6.1

In tornado 5.1.1 `_execute` is implemented as `gen.coroutine` [link](https://github.com/tornadoweb/tornado/blob/branch5.1/tornado/web.py#L1554) whereas it is converted to a native coroutine in tornado 6 [link](https://github.com/tornadoweb/tornado/blob/branch6.0/tornado/web.py#L1659). `contextvars` works corretcly with native coroutines. So, changing the supported version for the agent to tornado>=6 solves the issue.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?
Reproduce the issue: Running instrumented tornado 5.1.1 app with agent throws error. `ERROR:opentelemetry.context:Failed to detach context`
This error doesn’t come with tornado>=6. Tested by running manually.

Details on the setup to reproduce can be found in the comment thread of the issue #904 

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Documentation has been updated
