### PR TITLE
Add psycopg2 native tags to sqlcommenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1187](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1187))
 - SQLCommenter semicolon bug fix
   ([#1200](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1200/files))
+- Add psycopg2 native tags to sqlcommenter
+  ([#1203](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1203))
 
 ### Added
 - `opentelemetry-instrumentation-redis` add support to instrument RedisCluster clients

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -414,7 +414,7 @@ class CursorTracer:
             if args and self._commenter_enabled:
                 try:
                     args_list = list(args)
-                    psycopg2_attributes = dict(
+                    commenter_data = dict(
                         # Psycopg2/framework information
                         db_driver='psycopg2:%s' % self._connect_module.__version__,
                         dbapi_threadsafety=self._connect_module.threadsafety,
@@ -422,11 +422,11 @@ class CursorTracer:
                         libpq_version=self._connect_module.__libpq_version__,
                         driver_paramstyle=self._connect_module.paramstyle,
             )
-                    commenter_data = {}
+                    if self._commenter_options.get('opentelemetry_values', True):
+                        commenter_data.update(**_get_opentelemetry_values())
 
-                    commenter_data.update(_get_opentelemetry_values())
                     # Filter down to just the requested attributes.
-                    data = {k: v for k, v in psycopg2_attributes.items() if self._commenter_options.get(k)}
+                    commenter_data = {k: v for k, v in commenter_data.items() if self._commenter_options.get(k, True)}
                     statement = _add_sql_comment(
                         args_list[0], **commenter_data
                     )

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -229,8 +229,20 @@ class TestDBApiIntegration(TestBase):
         )
 
     def test_executemany_comment(self):
+
+        connect_module = mock.MagicMock()
+        connect_module.__version__ = mock.MagicMock()
+        connect_module.__libpq_version__ = 123
+        connect_module.apilevel = 123
+        connect_module.threadsafety = 123
+        connect_module.paramstyle = "test"
+
         db_integration = dbapi.DatabaseApiIntegration(
-            "testname", "testcomponent", enable_commenter=True
+            "testname",
+            "testcomponent",
+            enable_commenter=True,
+            commenter_options={"db_driver": False, "dbapi_level": False},
+            connect_module=connect_module,
         )
         mock_connection = db_integration.wrapped_connection(
             mock_connect, {}, {}
@@ -239,7 +251,7 @@ class TestDBApiIntegration(TestBase):
         cursor.executemany("Select 1;")
         self.assertRegex(
             cursor.query,
-            r"Select 1 /\*traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
+            r"Select 1 /\*dbapi_threadsafety=123,driver_paramstyle='test',libpq_version=123,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
         )
 
     def test_callproc(self):

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -18,6 +18,62 @@ using ``Psycopg2Instrumentor``.
 
 .. _Psycopg: http://initd.org/psycopg/
 
+SQLCOMMENTER
+*****************************************
+You can optionally configure Psycopg2 instrumentation to enable sqlcommenter which enriches
+the query with contextual information.
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry.instrumentation.django import Psycopg2Instrumentor
+
+    Psycopg2Instrumentor().instrument(enable_commenter=True, commenter_options={})
+
+
+For example,
+::
+
+   Invoking cursor.execute("select * from auth_users") will lead to sql query "select * from auth_users" but when SQLCommenter is enabled
+   the query will get appended with some configurable tags like "select * from auth_users /*tag=value*/;"
+
+
+SQLCommenter Configurations
+***************************
+We can configure the tags to be appended to the sqlquery log by adding configuration inside commenter_options(default:{}) keyword
+
+db_driver = True(Default) or False
+
+For example,
+::
+Enabling this flag will add psycopg2 and it's version which is /*psycopg2%%3A2.9.3*/
+
+dbapi_threadsafety = True(Default) or False
+
+For example,
+::
+Enabling this flag will add threadsafety /*dbapi_threadsafety=2*/
+
+dbapi_level = True(Default) or False
+
+For example,
+::
+Enabling this flag will add dbapi_level /*dbapi_level='2.0'*/
+
+libpq_version = True(Default) or False
+
+For example,
+::
+Enabling this flag will add libpq_version /*libpq_version=140001*/
+
+driver_paramstyle = True(Default) or False
+
+For example,
+::
+Enabling this flag will add driver_paramstyle /*driver_paramstyle='pyformat'*/
+
 Usage
 -----
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -77,6 +77,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
         enable_sqlcommenter = kwargs.get("enable_commenter", False)
+        commenter_options = kwargs.get("commenter_options", {})
         dbapi.wrap_connect(
             __name__,
             psycopg2,
@@ -87,6 +88,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
             tracer_provider=tracer_provider,
             db_api_integration_factory=DatabaseApiIntegration,
             enable_commenter=enable_sqlcommenter,
+            commenter_options=commenter_options,
         )
 
     def _uninstrument(self, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -28,7 +28,7 @@ Usage
 
 .. code:: python
 
-    from opentelemetry.instrumentation.django import Psycopg2Instrumentor
+    from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 
     Psycopg2Instrumentor().instrument(enable_commenter=True, commenter_options={})
 
@@ -73,6 +73,12 @@ driver_paramstyle = True(Default) or False
 For example,
 ::
 Enabling this flag will add driver_paramstyle /*driver_paramstyle='pyformat'*/
+
+opentelemetry_values = True(Default) or False
+
+For example,
+::
+Enabling this flag will add traceparent values /*traceparent='00-03afa25236b8cd948fa853d67038ac79-405ff022e8247c46-01'*/
 
 Usage
 -----

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
@@ -50,5 +50,5 @@ class TestFunctionalPsycopg(TestBase):
         self._cursor.execute("SELECT  1;")
         self.assertRegex(
             self._cursor.query.decode("ascii"),
-            r"SELECT  1 /\*traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
+            r"SELECT  1 /\*db_driver='psycopg2(.*)',dbapi_level='\d.\d',dbapi_threadsafety=\d,driver_paramstyle=(.*),libpq_version=\d*,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
         )


### PR DESCRIPTION
# Description

This PR adds options to add additional tags such as psycopg2 version, libpq_version,etc to the psycopg2 sqlcommenter.

## Usage
This is made configurable using commenter_options keyword

```python
Psycopg2Instrumentor()._instrument(tracer_provider=provider, enable_commenter=True, commenter_options={'db_driver':True})
```

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Had modified existing testcases to accomadate this change

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
