### PR TITLE
Get rid of pymongo command in pymongo instrumentation span name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `opentelemetry-instrumentation-boto3sqs` Make propagation compatible with other SQS instrumentations, add 'messaging.url' span attribute, and fix missing package dependencies.
-  ([#1234](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1234))
+  ([#1234](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1234)) 
+- `opentelemetry-instrumentation-pymongo` Change span names to not contain queries but only database name and command name
+  ([#1247](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1247)) 
 - restoring metrics in django framework
   ([#1208](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1208))
 - `opentelemetry-instrumentation-aiohttp-client` Fix producing additional spans with each newly created ClientSession

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -121,7 +121,7 @@ class CommandTracer(monitoring.CommandListener):
         ):
             return
         command = event.command.get(event.command_name, "")
-        name = event.command_name
+        name = f"{event.database_name}.{event.command_name}" if event.database_name else event.command_name
         statement = event.command_name
         if command:
             statement += " " + str(command)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -122,7 +122,7 @@ class CommandTracer(monitoring.CommandListener):
             return
         command = event.command.get(event.command_name, "")
         name = event.database_name
-        name +=  "." + event.command_name
+        name += "." + event.command_name
         statement = event.command_name
         if command:
             statement += " " + str(command)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -124,7 +124,6 @@ class CommandTracer(monitoring.CommandListener):
         name = event.command_name
         statement = event.command_name
         if command:
-            name += "." + str(command)
             statement += " " + str(command)
 
         try:

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -121,7 +121,8 @@ class CommandTracer(monitoring.CommandListener):
         ):
             return
         command = event.command.get(event.command_name, "")
-        name = f"{event.database_name}.{event.command_name}" if event.database_name else event.command_name
+        name = event.database_name
+        name +=  "." + event.command_name
         statement = event.command_name
         if command:
             statement += " " + str(command)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -40,7 +40,6 @@ class TestPymongo(TestBase):
         )
         with patch:
             PymongoInstrumentor().instrument()
-
         self.assertTrue(mock_register.called)
 
     def test_started(self):
@@ -59,7 +58,7 @@ class TestPymongo(TestBase):
         # pylint: disable=protected-access
         span = command_tracer._pop_span(mock_event)
         self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
-        self.assertEqual(span.name, "command_name.find")
+        self.assertEqual(span.name, "database_name.command_name")
         self.assertEqual(span.attributes[SpanAttributes.DB_SYSTEM], "mongodb")
         self.assertEqual(
             span.attributes[SpanAttributes.DB_NAME], "database_name"
@@ -189,8 +188,7 @@ class TestPymongo(TestBase):
 
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
-
-        self.assertEqual(span.name, "command_name.123")
+        self.assertEqual(span.name, "database_name.command_name")
 
 
 class MockCommand:


### PR DESCRIPTION
As others have pointed out 
https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/341
by including the query within the span name we lead to very high cardinality which is too high to be useful and this can also lead to privacy concerns

This pull requests follows the logic found in the java and golang mongo instrumentations and does not include the entire command but the database name and command name within the span name

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1

https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] test_pymongo.py

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
