### PR TITLE
Temporary fix for dd exporter publish 400 issue

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,5 +42,5 @@ DISTDIR=dist
  )
 )
 
-# FIXME: This is a temporary workaround.
+# FIXME: This is a temporary workaround, see #1357.
 rm -rf $DISTDIR/opentelemetry_exporter_datadog-0.30b0.tar.gz

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,3 +41,6 @@ DISTDIR=dist
    done
  )
 )
+
+# FIXME: This is a temporary workaround.
+rm -rf $DISTDIR/opentelemetry_exporter_datadog-0.30b0.tar.gz


### PR DESCRIPTION
# Description

The naming of the .tar.gz files used to be separated by - previously but with the new build tool they are _. It used to skip with a warning earlier with a message file already exists https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/2827866155/jobs/4470177468 but it fails now because the naming is mismatching https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/3131270761/jobs/5082435841. This is for the package datadog exporter we stopped accepting any changes. adding a skipping step for this exporter (thought already existed) would fix the issue.

Fixes #1355