### PR TITLE
pyramid: Only categorize 400s and 500s exceptions as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.12.0rc1-0.31b0...HEAD)
+- Pyramid: Only categorize 400s and 500s exceptions as errors
+  ([#1037](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1037))
 
 ### Fixed
 - Fix bug in system metrics by checking their configuration

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -15,7 +15,7 @@
 from logging import getLogger
 
 from pyramid.events import BeforeTraversal
-from pyramid.httpexceptions import HTTPException
+from pyramid.httpexceptions import HTTPError, HTTPException
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 
@@ -198,7 +198,9 @@ def trace_tween_factory(handler, registry):
 
                 activation = request.environ.get(_ENVIRON_ACTIVATION_KEY)
 
-                if isinstance(response, HTTPException):
+                # Only considering HTTPClientError and HTTPServerError
+                # to make sure HTTPRedirection is not reported as error
+                if isinstance(response, HTTPError):
                     activation.__exit__(
                         type(response),
                         response,

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
@@ -26,6 +26,8 @@ class InstrumentationTest:
             raise exc.HTTPInternalServerError()
         if helloid == 302:
             raise exc.HTTPFound()
+        if helloid == 204:
+            raise exc.HTTPNoContent()
         if helloid == 900:
             raise NotImplementedError()
         return Response("Hello: " + str(helloid))

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
@@ -24,6 +24,8 @@ class InstrumentationTest:
         helloid = int(request.matchdict["helloid"])
         if helloid == 500:
             raise exc.HTTPInternalServerError()
+        if helloid == 302:
+            raise exc.HTTPFound()
         if helloid == 900:
             raise NotImplementedError()
         return Response("Hello: " + str(helloid))

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -115,6 +115,27 @@ class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
 
+    def test_204_empty_response_is_not_an_error(self):
+        tween_list = "pyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        self._common_initialization(config)
+        resp = self.client.get("/hello/204")
+        self.assertEqual(204, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].status.status_code, StatusCode.UNSET)
+
+        PyramidInstrumentor().uninstrument()
+
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/204")
+        self.assertEqual(204, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
 
 class TestWrappedWithOtherFramework(
     InstrumentationTest, TestBase, WsgiTestBase

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -22,6 +22,7 @@ from opentelemetry.test.globals_test import reset_trace_globals
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import StatusCode
 from opentelemetry.util.http import (
     OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
     OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
@@ -92,6 +93,27 @@ class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
         self.assertEqual(
             config.registry.__name__, __name__.rsplit(".", maxsplit=1)[0]
         )
+
+    def test_redirect_response_is_not_an_error(self):
+        tween_list = "pyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        self._common_initialization(config)
+        resp = self.client.get("/hello/302")
+        self.assertEqual(302, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].status.status_code, StatusCode.UNSET)
+
+        PyramidInstrumentor().uninstrument()
+
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/302")
+        self.assertEqual(302, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
 
 
 class TestWrappedWithOtherFramework(


### PR DESCRIPTION
# Description

Pyramid instrumentation was categorizing all `HTTPException`s including 300s (redirects) and some 200s (for example, 204 No Content) as errors. This pull request updates this functionality to only categorize `HTTPError`s as errors. [List of exceptions in Pyramid](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html)

Fixes [#1037](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1037)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests to check that redirect and no content exceptions are not categorized as errors to `pyramid-redirect-error-fix/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py`

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
