### PR TITLE
Add grpc.aio instrumentation to be auto-instrumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1424](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1424))
 - Remove db.name attribute from Redis instrumentation
   ([#1427](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1427))
+- Add grpc.aio instrumentation to package entry points
+  ([#1442](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1442))
 
 ## Version 1.14.0/0.35b0 (2022-11-03)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
@@ -46,6 +46,8 @@ test = [
 [project.entry-points.opentelemetry_instrumentor]
 grpc_client = "opentelemetry.instrumentation.grpc:GrpcInstrumentorClient"
 grpc_server = "opentelemetry.instrumentation.grpc:GrpcInstrumentorServer"
+grpc_aio_client = "opentelemetry.instrumentation.grpc:GrpcAioInstrumentorClient"
+grpc_aio_server = "opentelemetry.instrumentation.grpc:GrpcAioInstrumentorServer"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc"


### PR DESCRIPTION
# Description

PR #1245 added grpc.aio instrumentation. It included the auto instrumentor for grpc.aio but did not include the entry-points hook for it to be run automatically on boot.

Currently, you need to manually include the instrumentor and call it. This makes that automatic and in line with the plain grpc instrumentation.

Fixes no-issue (but can raise one if needed)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't been tested because I'm unsure how. I'd presumably need to build a dev version and package it to an app but given the simplicity of the change, I'm hoping it's fine. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
