### PR TITLE
Fix Flask instrumentation doc link

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-flask/README.rst
@@ -61,6 +61,6 @@ Flask Request object reference: https://flask.palletsprojects.com/en/2.0.x/api/#
 References
 ----------
 
-* `OpenTelemetry Flask Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/stable/instrumentation/flask/flask.html>`_
+* `OpenTelemetry Flask Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/flask/flask.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_


### PR DESCRIPTION
# Description

The link to the Flask instrumentation documentation is currently broken. This PR fixes the link.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?

Documentation change, testing not relevant.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Documentation has been updated
