### PR TITLE
Add urllib readthedocs documentation

### DIFF
--- a/docs/instrumentation/urllib/urllib3.rst
+++ b/docs/instrumentation/urllib/urllib3.rst
@@ -1,0 +1,7 @@
+OpenTelemetry urllib Instrumentation
+============================================
+
+.. automodule:: opentelemetry.instrumentation.urllib
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """
 This library allows tracing HTTP requests made by the
-`urllib https://docs.python.org/3/library/urllib.html>`_ library.
+`urllib <https://docs.python.org/3/library/urllib>`_ library.
 
 Usage
 -----
-
 .. code-block:: python
 
     from urllib import request
@@ -43,7 +41,7 @@ request and response hooks. These are functions that are called back by the inst
 right after a Span is created for a request and right before the span is finished processing a response respectively.
 The hooks can be configured as follows:
 
-..code:: python
+.. code:: python
 
     # `request_obj` is an instance of urllib.request.Request
     def request_hook(span, request_obj):


### PR DESCRIPTION
# Description

Enable readthedocs auto-generated documentation to parse __init.py__ doc
Fixes #1503 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] tox -e docs
- [X] tox -e lint 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

