### PR TITLE
Update DataDog exporter's `semantic-conventions` dependency

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/setup.cfg
+++ b/exporter/opentelemetry-exporter-datadog/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     ddtrace>=0.34.0,<0.47.0
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
-    opentelemetry-semantic-conventions == 0.30b0
+    opentelemetry-semantic-conventions == 0.31b0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
# Description

Update DataDog exporter's `semantic-conventions` dependency to `0.31b0` (as do all the other exporters).

It was causing a conflict when running the `scripts/eachdist.py develop` script
otherwise.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Cloned the repo fresh in `/tmp`. Attempted `python3 scripts/eachdist.py develop` in a fresh virtualenv. Did not work (failed with dependency conflict). Ran again to be sure. Applied this branch, ran again - worked.

Ran `tox` afterwards, just to be sure (but I don't think it has any DataDog tests).

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated - N/A - minor dependency change
- [ ] Unit tests have been added - N/A
- [ ] Documentation has been updated - N/A
