### PR TITLE
[TortoiseORM instrumentation] Fix `AttributeError: type object 'Config' has no attribute 'title'`

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
@@ -300,7 +300,7 @@ class TortoiseORMInstrumentor(BaseInstrumentor):
 
                 model_config = getattr(modelcls, "Config", None)
                 if model_config:
-                    model_title = getattr(modelcls.Config, "title")
+                    model_title = getattr(modelcls.Config, "title", modelcls.__name__)
                     if model_title:
                         span_attributes["pydantic.model"] = model_title
 


### PR DESCRIPTION
# Description
The attribute `title` from `PydanticModel.Config` is optional, however, this instrumentation assumes that it will be present, which will raise an `AttributeError` when the `title` is missing. To avoid users to add the title attribute for all pydantic models, this PR adds the model name as the default title value.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
