### PR TITLE
[WIP] Add support for AsyncElasticsearch

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -172,8 +172,11 @@ def _extract(args, kwargs, span_name_prefix):
     op_name = span_name_prefix + (url or method or _DEFAULT_OP_NAME)
     doc_id = None
     if url:
-        # TODO: This regex-based solution avoids creating an unbounded number of span names, but should be replaced by instrumenting individual Elasticsearch methods instead of Transport.perform_request()
-        # A limitation of the regex is that only the '_doc' mapping type is supported. Mapping types are deprecated since Elasticsearch 7
+        # TODO: This regex-based solution avoids creating an unbounded number of span names,
+        #  but should be replaced by instrumenting individual Elasticsearch methods instead of
+        #  Transport.perform_request()
+        # A limitation of the regex is that only the '_doc' mapping type is supported.
+        # Mapping types are deprecated since Elasticsearch 7
         # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/708
         match = _regex_doc_url.search(url)
         if match is not None:

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -130,7 +130,7 @@ class ElasticsearchInstrumentor(BaseInstrumentor):
 
     def _instrument(self, **kwargs):
         """
-        Instruments elasticsarch module
+        Instruments elasticsearch module
         """
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
@@ -143,12 +143,80 @@ class ElasticsearchInstrumentor(BaseInstrumentor):
                 tracer, self._span_name_prefix, request_hook, response_hook
             ),
         )
+        _wrap(
+            elasticsearch,
+            "AsyncTransport.perform_request",
+            _wrap_perform_async_request(
+                tracer, self._span_name_prefix, request_hook, response_hook
+            ),
+        )
 
     def _uninstrument(self, **kwargs):
         unwrap(elasticsearch.Transport, "perform_request")
+        unwrap(elasticsearch.AsyncTransport, "perform_request")
 
 
 _regex_doc_url = re.compile(r"/_doc/([^/]+)")
