### PR TITLE
Add tornado instrumentation component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -34,3 +34,6 @@ components:
 
   instrumentation/opentelemetry-instrumentation-tortoiseorm:
     - tonybaloney
+
+  instrumentation/opentelemetry-instrumentation-tornado:
+    - shalevr


### PR DESCRIPTION
# Description
Added entry to component_owners.yml for tornado,
I contributed the client + server metrics instrumentation for tornado
https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1252
