### PR TITLE
Fix Tornado errors mapping to 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.10.0-0.29b0...HEAD)
 
 ### Fixed
-
+- `opentelemetry-instrumentation-tornado` Fix Tornado errors mapping to 500
+  ([#1048])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1048)
 - `opentelemetry-instrumentation-urllib` make span attributes available to sampler
   ([1014](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1014))
 - `opentelemetry-instrumentation-flask` Fix non-recording span bug

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -420,14 +420,15 @@ def _finish_span(tracer, handler, error=None):
             status_code = error.status_code
             if not ctx and status_code == 404:
                 ctx = _start_span(tracer, handler, _time_ns())
-        if status_code != 404:
+        else:
+            status_code = 500
+            reason = None
+        if status_code >= 500:
             finish_args = (
                 type(error),
                 error,
                 getattr(error, "__traceback__", None),
             )
-            status_code = 500
-            reason = None
 
     if not ctx:
         return

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/tornado_test_app.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/tornado_test_app.py
@@ -105,6 +105,11 @@ class CustomResponseHeaderHandler(tornado.web.RequestHandler):
         self.set_status(200)
 
 
+class RaiseHTTPErrorHandler(tornado.web.RequestHandler):
+    def get(self):
+        raise tornado.web.HTTPError(403)
+
+
 def make_app(tracer):
     app = tornado.web.Application(
         [
@@ -116,6 +121,7 @@ def make_app(tracer):
             (r"/healthz", HealthCheckHandler),
             (r"/ping", HealthCheckHandler),
             (r"/test_custom_response_headers", CustomResponseHeaderHandler),
+            (r"/raise_403", RaiseHTTPErrorHandler),
         ]
     )
     app.tracer = tracer


### PR DESCRIPTION
# Description

Fix bug in Tornado instrumentation. Current implementation erase http status codes and set 500 for any types of exceptions (tornado.web.HTTPError and others). But in Tornado [implemantation](https://github.com/tornadoweb/tornado/blob/master/tornado/web.py#L1767-L1770) setting http status 500 if exception not tornado.web.HTTPError. Otherwise, http status will set from exception. This fix repeat Tornado implementation logic. 

Fixes #997

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Just create handler which raise tornado.web.HTTPError with some code. (See unit test)

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
