### PR TITLE
Fix dbapi connection instrument wrapper has no _sock member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `opentelemetry-instrumentation-pymysql` Add tests for commit() and rollback().
+  ([#1424](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1424))
+
 ### Fixed
 
 - Fix bug in Urllib instrumentation - add status code to span attributes only if the status code is not None. 
   ([#1430](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1430))
+- `opentelemetry-instrumentation-pymysql` Fix dbapi connection instrument wrapper has no _sock member.
+  ([#1424](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1424))
+- `opentelemetry-instrumentation-dbapi` Fix the check for the connection already being instrumented in instrument_connection().
+  ([#1424](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1424))
 
 ## Version 1.14.0/0.35b0 (2022-11-03)
 

--- a/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -109,3 +109,19 @@ class TestFunctionalPyMysql(TestBase):
         ):
             self._cursor.callproc("test", ())
             self.validate_spans("test")
+
+    def test_commit(self):
+        stmt = "INSERT INTO test (id) VALUES (%s)"
+        with self._tracer.start_as_current_span("rootSpan"):
+            data = (("4",), ("5",), ("6",))
+            self._cursor.executemany(stmt, data)
+            self._connection.commit()
+        self.validate_spans("INSERT")
+
+    def test_rollback(self):
+        stmt = "INSERT INTO test (id) VALUES (%s)"
+        with self._tracer.start_as_current_span("rootSpan"):
+            data = (("7",), ("8",), ("9",))
+            self._cursor.executemany(stmt, data)
+            self._connection.rollback()
+        self.validate_spans("INSERT")

--- a/tox.ini
+++ b/tox.ini
@@ -515,6 +515,7 @@ commands =
   python scripts/eachdist.py lint --check-only
 
 [testenv:docker-tests]
+basepython: python3.9
 deps =
   pip >= 20.3.3
   pytest


### PR DESCRIPTION
# Description

Fix the check for the connection already being instrumented in instrument_connection()
Add tests for commit() and rollback()
Add a couple missing docstring items.
Add basepython to docker-tests to fix running the tests on macOS.

Based on #1382

Fixes #1353

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Wrote and ran new unit tests.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
