### PR TITLE
botocore: Add enhanced support for SQS

### DIFF
--- a/docs/instrumentation/botocore/botocore.rst
+++ b/docs/instrumentation/botocore/botocore.rst
@@ -5,3 +5,11 @@ OpenTelemetry Botocore Instrumentation
     :members:
     :undoc-members:
     :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+    :maxdepth: 1
+
+    sqs

--- a/docs/instrumentation/botocore/sqs.rst
+++ b/docs/instrumentation/botocore/sqs.rst
@@ -1,0 +1,7 @@
+OpenTelemetry Botocore Instrumentation - SQS
+============================================
+
+.. automodule:: opentelemetry.instrumentation.botocore.extensions.sqs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -47,15 +47,15 @@ API
 
 The `instrument` method accepts the following keyword args:
 
-tracer_provider (TracerProvider) - an optional tracer provider
-request_hook (Callable) - a function with extra user-defined logic to be performed before performing the request
-this function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, api_params: dict) -> None
-response_hook (Callable) - a function with extra user-defined logic to be performed after performing the request
-this function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, result: dict) -> None
+* tracer_provider (TracerProvider) - an optional tracer provider
+* request_hook (Callable) - a function with extra user-defined logic to be performed before performing the request.
+  This function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, api_params: dict) -> None
+* response_hook (Callable) - a function with extra user-defined logic to be performed after performing the request.
+  This function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, result: dict) -> None
 
 for example:
 
-.. code: python
+.. code:: python
 
     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
     import botocore
@@ -103,7 +103,7 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagate import inject
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import get_tracer
+from opentelemetry.trace import Tracer, get_tracer
 from opentelemetry.trace.span import Span
 
 logger = logging.getLogger(__name__)
@@ -161,7 +161,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return original_func(*args, **kwargs)
 
-        call_context = _determine_call_context(instance, args)
+        call_context = _determine_call_context(instance, args, self._tracer)
         if call_context is None:
             return original_func(*args, **kwargs)
 
@@ -262,10 +262,10 @@ def _apply_response_attributes(span: Span, result):
 
 
 def _determine_call_context(
-    client: BaseClient, args: Tuple[str, Dict[str, Any]]
+    client: BaseClient, args: Tuple[str, Dict[str, Any]], tracer: Tracer
 ) -> Optional[_AwsSdkCallContext]:
     try:
-        call_context = _AwsSdkCallContext(client, args)
+        call_context = _AwsSdkCallContext(client, args, tracer)
 
         logger.debug(
             "AWS SDK invocation: %s %s",

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
@@ -11,59 +11,428 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 
+"""
+The OpenTelemetry botocore instrumentation provides enhanced support for SQS
+by setting additional span attributes and injecting/extracting the trace context
+to properly link spans.
+
+The following SQS operations are automatically enhanced:
+
+send_message / send_message_batch
+---------------------------------
+
+* Messaging span attributes are added according to the `messaging specification`_.
+* The OpenTelemetry trace context is injected into the SQS MessageAttributes of
+  each message, so the service receiving the message can link cascading spans
+  to the trace which created the message.
+
+receive_message
+---------------
+
+The ``receive_message`` operation returns a batch of message and typically
+each message is then processed separately. According to the OpenTelemetry
+`messaging specification`_, users of this instrumentation would expect so see
+one span for the receive operation and a separate span for the processing of
+each message.
+The span for the ``receive_message`` operation is automatically created and span
+attributes are set accordingly. Processing spans require some manual instrumentation.
+
+Processing Spans
+^^^^^^^^^^^^^^^^
+
+The processing of SQS messages might differ per message. E.g. one message might
+result in storing something to a DB, where another message might result in
+calling an external HTTP endpoint.
+
+For the botocore instrumentation it is not possible when the processing of an
+SQS message starts, respectively ends. Thus, the processing operation needs to
+be manually instrumented.
+The botocore instrumentation provides the following means for tracing the
+processing of SQS messages:
+
+* `wrap_sqs_processing` decorator, to create the processing span for an arbitrary
+  processing function that takes an SQS message as argument.
+* `sqs_processing_span` context manager, to create the processing span for the
+  scope where context manager is active.
+
+The trace context is extracted from the SQS MessageAttributes and set on
+the processing span's links accordingly. The parent of the processing span is
+the span of the ``receive_message`` operation.
+
+Integrating with SNS
+^^^^^^^^^^^^^^^^^^^^
+
+SQS queues can subscribe to SNS topics, so that the messages published to an SNS
+topic is forwarded to the subscribed SQS queue. The form in which the SNS message
+is forwarded to the SQS queue depends on the `raw message delivery`_ configuration
+on the subscription.
+
+* If raw message delivery is enabled the SNS message is
+  forwarded to SQS as is. SNS MessageAttributes are converted into SQS
+  MessageAttributes and are directly available on the SQS message.
+* If raw message delivery is disabled (the default), the SNS message and its
+  MessageAttributes is serialized as JSON string into the message body of the
+  SQS message.
+
+By default, the instrumentation, when creating the processing span, extracts the
+trace context only from the MessageAttributes of the SQS message. To also extract
+the trace context from the SQS message's body (and thus properly link the
+processing span to the sender span) the ``extract_from_payload=True`` argument
+needs to be passed to either the `wrap_sqs_processing` decorator or the
+`sqs_processing_span` context manager.
+
+.. _messaging Specification: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md
+.. _raw message delivery: https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
+"""
+
+import abc
+import contextlib
+import functools
+import inspect
+import itertools
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    NamedTuple,
+    Optional,
+    TypeVar,
+    cast,
+)
+
+from opentelemetry.instrumentation.botocore.extensions._messaging import (
+    extract_propagation_context,
+    inject_span_into_message,
+)
 from opentelemetry.instrumentation.botocore.extensions.types import (
     _AttributeMapT,
+    _AwsSdkCallContext,
     _AwsSdkExtension,
     _BotoResultT,
 )
