### PR TITLE
fix: No module named httpx

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
@@ -39,7 +39,8 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-fastapi[instruments]",
   "opentelemetry-test-utils == 0.36b0.dev",
-  "requests ~= 2.23.0", # needed for testclient
+  "requests ~= 2.23", # needed for testclient
+  "httpx ~= 0.22", # needed for testclient
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
@@ -39,7 +39,8 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-starlette[instruments]",
   "opentelemetry-test-utils == 0.36b0.dev",
-  "requests ~= 2.23.0", # needed for testclient
+  "requests ~= 2.23", # needed for testclient
+  "httpx ~= 0.22", # needed for testclient
 ]
 
 [project.entry-points.opentelemetry_instrumentor]


### PR DESCRIPTION
# Description

Example run where if fails https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/3464839503/jobs/5786861818