### PR TITLE
Make span attributes available to sampler in aiohttp_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.11.1-0.30b1...HEAD)
 
 ### Fixed
+- `opentelemetry-instrumentation-aiohttp-client` make span attributes available to sampler
+  ([1072](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1072))
 - `opentelemetry-instrumentation-aws-lambda` Fixed an issue - in some rare cases (API GW proxy integration test)
   headers are set to None, breaking context propagators.
   ([#1055](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1055))

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -183,7 +183,7 @@ def create_trace_config(
         request_url = (
             remove_url_credentials(trace_config_ctx.url_filter(params.url))
             if callable(trace_config_ctx.url_filter)
-            else remove_url_credentials(str(params.url)),
+            else remove_url_credentials(str(params.url))
         )
 
         span_attributes = {

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -180,26 +180,21 @@ def create_trace_config(
 
         http_method = params.method.upper()
         request_span_name = f"HTTP {http_method}"
+        request_url = remove_url_credentials(trace_config_ctx.url_filter(params.url)) if callable(trace_config_ctx.url_filter) else remove_url_credentials(str(params.url)),
+
+        span_attributes = {
+            SpanAttributes.HTTP_METHOD: http_method,
+            SpanAttributes.HTTP_URL: request_url,
+        }
 
         trace_config_ctx.span = trace_config_ctx.tracer.start_span(
             request_span_name,
             kind=SpanKind.CLIENT,
+            attributes=span_attributes
         )
 
         if callable(request_hook):
             request_hook(trace_config_ctx.span, params)
-
-        if trace_config_ctx.span.is_recording():
-            attributes = {
-                SpanAttributes.HTTP_METHOD: http_method,
-                SpanAttributes.HTTP_URL: remove_url_credentials(
-                    trace_config_ctx.url_filter(params.url)
-                )
-                if callable(trace_config_ctx.url_filter)
-                else remove_url_credentials(str(params.url)),
-            }
-            for key, value in attributes.items():
-                trace_config_ctx.span.set_attribute(key, value)
 
         trace_config_ctx.token = context_api.attach(
             trace.set_span_in_context(trace_config_ctx.span)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -180,7 +180,11 @@ def create_trace_config(
 
         http_method = params.method.upper()
         request_span_name = f"HTTP {http_method}"
-        request_url = remove_url_credentials(trace_config_ctx.url_filter(params.url)) if callable(trace_config_ctx.url_filter) else remove_url_credentials(str(params.url)),
+        request_url = (
+            remove_url_credentials(trace_config_ctx.url_filter(params.url))
+            if callable(trace_config_ctx.url_filter)
+            else remove_url_credentials(str(params.url)),
+        )
 
         span_attributes = {
             SpanAttributes.HTTP_METHOD: http_method,
@@ -188,9 +192,7 @@ def create_trace_config(
         }
 
         trace_config_ctx.span = trace_config_ctx.tracer.start_span(
-            request_span_name,
-            kind=SpanKind.CLIENT,
-            attributes=span_attributes
+            request_span_name, kind=SpanKind.CLIENT, attributes=span_attributes
         )
 
         if callable(request_hook):


### PR DESCRIPTION
# Description

Makes span attributes available in aiohttp_client at span start.

Fixes #939

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing test suite ran successfully

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
