### PR TITLE
Prune autoinstrumentation sitecustomize module directory from PYTHONPATH immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.11.0-0.30b0...HEAD)
 
+- Prune autoinstrumentation sitecustomize module directory from PYTHONPATH immediately
+  ([#1066](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1066))
+
 ## [1.11.0-0.30b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.11.0-0.30b0) - 2022-04-18
 
 ### Fixed

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -110,6 +110,13 @@ def _load_configurators():
 
 
 def initialize():
+    # prevents auto-instrumentation of subprocesses if code execs another python process
+    environ["PYTHONPATH"] = sub(
+        rf"{dirname(abspath(__file__))}{pathsep}?",
+        "",
+        environ["PYTHONPATH"],
+    )
+
     try:
         distro = _load_distros()
         distro.configure()
@@ -117,12 +124,6 @@ def initialize():
         _load_instrumentors(distro)
     except Exception:  # pylint: disable=broad-except
         logger.exception("Failed to auto initialize opentelemetry")
-    finally:
-        environ["PYTHONPATH"] = sub(
-            rf"{dirname(abspath(__file__))}{pathsep}?",
-            "",
-            environ["PYTHONPATH"],
-        )
 
 
 initialize()


### PR DESCRIPTION
# Description

This prevents auto-instrumentation of subprocesses launched with `exec*` as soon as possible. The risk of autoinstrumenting these subprocesses is creating a loop of autoinstrumentation if the initialization code creates the subprocess.

Fixes #1050

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested manually

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
