### PR TITLE
Pyramid: only categorize 500 exceptions as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.12.0rc1-0.31b0...HEAD)
-- Pyramid: Only categorize 400s and 500s exceptions as errors
+- Pyramid: Only categorize 500s server exceptions as errors
   ([#1037](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1037))
 
 ### Fixed

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -15,7 +15,7 @@
 from logging import getLogger
 
 from pyramid.events import BeforeTraversal
-from pyramid.httpexceptions import HTTPServerError, HTTPException
+from pyramid.httpexceptions import HTTPException, HTTPServerError
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -15,7 +15,7 @@
 from logging import getLogger
 
 from pyramid.events import BeforeTraversal
-from pyramid.httpexceptions import HTTPError, HTTPException
+from pyramid.httpexceptions import HTTPServerError, HTTPException
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 
@@ -198,9 +198,9 @@ def trace_tween_factory(handler, registry):
 
                 activation = request.environ.get(_ENVIRON_ACTIVATION_KEY)
 
-                # Only considering HTTPClientError and HTTPServerError
-                # to make sure HTTPRedirection is not reported as error
-                if isinstance(response, HTTPError):
+                # Only considering HTTPServerError
+                # to make sure 200, 300 and 400 exceptions are not reported as error
+                if isinstance(response, HTTPServerError):
                     activation.__exit__(
                         type(response),
                         response,

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/pyramid_base_test.py
@@ -24,6 +24,8 @@ class InstrumentationTest:
         helloid = int(request.matchdict["helloid"])
         if helloid == 500:
             raise exc.HTTPInternalServerError()
+        if helloid == 404:
+            raise exc.HTTPNotFound()
         if helloid == 302:
             raise exc.HTTPFound()
         if helloid == 204:

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -136,6 +136,27 @@ class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
 
+    def test_400s_response_is_not_an_error(self):
+        tween_list = "pyramid.tweens.excview_tween_factory"
+        config = Configurator(settings={"pyramid.tweens": tween_list})
+        self._common_initialization(config)
+        resp = self.client.get("/hello/404")
+        self.assertEqual(404, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].status.status_code, StatusCode.UNSET)
+
+        PyramidInstrumentor().uninstrument()
+
+        self.config = Configurator()
+
+        self._common_initialization(self.config)
+
+        resp = self.client.get("/hello/404")
+        self.assertEqual(404, resp.status_code)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
 
 class TestWrappedWithOtherFramework(
     InstrumentationTest, TestBase, WsgiTestBase


### PR DESCRIPTION
# Description

Update to the previous pull on the same topic according to discussion in https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1037#issuecomment-1157949209

400 exceptions no longer generate error status as per [spec here](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#status)

Updated the tests to include the case for 400s errors.

Fixes #1037

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a text to check that 404 response doesn't generate an error 

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
