### PR TITLE
Fix UnboundLocalError in asgi handler

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -572,15 +572,17 @@ class OpenTelemetryMiddleware:
                     duration_attrs,
                 )
                 start = default_timer()
-
-                await self.app(scope, otel_receive, otel_send)
+                try:
+                    await self.app(scope, otel_receive, otel_send)
+                finally:
+                    if scope["type"] == "http":
+                        target = _collect_target_attribute(scope)
+                        if target:
+                            duration_attrs[SpanAttributes.HTTP_TARGET] = target
+                        duration = max(round((default_timer() - start) * 1000), 0)
+                        self.duration_histogram.record(duration, duration_attrs)
         finally:
             if scope["type"] == "http":
-                target = _collect_target_attribute(scope)
-                if target:
-                    duration_attrs[SpanAttributes.HTTP_TARGET] = target
-                duration = max(round((default_timer() - start) * 1000), 0)
-                self.duration_histogram.record(duration, duration_attrs)
                 self.active_requests_counter.add(
                     -1, active_requests_count_attrs
                 )


### PR DESCRIPTION
# Description
Currently the duration calculation in the ASGI instrumentation fails if anything outside the `self.app` call raises an error because start will not have been instantiated.

This hides any instansation errors are actually occurring since they will be replaced by the `UnboundLocalError`

This PR moves the duration tracking into its own try/finally block so it will not be ran unless self.app was called.

It would have also been possible to set `start` to None at the top of the function and then have an if statement inside the finally block, however I decided that was too close to overloading the concept of the `start` variable as a `should record duration` control flow flag.

The actual issue is a unicode decoding error in the handling of headers, however since https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1492 potentially fixes this issue too I have restricted the scope of this PR to be focused on error propagation.



Fixes [(#1478)](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1478)

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added new unit test (`test_failed_instrumentation_errors_propagate`) it currently uses the `server_request_hook` functionality to force an instrumentation error without relying on any specific bugs.

The test does also rely on setting self.communicator to None in order to prevent the error being re-raised in teardown, relevant code links:

https://github.com/open-telemetry/opentelemetry-python/blob/b184dc95844561f0dce3f5c0a496bc89d0fb9a6d/tests/opentelemetry-test-utils/src/opentelemetry/test/asgitestutil.py#L38

https://github.com/django/asgiref/blob/36022636d3390c1c1cbb952336a34d652a6bfb26/asgiref/testing.py#L8


# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [ x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ x] Unit tests have been added
- [ ] Documentation has been updated
