### PR TITLE
Detect log group name in EKS Resource Detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1369](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1369))
 - `opentelemetry-instrumentation-system-metrics` add supports to collect system thread count. ([#1339](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1339))
 - `opentelemetry-exporter-richconsole` Fixing RichConsoleExpoter to allow multiple traces, fixing duplicate spans and include resources ([#1336](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1336))
+- `opentelemetry-sdk-extension-aws` Detect log group name in EKS Resource detector. ([#1386](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1386))
 
 ## [1.13.0-0.34b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.13.0-0.34b0) - 2022-09-26
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/eks.py
@@ -121,14 +121,19 @@ class AwsEksResourceDetector(ResourceDetector):
                     "Neither cluster name nor container ID found on EKS process."
                 )
 
-            return Resource(
-                {
-                    ResourceAttributes.CLOUD_PROVIDER: CloudProviderValues.AWS.value,
-                    ResourceAttributes.CLOUD_PLATFORM: CloudPlatformValues.AWS_EKS.value,
-                    ResourceAttributes.K8S_CLUSTER_NAME: cluster_name,
-                    ResourceAttributes.CONTAINER_ID: container_id,
-                }
-            )
+            resource_attributes = {
+                ResourceAttributes.CLOUD_PROVIDER: CloudProviderValues.AWS.value,
+                ResourceAttributes.CLOUD_PLATFORM: CloudPlatformValues.AWS_EKS.value,
+                ResourceAttributes.K8S_CLUSTER_NAME: cluster_name,
+                ResourceAttributes.CONTAINER_ID: container_id
+            }
+
+            if cluster_name:
+                log_group_name = f"/aws/containerinsights/{cluster_name}/application"
+                resource_attributes[ResourceAttributes.AWS_LOG_GROUP_NAMES] = [log_group_name]
+
+            return Resource(resource_attributes)
+
         # pylint: disable=broad-except
         except Exception as exception:
             if self.raise_on_error:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
@@ -28,6 +28,7 @@ MockEksResourceAttributes = {
     ResourceAttributes.CLOUD_PLATFORM: CloudPlatformValues.AWS_EKS.value,
     ResourceAttributes.K8S_CLUSTER_NAME: "mock-cluster-name",
     ResourceAttributes.CONTAINER_ID: "a4d00c9dd675d67f866c786181419e1b44832d4696780152e61afd44a3e02856",
+    ResourceAttributes.AWS_LOG_GROUP_NAMES: ("/aws/containerinsights/mock-cluster-name/application",)
 }
 
 


### PR DESCRIPTION
# Description

Update EKS resource detector to detect log group name so that it is possible to link trace to CloudWatch logs. This is similar to a change in the Java equivalent of this resource detector: https://github.com/open-telemetry/opentelemetry-java-contrib/pull/533

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
