### PR TITLE
Changed the format of traceparent id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-dbapi` Changed the format of traceparent id.
+  ([#941](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/941))
 - `opentelemetry-instrumentation-logging` retrieves service name defensively.
   ([#890](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/890))
 - `opentelemetry-instrumentation-wsgi` WSGI: Conditionally create SERVER spans

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -46,9 +46,9 @@ import wrapt
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.dbapi.version import __version__
 from opentelemetry.instrumentation.utils import (
+    _generate_opentelemetry_traceparent,
     _generate_sql_comment,
     unwrap,
-    _generate_opentelemetry_traceparent,
 )
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -45,7 +45,11 @@ import wrapt
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.dbapi.version import __version__
-from opentelemetry.instrumentation.utils import _generate_sql_comment, unwrap, _generate_opentelemetry_traceparent
+from opentelemetry.instrumentation.utils import (
+    _generate_sql_comment,
+    unwrap,
+    _generate_opentelemetry_traceparent,
+)
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -45,7 +45,7 @@ import wrapt
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.dbapi.version import __version__
-from opentelemetry.instrumentation.utils import _generate_sql_comment, unwrap
+from opentelemetry.instrumentation.utils import _generate_sql_comment, unwrap, _generate_opentelemetry_traceparent
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer
 
@@ -369,14 +369,7 @@ class CursorTracer:
         span_context = span.get_span_context()
         meta = {}
         if span_context.is_valid:
-            meta.update(
-                {
-                    "trace_id": span_context.trace_id,
-                    "span_id": span_context.span_id,
-                    "trace_flags": span_context.trace_flags,
-                    "trace_state": span_context.trace_state.to_header(),
-                }
-            )
+            meta.update(_generate_opentelemetry_traceparent(span))
         # TODO(schekuri): revisit to enrich with info such as route, db_driver etc...
         return _generate_sql_comment(**meta)
 


### PR DESCRIPTION
# Changed the format of traceparent id

Compressed the format of traceparent id from `/*span_id=16659691402252420308,trace_flags=1,trace_id=283190570959089573593920162873354610508,trace_state=''*/` to `/*traceparent='00-91be8b5a37d16542524ae5ae0907ec5f-543bfa9675358c75-1'*/`


## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [X] tox -e test-instrumentation-dbapi                                         

# Does This PR Require a Core Repo Change?

- [X] Yes. - Link to [PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/924/files#diff-4bf18e7d840238995e3eb1152d6bf0a3f56ce6ab6f2bcf1726ecbac7a79afedb) 

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