-from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace.span import Span
+from opentelemetry.propagate import get_global_textmap
+from opentelemetry.semconv.trace import (
+    MessagingDestinationKindValues,
+    MessagingOperationValues,
+    SpanAttributes,
+)
+from opentelemetry.trace import Link, SpanKind, Tracer
+from opentelemetry.trace.propagation import set_span_in_context
+from opentelemetry.trace.span import INVALID_SPAN, Span
 
-_SUPPORTED_OPERATIONS = ["SendMessage", "SendMessageBatch", "ReceiveMessage"]
+_messaging_system = "aws.sqs"
+_sqs_msg_attr_key = "_otel_msg_ctx"
 
-_logger = logging.getLogger(__name__)
+
+################################################################################
+# common utils
+################################################################################
+
+
+def _add_common_attributes(
+    attrs: _AttributeMapT, queue_url: Optional[str]
+) -> Optional[str]:
+    attrs[
+        SpanAttributes.MESSAGING_DESTINATION_KIND
+    ] = MessagingDestinationKindValues.QUEUE.value
+
+    queue_name = None if not queue_url else queue_url.split("/")[-1]
+    if queue_url:
+        attrs[SpanAttributes.MESSAGING_DESTINATION] = queue_name
+        attrs[SpanAttributes.MESSAGING_URL] = queue_url
+
+    return queue_name
+
+
+def _destination_name_from_url(queue_url: Optional[str]) -> Optional[str]:
+    return None if not queue_url else queue_url.split("/")[-1]
+
+
+class _PatchableDict(Dict):
+    pass
+
+
+class _SqsMessageContext(NamedTuple):
+    tracer: Tracer
+    receive_span: Span
+    queue_url: str
+
+
+################################################################################
+# SQS operations
+################################################################################
+
+
+class _SqsOperation(abc.ABC):
+    operation_name: str = None
+    span_kind = SpanKind.CLIENT
+    span_name_suffix: str = None
+
+    @classmethod
+    def extract_attributes(
+        cls, call_context: _AwsSdkCallContext, attributes: _AttributeMapT
+    ):
+        queue_name = _add_common_attributes(
+            attributes, call_context.params.get("QueueUrl")
+        )
+        if cls.span_name_suffix:
+            call_context.span_name = (
+                f"{queue_name or 'unknown'} {cls.span_name_suffix}"
+            )
+
+    @classmethod
+    def before_service_call(cls, call_context: _AwsSdkCallContext, span: Span):
+        pass
+
+    @classmethod
+    def on_response(
+        cls, call_context: _AwsSdkCallContext, span: Span, result: _BotoResultT
+    ):
+        pass
+
+
+class _OpSendMessage(_SqsOperation):
+    operation_name = "SendMessage"
+    span_kind = SpanKind.PRODUCER
+    span_name_suffix = "send"
+
+    @classmethod
+    def before_service_call(cls, call_context: _AwsSdkCallContext, span: Span):
+        inject_span_into_message(call_context.params)
+
+    @classmethod
+    def on_response(
+        cls, call_context: _AwsSdkCallContext, span: Span, result: _BotoResultT
+    ):
+        span.set_attribute(
+            SpanAttributes.MESSAGING_MESSAGE_ID, result.get("MessageId")
+        )
+
+
+class _OpSendMessageBatch(_SqsOperation):
+    operation_name = "SendMessageBatch"
+    span_kind = SpanKind.PRODUCER
+    span_name_suffix = "send"
+
+    @classmethod
+    def before_service_call(cls, call_context: _AwsSdkCallContext, span: Span):
+        for message in call_context.params.get("Entries") or ():
+            inject_span_into_message(message)
+
+    @classmethod
+    def on_response(
+        cls, call_context: _AwsSdkCallContext, span: Span, result: _BotoResultT
+    ):
+        # TODO: How to handle setting span attributes for multiple messages?
+        pass
+
+
+class _OpReceiveMessage(_SqsOperation):
+    operation_name = "ReceiveMessage"
+    span_kind = SpanKind.CONSUMER
+    span_name_suffix = "receive"
+
+    @classmethod
+    def extract_attributes(
+        cls, call_context: _AwsSdkCallContext, attributes: _AttributeMapT
+    ):
+        super().extract_attributes(call_context, attributes)
+
+        attributes[
+            SpanAttributes.MESSAGING_OPERATION
+        ] = MessagingOperationValues.RECEIVE.value
+
+        # make AWS deliver the attributes required for context propagation
+        msg_attr_names = list(
+            call_context.params.get("MessageAttributeNames") or ()
+        )
+        msg_attr_names.extend(get_global_textmap().fields)
+        call_context.params["MessageAttributeNames"] = msg_attr_names
+
+    @classmethod
+    def on_response(
+        cls, call_context: _AwsSdkCallContext, span: Span, result: _BotoResultT
+    ):
+        sqs_msg_ctx = _SqsMessageContext(
+            call_context.tracer, span, call_context.params.get("QueueUrl")
+        )
+        result["Messages"] = [
+            cls._patch_message(message, sqs_msg_ctx)
+            for message in result.get("Messages") or ()
+        ]
+
+    @classmethod
+    def _patch_message(
+        cls, message: Dict[str, Any], sqs_msg_ctx: "_SqsMessageContext"
+    ) -> "_PatchableDict":
+        patchable_message = _PatchableDict(message)
+        setattr(patchable_message, _sqs_msg_attr_key, sqs_msg_ctx)
+
+        return patchable_message
+
+
+################################################################################
+# SQS extension
+################################################################################
+
+_OPERATION_MAPPING = {
+    op.operation_name: op
+    for op in globals().values()
+    if inspect.isclass(op)
+    and issubclass(op, _SqsOperation)
+    and not inspect.isabstract(op)
+}  # type: Dict[str, _SqsOperation]
 
 
 class _SqsExtension(_AwsSdkExtension):
