### PR TITLE
Pin importlib-metadata version for celery tests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
@@ -36,6 +36,7 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-celery[instruments]",
   "opentelemetry-test-utils == 0.34b0",
+  "importlib-metadata==4.13.0",
   "pytest",
 ]
 


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1371


The `importlib-metadata` released a new 5.0 with breaking changes last week and it's breaking the workflows. The end user decides which version of `celery` and `importlib-metadata` to use so we only pin the version in tests until we this issue is fixed upstream. 