### PR TITLE
aiohttp-client: Fix producing additional spans with each newly created ClientSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-boto3sqs` Make propagation compatible with other SQS instrumentations, add 'messaging.url' span attribute, and fix missing package dependencies.
   ([#1234](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1234))
-
 - restoring metrics in django framework
   ([#1208](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1208))
+- `opentelemetry-instrumentation-aiohttp-client` Fix producing additional spans with each newly created ClientSession
+- ([#1246](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1246))
 
 ## [1.12.0-0.33b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0-0.33b0) - 2022-08-08
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -262,7 +262,9 @@ def _instrument(
     url_filter: _UrlFilterT = None,
     request_hook: _RequestHookT = None,
     response_hook: _ResponseHookT = None,
-    trace_configs: typing.Optional[aiohttp.TraceConfig] = None,
+    trace_configs: typing.Optional[
+        typing.Sequence[aiohttp.TraceConfig]
+    ] = None,
 ):
     """Enables tracing of all ClientSessions
 
@@ -270,16 +272,15 @@ def _instrument(
     the session's trace_configs.
     """
 
-    if trace_configs is None:
-        trace_configs = []
+    trace_configs = trace_configs or ()
 
     # pylint:disable=unused-argument
     def instrumented_init(wrapped, instance, args, kwargs):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        if kwargs.get("trace_configs"):
-            trace_configs.extend(kwargs.get("trace_configs"))
+        client_trace_configs = list(kwargs.get("trace_configs", ()))
+        client_trace_configs.extend(trace_configs)
 
         trace_config = create_trace_config(
             url_filter=url_filter,
@@ -288,9 +289,9 @@ def _instrument(
             tracer_provider=tracer_provider,
         )
         trace_config._is_instrumented_by_opentelemetry = True
-        trace_configs.append(trace_config)
+        client_trace_configs.append(trace_config)
 
-        kwargs["trace_configs"] = trace_configs
+        kwargs["trace_configs"] = client_trace_configs
         return wrapped(*args, **kwargs)
 
     wrapt.wrap_function_wrapper(


### PR DESCRIPTION
# Description

TraceConfigs that are created when a new ClientSession is created were incorrectly added to the effectively global list of trace configs that can be passed as argument to the instrumentor's `instrument` function. The global list then got inject into the arguments to create the ClientSession. With every TraceConfig in the global list an additional span got created per request.
This even happened when there wasn't passed any trace config list to the `instrument` function since as default an empty list was used.

Fixes #1207

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Adapted existing tests and added a new one.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