+    def __init__(self, call_context: _AwsSdkCallContext):
+        super().__init__(call_context)
+        self._op = _OPERATION_MAPPING.get(call_context.operation)
+        if self._op:
+            call_context.span_kind = self._op.span_kind
+
     def extract_attributes(self, attributes: _AttributeMapT):
-        queue_url = self._call_context.params.get("QueueUrl")
-        if queue_url:
-            # TODO: update when semantic conventions exist
-            attributes["aws.queue_url"] = queue_url
-            attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.sqs"
-            attributes[SpanAttributes.MESSAGING_URL] = queue_url
-            try:
-                attributes[
-                    SpanAttributes.MESSAGING_DESTINATION
-                ] = queue_url.split("/")[-1]
-            except IndexError:
-                _logger.error(
-                    "Could not extract messaging destination from '%s'",
-                    queue_url,
-                )
+        attributes[SpanAttributes.MESSAGING_SYSTEM] = _messaging_system
+
+        if self._op:
+            self._op.extract_attributes(self._call_context, attributes)
+
+    def before_service_call(self, span: Span):
+        if self._op:
+            self._op.before_service_call(self._call_context, span)
 
     def on_success(self, span: Span, result: _BotoResultT):
-        operation = self._call_context.operation
-        if operation in _SUPPORTED_OPERATIONS:
-            try:
-                if operation == "SendMessage":
-                    span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
-                        result.get("MessageId"),
-                    )
-                elif operation == "SendMessageBatch" and result.get(
-                    "Successful"
-                ):
-                    span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
-                        result["Successful"][0]["MessageId"],
-                    )
-                elif operation == "ReceiveMessage" and result.get("Messages"):
-                    span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
-                        result["Messages"][0]["MessageId"],
-                    )
-            except (IndexError, KeyError):
-                _logger.error("Could not extract the messaging message ID")
+        if self._op:
+            self._op.on_response(self._call_context, span, result)
+
+
+################################################################################
+# Processing received SQS messages
+################################################################################
+
+
+@contextlib.contextmanager
+def sqs_processing_span(
+    message: Dict[str, Any], extract_from_payload: bool = False
+) -> Iterator[Span]:
+    """A context manager to trace the processing of a received SQS message.
+
+    Example::
+
+        import botocore
+        from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+        from opentelemetry.instrumentation.botocore.extensions.sqs import sqs_processing_span
+
+        BotocoreInstrumentor().instrument()
+
+        session = botocore.session.get_session()
+        session.set_credentials(access_key="access-key", secret_key="secret-key")
+        client = self.client = session.create_client("sqs", region_name="us-west-2")
+
+        result = self.client.receive_message(QueueUrl='<queue-url>')
+        for message in result["Messages"]:
+            with sqs_processing_span(message):
+                # message processing goes here
+                pass
+
+    Args:
+        message: the SQS message to trace
+        extract_from_payload: AWS delivers SNS messages as payload in the SQS
+            message body when an SQS queue is subscribed to an SNS topic and
+            ``raw message delivery`` is disabled. Set this parameter to ``True``
+            to extract the propagation context from the payload of the SQS message.
+    """
+    msg_ctx = getattr(
+        message, _sqs_msg_attr_key, None
+    )  # type: Optional[_SqsMessageContext]
+    if not msg_ctx:
+        yield INVALID_SPAN
+        return
+
+    attrs = {
+        SpanAttributes.MESSAGING_SYSTEM: _messaging_system,
+        SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.PROCESS.value,
+        SpanAttributes.MESSAGING_MESSAGE_ID: message.get("MessageId"),
+    }
+    queue_name = _add_common_attributes(attrs, msg_ctx.queue_url)
+
+    parent_ctx = set_span_in_context(msg_ctx.receive_span)
+    link_span = extract_propagation_context(message, extract_from_payload)
+
+    links = ()
+    link_span_ctx = link_span.get_span_context()
+    if link_span_ctx.is_valid:
+        links = [Link(link_span_ctx)]
+
+    with msg_ctx.tracer.start_as_current_span(
+        f"{queue_name or 'unknown'} process",
+        parent_ctx,
+        SpanKind.CONSUMER,
+        attributes=attrs,
+        links=links,
+    ) as span:
+        yield span
+
+
+_ProcessFuncT = TypeVar("_ProcessFuncT", bound=Callable[..., Any])
+
+
+def wrap_sqs_processing(
+    func: _ProcessFuncT = None, extract_from_payload: bool = False
+) -> _ProcessFuncT:
+    """A decorator to trace the processing of received SQS messages.
+
+    The SQS message can be anywhere in the parameter list of the decorated
+    function. The decorator will automatically detect the SQS message and create
+    a corresponding processing span.
+
+    Example::
+
+        import botocore
+        from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+        from opentelemetry.instrumentation.botocore.extensions.sqs import wrap_sqs_processing
+
+        BotocoreInstrumentor().instrument()
+
+        session = botocore.session.get_session()
+        session.set_credentials(access_key="access-key", secret_key="secret-key")
+        client = self.client = session.create_client("sqs", region_name="us-west-2")
+
+        @wrap_sqs_processing()
+        def process_sqs_message(message):
+            # message processing goes here
+            pass
+
+        result = self.client.receive_message(QueueUrl='<queue-url>')
+        for message in result["Messages"]:
+            process_sqs_message(message)
+
+    Args:
+        func: the processing function to decorate
+        extract_from_payload: AWS delivers SNS messages as payload in the SQS
+            message body when an SQS queue is subscribed to an SNS topic and
+            ``raw message delivery`` is disabled. Set this parameter to ``True``
+            to extract the propagation context from the payload of the SQS message.
+    """
+    if func is None:
+        return functools.partial(
+            wrap_sqs_processing, extract_from_payload=extract_from_payload
+        )
+
+    if not callable(func):
+        return cast(_ProcessFuncT, func)
+
+    @functools.wraps(func)
+    def _wrapper(*wargs, **wkwargs):
+        message = None
+        for arg in itertools.chain(wargs, wkwargs.values()):
+            if getattr(arg, _sqs_msg_attr_key, None):
+                message = arg
+                break
+
+        with sqs_processing_span(message, extract_from_payload):
+            return func(*wargs, **wkwargs)
+
+    return cast(_ProcessFuncT, _wrapper)

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/types.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/types.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.trace.span import Span
 from opentelemetry.util.types import AttributeValue
 
