### PR TITLE
add a test using NoOpTracerProvider - sqlalchemy

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -260,6 +260,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             engine=engine,
             tracer_provider=trace.NoOpTracerProvider,
         )
-        engine.connect()
+        cnx = engine.connect()
+        cnx.execute("SELECT	1 + 1;").fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -261,6 +261,6 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=trace.NoOpTracerProvider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute("SELECT 1 + 1;").fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -253,3 +253,13 @@ class TestSqlalchemyInstrumentation(TestBase):
         cnx2.execute("SELECT	2 + 2;").fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
+
+    def test_no_op_tracer_provider(self):
+        engine = create_engine("sqlite:///:memory:")
+        SQLAlchemyInstrumentor().instrument(
+            engine=engine,
+            tracer_provider=trace.NoOpTracerProvider,
+        )
+        engine.connect()
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)


### PR DESCRIPTION
# Description

Add a test for sqlalchemy instrumentation to ensure that NoOpTracerProvider works

Fixes #965 

# How Has This Been Tested?

- Instrument the library using a NoOpTracerProvider. the test validates that no spans are being produced.

# Does This PR Require a Core Repo Change?

- No.
