### PR TITLE
Requesting codeowner permission for opentelemetry-sdk-extension-aws

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -30,3 +30,4 @@ components:
 
   sdk-extension/opentelemetry-sdk-extension-aws:
     - NathanielRN
+    - Kausik-A


### PR DESCRIPTION
# Description
Requesting codeowner permission for `sdk-extension/opentelemetry-sdk-extension-aws`

Fixes # (issue)

none

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated `Not Applicable` 
- [ ] Unit tests have been added `Not Applicable` 
- [ ] Documentation has been updated `Not Applicable` 
