### PR TITLE
Flask: Capture custom request/response headers as span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-wsgi` Capture custom request/response headers in span attributes
   ([#925])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/925)
 
+- `opentelemetry-instrumentation-flask` Flask: Capture custom request/response headers in span attributes
+  ([#952])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/952)
+
 ### Added
 
 - `opentelemetry-instrumentation-dbapi` add experimental sql commenter capability

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -153,6 +153,8 @@ def _rewrapped_app(wsgi_app, response_hook=None, excluded_urls=None):
                     otel_wsgi.add_response_attributes(
                         span, status, response_headers
                     )
+                    if span.kind == trace.SpanKind.SERVER:
+                        otel_wsgi.add_custom_response_headers(span, response_headers)
                 else:
                     _logger.warning(
                         "Flask environ's OpenTelemetry span "
@@ -200,6 +202,8 @@ def _wrapped_before_request(
                 ] = flask.request.url_rule.rule
             for key, value in attributes.items():
                 span.set_attribute(key, value)
+            if span.kind == trace.SpanKind.SERVER:
+                otel_wsgi.add_custom_request_headers(span, flask_request_environ)
 
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -154,7 +154,9 @@ def _rewrapped_app(wsgi_app, response_hook=None, excluded_urls=None):
                         span, status, response_headers
                     )
                     if span.kind == trace.SpanKind.SERVER:
-                        otel_wsgi.add_custom_response_headers(span, response_headers)
+                        otel_wsgi.add_custom_response_headers(
+                            span, response_headers
+                        )
                 else:
                     _logger.warning(
                         "Flask environ's OpenTelemetry span "
@@ -203,7 +205,9 @@ def _wrapped_before_request(
             for key, value in attributes.items():
                 span.set_attribute(key, value)
             if span.kind == trace.SpanKind.SERVER:
-                otel_wsgi.add_custom_request_headers(span, flask_request_environ)
+                otel_wsgi.add_custom_request_headers(
+                    span, flask_request_environ
+                )
 
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from flask import Response
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
-from flask import Response
+
 
 class InstrumentationTest:
     @staticmethod
@@ -28,22 +29,26 @@ class InstrumentationTest:
         resp = Response("test response")
         resp.headers["content-type"] = "text/plain; charset=utf-8"
         resp.headers["content-length"] = "13"
-        resp.headers["my-custom-header"] = "my-custom-value-1,my-custom-header-2"
+        resp.headers[
+            "my-custom-header"
+        ] = "my-custom-value-1,my-custom-header-2"
         return resp
-    
+
     def _common_initialization(self):
         def excluded_endpoint():
             return "excluded"
 
         def excluded2_endpoint():
             return "excluded2"
-        
+
         # pylint: disable=no-member
         self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
         self.app.route("/excluded/<int:helloid>")(self._hello_endpoint)
         self.app.route("/excluded")(excluded_endpoint)
         self.app.route("/excluded2")(excluded2_endpoint)
-        self.app.route("/test_custom_response_headers")(self._custom_response_headers)
+        self.app.route("/test_custom_response_headers")(
+            self._custom_response_headers
+        )
 
         # pylint: disable=attribute-defined-outside-init
         self.client = Client(self.app, BaseResponse)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -14,7 +14,7 @@
 
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
-
+from flask import Response
 
 class InstrumentationTest:
     @staticmethod
@@ -23,18 +23,27 @@ class InstrumentationTest:
             raise ValueError(":-(")
         return "Hello: " + str(helloid)
 
+    @staticmethod
+    def _custom_response_headers():
+        resp = Response("test response")
+        resp.headers["content-type"] = "text/plain; charset=utf-8"
+        resp.headers["content-length"] = "13"
+        resp.headers["my-custom-header"] = "my-custom-value-1,my-custom-header-2"
+        return resp
+    
     def _common_initialization(self):
         def excluded_endpoint():
             return "excluded"
 
         def excluded2_endpoint():
             return "excluded2"
-
+        
         # pylint: disable=no-member
         self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
         self.app.route("/excluded/<int:helloid>")(self._hello_endpoint)
         self.app.route("/excluded")(excluded_endpoint)
         self.app.route("/excluded2")(excluded2_endpoint)
+        self.app.route("/test_custom_response_headers")(self._custom_response_headers)
 
         # pylint: disable=attribute-defined-outside-init
         self.client = Client(self.app, BaseResponse)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -442,3 +442,99 @@ class TestProgrammaticWrappedWithOtherFramework(
         self.assertEqual(
             span_list[0].parent.span_id, span_list[1].context.span_id
         )
+
+
+class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+
+        self.env_patch = patch.dict(
+            "os.environ",
+            {
+                "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST": "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3",
+                "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE": "content-type,content-length,my-custom-header,invalid-header"
+            },
+        )
+        self.env_patch.start()
+        self.app = Flask(__name__)
+        FlaskInstrumentor().instrument_app(self.app)
+
+        self._common_initialization()
+
+    def tearDown(self):
+        super().tearDown()
+        self.env_patch.stop()
+        with self.disable_logging():
+            FlaskInstrumentor().uninstrument_app(self.app)
+    
+    def test_custom_request_header_added_in_server_span(self):
+        headers = {
+            "Custom-Test-Header-1": "Test Value 1",
+            "Custom-Test-Header-2": "TestValue2,TestValue3",
+        }
+        resp = self.client.get("/hello/123", headers=headers)
+        self.assertEqual(200, resp.status_code)
+        span = self.memory_exporter.get_finished_spans()[0]
+        expected = {
+            "http.request.header.custom_test_header_1": ("Test Value 1",),
+            "http.request.header.custom_test_header_2": (
+                "TestValue2,TestValue3",
+            ),
+        }
+        self.assertEqual(span.kind, trace.SpanKind.SERVER)
+        self.assertSpanHasAttributes(span, expected)
+
+    def test_custom_request_header_not_added_in_internal_span(self):
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span("test", kind=trace.SpanKind.SERVER):
+            headers = {
+                "Custom-Test-Header-1": "Test Value 1",
+                "Custom-Test-Header-2": "TestValue2,TestValue3",
+            }
+            resp = self.client.get("/hello/123", headers=headers)
+            self.assertEqual(200, resp.status_code)
+            span = self.memory_exporter.get_finished_spans()[0]
+            not_expected = {
+                "http.request.header.custom_test_header_1": ("Test Value 1",),
+                "http.request.header.custom_test_header_2": (
+                    "TestValue2,TestValue3",
+                ),
+            }
+            self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
+            for key, _ in not_expected.items():
+                self.assertNotIn(key, span.attributes)
+    
+    def test_custom_response_header_added_in_server_span(self):
+        resp = self.client.get("/test_custom_response_headers")
+        self.assertEqual(resp.status_code, 200)
+        span = self.memory_exporter.get_finished_spans()[0]
+        expected = {
+            "http.response.header.content_type": (
+                "text/plain; charset=utf-8",
+            ),
+            "http.response.header.content_length": ("13",),
+            "http.response.header.my_custom_header": (
+                "my-custom-value-1,my-custom-header-2",
+            ),
+        }
+        self.assertEqual(span.kind, trace.SpanKind.SERVER)
+        self.assertSpanHasAttributes(span, expected)
+    
+    def test_custom_response_header_not_added_in_internal_span(self):
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span("test", kind=trace.SpanKind.SERVER):
+            resp = self.client.get("/test_custom_response_headers")
+            self.assertEqual(resp.status_code, 200)
+            span = self.memory_exporter.get_finished_spans()[0]
+            not_expected = {
+                "http.response.header.content_type": (
+                    "text/plain; charset=utf-8",
+                ),
+                "http.response.header.content_length": ("13",),
+                "http.response.header.my_custom_header": (
+                    "my-custom-value-1,my-custom-header-2",
+                ),
+            }
+            self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
+            for key, _ in not_expected.items():
+                self.assertNotIn(key, span.attributes)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -444,7 +444,9 @@ class TestProgrammaticWrappedWithOtherFramework(
         )
 
 
-class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBase):
+class TestCustomRequestResponseHeaders(
+    InstrumentationTest, TestBase, WsgiTestBase
+):
     def setUp(self):
         super().setUp()
 
@@ -452,7 +454,7 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBa
             "os.environ",
             {
                 "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST": "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3",
-                "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE": "content-type,content-length,my-custom-header,invalid-header"
+                "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE": "content-type,content-length,my-custom-header,invalid-header",
             },
         )
         self.env_patch.start()
@@ -466,7 +468,7 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBa
         self.env_patch.stop()
         with self.disable_logging():
             FlaskInstrumentor().uninstrument_app(self.app)
-    
+
     def test_custom_request_header_added_in_server_span(self):
         headers = {
             "Custom-Test-Header-1": "Test Value 1",
@@ -503,7 +505,7 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBa
             self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
             for key, _ in not_expected.items():
                 self.assertNotIn(key, span.attributes)
-    
+
     def test_custom_response_header_added_in_server_span(self):
         resp = self.client.get("/test_custom_response_headers")
         self.assertEqual(resp.status_code, 200)
@@ -519,7 +521,7 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, TestBase, WsgiTestBa
         }
         self.assertEqual(span.kind, trace.SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
-    
+
     def test_custom_response_header_not_added_in_internal_span(self):
         tracer = trace.get_tracer(__name__)
         with tracer.start_as_current_span("test", kind=trace.SpanKind.SERVER):


### PR DESCRIPTION
# Description
This PR implements the [HTTP request/response headers as span attributes semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md) for flask framework.

Fixes #911 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Added unit tests for the changes. Also, tested by capturing headers manually with instrumented flask app and observing the output on jaeger backend.

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
