### PR TITLE
Celery add support for anon tasks

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -132,6 +132,9 @@ def attach_span(task, task_id, span, is_publish=False):
     NOTE: We cannot test for this well yet, because we do not run a celery worker,
     and cannot run `task.apply_async()`
     """
+    if task is None:
+        return
+
     span_dict = getattr(task, CTX_KEY, None)
     if span_dict is None:
         span_dict = {}

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -133,6 +133,8 @@ def attach_span(task, task_id, span, is_publish=False):
     and cannot run `task.apply_async()`
     """
     if task is None:
+        # task objects can be optional, if None is passed in, there is nothing to attach
+        # the context state to...
         return
 
     span_dict = getattr(task, CTX_KEY, None)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -77,3 +77,46 @@ class TestCeleryInstrumentation(TestBase):
         self.assertNotEqual(consumer.parent, producer.context)
         self.assertEqual(consumer.parent.span_id, producer.context.span_id)
         self.assertEqual(consumer.context.trace_id, producer.context.trace_id)
+
+
+class TestCelerySignatureTask(TestBase):
+    def setUp(self):
+        super().setUp()
+
+        def start_app(*args, **kwargs):
+            # Add an additional task that will not be registered with parent thread
+            @app.task
+            def hidden_task(x):
+                return x * 2
+
+            self._worker = app.Worker(app=app, pool="solo", concurrency=1)
+            return self._worker.start(*args, **kwargs)
+
+        self._thread = threading.Thread(target=start_app)
+        self._worker = app.Worker(app=app, pool="solo", concurrency=1)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self._worker.stop()
+        self._thread.join()
+
+    def test_hidden_task(self):
+        # no-op since already instrumented
+        CeleryInstrumentor().instrument()
+        import ipdb; ipdb.set_trace()
+
+        res = app.signature("app.hidden_task", (2,)).apply_async()
+        while not res.ready():
+            time.sleep(0.05)
+
+        spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
+        self.assertEqual(len(spans), 1)
+
+        producer = spans
+
+        self.assertEqual(
+            producer.name, "apply_async/app.hidden_task"
+        )
+        self.assertEqual(producer.kind, SpanKind.PRODUCER)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -181,9 +181,17 @@ class TestUtils(unittest.TestCase):
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
         utils.attach_span(fn_task, task_id, span)
+
         # delete the Span
         utils.detach_span(fn_task, task_id)
         self.assertEqual(utils.retrieve_span(fn_task, task_id), (None, None))
+
+    def test_optional_task_span_attach(self):
+        task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+
+        # assert this is is a no-aop
+        self.assertIsNone(utils.attach_span(None, task_id, span))
 
     def test_span_delete_empty(self):
         # ensure detach_span doesn't raise an exception if span is not present


### PR DESCRIPTION
# Description

This changes the way spans are initialized for the celery instrumentation hooks and handles the case where Celery tasks are not available in the registry and called anonymously using the `signature()` or `send_task()`

Fixes #1002, #609 
possibly addresses #784 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran changes against reproduced issue in repo linked in issue -> https://github.com/goatsthatcode/opentelemetry-instrumentation-celery-example
- [x] Added Unit Test to cover new conditional branch
- [x] Passed existing test suite

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
