### PR TITLE
Pin bleach to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ sphinx-autodoc-typehints
 pytest!=5.2.3
 pytest-cov>=2.8
 readme-renderer~=24.0
+bleach==4.1.0 # transient dependency for readme-renderer
 grpcio-tools==1.29.0
 mypy-protobuf>=1.23
 protobuf>=3.13.0


### PR DESCRIPTION
# Description

This fresh release https://github.com/mozilla/bleach/releases/tag/v5.0.0 which is used by `readme-renderer` (which didn't pin the major version) causing some lint failures.  

Probably something like `pip-tools` helps us in longterm to solve problems.

