### PR TITLE
fix(asgi-instrumentation): extract target after running the framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1424](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1424))
 - Remove db.name attribute from Redis instrumentation
   ([#1427](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1427))
+- `opentelemetry-instrumentation-asgi` Fix target extraction for duration metric
+  ([#1461](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1461))
 
 ## Version 1.14.0/0.35b0 (2022-11-03)
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -542,11 +542,6 @@ class OpenTelemetryMiddleware:
         )
         duration_attrs = _parse_duration_attrs(attributes)
 
-        target = _collect_target_attribute(scope)
-        if target:
-            active_requests_count_attrs[SpanAttributes.HTTP_TARGET] = target
-            duration_attrs[SpanAttributes.HTTP_TARGET] = target
-
         if scope["type"] == "http":
             self.active_requests_counter.add(1, active_requests_count_attrs)
         try:
@@ -581,6 +576,9 @@ class OpenTelemetryMiddleware:
                 await self.app(scope, otel_receive, otel_send)
         finally:
             if scope["type"] == "http":
+                target = _collect_target_attribute(scope)
+                if target:
+                    duration_attrs[SpanAttributes.HTTP_TARGET] = target
                 duration = max(round((default_timer() - start) * 1000), 0)
                 self.duration_histogram.record(duration, duration_attrs)
                 self.active_requests_counter.add(

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -617,7 +617,7 @@ class TestAsgiApplication(AsgiTestBase):
                                 expected_target,
                             )
                             assertions += 1
-        self.assertEqual(assertions, 2)
+        self.assertEqual(assertions, 1)
 
     def test_no_metric_for_websockets(self):
         self.scope = {

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -608,14 +608,10 @@ class TestAsgiApplication(AsgiTestBase):
         for resource_metric in metrics_list.resource_metrics:
             for scope_metrics in resource_metric.scope_metrics:
                 for metric in scope_metrics.metrics:
+                    if metric.name != "http.server.duration":
+                        continue
                     for point in metric.data.data_points:
                         if isinstance(point, HistogramDataPoint):
-                            self.assertEqual(
-                                point.attributes["http.target"],
-                                expected_target,
-                            )
-                            assertions += 1
-                        elif isinstance(point, NumberDataPoint):
                             self.assertEqual(
                                 point.attributes["http.target"],
                                 expected_target,

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -46,7 +46,7 @@ _expected_metric_names = [
 ]
 _recommended_attrs = {
     "http.server.active_requests": _active_requests_count_attrs,
-    "http.server.duration": _duration_attrs + [SpanAttributes.HTTP_TARGET],
+    "http.server.duration": {*_duration_attrs, SpanAttributes.HTTP_TARGET},
 }
 
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -46,7 +46,7 @@ _expected_metric_names = [
 ]
 _recommended_attrs = {
     "http.server.active_requests": _active_requests_count_attrs,
-    "http.server.duration": _duration_attrs,
+    "http.server.duration": _duration_attrs + [SpanAttributes.HTTP_TARGET],
 }
 
 
@@ -218,6 +218,7 @@ class TestFastAPIManualInstrumentation(TestBase):
             "http.server_name": "testserver",
             "net.host.port": 80,
             "http.status_code": 200,
+            "http.target": "/foobar",
         }
         expected_requests_count_attributes = {
             "http.method": "GET",


### PR DESCRIPTION
# Description
There was a mistake in the original strategy to extract the feature, as before running the framework the scope does not have all the information necessary to deduct the route.

We move the target extraction after running the framewrork function, but that means that we won't have those attributes for the span or for the active_requests metrics. The target will be available only for the duration metric.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Added a print statement to the middleware that prints `duration_attrs` just before sending the metric.
- Changed unit test to reflect the fact that the scope changes after running the framework function.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
