### PR TITLE
add a test for urllib3 using NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -349,6 +349,15 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertIn("response_hook_attr", span.attributes)
         self.assertEqual(span.attributes["response_hook_attr"], "value")
 
+    def test_no_op_tracer_provider(self):
+        URLLibInstrumentor().uninstrument()
+        tracer_provider = trace.NoOpTracerProvider
+        URLLibInstrumentor().instrument(tracer_provider=tracer_provider)
+
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.read(), b"Hello!")
+        self.assert_span(num_spans=0)
+
 
 class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -330,3 +330,12 @@ class TestURLLib3Instrumentor(TestBase):
 
         self.assertIn("request_hook_body", span.attributes)
         self.assertEqual(span.attributes["request_hook_body"], body)
+
+    def test_no_op_tracer_provider(self):
+        URLLib3Instrumentor().uninstrument()
+        tracer_provider = trace.NoOpTracerProvider
+        URLLib3Instrumentor().instrument(tracer_provider=tracer_provider)
+
+        response = self.perform_request(self.HTTP_URL)
+        self.assertEqual(b"Hello!", response.data)
+        self.assert_span(num_spans=0)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -333,7 +333,7 @@ class TestURLLib3Instrumentor(TestBase):
 
     def test_no_op_tracer_provider(self):
         URLLib3Instrumentor().uninstrument()
-        tracer_provider = trace.NoOpTracerProvider
+        tracer_provider = trace.NoOpTracerProvider()
         URLLib3Instrumentor().instrument(tracer_provider=tracer_provider)
 
         response = self.perform_request(self.HTTP_URL)


### PR DESCRIPTION
# Description

Add a test for urllib3 instrumentation to ensure that NoOpTracerProvider works

Fixes #960 

# How Has This Been Tested?

- Instrument the library using a NoOpTracerProvider. the test validates that no spans are being produced.

# Does This PR Require a Core Repo Change?

- No.
