### PR TITLE
Add aws lambda instrumentation hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
+- `opentelemetry-instrumentation-aws-lambda` Add request and response hooks
+  ([#1476](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1476))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -349,7 +349,9 @@ def _instrument(
                     SpanAttributes.FAAS_EXECUTION,
                     lambda_context.aws_request_id,
                 )
-                _safe_execute_hook(request_hook, span, lambda_event, lambda_context)
+                _safe_execute_hook(
+                    request_hook, span, lambda_event, lambda_context
+                )
 
             lambda_error = None
             try:

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -301,8 +301,8 @@ def _safe_execute_hook(hook_func, *args):
 
     try:
         hook_func(*args)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning("Failed executing hook: %s", e)
+    except Exception as err:  # pylint: disable=broad-except
+        logger.warning("Failed executing hook: %s", err)
 
 
 def _instrument(

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -305,7 +305,7 @@ def _safe_execute_hook(hook_func, *args):
         logger.warning("Failed executing hook: %s", err)
 
 
-def _instrument(
+def _instrument(  # noqa pylint: disable=too-many-statements
     wrapped_module_name,
     wrapped_function_name,
     flush_timeout,
@@ -316,7 +316,7 @@ def _instrument(
     request_hook: Callable[[Span, Any, Any], None] = None,
     response_hook: Callable[[Span, Any, Any], None] = None,
 ):
-    def _instrumented_lambda_handler_call(  # noqa pylint: disable=too-many-branches
+    def _instrumented_lambda_handler_call(  # noqa pylint: disable=too-many-branches, too-many-locals, too-many-statements
         call_wrapped, instance, args, kwargs
     ):
         orig_handler_name = ".".join(

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -64,7 +64,31 @@ for example:
         event_context_extractor=custom_event_context_extractor
     )
 
----
+request_hook (Callable) - hook for adding custom attributes before lambda starts handling the request.
+    Function signature is : def request_hook(span: Span, lambda_event: Any, lambda_context: Any) -> None
+    for example:
+
+.. code:: python
+
+    from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
+
+    def request_hook(span, lambda_event, lambda_context):
+        span.set_attribute('lambda_event_attribute', json.dumps(lambda_event))
+
+    AwsLambdaInstrumentor().instrument(request_hook=request_hook)
+
+response_hook (Callable) - hook for adding custom attributes before lambda returns the response.
+    Function signature is : def request_hook(span: Span, lambda_result: Any, lambda_error: Any) -> None
+    for example:
+
+.. code:: python
+
+    from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
+
+    def response_hook(span, lambda_result, lambda_error):
+        span.set_attribute('lambda_result_attribute', json.dumps(lambda_result))
+
+    AwsLambdaInstrumentor().instrument(response_hook=response_hook)
 """
 
 import logging
@@ -334,7 +358,6 @@ def _instrument(
         ) as span:
             if span.is_recording():
                 lambda_context = args[1]
-
                 # NOTE: The specs mention an exception here, allowing the
                 # `ResourceAttributes.FAAS_ID` attribute to be set as a span
                 # attribute instead of a resource attribute.

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -377,6 +377,7 @@ def _instrument(
                 )
 
             lambda_error = None
+            result = None
             try:
                 result = call_wrapped(*args, **kwargs)
             except Exception as err:

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -296,12 +296,13 @@ def _set_api_gateway_v2_proxy_attributes(
 
 def _safe_execute_hook(hook_func, *args):
     if not callable(hook_func):
+        logger.warning("hook function isn't callable")
         return
 
     try:
         hook_func(*args)
-    except Exception:  # pylint: disable=broad-except
-        logger.warning("Failed executing hook")
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning("Failed executing hook: %s", e)
 
 
 def _instrument(

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -424,7 +424,6 @@ class TestAwsLambdaInstrumentor(TestBase):
         assert spans is not None
         self.assertEqual(len(spans), 0)
 
-
     def test_successful_request_hook(self):
         lambda_event_attribute = "lambda.event"
         lambda_event = {"abcd": 1234}


### PR DESCRIPTION
# Description

Support request/response hooks for the aws-lambda instrumentation. Similar hooks are available in the node.js instrumentation - see https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda#aws-lambda-instrumentation-options.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests were added.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
