### PR TITLE
Add falcon version 1.4.1 support to opentelemetry-instrumentation-falcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1004])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1004)
 - `opentelemetry-instrumentation-psycopg2` extended the sql commenter support of dbapi into psycopg2
   ([#940](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/940))
+- `opentelemetry-instrumentation-falcon` Add support for falcon==1.4.1
+  ([#1000])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1000)
 - `opentelemetry-instrumentation-falcon` Falcon: Capture custom request/response headers in span attributes
   ([#1003])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1003)
 - `opentelemetry-instrumentation-elasticsearch` no longer creates unique span names by including search target, replaces them with `<target>` and puts the value in attribute `elasticsearch.target`

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -12,7 +12,7 @@
 | [opentelemetry-instrumentation-dbapi](./opentelemetry-instrumentation-dbapi) | dbapi |
 | [opentelemetry-instrumentation-django](./opentelemetry-instrumentation-django) | django >= 1.10 |
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 2.0 |
-| [opentelemetry-instrumentation-falcon](./opentelemetry-instrumentation-falcon) | falcon >= 2.0.0, < 4.0.0 |
+| [opentelemetry-instrumentation-falcon](./opentelemetry-instrumentation-falcon) | falcon >= 1.4.1, < 4.0.0 |
 | [opentelemetry-instrumentation-fastapi](./opentelemetry-instrumentation-fastapi) | fastapi ~= 0.58 |
 | [opentelemetry-instrumentation-flask](./opentelemetry-instrumentation-flask) | flask >= 1.0, < 3.0 |
 | [opentelemetry-instrumentation-grpc](./opentelemetry-instrumentation-grpc) | grpcio ~= 1.27 |

--- a/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-falcon/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     opentelemetry-instrumentation == 0.29b0
     opentelemetry-api ~= 1.3
     opentelemetry-semantic-conventions == 0.29b0
+    packaging >= 20.0
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -326,14 +326,13 @@ class _TraceMiddleware:
 
             # Falcon 1 does not support response headers. So
             # send an empty dict.
-            if _falcon_version == 1:
-                _response_headers_dict = {}.items()
-            else:
-                _response_headers_dict = resp.headers.items()
+            response_headers = {}
+            if _falcon_version > 1:
+                response_headers = resp.headers
 
             if span.is_recording() and span.kind == trace.SpanKind.SERVER:
                 otel_wsgi.add_custom_response_headers(
-                    span, _response_headers_dict
+                    span, response_headers.items()
                 )
         except ValueError:
             pass

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -95,6 +95,7 @@ from sys import exc_info
 from typing import Collection
 
 import falcon
+from packaging import version as package_version
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import context, trace
@@ -126,12 +127,19 @@ _ENVIRON_EXC = "opentelemetry-falcon.exc"
 
 _response_propagation_setter = FuncSetter(falcon.Response.append_header)
 
-if hasattr(falcon, "App"):
+_parsed_falcon_version = package_version.parse(falcon.__version__)
+if _parsed_falcon_version >= package_version.parse("3.0.0"):
     # Falcon 3
     _instrument_app = "App"
-else:
+    _falcon_version = 3
+elif _parsed_falcon_version >= package_version.parse("2.0.0"):
     # Falcon 2
     _instrument_app = "API"
+    _falcon_version = 2
+else:
+    # Falcon 1
+    _instrument_app = "API"
+    _falcon_version = 1
 
 
 class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
@@ -163,12 +171,30 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
         super().__init__(*args, **kwargs)
 
     def _handle_exception(
-        self, req, resp, ex, params
+        self, arg1, arg2, arg3, arg4
     ):  # pylint: disable=C0103
         # Falcon 3 does not execute middleware within the context of the exception
         # so we capture the exception here and save it into the env dict
+
+        # Translation layer for handling the changed arg position of "ex" in Falcon > 2 vs
+        # Falcon < 2
+        if _falcon_version == 1:
+            ex = arg1
+            req = arg2
+            resp = arg3
+            params = arg4
+        else:
+            req = arg1
+            resp = arg2
+            ex = arg3
+            params = arg4
+
         _, exc, _ = exc_info()
         req.env[_ENVIRON_EXC] = exc
+
+        if _falcon_version == 1:
+            return super()._handle_exception(ex, req, resp, params)
+
         return super()._handle_exception(req, resp, ex, params)
 
     def __call__(self, env, start_response):
@@ -260,7 +286,7 @@ class _TraceMiddleware:
 
     def process_response(
         self, req, resp, resource, req_succeeded=None
-    ):  # pylint:disable=R0201
+    ):  # pylint:disable=R0201,R0912
         span = req.env.get(_ENVIRON_SPAN_KEY)
 
         if not span or not span.is_recording():
@@ -297,9 +323,17 @@ class _TraceMiddleware:
                     description=reason,
                 )
             )
+
+            # Falcon 1 does not support response headers. So
+            # send an empty dict.
+            if _falcon_version == 1:
+                _response_headers_dict = {}.items()
+            else:
+                _response_headers_dict = resp.headers.items()
+
             if span.is_recording() and span.kind == trace.SpanKind.SERVER:
                 otel_wsgi.add_custom_response_headers(
-                    span, resp.headers.items()
+                    span, _response_headers_dict
                 )
         except ValueError:
             pass

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/package.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("falcon >= 2.0.0, < 4.0.0",)
+_instruments = ("falcon >= 1.4.1, < 4.0.0",)

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
@@ -48,15 +48,12 @@ class CustomResponseHeaderResource:
 
 def make_app():
     _parsed_falcon_version = package_version.parse(falcon.__version__)
-    if _parsed_falcon_version >= package_version.parse("3.0.0"):
-        # Falcon 3
-        app = falcon.App()
-    elif _parsed_falcon_version >= package_version.parse("2.0.0"):
-        # Falcon 2
+    if _parsed_falcon_version < package_version.parse("3.0.0"):
+        # Falcon 1 and Falcon 2
         app = falcon.API()
     else:
-        # Falcon 1
-        app = falcon.API()
+        # Falcon 3
+        app = falcon.App()
 
     app.add_route("/hello", HelloWorldResource())
     app.add_route("/ping", HelloWorldResource())

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
@@ -1,4 +1,5 @@
 import falcon
+from packaging import version as package_version
 
 # pylint:disable=R0201,W0613,E0602
 
@@ -46,12 +47,17 @@ class CustomResponseHeaderResource:
 
 
 def make_app():
-    if hasattr(falcon, "App"):
+    _parsed_falcon_version = package_version.parse(falcon.__version__)
+    if _parsed_falcon_version >= package_version.parse("3.0.0"):
         # Falcon 3
         app = falcon.App()
-    else:
+    elif _parsed_falcon_version >= package_version.parse("2.0.0"):
         # Falcon 2
         app = falcon.API()
+    else:
+        # Falcon 1
+        app = falcon.API()
+
     app.add_route("/hello", HelloWorldResource())
     app.add_route("/ping", HelloWorldResource())
     app.add_route("/error", ErrorResource())

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -53,7 +53,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-elasticsearch==0.29b0",
     },
     "falcon": {
-        "library": "falcon >= 2.0.0, < 4.0.0",
+        "library": "falcon >= 1.4.1, < 4.0.0",
         "instrumentation": "opentelemetry-instrumentation-falcon==0.29b0",
     },
     "fastapi": {

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,10 @@ envlist =
     pypy3-test-instrumentation-elasticsearch5
 
     ; opentelemetry-instrumentation-falcon
+    ; py310 does not work with falcon 1
+    py3{6,7,8,9}-test-instrumentation-falcon1
     py3{6,7,8,9,10}-test-instrumentation-falcon{2,3}
-    pypy3-test-instrumentation-falcon{2,3}
+    pypy3-test-instrumentation-falcon{1,2,3}
 
     ; opentelemetry-instrumentation-fastapi
     ; fastapi only supports 3.6 and above.
@@ -219,6 +221,7 @@ deps =
   ; FIXME: Elasticsearch >=7 causes CI workflow tests to hang, see open-telemetry/opentelemetry-python-contrib#620
   ; elasticsearch7: elasticsearch-dsl>=7.0,<8.0
   ; elasticsearch7: elasticsearch>=7.0,<8.0
+  falcon1: falcon ==1.4.1
   falcon2: falcon >=2.0.0,<3.0.0
   falcon3: falcon >=3.0.0,<4.0.0
   sqlalchemy11: sqlalchemy>=1.1,<1.2
@@ -258,7 +261,7 @@ changedir =
   test-instrumentation-dbapi: instrumentation/opentelemetry-instrumentation-dbapi/tests
   test-instrumentation-django{1,2,3,4}: instrumentation/opentelemetry-instrumentation-django/tests
   test-instrumentation-elasticsearch{2,5,6}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
-  test-instrumentation-falcon{2,3}: instrumentation/opentelemetry-instrumentation-falcon/tests
+  test-instrumentation-falcon{1,2,3}: instrumentation/opentelemetry-instrumentation-falcon/tests
   test-instrumentation-fastapi: instrumentation/opentelemetry-instrumentation-fastapi/tests
   test-instrumentation-flask: instrumentation/opentelemetry-instrumentation-flask/tests
   test-instrumentation-urllib: instrumentation/opentelemetry-instrumentation-urllib/tests
@@ -312,8 +315,8 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon{2,3},flask,django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,requests,urllib,urllib3,wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
-  wsgi,falcon{2,3},flask,django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
+  falcon{1,2,3},flask,django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,requests,urllib,urllib3,wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  wsgi,falcon{1,2,3},flask,django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   asgi,django{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 
   asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg[test]
@@ -323,7 +326,7 @@ commands_pre =
   boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
   boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-boto[test]
 
-  falcon{2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
+  falcon{1,2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
 
   flask: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
 


### PR DESCRIPTION
# Description

The largest change between falcon 1.x and 2.x was the changing the placement of some exception args. This PR adds some logic to place those args in the correct places for all versions of falcon.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Made sure tests pass
- Forked and ran against falcon instance internally.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
