### PR TITLE
Unpin the version of requests

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
@@ -41,7 +41,7 @@ packages=find_namespace:
 install_requires =
     snappy >= 2.8
     protobuf >= 3.13.0
-    requests == 2.25.0
+    requests >= 2.25.0
     opentelemetry-api == 0.18.dev0
     opentelemetry-sdk == 0.18.dev0
     python-snappy >= 0.5.4


### PR DESCRIPTION
# Description

This unpins the version of requests in
`opentelemetry-exporter-prometheus-remote-write`.  Having the version
pinned in a project that uses requests for other things can cause
unresolvable dependency issues.  This is a trivial change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.