### PR TITLE
Update .instrument() call `response_hook` argument name in the documentation for Botocore and Pymongo

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -67,7 +67,7 @@ for example:
         # response hook logic
 
     # Instrument Botocore with hooks
-    BotocoreInstrumentor().instrument(request_hook=request_hook, response_hooks=response_hook)
+    BotocoreInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook)
 
     # This will create a span with Botocore-specific attributes, including custom attributes added from the hooks
     session = botocore.session.get_session()

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -64,7 +64,7 @@ for example:
         # failed hook logic
 
     # Instrument pymongo with hooks
-    PymongoInstrumentor().instrument(request_hook=request_hook, response_hooks=response_hook, failed_hook=failed_hook)
+    PymongoInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook, failed_hook=failed_hook)
 
     # This will create a span with pymongo specific attributes, including custom attributes added from the hooks
     client = MongoClient()


### PR DESCRIPTION
# Description

The current documentation for Botocore and Pymongo instrumentation has incorrectly specified the argument `response_hook` as `response_hooks` for the `.instrument()` call. This PR fixes the argument name to use `response_hook` instead.

Correct Format:
`BotocoreInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook)`

`PymongoInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook, failed_hook=failed_hook)
`
## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

All tests of the project have been run. 

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

- [X] Documentation has been updated