+
+
+def _extract(args, kwargs, span_name_prefix):
+    method = url = None
+    try:
+        method, url, *_ = args
+    except IndexError:
+        logger.warning(
+            "expected perform_request to receive two positional arguments. "
+            "Got %d",
+            len(args),
+        )
+    op_name = span_name_prefix + (url or method or _DEFAULT_OP_NAME)
+    doc_id = None
+    if url:
+        # TODO: This regex-based solution avoids creating an unbounded number of span names, but should be replaced by instrumenting individual Elasticsearch methods instead of Transport.perform_request()
+        # A limitation of the regex is that only the '_doc' mapping type is supported. Mapping types are deprecated since Elasticsearch 7
+        # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/708
+        match = _regex_doc_url.search(url)
+        if match is not None:
+            # Remove the full document ID from the URL
+            doc_span = match.span()
+            op_name = (
+                span_name_prefix
+                + url[: doc_span[0]]
+                + "/_doc/:id"
+                + url[doc_span[1] :]
+            )
+            # Put the document ID in attributes
+            doc_id = match.group(1)
+    params = kwargs.get("params", {})
+    body = kwargs.get("body", None)
+    return method, url, op_name, body, params, doc_id
+
+
+def _set_span_attributes(span, url, method, body, params, doc_id):
+    attributes = {
+        SpanAttributes.DB_SYSTEM: "elasticsearch",
+    }
+    if url:
+        attributes["elasticsearch.url"] = url
+    if method:
+        attributes["elasticsearch.method"] = method
+    if body:
+        attributes[SpanAttributes.DB_STATEMENT] = str(body)
+    if params:
+        attributes["elasticsearch.params"] = str(params)
+    if doc_id:
+        attributes["elasticsearch.id"] = doc_id
+    for key, value in attributes.items():
+        span.set_attribute(key, value)
+
+
+def _set_span_attributes_from_rv(span, return_value):
+    for member in _ATTRIBUTES_FROM_RESULT:
+        if member in return_value:
+            span.set_attribute(
+                f"elasticsearch.{member}",
+                str(return_value[member]),
+            )
 
 
 def _wrap_perform_request(
@@ -156,36 +224,9 @@ def _wrap_perform_request(
 ):
     # pylint: disable=R0912
     def wrapper(wrapped, _, args, kwargs):
-        method = url = None
-        try:
-            method, url, *_ = args
-        except IndexError:
-            logger.warning(
-                "expected perform_request to receive two positional arguments. "
-                "Got %d",
-                len(args),
-            )
-
-        op_name = span_name_prefix + (url or method or _DEFAULT_OP_NAME)
-        doc_id = None
-        if url:
-            # TODO: This regex-based solution avoids creating an unbounded number of span names, but should be replaced by instrumenting individual Elasticsearch methods instead of Transport.perform_request()
-            # A limitation of the regex is that only the '_doc' mapping type is supported. Mapping types are deprecated since Elasticsearch 7
-            # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/708
-            match = _regex_doc_url.search(url)
-            if match is not None:
-                # Remove the full document ID from the URL
-                doc_span = match.span()
-                op_name = (
-                    span_name_prefix
-                    + url[: doc_span[0]]
-                    + "/_doc/:id"
-                    + url[doc_span[1] :]
-                )
-                # Put the document ID in attributes
-                doc_id = match.group(1)
-        params = kwargs.get("params", {})
-        body = kwargs.get("body", None)
+        method, url, op_name, body, params, doc_id = _extract(
+            args, kwargs, span_name_prefix
+        )
 
         with tracer.start_as_current_span(
             op_name,
@@ -196,33 +237,45 @@ def _wrap_perform_request(
                 request_hook(span, method, url, kwargs)
 
             if span.is_recording():
-                attributes = {
-                    SpanAttributes.DB_SYSTEM: "elasticsearch",
-                }
-                if url:
-                    attributes["elasticsearch.url"] = url
-                if method:
-                    attributes["elasticsearch.method"] = method
-                if body:
-                    attributes[SpanAttributes.DB_STATEMENT] = str(body)
-                if params:
-                    attributes["elasticsearch.params"] = str(params)
-                if doc_id:
-                    attributes["elasticsearch.id"] = doc_id
-                for key, value in attributes.items():
-                    span.set_attribute(key, value)
+                _set_span_attributes(span, url, method, body, params, doc_id)
 
-            rv = wrapped(*args, **kwargs)
-            if isinstance(rv, dict) and span.is_recording():
-                for member in _ATTRIBUTES_FROM_RESULT:
-                    if member in rv:
-                        span.set_attribute(
-                            f"elasticsearch.{member}",
-                            str(rv[member]),
-                        )
+            return_value = wrapped(*args, **kwargs)
+            if isinstance(return_value, dict) and span.is_recording():
+                _set_span_attributes_from_rv(span, return_value)
 
             if callable(response_hook):
-                response_hook(span, rv)
-            return rv
+                response_hook(span, return_value)
+            return return_value
+
+    return wrapper
+
+
+def _wrap_perform_async_request(
+    tracer, span_name_prefix, request_hook=None, response_hook=None
+):
+    # pylint: disable=R0912
+    async def wrapper(wrapped, _, args, kwargs):
+        method, url, op_name, body, params, doc_id = _extract(
+            args, kwargs, span_name_prefix
+        )
+
+        with tracer.start_as_current_span(
+            op_name,
+            kind=SpanKind.CLIENT,
+        ) as span:
+
+            if callable(request_hook):
+                request_hook(span, method, url, kwargs)
+
+            if span.is_recording():
+                _set_span_attributes(span, url, method, body, params, doc_id)
+
+            return_value = await wrapped(*args, **kwargs)
+            if isinstance(return_value, dict) and span.is_recording():
+                _set_span_attributes_from_rv(span, return_value)
+
+            if callable(response_hook):
+                response_hook(span, return_value)
+            return return_value
 
     return wrapper

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("elasticsearch >= 2.0",)
+_instruments = ("elasticsearch >= 2.0, < 8.0.0",)


### PR DESCRIPTION
# Description

The current elasticsearch instrumentation does not support version 8.x (see https://github.com/open-telemetry/opentelemetry-python-contrib/issues/620), which this PR does not fix, but it also does not support the async capabilities introduced in elasticsearch-python version 7.8.0 (https://elasticsearch-py.readthedocs.io/en/7.x/async.html#using-asyncio-with-elasticsearch). This PR aims to fix the latter, until a solution for the former is implemented.

This adds a wrapping of the `AsyncTransport` in addition to the already existing wrapping of `Transport`.

Progress:
- [x] Wrap AsyncTransport
- [x] Extract common parts
- [ ] Ensure it only runs if `AsyncTransport` is actually available (elasticsearch>=7.8.0)
- [ ] Add tests

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (probably?)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Original tests pass
- [x] Manually checked that traces are delivered with elasticsearch==7.17.1 both with sync and async clients
- [ ] Automatic tests for older versions of elasticsearch
- [ ] Automatic tests for newer versions of elasticsearch

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
