### PR TITLE
Fix Urllib instrumentation - Add status code to span if not None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix bug in Urllib instrumentation
+- Fix bug in Urllib instrumentation - add status code to span attributes only if the status code is not None. 
   ([#1430](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1430))
 
 ## Version 1.14.0/0.35b0 (2022-11-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix bug in Urllib instrumentation
+  ([#1430](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1430))
+
 ## Version 1.14.0/0.35b0 (2022-11-03)
 
 ### Deprecated

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -206,7 +206,7 @@ def _instrument(
                 code_ = result.getcode()
                 labels[SpanAttributes.HTTP_STATUS_CODE] = str(code_)
 
-                if span.is_recording():
+                if span.is_recording() and code_:
                     span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, code_)
                     span.set_status(Status(http_status_to_status_code(code_)))
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -206,7 +206,7 @@ def _instrument(
                 code_ = result.getcode()
                 labels[SpanAttributes.HTTP_STATUS_CODE] = str(code_)
 
-                if span.is_recording() and code_:
+                if span.is_recording() and code_ is not None:
                     span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, code_)
                     span.set_status(Status(http_status_to_status_code(code_)))
 


### PR DESCRIPTION
# Description

Add test_response_code_none test that verify it
[Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1401)
Add the status code to span only if not None.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tox -e test-instrumentation-urllib

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
