### PR TITLE
Instrument RedisCluster clients

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/docker-compose.yml
+++ b/tests/opentelemetry-docker-tests/tests/docker-compose.yml
@@ -27,6 +27,17 @@ services:
       image: redis:4.0-alpine
       ports:
         - "127.0.0.1:6379:6379"
+  otrediscluster:
+      image: grokzen/redis-cluster:6.2.0
+      environment:
+          - IP=0.0.0.0
+      ports:
+          - "127.0.0.1:7000:7000"
+          - "127.0.0.1:7001:7001"
+          - "127.0.0.1:7002:7002"
+          - "127.0.0.1:7003:7003"
+          - "127.0.0.1:7004:7004"
+          - "127.0.0.1:7005:7005"
   otjaeger:
     image: jaegertracing/all-in-one:1.8
     environment:

--- a/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
@@ -124,6 +124,70 @@ class TestRedisInstrument(TestBase):
         self.assertEqual(child_span.name, "GET")
 
 
+class TestRedisClusterInstrument(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.redis_client = redis.cluster.RedisCluster(host="localhost", port=7000)
+        self.redis_client.flushall()
+        RedisInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+    def tearDown(self):
+        super().tearDown()
+        RedisInstrumentor().uninstrument()
+
+    def _check_span(self, span, name):
+        self.assertEqual(span.name, name)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
+
+    def test_basics(self):
+        self.assertIsNone(self.redis_client.get("cheese"))
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self._check_span(span, "GET")
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.DB_STATEMENT), "GET cheese"
+        )
+        self.assertEqual(span.attributes.get("db.redis.args_length"), 2)
+
+    def test_pipeline_traced(self):
+        with self.redis_client.pipeline(transaction=False) as pipeline:
+            pipeline.set("blah", 32)
+            pipeline.rpush("foo", "éé")
+            pipeline.hgetall("xxx")
+            pipeline.execute()
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self._check_span(span, "SET RPUSH HGETALL")
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.DB_STATEMENT),
+            "SET blah 32\nRPUSH foo éé\nHGETALL xxx",
+        )
+        self.assertEqual(span.attributes.get("db.redis.pipeline_length"), 3)
+
+    def test_parent(self):
+        """Ensure OpenTelemetry works with redis."""
+        ot_tracer = trace.get_tracer("redis_svc")
+
+        with ot_tracer.start_as_current_span("redis_get"):
+            self.assertIsNone(self.redis_client.get("cheese"))
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        child_span, parent_span = spans[0], spans[1]
+
+        # confirm the parenting
+        self.assertIsNone(parent_span.parent)
+        self.assertIs(child_span.parent, parent_span.get_span_context())
+
+        self.assertEqual(parent_span.name, "redis_get")
+        self.assertEqual(parent_span.instrumentation_info.name, "redis_svc")
+
+        self.assertEqual(child_span.name, "GET")
+
+
 def async_call(coro):
     loop = asyncio.get_event_loop()
     return loop.run_until_complete(coro)
@@ -216,6 +280,75 @@ class TestAsyncRedisInstrument(TestBase):
         self.assertEqual(
             span.attributes.get(SpanAttributes.DB_STATEMENT), "SET b 2"
         )
+
+    def test_parent(self):
+        """Ensure OpenTelemetry works with redis."""
+        ot_tracer = trace.get_tracer("redis_svc")
+
+        with ot_tracer.start_as_current_span("redis_get"):
+            self.assertIsNone(async_call(self.redis_client.get("cheese")))
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        child_span, parent_span = spans[0], spans[1]
+
+        # confirm the parenting
+        self.assertIsNone(parent_span.parent)
+        self.assertIs(child_span.parent, parent_span.get_span_context())
+
+        self.assertEqual(parent_span.name, "redis_get")
+        self.assertEqual(parent_span.instrumentation_info.name, "redis_svc")
+
+        self.assertEqual(child_span.name, "GET")
+
+
+class TestAsyncRedisClusterInstrument(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.redis_client = redis.asyncio.cluster.RedisCluster(host="localhost", port=7000)
+        async_call(self.redis_client.flushall())
+        RedisInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+    def tearDown(self):
+        super().tearDown()
+        RedisInstrumentor().uninstrument()
+
+    def _check_span(self, span, name):
+        self.assertEqual(span.name, name)
+        self.assertIs(span.status.status_code, trace.StatusCode.UNSET)
+
+    def test_basics(self):
+        self.assertIsNone(async_call(self.redis_client.get("cheese")))
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self._check_span(span, "GET")
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.DB_STATEMENT), "GET cheese"
+        )
+        self.assertEqual(span.attributes.get("db.redis.args_length"), 2)
+
+    def test_pipeline_traced(self):
+        async def pipeline_simple():
+            async with self.redis_client.pipeline(
+                transaction=False
+            ) as pipeline:
+                pipeline.set("blah", 32)
+                pipeline.rpush("foo", "éé")
+                pipeline.hgetall("xxx")
+                await pipeline.execute()
+
+        async_call(pipeline_simple())
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self._check_span(span, "SET RPUSH HGETALL")
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.DB_STATEMENT),
+            "SET blah 32\nRPUSH foo éé\nHGETALL xxx",
+        )
+        self.assertEqual(span.attributes.get("db.redis.pipeline_length"), 3)
 
     def test_parent(self):
         """Ensure OpenTelemetry works with redis."""

--- a/tox.ini
+++ b/tox.ini
@@ -500,7 +500,7 @@ deps =
   psycopg2 ~= 2.8.4
   aiopg >= 0.13.0, < 1.3.0
   sqlalchemy ~= 1.4
-  redis ~= 4.2
+  redis ~= 4.3
   celery[pytest] >= 4.0, < 6.0
   protobuf~=3.13
   requests==2.25.0


### PR DESCRIPTION
# Description

This PR adds instrumentation to RedisCluster clients in the Redis library. ([redis.cluster.RedisCluster](https://github.com/redis/redis-py/blob/master/redis/cluster.py), [redis.asyncio.cluster.RedisCluster](https://github.com/redis/redis-py/blob/master/redis/asyncio/cluster.py))

Closes #1167 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Functional tests are added to `test_redis_functional.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
