### PR TITLE
fix the instantiation of NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -150,7 +150,7 @@ class TestRedis(TestBase):
 
     def test_no_op_tracer_provider(self):
         RedisInstrumentor().uninstrument()
-        tracer_provider = trace.NoOpTracerProvider
+        tracer_provider = trace.NoOpTracerProvider()
         RedisInstrumentor().instrument(tracer_provider=tracer_provider)
 
         redis_client = redis.Redis()

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -258,7 +258,7 @@ class TestSqlalchemyInstrumentation(TestBase):
         engine = create_engine("sqlite:///:memory:")
         SQLAlchemyInstrumentor().instrument(
             engine=engine,
-            tracer_provider=trace.NoOpTracerProvider,
+            tracer_provider=trace.NoOpTracerProvider(),
         )
         cnx = engine.connect()
         cnx.execute("SELECT 1 + 1;").fetchall()

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -351,7 +351,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
     def test_no_op_tracer_provider(self):
         URLLibInstrumentor().uninstrument()
-        tracer_provider = trace.NoOpTracerProvider
+        tracer_provider = trace.NoOpTracerProvider()
         URLLibInstrumentor().instrument(tracer_provider=tracer_provider)
 
         result = self.perform_request(self.URL)


### PR DESCRIPTION
# Description

Due to a [comment](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1574#discussion_r1068129310) raised by @mariojonke, fix the instantiation of NoOpTracerProvider in a few test cases.

This will make sure that the objects are being instantiated properly.
