### PR TITLE
Update pymemcache instrumentation to support pymemcache >=1.3.5,<4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-kafka-python` Fix topic extraction
   ([#949](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/949))
 
+### Changed
+
+- `opentelemetry-instrumentation-pymemcache` should run against newer versions of pymemcache.
+  ([#935](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/935))
+
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 
 ### Fixed

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -23,7 +23,7 @@
 | [opentelemetry-instrumentation-mysql](./opentelemetry-instrumentation-mysql) | mysql-connector-python ~= 8.0 |
 | [opentelemetry-instrumentation-pika](./opentelemetry-instrumentation-pika) | pika >= 0.12.0 |
 | [opentelemetry-instrumentation-psycopg2](./opentelemetry-instrumentation-psycopg2) | psycopg2 >= 2.7.3.1 |
-| [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache ~= 1.3 |
+| [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache >= 1.3.5, < 4 |
 | [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 |
 | [opentelemetry-instrumentation-pymysql](./opentelemetry-instrumentation-pymysql) | PyMySQL < 2 |
 | [opentelemetry-instrumentation-pyramid](./opentelemetry-instrumentation-pyramid) | pyramid >= 1.7 |

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("pymemcache ~= 1.3",)
+_instruments = ("pymemcache >= 1.3.5, < 4",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -93,7 +93,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-psycopg2==0.29b0",
     },
     "pymemcache": {
-        "library": "pymemcache ~= 1.3",
+        "library": "pymemcache >= 1.3.5, < 4",
         "instrumentation": "opentelemetry-instrumentation-pymemcache==0.29b0",
     },
     "pymongo": {

--- a/tox.ini
+++ b/tox.ini
@@ -111,8 +111,8 @@ envlist =
     ; ext-psycopg2 intentionally excluded from pypy3
 
     ; opentelemetry-instrumentation-pymemcache
-    py3{6,7,8,9,10}-test-instrumentation-pymemcache
-    pypy3-test-instrumentation-pymemcache
+    py3{6,7,8,9,10}-test-instrumentation-pymemcache{135,200,300,342}
+    pypy3-test-instrumentation-pymemcache{135,200,300,342}
 
     ; opentelemetry-instrumentation-pymongo
     py3{6,7,8,9,10}-test-instrumentation-pymongo
@@ -222,6 +222,10 @@ deps =
   sqlalchemy14: sqlalchemy~=1.4
   pika0: pika>=0.12.0,<1.0.0
   pika1: pika>=1.0.0
+  pymemcache135: pymemcache ==1.3.5
+  pymemcache200: pymemcache >2.0.0,<3.0.0
+  pymemcache300: pymemcache >3.0.0,<3.4.2
+  pymemcache342: pymemcache ==3.4.2
   httpx18: httpx>=0.18.0,<0.19.0
   httpx18: respx~=0.17.0
   httpx21: httpx>=0.19.0
@@ -262,7 +266,7 @@ changedir =
   test-instrumentation-mysql: instrumentation/opentelemetry-instrumentation-mysql/tests
   test-instrumentation-pika{0,1}: instrumentation/opentelemetry-instrumentation-pika/tests
   test-instrumentation-psycopg2: instrumentation/opentelemetry-instrumentation-psycopg2/tests
-  test-instrumentation-pymemcache: instrumentation/opentelemetry-instrumentation-pymemcache/tests
+  test-instrumentation-pymemcache{135,200,300,342}: instrumentation/opentelemetry-instrumentation-pymemcache/tests
   test-instrumentation-pymongo: instrumentation/opentelemetry-instrumentation-pymongo/tests
   test-instrumentation-pymysql: instrumentation/opentelemetry-instrumentation-pymysql/tests
   test-instrumentation-pyramid: instrumentation/opentelemetry-instrumentation-pyramid/tests
@@ -332,7 +336,7 @@ commands_pre =
 
   mysql: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql[test]
 
-  pymemcache: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
+  pymemcache{135,200,300,342}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
 
   pymongo: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo[test]
 


### PR DESCRIPTION
# Description

Update pymemcache instrumentation to support newer versions of pymemcache

Fixes #842
Fixes #907

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated tests to run against newer versions of pymemcache. 

# Does This PR Require a Core Repo Change?
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