@@ -46,7 +46,12 @@ class _AwsSdkCallContext:
         span_kind: the kind used to create the span.
     """
 
-    def __init__(self, client: _BotoClientT, args: Tuple[str, Dict[str, Any]]):
+    def __init__(
+        self,
+        client: _BotoClientT,
+        args: Tuple[str, Dict[str, Any]],
+        tracer: Tracer,
+    ):
         operation = args[0]
         try:
             params = args[1]
@@ -57,6 +62,7 @@ class _AwsSdkCallContext:
         boto_meta = client.meta
         service_model = boto_meta.service_model
 
+        self.tracer = tracer
         self.service = service_model.service_name.lower()  # type: str
         self.operation = operation  # type: str
         self.params = params  # type: Dict[str, Any]

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -185,27 +185,6 @@ class TestBotocoreInstrumentor(TestBase):
             "SQS", "ListQueues", request_id=_REQUEST_ID_REGEX_MATCH
         )
 
-    @mock_sqs
-    def test_sqs_send_message(self):
-        sqs = self._make_client("sqs")
-        test_queue_name = "test_queue_name"
-
-        response = sqs.create_queue(QueueName=test_queue_name)
-        self.assert_span(
-            "SQS", "CreateQueue", request_id=_REQUEST_ID_REGEX_MATCH
-        )
-        self.memory_exporter.clear()
-
-        queue_url = response["QueueUrl"]
-        sqs.send_message(QueueUrl=queue_url, MessageBody="Test SQS MESSAGE!")
-
-        self.assert_span(
-            "SQS",
-            "SendMessage",
-            request_id=_REQUEST_ID_REGEX_MATCH,
-            attributes={"aws.queue_url": queue_url},
-        )
-
     @mock_kinesis
     def test_kinesis_client(self):
         kinesis = self._make_client("kinesis")

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_messaging.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_messaging.py
@@ -11,12 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+from typing import Any, MutableMapping
 
 from opentelemetry.instrumentation.botocore.extensions._messaging import (
+    extract_propagation_context,
     inject_propagation_context,
+    message_attributes_getter,
     message_attributes_setter,
 )
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.span import (
+    INVALID_SPAN,
+    format_span_id,
+    format_trace_id,
+)
+
+
+def _add_trace_parent(
+    message: MutableMapping[str, Any], trace_id: int, span_id: int
+):
+    attrs = message.setdefault("MessageAttributes", {})
+    attrs["traceparent"] = {
+        "DataType": "String",
+        "StringValue": f"00-{format_trace_id(trace_id)}-{format_span_id(span_id)}-01",
+    }
+    return message
 
 
 class TestMessageAttributes(TestBase):
@@ -50,3 +70,56 @@ class TestMessageAttributes(TestBase):
             inject_propagation_context(carrier)
 
         self.assertEqual(10, len(carrier))
+
+    def test_message_attributes_getter(self):
+        carrier = {
+            "sqs-key": {"DataType": "String", "StringValue": "sqs-value"},
+            "sns-key": {"Type": "String", "Value": "sns-value"},
+            "other": {"some": "value"},
+            "other2": "value",
+        }
+
+        self.assertEqual(
+            ["sqs-value"], message_attributes_getter.get(carrier, "sqs-key")
+        )
+        self.assertEqual(
+            ["sns-value"], message_attributes_getter.get(carrier, "sns-key")
+        )
+        self.assertIsNone(message_attributes_getter.get(carrier, "other"))
+        self.assertIsNone(message_attributes_getter.get(carrier, "other2"))
+
+    def test_extract_propagation_context(self):
+        message = _add_trace_parent({}, 17, 42)
+        span = extract_propagation_context(message)
+        self.assertEqual(17, span.get_span_context().trace_id)
+        self.assertEqual(42, span.get_span_context().span_id)
+
+    def test_extract_propagation_context_from_payload(self):
+        message = {"Body": json.dumps(_add_trace_parent({}, 17, 42))}
+        span = extract_propagation_context(message, extract_from_payload=False)
+        self.assertIs(INVALID_SPAN, span)
+
+        span = extract_propagation_context(message, extract_from_payload=True)
+        self.assertEqual(17, span.get_span_context().trace_id)
+        self.assertEqual(42, span.get_span_context().span_id)
+
+    def test_extract_propagation_context_from_payload_without_msg_attrs(self):
+        message = {"Body": "{}"}
+        self.assertIs(
+            INVALID_SPAN,
+            extract_propagation_context(message, extract_from_payload=True),
+        )
+
+    def test_extract_propagation_context_from_malformed_payload(self):
+        message = {"Body": '{"MessageAttributes": {'}
+        self.assertIs(
+            INVALID_SPAN,
+            extract_propagation_context(message, extract_from_payload=True),
+        )
+
+    def test_extract_propagation_context_from_non_dict_payload(self):
+        message = {"Body": "123"}
+        self.assertIs(
+            INVALID_SPAN,
+            extract_propagation_context(message, extract_from_payload=True),
+        )

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sqs.py
@@ -1,9 +1,55 @@
-import botocore.session
-from moto import mock_sqs
+import contextlib
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple
 
+import botocore.session
+from moto import mock_sns, mock_sqs
+
+from opentelemetry.context import attach, detach
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.instrumentation.botocore.extensions.sqs import (
+    sqs_processing_span,
+    wrap_sqs_processing,
+)
+from opentelemetry.semconv.trace import (
+    MessagingDestinationKindValues,
+    MessagingOperationValues,
+    SpanAttributes,
+)
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.propagation import set_span_in_context
+from opentelemetry.trace.span import (
+    NonRecordingSpan,
+    Span,
+    SpanContext,
+    TraceFlags,
+)
+
+_default_queue_name = "test-queue"
+_default_topic_name = "test-topic"
+
+
+class SqsQueue(NamedTuple):
+    url: str
+    name: str
+
+
+class SnsTopic(NamedTuple):
+    arn: str
+    name: str
+
+
+@contextlib.contextmanager
+def _active_span(trace_id: int = 37, span_id: int = 73):
+    sampled = TraceFlags(TraceFlags.SAMPLED)
+    span = NonRecordingSpan(
+        SpanContext(trace_id, span_id, is_remote=False, trace_flags=sampled)
+    )
+    token = attach(set_span_in_context(span))
+    try:
+        yield span
+    finally:
+        detach(token)
 
 
 class TestSqsExtension(TestBase):
@@ -17,120 +63,402 @@ class TestSqsExtension(TestBase):
         )
         self.region = "us-west-2"
         self.client = session.create_client("sqs", region_name=self.region)
+        self.sns_client = session.create_client("sns", region_name=self.region)
 
     def tearDown(self):
         super().tearDown()
         BotocoreInstrumentor().uninstrument()
 
-    @mock_sqs
-    def test_sqs_messaging_send_message(self):
-        create_queue_result = self.client.create_queue(
-            QueueName="test_queue_name"
-        )
-        queue_url = create_queue_result["QueueUrl"]
-        response = self.client.send_message(
-            QueueUrl=queue_url, MessageBody="content"
+    def _create_queue(self, queue_name: str = _default_queue_name) -> SqsQueue:
+        result = self.client.create_queue(QueueName=queue_name)
+
+        # ignore create queue span
+        self.memory_exporter.clear()
+
+        return SqsQueue(result["QueueUrl"], queue_name)
+
+    def _create_sns_to_sqs(
+        self,
+        queue_name: str = _default_queue_name,
+        topic_name: str = _default_topic_name,
+        raw_msg_delivery: bool = False,
+    ) -> Tuple[SqsQueue, SnsTopic]:
+        topic = self.sns_client.create_topic(Name=topic_name)
+        queue = self.client.create_queue(QueueName=queue_name)
+        queue_arn = self.client.get_queue_attributes(
+            QueueUrl=queue["QueueUrl"], AttributeNames=["QueueArn"]
         )
 
+        self.sns_client.subscribe(
+            TopicArn=topic["TopicArn"],
+            Protocol="sqs",
+            Endpoint=queue_arn["Attributes"]["QueueArn"],
+            Attributes={
+                "RawMessageDelivery": "true" if raw_msg_delivery else "false"
+            },
+        )
+
+        self.memory_exporter.clear()
+        return (
+            SqsQueue(queue["QueueUrl"], queue_name),
+            SnsTopic(topic["TopicArn"], topic_name),
+        )
+
+    def _assert_span(self, name: str, span_kind=SpanKind.PRODUCER) -> Span:
         spans = self.memory_exporter.get_finished_spans()
-        assert spans
-        self.assertEqual(len(spans), 2)
-        span = spans[1]
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+
+        self.assertEqual(span_kind, span.kind)
+        self.assertEqual(name, span.name)
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+            "aws.sqs", span.attributes[SpanAttributes.MESSAGING_SYSTEM]
+        )
+
+        return span
+
+    def _assert_common_span_attrs(self, span: Span, queue: SqsQueue):
+        self.assertEqual(
+            queue.url, span.attributes[SpanAttributes.MESSAGING_URL]
         )
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
+            queue.name, span.attributes[SpanAttributes.MESSAGING_DESTINATION]
         )
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
-            "test_queue_name",
+            MessagingDestinationKindValues.QUEUE.value,
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION_KIND],
         )
+
+    def _assert_send_span(
+        self,
+        queue: SqsQueue,
+        message: Optional[Dict[str, Any]] = None,
+    ) -> Span:
+        span = self._assert_span(f"{queue.name} send", SpanKind.PRODUCER)
+        self._assert_common_span_attrs(span, queue)
+        if message:
+            self.assertEqual(
+                message["MessageId"],
+                span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            )
+        return span
+
+    def _assert_receive_span(self, queue: SqsQueue) -> Span:
+        span = self._assert_span(f"{queue.name} receive", SpanKind.CONSUMER)
+        self._assert_common_span_attrs(span, queue)
         self.assertEqual(
+            MessagingOperationValues.RECEIVE.value,
+            span.attributes[SpanAttributes.MESSAGING_OPERATION],
+        )
+        return span
+
+    def _assert_process_span(
+        self, queue: SqsQueue, message: Dict[str, Any]
+    ) -> Span:
+        span = self._assert_span(f"{queue.name} process", SpanKind.CONSUMER)
+        self._assert_common_span_attrs(span, queue)
+        self.assertEqual(
+            message["MessageId"],
             span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
-            response["MessageId"],
         )
+        self.assertEqual(
+            MessagingOperationValues.PROCESS.value,
+            span.attributes[SpanAttributes.MESSAGING_OPERATION],
+        )
+        return span
+
+    def _assert_link(self, span: Span, linked_span: Optional[Span]):
+        if not linked_span:
+            self.assertEqual(0, len(span.links))
+            return
+
+        self.assertEqual(1, len(span.links))
+        link_ctx = span.links[0].context
+        expected_ctx = linked_span.get_span_context()
+
+        self.assertEqual(expected_ctx.trace_id, link_ctx.trace_id)
+        self.assertEqual(expected_ctx.span_id, link_ctx.span_id)
+
+    def _assert_injected_span(self, message_attrs: Dict[str, Any], span: Span):
+        # traceparent: <ver>-<trace-id>-<span-id>-<flags>
+        trace_parent = message_attrs["traceparent"]["StringValue"].split("-")
+        span_context = span.get_span_context()
+
+        self.assertEqual(span_context.trace_id, int(trace_parent[1], 16))
+        self.assertEqual(span_context.span_id, int(trace_parent[2], 16))
+
+    def _assert_parent(self, span: Span, parent_span: Span = None):
+        if not parent_span:
+            self.assertIsNone(span.parent)
+            return
+
+        parent_ctx = parent_span.get_span_context()
+        self.assertEqual(parent_ctx.trace_id, span.parent.trace_id)
+        self.assertEqual(parent_ctx.span_id, span.parent.span_id)
+
+    @mock_sqs
+    def test_sqs_messaging_send_message(self):
+        queue = self._create_queue()
+
+        response = self.client.send_message(
+            QueueUrl=queue.url, MessageBody="content"
+        )
+
+        span = self._assert_send_span(queue, response)
+        self.assertEqual(
+            "SendMessage", span.attributes[SpanAttributes.RPC_METHOD]
+        )
+
+    @mock_sqs
+    def test_send_message_injects_span(self):
+        msg_attrs = {}
+        queue = self._create_queue()
+        self.client.send_message(
+            QueueUrl=queue.url, MessageBody="msg", MessageAttributes=msg_attrs
+        )
+
+        span = self._assert_send_span(queue)
+        self._assert_injected_span(msg_attrs, span)
 
     @mock_sqs
     def test_sqs_messaging_send_message_batch(self):
-        create_queue_result = self.client.create_queue(
-            QueueName="test_queue_name"
-        )
-        queue_url = create_queue_result["QueueUrl"]
-        response = self.client.send_message_batch(
-            QueueUrl=queue_url,
+        queue = self._create_queue()
+
+        self.client.send_message_batch(
+            QueueUrl=queue.url,
             Entries=[
                 {"Id": "1", "MessageBody": "content"},
                 {"Id": "2", "MessageBody": "content2"},
             ],
         )
 
-        spans = self.memory_exporter.get_finished_spans()
-        assert spans
-        self.assertEqual(len(spans), 2)
-        span = spans[1]
-        self.assertEqual(span.attributes["rpc.method"], "SendMessageBatch")
+        span = self._assert_send_span(queue)
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+            "SendMessageBatch", span.attributes[SpanAttributes.RPC_METHOD]
         )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
+
+    @mock_sqs
+    def test_send_message_batch_injects_span(self):
+        msg_attrs1 = {}
+        msg_attrs2 = {}
+        queue = self._create_queue()
+        self.client.send_message_batch(
+            QueueUrl=queue.url,
+            Entries=[
+                {
+                    "Id": "1",
+                    "MessageBody": "Msg 1",
+                    "MessageAttributes": msg_attrs1,
+                },
+                {
+                    "Id": "2",
+                    "MessageBody": "Msg 2",
+                    "MessageAttributes": msg_attrs2,
+                },
+            ],
         )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
-            "test_queue_name",
+
+        span = self._assert_send_span(queue)
+        self._assert_injected_span(msg_attrs1, span)
+        self._assert_injected_span(msg_attrs2, span)
+
+    def _send_and_receive_message(
+        self,
+    ) -> Tuple[SqsQueue, Span, Span, Dict[str, Any]]:
+        queue = self._create_queue()
+
+        result = self.client.send_message(
+            QueueUrl=queue.url, MessageBody="hello"
         )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
-            response["Successful"][0]["MessageId"],
-        )
+        send_span = self._assert_send_span(queue, result)
+        self.memory_exporter.clear()
+
+        result = self.client.receive_message(QueueUrl=queue.url)
+        receive_span = self._assert_receive_span(queue)
+        self.memory_exporter.clear()
+
+        self.assertEqual(1, len(result["Messages"]))
+
+        return queue, send_span, receive_span, result
 
     @mock_sqs
     def test_sqs_messaging_receive_message(self):
-        create_queue_result = self.client.create_queue(
-            QueueName="test_queue_name"
-        )
-        queue_url = create_queue_result["QueueUrl"]
-        self.client.send_message(QueueUrl=queue_url, MessageBody="content")
-        message_result = self.client.receive_message(
-            QueueUrl=create_queue_result["QueueUrl"]
-        )
+        _, _, span, _ = self._send_and_receive_message()
 
-        spans = self.memory_exporter.get_finished_spans()
-        assert spans
-        self.assertEqual(len(spans), 3)
-        span = spans[-1]
-        self.assertEqual(span.attributes["rpc.method"], "ReceiveMessage")
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
-        )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
-        )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
-            "test_queue_name",
-        )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
-            message_result["Messages"][0]["MessageId"],
+            "ReceiveMessage", span.attributes[SpanAttributes.RPC_METHOD]
         )
 
     @mock_sqs
-    def test_sqs_messaging_failed_operation(self):
-        with self.assertRaises(Exception):
-            self.client.send_message(
-                QueueUrl="non-existing", MessageBody="content"
-            )
+    def test_process_message_ctx_manager(self):
+        queue, send_span, rcv_span, result = self._send_and_receive_message()
 
-        spans = self.memory_exporter.get_finished_spans()
-        assert spans
-        self.assertEqual(len(spans), 1)
-        span = spans[0]
-        self.assertEqual(span.attributes["rpc.method"], "SendMessage")
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+        with sqs_processing_span(result["Messages"][0]):
+            pass
+
+        span = self._assert_process_span(queue, result["Messages"][0])
+        self._assert_parent(span, rcv_span)
+        self._assert_link(span, send_span)
+
+    @mock_sqs
+    def test_process_message_ctx_manager_with_active_span(self):
+        queue, send_span, rcv_span, result = self._send_and_receive_message()
+
+        with _active_span():
+            with sqs_processing_span(result["Messages"][0]):
+                pass
+
+        span = self._assert_process_span(queue, result["Messages"][0])
+        self._assert_parent(span, rcv_span)
+        self._assert_link(span, send_span)
+
+    @mock_sqs
+    def test_process_message_decorator(self):
+        queue, send_span, rcv_span, result = self._send_and_receive_message()
+
+        @wrap_sqs_processing
+        def _process(_):
+            pass
+
+        _process(result["Messages"][0])
+        span = self._assert_process_span(queue, result["Messages"][0])
+        self._assert_parent(span, rcv_span)
+        self._assert_link(span, send_span)
+
+    @mock_sqs
+    def test_process_message_decorator_with_active_span(self):
+        queue, send_span, rcv_span, result = self._send_and_receive_message()
+
+        @wrap_sqs_processing
+        def _process(_):
+            pass
+
+        with _active_span():
+            _process(result["Messages"][0])
+
+        span = self._assert_process_span(queue, result["Messages"][0])
+        self._assert_parent(span, rcv_span)
+        self._assert_link(span, send_span)
+
+    def test_process_message_ctx_manager_ignores_non_receive_msg(self):
+        with sqs_processing_span({}):
+            pass
+
+        self.assertEqual(0, len(self.memory_exporter.get_finished_spans()))
+
+    def test_process_message_decorator_ignores_non_receive_msg(self):
+        @wrap_sqs_processing
+        def process(_1, _msg, _2):
+            pass
+
+        process(1, {}, 2)
+
+        self.assertEqual(0, len(self.memory_exporter.get_finished_spans()))
+
+    @mock_sqs
+    def test_receive_and_process_multiple_messages(self):
+        queue = self._create_queue()
+        self.client.send_message_batch(
+            QueueUrl=queue.url,
+            Entries=[
+                {"Id": "1", "MessageBody": "msg1"},
+                {"Id": "2", "MessageBody": "msg2"},
+            ],
         )
-        self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_URL], "non-existing"
+
+        send_span = self._assert_send_span(queue)
+        self.memory_exporter.clear()
+
+        response = self.client.receive_message(QueueUrl=queue.url)
+        self._assert_receive_span(queue)
+
+        self.assertGreater(len(response["Messages"]), 0)
+        for message in response["Messages"]:
+            self.memory_exporter.clear()
+
+            with sqs_processing_span(message):
+                pass
+
+            span = self._assert_process_span(queue, message)
+            self._assert_link(span, send_span)
+
+    @mock_sqs
+    @mock_sns
+    def _test_sns_to_sqs(
+        self,
+        raw_message_delivery: bool,
+        processor: Callable[[Any], None] = None,
+    ):
+        queue, topic = self._create_sns_to_sqs(
+            raw_msg_delivery=raw_message_delivery
         )
+
+        # send message -> sns
+        self.sns_client.publish(TopicArn=topic.arn, Message="Hello message")
+        self.assertEqual(1, len(self.memory_exporter.get_finished_spans()))
+        send_span = self.memory_exporter.get_finished_spans()[0]
+        self.memory_exporter.clear()
+
+        # sqs -> receive message
+        result = self.client.receive_message(QueueUrl=queue.url)
+        receive_span = self._assert_receive_span(queue)
+        self.memory_exporter.clear()
+
+        # process message
+        message = result["Messages"][0]
+        if processor:
+            processor(message)
+        else:
+            with sqs_processing_span(
+                message, extract_from_payload=not raw_message_delivery
+            ):
+                pass
+
+        span = self._assert_process_span(queue, message)
+        self._assert_parent(span, receive_span)
+        self._assert_link(span, send_span)
+
+    def test_sns_to_sqs_via_payload_delivery(self):
+        self._test_sns_to_sqs(raw_message_delivery=False)
+
+    def test_sns_to_sqs_raw_message_delivery(self):
+        self._test_sns_to_sqs(raw_message_delivery=True)
+
+    def test_sns_to_sqs_via_payload_delivery_decorator(self):
+        @wrap_sqs_processing(extract_from_payload=True)
+        def _process(_):
+            pass
+
+        self._test_sns_to_sqs(raw_message_delivery=False, processor=_process)
+
+    @mock_sqs
+    @mock_sns
+    def test_sns_to_sqs_payload_delivery_no_extract(self):
+        queue, topic = self._create_sns_to_sqs(raw_msg_delivery=False)
+
+        self.sns_client.publish(TopicArn=topic.arn, Message="Hello message")
+        self.memory_exporter.clear()
+
+        result = self.client.receive_message(QueueUrl=queue.url)
+        self._assert_receive_span(queue)
+        self.memory_exporter.clear()
+
+        # process message
+        message = result["Messages"][0]
+        with sqs_processing_span(message, extract_from_payload=False):
+            pass
+
+        span = self._assert_process_span(queue, message)
+        self._assert_link(span, None)  # no links, not extracted form payload
+
+    @mock_sqs
+    def test_sqs_messaging_failed_operation(self):
+        queue = SqsQueue("non-existing", "non-existing")
+        with self.assertRaises(Exception):
+            self.client.send_message(QueueUrl=queue.url, MessageBody="content")
+
+        span = self._assert_send_span(queue)
+        self.assertEqual(1, len(span.events))
+        error_event = span.events[0]
+        self.assertIn(SpanAttributes.EXCEPTION_MESSAGE, error_event.attributes)
+        self.assertIn(SpanAttributes.EXCEPTION_TYPE, error_event.attributes)


### PR DESCRIPTION
# Description

Adds enhanced support for SQS by setting relevant span attributes, and injecting/extracting the trace context into/from the MessageAttributes of SQS messages.

This PR adds the same functionality to the `botocore` instrumentation that already exists in the [Node.Js AWS-SDK instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk) and in the separate [boto3sqs instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto3sqs) package.

The way how SQS processing spans are handled is different though between the `boto3sqs` instrumentation and the approach in this PR.
The `boto3sqs` instrumentation tries to automatically create the processing spans while the `Messages` list (the return value of the `sqs.receive_message` call) is iterated. This is rather error prone since e.g. the list might be iterated multiple times, and the processing spans are tracked by the instrumentation in a more or less global dictionary which might lead to memory leaks.
Since for an instrumentation it is not reasonably possible to determine when to start/end a processing span, the automatic detection "feature" was not considered in this PR.
Instead the instrumentation provides a context manager and a decorator that need to be added manually, which in turn create the processing span for a corresponding SQS message.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added multiple unit tests to verify span attributes and trace context propagation for SQS and also SNS to SQS scenarios.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
