### PR TITLE
Fix 1455: [test-only] Protect metric data_points from raw next() calls

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -57,7 +57,7 @@ class TornadoTest(AsyncHTTPTestCase, TestBase):
     def assert_metric_expected(
         self, metric, expected_value, expected_attributes
     ):
-        data_point = next(metric.data.data_points)
+        data_point = next(iter(metric.data.data_points))
 
         if isinstance(data_point, HistogramDataPoint):
             self.assertEqual(
@@ -78,7 +78,7 @@ class TornadoTest(AsyncHTTPTestCase, TestBase):
     def assert_duration_metric_expected(
         self, metric, duration_estimated, expected_attributes
     ):
-        data_point = next(metric.data.data_points)
+        data_point = next(iter(metric.data.data_points))
 
         self.assertAlmostEqual(
             data_point.sum,


### PR DESCRIPTION
- Ensure we wrap data_points so we don't assume `Iterator` traits

# Description

In the course of resolving https://github.com/open-telemetry/opentelemetry-python/pull/3035 it turned out that these tests were making some assumptions about the `data_points` property that are not supported by the current type annotations (although the implementation happens to).


Fixes #1455

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is a test-only issue for the sake of compatibility.

# Does This PR Require a Core Repo Change?
Should be forward-compatible with the related Core PR
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
