### PR TITLE
asyncpg: Use only the first word from query as a span name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+- `opentelemetry-instrumentation-asyncpg` Fix high cardinality in the span name
+  ([#1170](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1324))
+
 ### Added
 
 - `opentelemetry-instrumentation-grpc` add supports to filter requests to instrument. ([#1241](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1241))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - `opentelemetry-instrumentation-asyncpg` Fix high cardinality in the span name
-  ([#1170](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1324))
+  ([#1324](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1324))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1208](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1208))
 - `opentelemetry-instrumentation-aiohttp-client` Fix producing additional spans with each newly created ClientSession
 - ([#1246](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1246))
-- Add _is_openetlemetry_instrumented check in _InstrumentedFastAPI class
+- Add _is_opentelemetry_instrumented check in _InstrumentedFastAPI class
   ([#1313](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1313))
 - Fix uninstrumentation of existing app instances in FastAPI
   ([#1258](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1258))

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -133,6 +133,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
         exception = None
         params = getattr(instance, "_params", {})
         name = args[0] if args[0] else params.get("database", "postgresql")
+        name = name.split()[0]
 
         with self._tracer.start_as_current_span(
             name, kind=SpanKind.CLIENT

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -133,7 +133,11 @@ class AsyncPGInstrumentor(BaseInstrumentor):
         exception = None
         params = getattr(instance, "_params", {})
         name = args[0] if args[0] else params.get("database", "postgresql")
-        name = name.split()[0]
+
+        try:
+            name = name.split()[0]
+        except IndexError:
+            name = ""
 
         with self._tracer.start_as_current_span(
             name, kind=SpanKind.CLIENT

--- a/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
@@ -62,9 +62,9 @@ class TestFunctionalAsyncPG(TestBase):
         self.assertEqual(len(spans), 1)
         self.assertIs(StatusCode.UNSET, spans[0].status.status_code)
         self.check_span(spans[0])
-        self.assertEqual(spans[0].name, "SELECT 42;")
+        self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
-            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT 42;"
+            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT"
         )
 
     def test_instrumented_fetch_method_without_arguments(self, *_, **__):
@@ -189,9 +189,9 @@ class TestFunctionalAsyncPG_CaptureParameters(TestBase):
         self.assertIs(StatusCode.UNSET, spans[0].status.status_code)
 
         self.check_span(spans[0])
-        self.assertEqual(spans[0].name, "SELECT $1;")
+        self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
-            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT $1;"
+            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT"
         )
         self.assertEqual(
             spans[0].attributes["db.statement.parameters"], "('1',)"

--- a/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
@@ -64,7 +64,7 @@ class TestFunctionalAsyncPG(TestBase):
         self.check_span(spans[0])
         self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
-            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT"
+            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT 42;"
         )
 
     def test_instrumented_fetch_method_without_arguments(self, *_, **__):
@@ -72,6 +72,7 @@ class TestFunctionalAsyncPG(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
         self.check_span(spans[0])
+        self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
             spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT 42;"
         )
@@ -191,7 +192,7 @@ class TestFunctionalAsyncPG_CaptureParameters(TestBase):
         self.check_span(spans[0])
         self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
-            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT"
+            spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT $1;"
         )
         self.assertEqual(
             spans[0].attributes["db.statement.parameters"], "('1',)"
@@ -203,6 +204,7 @@ class TestFunctionalAsyncPG_CaptureParameters(TestBase):
         self.assertEqual(len(spans), 1)
 
         self.check_span(spans[0])
+        self.assertEqual(spans[0].name, "SELECT")
         self.assertEqual(
             spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT $1;"
         )


### PR DESCRIPTION
# Description

to reduce high cardinal value for a span name in the DB instrumentation use only the first word from the query.

Other DB instrumentations (e.g. psycopg2) do likewise.

Fixes #1170 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

tested locally with a simple endpoint which selects data from a local db

before:
![image](https://user-images.githubusercontent.com/8479133/189524047-21edf91a-eb4f-4c24-948f-fb341705b9a7.png)
after:
![image](https://user-images.githubusercontent.com/8479133/189524017-a85626cb-8b8f-4e10-bea4-dbac802a4d26.png)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
