### PR TITLE
[WIP]Celery add support for anon tasks

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -132,6 +132,8 @@ def attach_span(task, task_id, span, is_publish=False):
     NOTE: We cannot test for this well yet, because we do not run a celery worker,
     and cannot run `task.apply_async()`
     """
+    if task is None:
+        return
     span_dict = getattr(task, CTX_KEY, None)
     if span_dict is None:
         span_dict = {}

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -185,6 +185,13 @@ class TestUtils(unittest.TestCase):
         utils.detach_span(fn_task, task_id)
         self.assertEqual(utils.retrieve_span(fn_task, task_id), (None, None))
 
+    def test_optional_task_span_attach(self):
+        task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+
+        # assert this is is a no-aop
+        self.assertIsNone(utils.attach_span(None, task_id, span))
+
     def test_span_delete_empty(self):
         # ensure detach_span doesn't raise an exception if span is not present
         @self.app.task


### PR DESCRIPTION
# Description
This PR is continue the work that [goatsthatcode](https://github.com/goatsthatcode) did on this PR https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1052, due to the fact that the author hasn't responded anymore, we are interested in resolving this issue.

This changes the way spans are initialized for the celery instrumentation hooks and handles the case where Celery tasks are not available in the registry and called anonymously using the signature() or send_task()

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1002, https://github.com/open-telemetry/opentelemetry-python-contrib/issues/609
possibly addresses https://github.com/open-telemetry/opentelemetry-python-contrib/issues/784

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran changes against reproduced issue in repo linked in issue -> https://github.com/goatsthatcode/opentelemetry-instrumentation-celery-example
- [x] Added Unit Test to cover new conditional branch
- [x] Passed existing test suite

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
