### PR TITLE
Adds an option to configure `disable_aws_context_propagation` by environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-instrumentation-aws-lambda` Adds an option to configure `disable_aws_context_propagation` by
+  environment variable: `OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION`
+  ([#](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/))
+
 ## Version 1.15.0/0.36b0 (2022-12-10)
 
 - Add uninstrument test for sqlalchemy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-aws-lambda` Adds an option to configure `disable_aws_context_propagation` by
   environment variable: `OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION`
-  ([#](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/))
+  ([#1507](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1507))
 
 ## Version 1.15.0/0.36b0 (2022-12-10)
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -415,7 +415,7 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
             "disable_aws_context_propagation", False
         ) or os.getenv(
             OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION, "False"
-        ).lower() in (
+        ).strip().lower() in (
             "true",
             "1",
             "t",

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -101,6 +101,9 @@ ORIG_HANDLER = "ORIG_HANDLER"
 OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT = (
     "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT"
 )
+OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION = (
+    "OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION"
+)
 
 
 def _default_event_context_extractor(lambda_event: Any) -> Context:
@@ -408,6 +411,16 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
                 flush_timeout_env,
             )
 
+        disable_aws_context_propagation = kwargs.get(
+            "disable_aws_context_propagation", False
+        ) or os.getenv(
+            OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION, "False"
+        ).lower() in (
+            "true",
+            "1",
+            "t",
+        )
+
         _instrument(
             self._wrapped_module_name,
             self._wrapped_function_name,
@@ -416,9 +429,7 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
                 "event_context_extractor", _default_event_context_extractor
             ),
             tracer_provider=kwargs.get("tracer_provider"),
-            disable_aws_context_propagation=kwargs.get(
-                "disable_aws_context_propagation", False
-            ),
+            disable_aws_context_propagation=disable_aws_context_propagation,
         )
 
     def _uninstrument(self, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -241,7 +241,7 @@ class TestAwsLambdaInstrumentor(TestBase):
                 xray_traceid=MOCK_XRAY_TRACE_CONTEXT_SAMPLED,
             ),
             TestCase(
-                name="no_custom_extractor_xray_disable_aws_propagatio_via_env_var",
+                name="no_custom_extractor_xray_disable_aws_propagation_via_env_var",
                 custom_extractor=None,
                 context={
                     "headers": {


### PR DESCRIPTION
# Description

The variable `OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION` can be used to disable aws context propagation. This is similar to the proposed changes in the JS implementation: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1227

Signed-off-by: Alex Boten <aboten@lightstep.com>

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
