### PR TITLE
Fix release script

### DIFF
--- a/eachdist.ini
+++ b/eachdist.ini
@@ -46,6 +46,7 @@ packages=
 
 [exclude_release]
 packages=
+    opentelemetry-exporter-datadog
     opentelemetry-sdk-extension-aws
     opentelemetry-propagator-aws-xray
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in exporter/*/ opentelemetry-instrumentation/ opentelemetry-distro/ instrumentation/*/ propagator/*/ sdk-extension/*/ util/*/ ; do
+ for d in exporter/*/ opentelemetry-instrumentation/ opentelemetry-contrib-instrumentations/ opentelemetry-distro/ instrumentation/*/ propagator/*/ sdk-extension/*/ util/*/ ; do
    (
      echo "building $d"
      cd "$d"


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1058

Also adds missing `opentelemetry-contrib-instrumentations` to build script.