### PR TITLE
use sqlalchemy module name not engine. fixes #922

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1055](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1055))
 - Refactoring custom header collection API for consistency
   ([#1064](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1064))
+- `opentelemetry-instrumentation-sqlalchemy` will correctly report `otel.library.name`
+  ([#1086](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1086))
 
 ### Added
 - `opentelemetry-instrument` and `opentelemetry-bootstrap` now include a `--version` flag

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -104,7 +104,7 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
 
         if kwargs.get("engine") is not None:
             return EngineTracer(
-                _get_tracer(kwargs.get("engine"), tracer_provider),
+                _get_tracer(tracer_provider),
                 kwargs.get("engine"),
                 kwargs.get("enable_commenter", False),
             )

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/package.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/package.py
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+_instrumenting_module_name = "opentelemetry.instrumentation.sqlalchemy"
 
 _instruments = ("sqlalchemy",)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -70,6 +70,10 @@ class TestSqlalchemyInstrumentation(TestBase):
             self.assertEqual(len(spans), 1)
             self.assertEqual(spans[0].name, "SELECT :memory:")
             self.assertEqual(spans[0].kind, trace.SpanKind.CLIENT)
+            self.assertEqual(
+                spans[0].instrumentation_scope.name,
+                "opentelemetry.instrumentation.sqlalchemy",
+            )
 
         asyncio.get_event_loop().run_until_complete(run())
 
@@ -104,6 +108,10 @@ class TestSqlalchemyInstrumentation(TestBase):
         self.assertEqual(len(spans), 1)
         self.assertEqual(spans[0].name, "SELECT :memory:")
         self.assertEqual(spans[0].kind, trace.SpanKind.CLIENT)
+        self.assertEqual(
+            spans[0].instrumentation_scope.name,
+            "opentelemetry.instrumentation.sqlalchemy",
+        )
 
     def test_custom_tracer_provider(self):
         provider = TracerProvider(
@@ -154,6 +162,10 @@ class TestSqlalchemyInstrumentation(TestBase):
             self.assertEqual(len(spans), 1)
             self.assertEqual(spans[0].name, "SELECT :memory:")
             self.assertEqual(spans[0].kind, trace.SpanKind.CLIENT)
+            self.assertEqual(
+                spans[0].instrumentation_scope.name,
+                "opentelemetry.instrumentation.sqlalchemy",
+            )
 
         asyncio.get_event_loop().run_until_complete(run())
 


### PR DESCRIPTION
# Description

Bug fix for module name emitted by sqlalchemy.

Other instrumentation libraries appear to be calling `get_tracer` with `__name__` but the [API docs](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html#opentelemetry.trace.TracerProvider.get_tracer) seems to recommend against this.

Fixes #922 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test cases for `instrumentation_scope.name`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
