### PR TITLE
Remove datadog exporter from tox

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,11 +7,11 @@ extension-pkg-whitelist=
 
 # Add list of files or directories to be excluded. They should be base names, not
 # paths.
-ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt,exporter/opentelemetry-exporter-datadog
+ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt
 
 # Add files or directories matching the regex patterns to be excluded. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=exporter/opentelemetry-exporter-datadog
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,8 @@ ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt
 
 # Add files or directories matching the regex patterns to be excluded. The
 # regex matches against base names, not paths.
-ignore-patterns=exporter/opentelemetry-exporter-datadog
+ignore-patterns=
+ignore-paths=exporter/opentelemetry-exporter-datadog/.*$
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add list of files or directories to be excluded. They should be base names, not
 # paths.
-ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt
+ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt,exporter/opentelemetry-exporter-datadog
 
 # Add files or directories matching the regex patterns to be excluded. The
 # regex matches against base names, not paths.

--- a/tox.ini
+++ b/tox.ini
@@ -98,9 +98,6 @@ envlist =
     py3{6,7,8,9,10}-test-instrumentation-logging
     pypy3-test-instrumentation-logging
 
-    ; opentelemetry-exporter-datadog
-    py3{6,7,8,9,10}-test-exporter-datadog
-
     ; opentelemetry-exporter-richconsole
     py3{6,7,8,9,10}-test-exporter-richconsole
 
@@ -291,7 +288,6 @@ changedir =
   test-sdkextension-aws: sdk-extension/opentelemetry-sdk-extension-aws/tests
   test-propagator-aws: propagator/opentelemetry-propagator-aws-xray/tests
   test-propagator-ot-trace: propagator/opentelemetry-propagator-ot-trace/tests
-  test-exporter-datadog: exporter/opentelemetry-exporter-datadog/tests
   test-exporter-richconsole: exporter/opentelemetry-exporter-richconsole/tests
 
 commands_pre =
@@ -373,8 +369,6 @@ commands_pre =
   aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
 
   aiopg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg[test]
-
-  datadog: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
 
   richconsole: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-richconsole[test]
 
@@ -476,7 +470,6 @@ commands_pre =
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-httpx[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aws-lambda[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics[test]
-  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-richconsole[test]
   python -m pip install -e {toxinidir}/sdk-extension/opentelemetry-sdk-extension-aws[test]
   python -m pip install -e {toxinidir}/propagator/opentelemetry-propagator-aws-xray[test]


### PR DESCRIPTION
It is deprecated and excluded from other scripts. Should no longer run as a part of test suite.