### PR TITLE
Set otlp-proto-grpc as the default metrics exporter for auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1082](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1082))
 - Added `opentelemetry-instrumention-confluent-kafka`
   ([#1111](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1111))
+- Set otlp-proto-grpc as the default metrics exporter for auto-instrumentation
+  ([#1127](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1127))
 
 
 ## [1.12.0rc1-0.31b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc1-0.31b0) - 2022-05-17

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -14,7 +14,10 @@
 
 import os
 
-from opentelemetry.environment_variables import OTEL_TRACES_EXPORTER
+from opentelemetry.environment_variables import (
+    OTEL_METRICS_EXPORTER,
+    OTEL_TRACES_EXPORTER,
+)
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
 
@@ -32,3 +35,4 @@ class OpenTelemetryDistro(BaseDistro):
     # pylint: disable=no-self-use
     def _configure(self, **kwargs):
         os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc")
+        os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp_proto_grpc")


### PR DESCRIPTION
# Description

In opentelemetry-distro, set `otlp-grpc-proto` as the default value for `OTLP_METRICS_EXPORTER`. This make it the default when using `opentelemetry-instrument`, similar to tracing.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Install the change in local venv and ran:

```sh
$ opentelemetry-instrument ipython
Python 3.9.12 (main, Mar 24 2022, 13:02:21)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.24.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from opentelemetry import metrics

In [2]: metrics.get_meter_provider()._sdk_config.metric_readers[0]._exporter
Out[2]: <opentelemetry.exporter.otlp.proto.grpc.metric_exporter.OTLPMetricExporter at 0x7fb4387ecdf0>
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- ~[ ] Documentation has been updated~ WIP, see https://github.com/open-telemetry/opentelemetry-python/issues/2732
