### PR TITLE
add a test for pymongo with NoOpTracer

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -14,7 +14,7 @@
 
 from unittest import mock
 
-from opentelemetry import context, trace
+from opentelemetry import context
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.pymongo import (
     CommandTracer,
@@ -193,7 +193,7 @@ class TestPymongo(TestBase):
     def test_no_op_tracer(self):
         mock_event = MockEvent({})
 
-        tracer = trace.NoOpTracer()
+        tracer = trace_api.NoOpTracer()
         command_tracer = CommandTracer(tracer)
         command_tracer.started(event=mock_event)
         command_tracer.succeeded(event=mock_event)

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -14,7 +14,7 @@
 
 from unittest import mock
 
-from opentelemetry import context
+from opentelemetry import context, trace
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.pymongo import (
     CommandTracer,
@@ -189,6 +189,17 @@ class TestPymongo(TestBase):
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
         self.assertEqual(span.name, "database_name.command_name")
+
+    def test_no_op_tracer(self):
+        mock_event = MockEvent({})
+
+        tracer = trace.NoOpTracer()
+        command_tracer = CommandTracer(tracer)
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
 
 
 class MockCommand:


### PR DESCRIPTION
# Description

Add a test for pymongo instrumentation to ensure that NoOpTracer works

Fixes #971 

# How Has This Been Tested?

- Instrument the library using a NoOpTracer. the test validates that no spans are being produced.

# Does This PR Require a Core Repo Change?

- No.
