### PR TITLE
Make the DatadogExportSpanProcessor re-initialize itself after fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#903](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/903))
 - `opentelemetry-instrumentation-falcon` Safer patching mechanism
   ([#895](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/895))
+- `opentelemetry-exporter-datadog` re-initializes itself on fork to prevent deadlocks ([#932](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/932))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 

--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -50,3 +50,5 @@ where = src
 
 [options.extras_require]
 test =
+    opentelemetry-test-utils == 0.28b1
+    flaky

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -676,7 +676,6 @@ class TestDatadogSpanExporter(unittest.TestCase):
 
 
 class TestDatadogSpanProcessorConcurrency(ConcurrencyTestBase):
-
     @unittest.skipUnless(
         hasattr(os, "fork") and sys.version_info >= (3, 7),
         "needs *nix and minor version 7 or later",

--- a/tox.ini
+++ b/tox.ini
@@ -360,7 +360,7 @@ commands_pre =
 
   aiopg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg[test]
 
-  datadog: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
+  datadog: pip install {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
 
   richconsole: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-richconsole[test]
 


### PR DESCRIPTION
# Description

The `DatadogExportSpanProcessor ` suffered from the same problems as the [`BatchSpanProcessor`](https://github.com/open-telemetry/opentelemetry-python/pull/2242). When using the `DatadogSpanProcessor` I would see my background workers initialized with `os.fork()` deadlock. I observed this in RQ but I'm sure the same types of problems would happen in Celery.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I effectively copied over the test from https://github.com/open-telemetry/opentelemetry-python/pull/2242. Test passes when re-initializing on fork, fails without it.

I haven't yet put this live into my project because there are a few questions I want to ask about the particulars of this implementation.

# Does This PR Require a Core Repo Change?

- [x] No

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
