### PR TITLE
[WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ lib64
 __pycache__
 venv*/
 .venv*/
-
+project_venv
 # Installer logs
 pip-log.txt
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -164,7 +164,9 @@ services ``GRPCTestServer`` and ``GRPCHealthServer``.
 """
 import os
 from typing import Callable, Collection, List, Union
-
+from logging import getLogger
+from . import _client
+from . import _server
 import grpc  # pylint:disable=import-self
 from wrapt import wrap_function_wrapper as _wrap
 
@@ -183,6 +185,22 @@ from opentelemetry.instrumentation.utils import unwrap
 # pylint:disable=import-outside-toplevel
 # pylint:disable=import-self
 # pylint:disable=unused-argument
+
+_logger = getLogger(__name__)
+
+class _InstrumentedServer(grpc._server):
+    _tracer_provider = None,
+    _request_hook = None,
+    _response_hook = None,
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._is_instrumented_by_opentelemetry = True
+        tracer_provider = _InstrumentedServer._tracer_provider,
+        request_hook = _InstrumentedServer._request_hook,
+        response_hook = _InstrumentedServer._response_hook,
+
 
 
 class GrpcInstrumentorServer(BaseInstrumentor):
@@ -205,7 +223,16 @@ class GrpcInstrumentorServer(BaseInstrumentor):
 
     # pylint:disable=attribute-defined-outside-init, redefined-outer-name
 
-    def __init__(self, filter_=None):
+    def __init__(self, 
+    filter_=None,
+    request_hook=None,
+    response_hook=None,
+    tracer_provider = None,
+    ):
+        self._request_hook = request_hook
+        self._response_hook = response_hook
+        self._tracer_provider = tracer_provider
+
         excluded_service_filter = _excluded_service_filter()
         if excluded_service_filter is not None:
             if filter_ is None:
@@ -219,7 +246,16 @@ class GrpcInstrumentorServer(BaseInstrumentor):
 
     def _instrument(self, **kwargs):
         self._original_func = grpc.server
+        request_hook = kwargs.get("request_hook")
+        response_hook = kwargs.get("response_hook")
+        if callable(request_hook):
+            _InstrumentedServer._request_hook = request_hook
+        if callable(response_hook):
+            _InstrumentedServer._response_hook = response_hook
         tracer_provider = kwargs.get("tracer_provider")
+        _InstrumentedServer._tracer_provider = tracer_provider
+
+        grpc._server = _InstrumentedServer
 
         def server(*args, **kwargs):
             if "interceptors" in kwargs:
@@ -229,6 +265,8 @@ class GrpcInstrumentorServer(BaseInstrumentor):
                     server_interceptor(
                         tracer_provider=tracer_provider, filter_=self._filter
                     ),
+                    request_hook=self._request_hook,
+                    response_hook=self._response_hook,
                 )
             else:
                 kwargs["interceptors"] = [
@@ -242,7 +280,59 @@ class GrpcInstrumentorServer(BaseInstrumentor):
 
     def _uninstrument(self, **kwargs):
         grpc.server = self._original_func
+        _InstrumentedServer._tracer_provider = None
+        _InstrumentedServer._request_hook = None
+        _InstrumentedServer._response_hook = None
+    
+    @staticmethod
+    def instrument_server(
+        server:grpc.server,
+        tracer_provider = None,
+        request_hook = None,
+        response_hook = None
+    ): 
+        if not hasattr(server, "_is_instrumented_by_opentelemetry"):
+            server._is_instrumented_by_opentelemetry = False
+        
+        if not server._is_instrumented_by_opentelemetry:
+            excluded_services = (
+                _parse_services(_excluded_service_filter)
+                if excluded_services is not None
+                else _excluded_service_filter
+            )
+            tracer_provider=tracer_provider,
+            request_hook=request_hook,
+            response_hook=response_hook
+            
+        else:
+            _logger.warning(
+                "Attempting to instrumenet grpc server while already instrumented"
+            )
+    
+    @staticmethod
+    def uninstrument_server(server):
+        if hasattr(server, "_original_grpc_server"):
+            server = server._original_grpc_server
+            del server._original_grpc_server
+            server._is_instrumented_by_opentelemetry = False
+        else:
+            _logger.warning(
+                "Attempting to instrument grpc server while already instrumented"
+            )
 
+
+class _InstrumentedClient(grpc.client):
+    _tracer_provider = None
+    _request_hook = None,
+    _response_hook = None
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._is_instrumented_by_opentelemetry = True
+        request_hook = _InstrumentedClient._request_hook
+        response_hook = _InstrumentedClient._response_hook
+        tracer_provider = _InstrumentedClient._tracer_provider
 
 class GrpcInstrumentorClient(BaseInstrumentor):
     """
@@ -263,7 +353,16 @@ class GrpcInstrumentorClient(BaseInstrumentor):
 
     """
 
-    def __init__(self, filter_=None):
+    def __init__(self, 
+    filter_=None, 
+    request_hook=None,
+    response_hook=None,
+    tracer_provider =None,
+    ):
+        self._request_hook = request_hook
+        self._response_hook = response_hook
+        self._tracer_provider = tracer_provider
+
         excluded_service_filter = _excluded_service_filter()
         if excluded_service_filter is not None:
             if filter_ is None:
@@ -292,6 +391,18 @@ class GrpcInstrumentorClient(BaseInstrumentor):
         return _instruments
 
     def _instrument(self, **kwargs):
+        self._original_client = grpc._client
+        requset_hook = kwargs.get("request_hook")
+        response_hook = kwargs.get("response_hook")
+        if callable(requset_hook):
+            _InstrumentedClient._request_hook = requset_hook
+        if callable(response_hook):
+            _InstrumentedServer._response_hook = response_hook
+        tracer_provider = kwargs.get("tracer_provider")
+        _InstrumentedClient._tracer_provider = tracer_provider
+        
+        grpc._client = _InstrumentedClient
+
         for ctype in self._which_channel(kwargs):
             _wrap(
                 "grpc",
@@ -300,9 +411,45 @@ class GrpcInstrumentorClient(BaseInstrumentor):
             )
 
     def _uninstrument(self, **kwargs):
+        grpc._client = self._original_client
+        _InstrumentedClient._request_hook = None
+        _InstrumentedClient._response_hook = None
+        _InstrumentedClient._tracer_provider = None
         for ctype in self._which_channel(kwargs):
             unwrap(grpc, ctype)
-
+        
+    @staticmethod
+    def instrument_client(
+        client:grpc._client,
+        tracer_provider = None,
+        request_hook = None,
+        response_hook = None,
+    ):
+        if not hasattr(client, "_is_instrumented_by_opentelemetry"):
+            client._is_instrumented_by_opentelemetry = False
+        
+        if not client._is_instrumented_by_opentelemetry:
+            excluded_services = (
+                _parse_services(_excluded_service_filter)
+                if excluded_services is not None
+                else _excluded_service_filter
+            )
+            tracer_provider=tracer_provider
+            request_hook=request_hook
+            response_hook=response_hook
+        else:
+            _logger.warning("Attempting to unstrument grpc client while already instrumented")
+        
+    @staticmethod
+    def uninstrument_client(client:grpc._client):
+        if hasattr(client, "_original_grpc_client"):
+            client = client._original_grpc_client
+            del client._original_grpc_client
+            client._is_instrumented_by_opentelemetry = False
+        else:
+            _logger.warning(
+                "Attempting to uninstrument grpc client while already instrumented"
+            )
     def wrapper_fn(self, original_func, instance, args, kwargs):
         channel = original_func(*args, **kwargs)
         tracer_provider = kwargs.get("tracer_provider")
@@ -311,11 +458,13 @@ class GrpcInstrumentorClient(BaseInstrumentor):
             client_interceptor(
                 tracer_provider=tracer_provider,
                 filter_=self._filter,
+                request_hook=self._request_hook,
+                response_hook=self._response_hook
             ),
         )
+    
 
-
-def client_interceptor(tracer_provider=None, filter_=None):
+def client_interceptor(tracer_provider=None, filter_=None, request_hook=None):
     """Create a gRPC client channel interceptor.
 
     Args:
@@ -332,10 +481,14 @@ def client_interceptor(tracer_provider=None, filter_=None):
 
     tracer = trace.get_tracer(__name__, __version__, tracer_provider)
 
-    return _client.OpenTelemetryClientInterceptor(tracer, filter_=filter_)
+    return _client.OpenTelemetryClientInterceptor(
+        tracer, 
+        filter_=filter_,
+        request_hook=request_hook
+    )
 
 
-def server_interceptor(tracer_provider=None, filter_=None):
+def server_interceptor(tracer_provider=None, filter_=None, response_hook=None):
     """Create a gRPC server interceptor.
 
     Args:
@@ -352,7 +505,11 @@ def server_interceptor(tracer_provider=None, filter_=None):
 
     tracer = trace.get_tracer(__name__, __version__, tracer_provider)
 
-    return _server.OpenTelemetryServerInterceptor(tracer, filter_=filter_)
+    return _server.OpenTelemetryServerInterceptor(
+        tracer, 
+        filter_=filter_,
+        response_hook=response_hook
+    )
 
 
 def _excluded_service_filter() -> Union[Callable[[object], bool], None]:

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -62,10 +62,10 @@ def _make_future_done_callback(span, rpc_info):
 class OpenTelemetryClientInterceptor(
     grpcext.UnaryClientInterceptor, grpcext.StreamClientInterceptor
 ):
-    def __init__(self, tracer, filter_=None):
+    def __init__(self, tracer, filter_=None, request_hook=None):
         self._tracer = tracer
         self._filter = filter_
-
+        self.request_hook = request_hook
     def _start_span(self, method, **kwargs):
         service, meth = method.lstrip("/").split("/", 1)
         attributes = {

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -185,9 +185,10 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
     """
 
-    def __init__(self, tracer, filter_=None):
+    def __init__(self, tracer, filter_=None, response_hook=None):
         self._tracer = tracer
         self._filter = filter_
+        self.response_hook = response_hook
 
     @contextmanager
     def _set_remote_context(self, servicer_context):


### PR DESCRIPTION
# Description
Enable users of the grpc plugin to register hooks on grpc request and response (server and client, unary and stream). The hooks are called before the stream begins to handle data, allowing the plugin user to register to events

Fixes # (issue)
Adding request/response hooks to grpc-instrumentation

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Test A

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
