### PR TITLE
code change to add custom http and websocket request and response hea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.9.1-0.28b1...HEAD)
 
 - `opentelemetry-instrumentation-wsgi` Capture custom request/response headers in span attributes
+  ([#1004])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1004)
+
+- `opentelemetry-instrumentation-wsgi` Capture custom request/response headers in span attributes
   ([#925])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/925)
 
 - `opentelemetry-instrumentation-flask` Flask: Capture custom request/response headers in span attributes

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -115,7 +115,15 @@ from opentelemetry.propagators.textmap import Getter, Setter
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, set_span_in_context
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.util.http import remove_url_credentials
+from opentelemetry.util.http import (
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
+    get_custom_headers,
+    normalise_request_header_name,
+    normalise_response_header_name,
+    remove_url_credentials,
+)
+
 
 _ServerRequestHookT = typing.Optional[typing.Callable[[Span, dict], None]]
 _ClientRequestHookT = typing.Optional[typing.Callable[[Span, dict], None]]
@@ -221,6 +229,41 @@ def collect_request_attributes(scope):
     result = {k: v for k, v in result.items() if v is not None}
 
     return result
+
+
+def collect_custom_request_headers_attributes(scope):
+    """returns custom HTTP request headers to be added into SERVER span as span attributes
+    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+
+    attributes = {}
+    custom_request_headers = get_custom_headers(
+        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST
+    )
+
+    for header in custom_request_headers:
+        values = asgi_getter.get(scope, header)
+        if values:
+            key = normalise_request_header_name(header)
+            attributes.setdefault(key, []).extend(values)
+
+    return attributes
+
+
+def collect_custom_response_headers_attributes(message):
+    """returns custom HTTP response headers to be added into SERVER span as span attributes
+    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+    attributes = {}
+    custom_response_headers = get_custom_headers(
+        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE
+    )
+
+    for header in custom_response_headers:
+        values = asgi_getter.get(message, header)
+        if values:
+            key = normalise_response_header_name(header)
+            attributes.setdefault(key, []).extend(values)
+
+    return attributes
 
 
 def get_host_port_url_tuple(scope):
@@ -342,6 +385,13 @@ class OpenTelemetryMiddleware:
                     for key, value in attributes.items():
                         current_span.set_attribute(key, value)
 
+                    if span.kind == trace.SpanKind.SERVER:
+                        custom_attributes = (
+                            collect_custom_request_headers_attributes(scope)
+                        )
+                        if len(custom_attributes) > 0:
+                            current_span.set_attributes(custom_attributes)
+
                 if callable(self.server_request_hook):
                     self.server_request_hook(current_span, scope)
 
@@ -395,6 +445,17 @@ class OpenTelemetryMiddleware:
                         set_status_code(server_span, 200)
                         set_status_code(send_span, 200)
                     send_span.set_attribute("type", message["type"])
+                    if (
+                        server_span.kind == trace.SpanKind.SERVER
+                        and "headers" in message
+                    ):
+                        custom_response_attributes = (
+                            collect_custom_response_headers_attributes(message)
+                        )
+                        if len(custom_response_attributes) > 0:
+                            server_span.set_attributes(
+                                custom_response_attributes
+                            )
 
                 propagator = get_global_response_propagator()
                 if propagator:

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -384,7 +384,7 @@ class OpenTelemetryMiddleware:
                     for key, value in attributes.items():
                         current_span.set_attribute(key, value)
 
-                    if span.kind == trace.SpanKind.SERVER:
+                    if current_span.kind == trace.SpanKind.SERVER:
                         custom_attributes = (
                             collect_custom_request_headers_attributes(scope)
                         )
@@ -445,7 +445,8 @@ class OpenTelemetryMiddleware:
                         set_status_code(send_span, 200)
                     send_span.set_attribute("type", message["type"])
                     if (
-                        server_span.kind == trace.SpanKind.SERVER
+                        server_span.is_recording()
+                        and server_span.kind == trace.SpanKind.SERVER
                         and "headers" in message
                     ):
                         custom_response_attributes = (

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -124,7 +124,6 @@ from opentelemetry.util.http import (
     remove_url_credentials,
 )
 
-
 _ServerRequestHookT = typing.Optional[typing.Callable[[Span, dict], None]]
 _ClientRequestHookT = typing.Optional[typing.Callable[[Span, dict], None]]
 _ClientResponseHookT = typing.Optional[typing.Callable[[Span, dict], None]]

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -25,16 +25,16 @@ from opentelemetry.instrumentation.propagators import (
 )
 from opentelemetry.sdk import resources
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.util.http import (
-    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
-    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
-)
 from opentelemetry.test.asgitestutil import (
     AsgiTestBase,
     setup_testing_defaults,
 )
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import SpanKind, format_span_id, format_trace_id
+from opentelemetry.util.http import (
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
+)
 
 
 async def http_app(scope, receive, send):

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -749,7 +749,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.send_input({"type": "websocket.connect"})
         self.send_input({"type": "websocket.receive", "text": "ping"})
         self.send_input({"type": "websocket.disconnect"})
-        # self.send_default_request()
+
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
@@ -782,7 +782,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.send_input({"type": "websocket.connect"})
         self.send_input({"type": "websocket.receive", "text": "ping"})
         self.send_input({"type": "websocket.disconnect"})
-        # self.send_default_request()
+
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         not_expected = {

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -25,6 +25,10 @@ from opentelemetry.instrumentation.propagators import (
 )
 from opentelemetry.sdk import resources
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.util.http import (
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
+)
 from opentelemetry.test.asgitestutil import (
     AsgiTestBase,
     setup_testing_defaults,
@@ -53,6 +57,47 @@ async def websocket_app(scope, receive, send):
         message = await receive()
         if message.get("type") == "websocket.connect":
             await send({"type": "websocket.accept"})
+
+        if message.get("type") == "websocket.receive":
+            if message.get("text") == "ping":
+                await send({"type": "websocket.send", "text": "pong"})
+
+        if message.get("type") == "websocket.disconnect":
+            break
+
+
+async def http_app_with_custom_headers(scope, receive, send):
+    message = await receive()
+    assert scope["type"] == "http"
+    if message.get("type") == "http.request":
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"Content-Type", b"text/plain"),
+                    (b"custom-test-header-1", b"test-header-value-1"),
+                    (b"custom-test-header-2", b"test-header-value-2"),
+                ],
+            }
+        )
+    await send({"type": "http.response.body", "body": b"*"})
+
+
+async def websocket_app_with_custom_headers(scope, receive, send):
+    assert scope["type"] == "websocket"
+    while True:
+        message = await receive()
+        if message.get("type") == "websocket.connect":
+            await send(
+                {
+                    "type": "websocket.accept",
+                    "headers": [
+                        (b"custom-test-header-1", b"test-header-value-1"),
+                        (b"custom-test-header-2", b"test-header-value-2"),
+                    ],
+                }
+            )
 
         if message.get("type") == "websocket.receive":
             if message.get("text") == "ping":
@@ -581,6 +626,238 @@ class TestWrappedApplication(AsgiTestBase):
         self.assertEqual(
             span_list[4].context.span_id, span_list[3].parent.span_id
         )
+
+
+@mock.patch.dict(
+    "os.environ",
+    {
+        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3",
+        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3",
+    },
+)
+class TestCustomHeaders(AsgiTestBase, TestBase):
+    def setUp(self):
+        super().setUp()
+        self.tracer_provider, self.exporter = TestBase.create_tracer_provider()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
+        self.app = otel_asgi.OpenTelemetryMiddleware(
+            simple_asgi, tracer_provider=self.tracer_provider
+        )
+
+    def test_http_custom_request_headers_in_span_attributes(self):
+        self.scope["headers"].extend(
+            [
+                (b"custom-test-header-1", b"test-header-value-1"),
+                (b"custom-test-header-2", b"test-header-value-2"),
+            ]
+        )
+        self.seed_app(self.app)
+        self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        expected = {
+            "http.request.header.custom_test_header_1": (
+                "test-header-value-1",
+            ),
+            "http.request.header.custom_test_header_2": (
+                "test-header-value-2",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                self.assertSpanHasAttributes(span, expected)
+
+    def test_http_custom_request_headers_not_in_span_attributes(self):
+        self.scope["headers"].extend(
+            [
+                (b"custom-test-header-1", b"test-header-value-1"),
+            ]
+        )
+        self.seed_app(self.app)
+        self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        expected = {
+            "http.request.header.custom_test_header_1": (
+                "test-header-value-1",
+            ),
+        }
+        not_expected = {
+            "http.request.header.custom_test_header_2": (
+                "test-header-value-2",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                self.assertSpanHasAttributes(span, expected)
+                for key, _ in not_expected.items():
+                    self.assertNotIn(key, span.attributes)
+
+    def test_http_custom_response_headers_in_span_attributes(self):
+        self.app = otel_asgi.OpenTelemetryMiddleware(
+            http_app_with_custom_headers, tracer_provider=self.tracer_provider
+        )
+        self.seed_app(self.app)
+        self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        expected = {
+            "http.response.header.custom_test_header_1": (
+                "test-header-value-1",
+            ),
+            "http.response.header.custom_test_header_2": (
+                "test-header-value-2",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                self.assertSpanHasAttributes(span, expected)
+
+    def test_http_custom_response_headers_not_in_span_attributes(self):
+        self.app = otel_asgi.OpenTelemetryMiddleware(
+            http_app_with_custom_headers, tracer_provider=self.tracer_provider
+        )
+        self.seed_app(self.app)
+        self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        not_expected = {
+            "http.response.header.custom_test_header_3": (
+                "test-header-value-3",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                for key, _ in not_expected.items():
+                    self.assertNotIn(key, span.attributes)
+
+    def test_websocket_custom_request_headers_in_span_attributes(self):
+        self.scope = {
+            "type": "websocket",
+            "http_version": "1.1",
+            "scheme": "ws",
+            "path": "/",
+            "query_string": b"",
+            "headers": [
+                (b"custom-test-header-1", b"test-header-value-1"),
+                (b"custom-test-header-2", b"test-header-value-2"),
+            ],
+            "client": ("127.0.0.1", 32767),
+            "server": ("127.0.0.1", 80),
+        }
+        self.seed_app(self.app)
+        self.send_input({"type": "websocket.connect"})
+        self.send_input({"type": "websocket.receive", "text": "ping"})
+        self.send_input({"type": "websocket.disconnect"})
+        # self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        expected = {
+            "http.request.header.custom_test_header_1": (
+                "test-header-value-1",
+            ),
+            "http.request.header.custom_test_header_2": (
+                "test-header-value-2",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                self.assertSpanHasAttributes(span, expected)
+
+    def test_websocket_custom_request_headers_not_in_span_attributes(self):
+        self.scope = {
+            "type": "websocket",
+            "http_version": "1.1",
+            "scheme": "ws",
+            "path": "/",
+            "query_string": b"",
+            "headers": [
+                (b"Custom-Test-Header-1", b"test-header-value-1"),
+                (b"Custom-Test-Header-2", b"test-header-value-2"),
+            ],
+            "client": ("127.0.0.1", 32767),
+            "server": ("127.0.0.1", 80),
+        }
+        self.seed_app(self.app)
+        self.send_input({"type": "websocket.connect"})
+        self.send_input({"type": "websocket.receive", "text": "ping"})
+        self.send_input({"type": "websocket.disconnect"})
+        # self.send_default_request()
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        not_expected = {
+            "http.request.header.custom_test_header_3": (
+                "test-header-value-3",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                for key, _ in not_expected.items():
+                    self.assertNotIn(key, span.attributes)
+
+    def test_websocket_custom_response_headers_in_span_attributes(self):
+        self.scope = {
+            "type": "websocket",
+            "http_version": "1.1",
+            "scheme": "ws",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 32767),
+            "server": ("127.0.0.1", 80),
+        }
+        self.app = otel_asgi.OpenTelemetryMiddleware(
+            websocket_app_with_custom_headers,
+            tracer_provider=self.tracer_provider,
+        )
+        self.seed_app(self.app)
+        self.send_input({"type": "websocket.connect"})
+        self.send_input({"type": "websocket.receive", "text": "ping"})
+        self.send_input({"type": "websocket.disconnect"})
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        expected = {
+            "http.response.header.custom_test_header_1": (
+                "test-header-value-1",
+            ),
+            "http.response.header.custom_test_header_2": (
+                "test-header-value-2",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                self.assertSpanHasAttributes(span, expected)
+
+    def test_websocket_custom_response_headers_not_in_span_attributes(self):
+        self.scope = {
+            "type": "websocket",
+            "http_version": "1.1",
+            "scheme": "ws",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 32767),
+            "server": ("127.0.0.1", 80),
+        }
+        self.app = otel_asgi.OpenTelemetryMiddleware(
+            websocket_app_with_custom_headers,
+            tracer_provider=self.tracer_provider,
+        )
+        self.seed_app(self.app)
+        self.send_input({"type": "websocket.connect"})
+        self.send_input({"type": "websocket.receive", "text": "ping"})
+        self.send_input({"type": "websocket.disconnect"})
+        self.get_all_output()
+        span_list = self.exporter.get_finished_spans()
+        not_expected = {
+            "http.response.header.custom_test_header_3": (
+                "test-header-value-3",
+            ),
+        }
+        for span in span_list:
+            if span.kind == SpanKind.SERVER:
+                for key, _ in not_expected.items():
+                    self.assertNotIn(key, span.attributes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
This PR will add a feature to add custom request and response headers of http as well as websocket application to span as attributes.

Fixes # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/919

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I have added a new sample http_app_with_custom_headers and new websocket_app_with_custom_headers which will gives us sample apps to test and I have created a test class which will check expected as well as not expected span attributes in both type of applications

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
