### PR TITLE
[1078] datadog-context-propagator: allow injecting non-recording span

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     ddtrace>=0.34.0,<0.47.0
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
-    opentelemetry-semantic-conventions == 0.30b0
+    opentelemetry-semantic-conventions == 0.30b1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -94,25 +94,25 @@ class DatadogFormat(TextMapPropagator):
         span_context = span.get_span_context()
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
-        sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0
+        sampled = (trace.TraceFlags.SAMPLED & span_context.trace_flags) != 0
         setter.set(
             carrier,
             self.TRACE_ID_KEY,
-            format_trace_id(span.context.trace_id),
+            format_trace_id(span_context.trace_id),
         )
         setter.set(
-            carrier, self.PARENT_ID_KEY, format_span_id(span.context.span_id)
+            carrier, self.PARENT_ID_KEY, format_span_id(span_context.span_id)
         )
         setter.set(
             carrier,
             self.SAMPLING_PRIORITY_KEY,
             str(constants.AUTO_KEEP if sampled else constants.AUTO_REJECT),
         )
-        if constants.DD_ORIGIN in span.context.trace_state:
+        if constants.DD_ORIGIN in span_context.trace_state:
             setter.set(
                 carrier,
                 self.ORIGIN_KEY,
-                span.context.trace_state[constants.DD_ORIGIN],
+                span_context.trace_state[constants.DD_ORIGIN],
             )
 
     @property

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -520,7 +520,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
 
             # give some time for exporter to loop
             # since wait is mocked it should return immediately
-            time.sleep(0.2)
+            time.sleep(0.1)
             mock_wait_calls = list(mock_wait.mock_calls)
 
             # find the index of the call that processed the singular span

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -520,7 +520,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
 
             # give some time for exporter to loop
             # since wait is mocked it should return immediately
-            time.sleep(0.1)
+            time.sleep(0.2)
             mock_wait_calls = list(mock_wait.mock_calls)
 
             # find the index of the call that processed the singular span

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -155,7 +155,7 @@ class TestDatadogFormat(unittest.TestCase):
             trace_id=trace_id,
             span_id=span_id,
             is_remote=True,
-            trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED)
+            trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
         span = trace_api.NonRecordingSpan(span_context)
 
@@ -176,7 +176,6 @@ class TestDatadogFormat(unittest.TestCase):
         self.assertEqual(
             carrier.get(FORMAT.ORIGIN_KEY), self.serialized_origin
         )
-
 
     def test_sampling_priority_auto_reject(self):
         """Test sampling priority rejected."""

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -235,7 +235,7 @@ class TestDatadogFormat(unittest.TestCase):
                             is_remote=False,
                             trace_flags=1,
                             trace_state={constants.DD_ORIGIN: 0},
-                        )
+                        ),
                     }
                 )
             }

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -235,10 +235,7 @@ class TestDatadogFormat(unittest.TestCase):
                             is_remote=False,
                             trace_flags=1,
                             trace_state={constants.DD_ORIGIN: 0},
-                        ),
-                        # "context.trace_flags": 0,
-                        # "context.trace_id": 1,
-                        # "context.trace_state": {constants.DD_ORIGIN: 0},
+                        )
                     }
                 )
             }

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -156,6 +156,9 @@ class TestDatadogFormat(unittest.TestCase):
             span_id=span_id,
             is_remote=True,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
+            trace_state=trace_api.TraceState(
+                [(constants.DD_ORIGIN, self.serialized_origin)]
+            ),
         )
         span = trace_api.NonRecordingSpan(span_context)
 
@@ -164,7 +167,7 @@ class TestDatadogFormat(unittest.TestCase):
         FORMAT.inject(carrier, context=context)
 
         self.assertEqual(
-            span[FORMAT.TRACE_ID_KEY], propagator.format_trace_id(trace_id)
+            carrier[FORMAT.TRACE_ID_KEY], propagator.format_trace_id(trace_id)
         )
         self.assertEqual(
             carrier[FORMAT.PARENT_ID_KEY], propagator.format_span_id(span_id)
@@ -226,10 +229,16 @@ class TestDatadogFormat(unittest.TestCase):
             **{
                 "return_value": Mock(
                     **{
-                        "get_span_context.return_value": None,
-                        "context.trace_flags": 0,
-                        "context.trace_id": 1,
-                        "context.trace_state": {constants.DD_ORIGIN: 0},
+                        "get_span_context.return_value": trace_api.SpanContext(
+                            trace_id=1,
+                            span_id=2,
+                            is_remote=False,
+                            trace_flags=1,
+                            trace_state={constants.DD_ORIGIN: 0},
+                        ),
+                        # "context.trace_flags": 0,
+                        # "context.trace_id": 1,
+                        # "context.trace_state": {constants.DD_ORIGIN: 0},
                     }
                 )
             }

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,9 @@ envlist =
     py3{6,7,8,9,10}-test-instrumentation-logging
     pypy3-test-instrumentation-logging
 
+    ; opentelemetry-exporter-datadog
+    py3{6,7,8,9,10}-test-exporter-datadog
+
     ; opentelemetry-exporter-richconsole
     py3{6,7,8,9,10}-test-exporter-richconsole
 
@@ -288,6 +291,7 @@ changedir =
   test-sdkextension-aws: sdk-extension/opentelemetry-sdk-extension-aws/tests
   test-propagator-aws: propagator/opentelemetry-propagator-aws-xray/tests
   test-propagator-ot-trace: propagator/opentelemetry-propagator-ot-trace/tests
+  test-exporter-datadog: exporter/opentelemetry-exporter-datadog/tests
   test-exporter-richconsole: exporter/opentelemetry-exporter-richconsole/tests
 
 commands_pre =
@@ -369,6 +373,8 @@ commands_pre =
   aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
 
   aiopg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg[test]
+
+  datadog: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
 
   richconsole: pip install flaky {toxinidir}/exporter/opentelemetry-exporter-richconsole[test]
 
@@ -470,6 +476,7 @@ commands_pre =
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-httpx[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aws-lambda[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-datadog[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-richconsole[test]
   python -m pip install -e {toxinidir}/sdk-extension/opentelemetry-sdk-extension-aws[test]
   python -m pip install -e {toxinidir}/propagator/opentelemetry-propagator-aws-xray[test]


### PR DESCRIPTION
# Description

Fixes an issue with datadog-context-propagator where a non-recording span will fail to inject.

I am aware that the exporter is now deprecated but the fix is for the context propagator, which should arguably be moved to `propagator/` directory but that should likely be done separately. In order to run tests and linter for this fix I had to re-add the exporter to `tox.ini`. I'll let the admins let me know how we want to continue with this...


Fixes: #1078

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `tox -e py39-test-exporter-datadog`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
