### PR TITLE
[WIP] Add support for AsyncElasticsearch

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("elasticsearch >= 2.0",)
+_instruments = ("elasticsearch >= 2.0, < 8.0.0",)


### PR DESCRIPTION
# Description

The current elasticsearch instrumentation does not support version 8.x (see https://github.com/open-telemetry/opentelemetry-python-contrib/issues/620), which this PR does not fix, but it also does not support the async capabilities introduced in elasticsearch-python version 7.8.0 (https://elasticsearch-py.readthedocs.io/en/7.x/async.html#using-asyncio-with-elasticsearch). This PR aims to fix the latter, until a solution for the former is implemented.

This adds a wrapping of the `AsyncTransport` in addition to the already existing wrapping of `Transport`.

Progress:
- [x] Wrap AsyncTransport
- [x] Extract common parts
- [ ] Ensure it only runs if `AsyncTransport` is actually available (elasticsearch>=7.8.0)
- [ ] Add tests

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (probably?)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Original tests pass
- [x] Manually checked that traces are delivered with elasticsearch==7.17.1 both with sync and async clients
- [ ] Automatic tests for older versions of elasticsearch
- [ ] Automatic tests for newer versions of elasticsearch

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
