### PR TITLE
README: fix link to Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 <p align="center">
   <strong>
-    <a href="https://opentelemetry-python-contrib.readthedocs.io/en/latest/getting-started.html">Getting Started<a/>
+    <a href="https://opentelemetry.io/docs/instrumentation/python/getting-started/">Getting Started<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://opentelemetry-python-contrib.readthedocs.io/">API Documentation<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;


### PR DESCRIPTION
The old link, https://opentelemetry-python-contrib.readthedocs.io/en/latest/getting-started.html, resulted in a 404:

> <img width="666" alt="image" src="https://user-images.githubusercontent.com/4140793/159188346-7e0d6a8d-0801-4c69-b13d-80fb16f66ba4.png">