### PR TITLE
Add entry for  urllib3 instrumentation component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -37,3 +37,6 @@ components:
 
   instrumentation/opentelemetry-instrumentation-tornado:
     - shalevr
+
+  instrumentation/opentelemetry-instrumentation-urllib3:
+    - shalevr


### PR DESCRIPTION
Added entry to component_owners.yml for urllib3,
I contributed the urllib3 metric instrumentation 
[#1198](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1198)