### PR TITLE
Allow to modify the computed Span name via callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug in Urllib instrumentation - add status code to span attributes only if the status code is not None. 
   ([#1430](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1430))
+- `opentelemetry-instrumentation-redis` Allow to modify the computed span name via callback.
 
 ## Version 1.14.0/0.35b0 (2022-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in Urllib instrumentation - add status code to span attributes only if the status code is not None. 
   ([#1430](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1430))
 - `opentelemetry-instrumentation-redis` Allow to modify the computed span name via callback.
+  ([#1431](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1431))
 
 ## Version 1.14.0/0.35b0 (2022-11-03)
 

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -124,9 +124,7 @@ _RequestHookT = typing.Optional[
 _ResponseHookT = typing.Optional[
     typing.Callable[[Span, redis.connection.Connection, Any], None]
 ]
-_NameCallbackT = typing.Optional[
-    typing.Callable[[str], str]
-]
+_NameCallbackT = typing.Optional[typing.Callable[[str], str]]
 
 _REDIS_ASYNCIO_VERSION = (4, 2, 0)
 if redis.VERSION >= _REDIS_ASYNCIO_VERSION:

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -161,8 +161,6 @@ class TestRedis(TestBase):
             tracer_provider=self.tracer_provider, name_callback=name_callback
         )
 
-        test_value = "test_value"
-
         with mock.patch.object(redis_client, "connection"):
             redis_client.get("key")
 


### PR DESCRIPTION
# Description

With Redis and Databases in a traces, there is no easy way from the span name to see if a "SELECT" is going to Redis or the database.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] TestRedis::test_name_callback

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [?] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
