### PR TITLE
Upgrading jinja2 to fix build failures

### DIFF
--- a/gen-requirements.txt
+++ b/gen-requirements.txt
@@ -1,6 +1,6 @@
 -c dev-requirements.txt
 astor==0.8.1
-jinja2~=2.7
+jinja2~=3.0
 isort
 black
 requests


### PR DESCRIPTION
# Description
Generate and Contrib Repo Tests (py310, instrumentation) are failing for #925 due to breaking change in markupsafe https://github.com/pallets/markupsafe/issues/282.
Upgrading jinja2 to latest version for fixing the build errors.


## Type of change
Fix for build errors

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated