### PR TITLE
Strip leading comments from SQL queries when generating the span name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1350](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1350))
 - `opentelemetry-instrumentation-starlette` Add support for regular expression matching and sanitization of HTTP headers.
   ([#1404](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1404))
+- Strip leading comments from SQL queries when generating the span name.
+  ([#1434](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1434))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -34,6 +34,7 @@ API
 ---
 """
 
+import re
 from typing import Collection
 
 import asyncpg
@@ -99,6 +100,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
         super().__init__()
         self.capture_parameters = capture_parameters
         self._tracer = None
+        self._leading_comment_remover = re.compile(r"^/\*.*?\*/")
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -135,7 +137,8 @@ class AsyncPGInstrumentor(BaseInstrumentor):
         name = args[0] if args[0] else params.get("database", "postgresql")
 
         try:
-            name = name.split()[0]
+            # Strip leading comments so we get the operation name.
+            name = self._leading_comment_remover.sub("", name).split()[0]
         except IndexError:
             name = ""
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -39,6 +39,7 @@ API
 
 import functools
 import logging
+import re
 import typing
 
 import wrapt
@@ -368,6 +369,7 @@ class CursorTracer:
             else {}
         )
         self._connect_module = self._db_api_integration.connect_module
+        self._leading_comment_remover = re.compile(r"^/\*.*?\*/")
 
     def _populate_span(
         self,
@@ -397,7 +399,8 @@ class CursorTracer:
 
     def get_operation_name(self, cursor, args):  # pylint: disable=no-self-use
         if args and isinstance(args[0], str):
-            return args[0].split()[0]
+            # Strip leading comments so we get the operation name.
+            return self._leading_comment_remover.sub("", args[0]).split()[0]
         return ""
 
     def get_statement(self, cursor, args):  # pylint: disable=no-self-use

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -88,11 +88,17 @@ class TestDBApiIntegration(TestBase):
         query"""
         )
         cursor.execute("tab\tseparated query")
+        cursor.execute("/* leading comment */ query")
+        cursor.execute("/* leading comment */ query /* trailing comment */")
+        cursor.execute("query /* trailing comment */")
         spans_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(spans_list), 3)
+        self.assertEqual(len(spans_list), 6)
         self.assertEqual(spans_list[0].name, "Test")
         self.assertEqual(spans_list[1].name, "multi")
         self.assertEqual(spans_list[2].name, "tab")
+        self.assertEqual(spans_list[3].name, "query")
+        self.assertEqual(spans_list[4].name, "query")
+        self.assertEqual(spans_list[5].name, "query")
 
     def test_span_succeeded_with_capture_of_statement_parameters(self):
         connection_props = {

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -216,7 +216,8 @@ class CursorTracer(dbapi.CursorTracer):
             statement = statement.as_string(cursor)
 
         if isinstance(statement, str):
-            return statement.split()[0]
+            # Strip leading comments so we get the operation name.
+            return self._leading_comment_remover.sub("", statement).split()[0]
 
         return ""
 

--- a/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/asyncpg/test_asyncpg_functional.py
@@ -77,6 +77,35 @@ class TestFunctionalAsyncPG(TestBase):
             spans[0].attributes[SpanAttributes.DB_STATEMENT], "SELECT 42;"
         )
 
+    def test_instrumented_remove_comments(self, *_, **__):
+        async_call(self._connection.fetch("/* leading comment */ SELECT 42;"))
+        async_call(
+            self._connection.fetch(
+                "/* leading comment */ SELECT 42; /* trailing comment */"
+            )
+        )
+        async_call(self._connection.fetch("SELECT 42; /* trailing comment */"))
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 3)
+        self.check_span(spans[0])
+        self.assertEqual(spans[0].name, "SELECT")
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.DB_STATEMENT],
+            "/* leading comment */ SELECT 42;",
+        )
+        self.check_span(spans[1])
+        self.assertEqual(spans[1].name, "SELECT")
+        self.assertEqual(
+            spans[1].attributes[SpanAttributes.DB_STATEMENT],
+            "/* leading comment */ SELECT 42; /* trailing comment */",
+        )
+        self.check_span(spans[2])
+        self.assertEqual(spans[2].name, "SELECT")
+        self.assertEqual(
+            spans[2].attributes[SpanAttributes.DB_STATEMENT],
+            "SELECT 42; /* trailing comment */",
+        )
+
     def test_instrumented_transaction_method(self, *_, **__):
         async def _transaction_execute():
             async with self._connection.transaction():


### PR DESCRIPTION
# Description

Currently an SQL statement that begins with a comment, such as

```
/* Get foo from bar */ SELECT foo FROM bar
```

Will have `span.name` set to `/*`, which makes it harder to tell what's going on in the waterfall view for a request.

Instead, this removes the leading comment so that the operation type is used instead.

Fixes #1433 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Added additional unit tests.
- [X] Tested against my company's code.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
