### PR TITLE
Narrow protobuf dependency to exclude protobuf >= 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.12.0rc1-0.31b0...HEAD)
 
+### Fixed
+- `opentelemetry-instrumentation-grpc` narrow protobuf dependency to exclude protobuf >= 4
+  ([1109](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1109))
+
 ## [1.12.0rc1-0.31b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc1-0.31b0) - 2022-05-17
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,5 +13,5 @@ readme-renderer~=24.0
 bleach==4.1.0 # transient dependency for readme-renderer
 grpcio-tools==1.29.0
 mypy-protobuf>=1.23
-protobuf>=3.13.0
+protobuf~=3.13
 markupsafe==2.0.1

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
 test =
     opentelemetry-test-utils == 0.31b0
     opentelemetry-sdk ~= 1.3
-    protobuf >= 3.13.0
+    protobuf ~= 3.13
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -493,7 +493,7 @@ deps =
   sqlalchemy ~= 1.4
   redis ~= 4.2
   celery[pytest] >= 4.0, < 6.0
-  protobuf>=3.13.0
+  protobuf~=3.13
   requests==2.25.0
   pyodbc~=4.0.30
   flaky==3.7.0


### PR DESCRIPTION
This is a stop-gap until the generated code can be updated with a newer
version of protoc, as required by the protobuf 4.x release.

# Description

`protobuf` 4.x requires that the generated files be generated with a newer version of protoc than has been used.

This is a historical breakage (i.e. affects previously released versions), so this is a simple fix that could be trivially backported to previous releases if desired.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/2717 (No corresponding bug lodged here)

The failure is visible in CI run for #1108 though.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] CI run
- [x] pip

## Pip Test

In a clean venv, with opentelementy-python main at .\open-telemetry-python, and this branch at \opentelemetry-python-contrib:
```
python -m pip install --upgrade --upgrade-strategy eager -e .\opentelemetry-python-contrib\instrumentation\opentelemetry-instrumentation-grpc[test] .\opentelemetry-python-contrib\opentelemetry-instrumentation\ .\opentelemetry-python\opentelemetry-semantic-conventions\ .\opentelemetry-python\opentelemetry-api\ .\opentelemetry-python\opentelemetry-sdk\  protobuf>4
```
passes.

WIth this PR, it fails:
```
ERROR: Cannot install opentelemetry-instrumentation-grpc[test]==0.31b0 and protobuf>4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested protobuf>4
    opentelemetry-instrumentation-grpc[test] 0.31b0 depends on protobuf~=3.13
```

Note that right now, this test must explicitly specify `protobuf>4` because the protobuf 4.x release package has been yanked, so it's no longer selected by default. Had this not been done, the test for this PR would have successfully installed, but chosen an earlier version of protobuf.

# Does This PR Require a Core Repo Change?

- [x] No.

There's a matching PR at https://github.com/open-telemetry/opentelemetry-python/pull/2720 though.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Changelogs have been updated