### PR TITLE
add docs/instrumentation component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,5 +1,8 @@
 components:
-  
+
+  docs/instrumentation:
+    - nemoshlag
+
   instrumentation/opentelemetry-instrumentation-aio-pika:
     - ofek1weiss
 


### PR DESCRIPTION
I've noticed many instrumentations are missing from the readthedocs documentation. I add myself as the component owner for verifying new instrumentations are added and to keep a similar documentation structure. 
See issue #1491 