### PR TITLE
`opentelemetry-instrumentation-aws-lambda`: Adding option to disable context propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#685](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/685))
 - Add metric instrumentation for tornado
   ([#1252](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1252))
+- `opentelemetry-instrumentation-aws-lambda` Add option to disable aws context propagation
+  ([])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add metric instrumentation for tornado
   ([#1252](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1252))
 - `opentelemetry-instrumentation-aws-lambda` Add option to disable aws context propagation
-  ([])
+  ([#1466](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1466))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -168,7 +168,9 @@ def _determine_parent_context(
 
     if (
         parent_context
-        and get_current_span(parent_context).get_span_context().trace_flags.sampled
+        and get_current_span(parent_context)
+        .get_span_context()
+        .trace_flags.sampled
     ):
         return parent_context
 
@@ -180,13 +182,17 @@ def _determine_parent_context(
     return parent_context
 
 
-def _set_api_gateway_v1_proxy_attributes(lambda_event: Any, span: Span) -> Span:
+def _set_api_gateway_v1_proxy_attributes(
+    lambda_event: Any, span: Span
+) -> Span:
     """Sets HTTP attributes for REST APIs and v1 HTTP APIs
 
     More info:
     https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
     """
-    span.set_attribute(SpanAttributes.HTTP_METHOD, lambda_event.get("httpMethod"))
+    span.set_attribute(
+        SpanAttributes.HTTP_METHOD, lambda_event.get("httpMethod")
+    )
     span.set_attribute(SpanAttributes.HTTP_ROUTE, lambda_event.get("resource"))
 
     if lambda_event.get("headers"):
@@ -208,12 +214,16 @@ def _set_api_gateway_v1_proxy_attributes(lambda_event: Any, span: Span) -> Span:
             f"{lambda_event.get('resource')}?{urlencode(lambda_event.get('queryStringParameters'))}",
         )
     else:
-        span.set_attribute(SpanAttributes.HTTP_TARGET, lambda_event.get("resource"))
+        span.set_attribute(
+            SpanAttributes.HTTP_TARGET, lambda_event.get("resource")
+        )
 
     return span
 
 
-def _set_api_gateway_v2_proxy_attributes(lambda_event: Any, span: Span) -> Span:
+def _set_api_gateway_v2_proxy_attributes(
+    lambda_event: Any, span: Span
+) -> Span:
     """Sets HTTP attributes for v2 HTTP APIs
 
     More info:
@@ -260,13 +270,19 @@ def _instrument(
     tracer_provider: TracerProvider = None,
     disable_aws_context_propagation: bool = False,
 ):
-    def _instrumented_lambda_handler_call(call_wrapped, instance, args, kwargs):
-        orig_handler_name = ".".join([wrapped_module_name, wrapped_function_name])
+    def _instrumented_lambda_handler_call(
+        call_wrapped, instance, args, kwargs
+    ):
+        orig_handler_name = ".".join(
+            [wrapped_module_name, wrapped_function_name]
+        )
 
         lambda_event = args[0]
 
         parent_context = _determine_parent_context(
-            lambda_event, event_context_extractor, disable_aws_context_propagation
+            lambda_event,
+            event_context_extractor,
+            disable_aws_context_propagation,
         )
 
         span_kind = None

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -59,7 +59,9 @@ MOCK_XRAY_TRACE_ID_STR = f"{MOCK_XRAY_TRACE_ID:x}"
 MOCK_XRAY_PARENT_SPAN_ID = 0x3328B8445A6DBAD2
 MOCK_XRAY_TRACE_CONTEXT_COMMON = f"Root={TRACE_ID_VERSION}-{MOCK_XRAY_TRACE_ID_STR[:TRACE_ID_FIRST_PART_LENGTH]}-{MOCK_XRAY_TRACE_ID_STR[TRACE_ID_FIRST_PART_LENGTH:]};Parent={MOCK_XRAY_PARENT_SPAN_ID:x}"
 MOCK_XRAY_TRACE_CONTEXT_SAMPLED = f"{MOCK_XRAY_TRACE_CONTEXT_COMMON};Sampled=1"
-MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED = f"{MOCK_XRAY_TRACE_CONTEXT_COMMON};Sampled=0"
+MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED = (
+    f"{MOCK_XRAY_TRACE_CONTEXT_COMMON};Sampled=0"
+)
 
 # See more:
 # https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
@@ -146,7 +148,9 @@ class TestAwsLambdaInstrumentor(TestBase):
         )
 
         parent_context = span.parent
-        self.assertEqual(parent_context.trace_id, span.get_span_context().trace_id)
+        self.assertEqual(
+            parent_context.trace_id, span.get_span_context().trace_id
+        )
         self.assertEqual(parent_context.span_id, MOCK_XRAY_PARENT_SPAN_ID)
         self.assertTrue(parent_context.is_remote)
 
@@ -256,10 +260,14 @@ class TestAwsLambdaInstrumentor(TestBase):
             assert spans
             self.assertEqual(len(spans), 1)
             span = spans[0]
-            self.assertEqual(span.get_span_context().trace_id, t.expected_traceid)
+            self.assertEqual(
+                span.get_span_context().trace_id, t.expected_traceid
+            )
 
             parent_context = span.parent
-            self.assertEqual(parent_context.trace_id, span.get_span_context().trace_id)
+            self.assertEqual(
+                parent_context.trace_id, span.get_span_context().trace_id
+            )
             self.assertEqual(parent_context.span_id, t.expected_parentid)
             self.assertEqual(
                 len(parent_context.trace_state), t.expected_trace_state_len


### PR DESCRIPTION
# Description

Adding the following option to disable context propagation `disable_aws_context_propagation`. This is similar to the disableAwsContextPropagation option in the nodejs instrumentation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added unit tests
- [x] Manually tested with custom lambda

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
