### PR TITLE
Add Redis instrumentation db_statement_serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `opentelemetry-instrumentation-redis` Add `db_statement_serializer` hook function to allow query sanitization.
+  ([#1571](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1571))
+
 ## Fixed
 
 - Fix aiopg instrumentation to work with aiopg < 2.0.0


### PR DESCRIPTION
# Description

Add user config function `db_statement_serializer` to allow users to sanitize queries set on the spans on the `db.statement` attribute.

This gives users a way to sanitize queries and not store any PII on the span.

This user function approach was chosen, because I've seen it in the Node.js OpenTelemetry instrumentation packages as well.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e test-instrumentation-redis`

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
