### PR TITLE
Add readthedocs documentation for confluent kafka instrumentation

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -43,6 +43,7 @@ tornado>=5.1.1
 tortoise-orm>=0.17.0
 ddtrace>=0.34.0
 httpx>=0.18.0
+confluent-kafka~=1.9.2
 
 # indirect dependency pins
 markupsafe==2.0.1

--- a/docs/instrumentation/confluent_kafka/confluent_kafka.rst
+++ b/docs/instrumentation/confluent_kafka/confluent_kafka.rst
@@ -1,0 +1,7 @@
+.. include:: ../../../instrumentation/opentelemetry-instrumentation-confluent-kafka/README.rst
+
+.. automodule:: opentelemetry.instrumentation.confluent_kafka
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/README.rst
@@ -16,6 +16,95 @@ Installation
     pip install opentelemetry-instrumentation-confluent-kafka
 
 
+"""
+Instrument confluent-kafka-python to report instrumentation-confluent-kafka produced and consumed messages
+
+Usage
+-----
+
+::
+
+    from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    from confluent_kafka import Producer, Consumer
+
+    # Instrument kafka
+    ConfluentKafkaInstrumentor().instrument()
+
+    # report a span of type producer with the default settings
+    conf1 = {'bootstrap.servers': "localhost:9092"}
+    producer = Producer(conf1)
+    producer.produce('my-topic',b'raw_bytes')
+    conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}
+    # report a span of type consumer with the default settings
+    consumer = Consumer(conf2)
+
+    def basic_consume_loop(consumer, topics):
+        try:
+            consumer.subscribe(topics)
+            running = True
+
+            while running:
+                msg = consumer.poll(timeout=1.0)
+
+                if msg is None: continue
+                if msg.error():
+
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+
+                        # End of partition event
+                        sys.stderr.write(f"{msg.topic() [{msg.partition()}] reached end at offset {msg.offset()}}")
+
+                    elif msg.error():
+                        raise KafkaException(msg.error())
+
+                else:
+                    msg_process(msg)
+        finally:
+            # Close down consumer to commit final offsets.
+            consumer.close()
+
+    basic_consume_loop(consumer, "my-topic")
+    ---
+
+The _instrument method accepts the following keyword args:
+tracer_provider (TracerProvider) - an optional tracer provider
+instrument_producer (Callable) - a function with extra user-defined logic to be performed before sending the message
+this function signature is:
+def instrument_producer(producer: Producer, tracer_provider=None)
+instrument_consumer (Callable) - a function with extra user-defined logic to be performed after consuming a message
+this function signature is:
+def instrument_consumer(consumer: Consumer, tracer_provider=None)
+for example:
+
+::
+    from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    from confluent_kafka import Producer, Consumer
+
+    inst = ConfluentKafkaInstrumentor()
+
+    p = confluent_kafka.Producer({'bootstrap.servers': 'localhost:29092'})
+    c = confluent_kafka.Consumer({
+        'bootstrap.servers': 'localhost:29092',
+        'group.id': 'mygroup',
+        'auto.offset.reset': 'earliest'
+    })
+
+    # instrument confluent kafka with produce and consume hooks
+    p = inst.instrument_producer(p, tracer_provider)
+    c = inst.instrument_consumer(c, tracer_provider=tracer_provider)
+
+
+    # Using kafka as normal now will automatically generate spans,
+    # including user custom attributes added from the hooks
+    conf = {'bootstrap.servers': "localhost:9092"}
+    p.produce('my-topic',b'raw_bytes')
+    msg = c.poll()
+
+API
+___
+"""
+
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """
-Instrument `confluent-kafka-python` to report instrumentation-confluent-kafka produced and consumed messages
+Instrument confluent-kafka-python to report instrumentation-confluent-kafka produced and consumed messages
 
 Usage
 -----
 
-..code:: python
+..code-block:: python
 
     from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
     from confluent_kafka import Producer, Consumer
@@ -30,26 +30,29 @@ Usage
     conf1 = {'bootstrap.servers': "localhost:9092"}
     producer = Producer(conf1)
     producer.produce('my-topic',b'raw_bytes')
-
-    conf2 = {'bootstrap.servers': "localhost:9092",
-        'group.id': "foo",
-        'auto.offset.reset': 'smallest'}
+    conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}
     # report a span of type consumer with the default settings
     consumer = Consumer(conf2)
+
     def basic_consume_loop(consumer, topics):
         try:
             consumer.subscribe(topics)
             running = True
+
             while running:
                 msg = consumer.poll(timeout=1.0)
-                if msg is None: continue
 
+                if msg is None: continue
                 if msg.error():
+
                     if msg.error().code() == KafkaError._PARTITION_EOF:
+
                         # End of partition event
-                        sys.stderr.write(f"{msg.topic()} [{msg.partition()}] reached end at offset {msg.offset()}}\n")
+                        sys.stderr.write(f"{msg.topic() [{msg.partition()}] reached end at offset {msg.offset()}}")
+
                     elif msg.error():
                         raise KafkaException(msg.error())
+
                 else:
                     msg_process(msg)
         finally:
@@ -57,18 +60,19 @@ Usage
             consumer.close()
 
     basic_consume_loop(consumer, "my-topic")
+    ---
 
-
-The `_instrument` method accepts the following keyword args:
+The _instrument method accepts the following keyword args:
 tracer_provider (TracerProvider) - an optional tracer provider
 instrument_producer (Callable) - a function with extra user-defined logic to be performed before sending the message
-                          this function signature is:
-                          def instrument_producer(producer: Producer, tracer_provider=None)
+this function signature is:
+def instrument_producer(producer: Producer, tracer_provider=None)
 instrument_consumer (Callable) - a function with extra user-defined logic to be performed after consuming a message
-                          this function signature is:
-                          def instrument_consumer(consumer: Consumer, tracer_provider=None)
+this function signature is:
+def instrument_consumer(consumer: Consumer, tracer_provider=None)
 for example:
-.. code: python
+
+.. code-block: python
     from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
     from confluent_kafka import Producer, Consumer
 
@@ -91,7 +95,6 @@ for example:
     conf = {'bootstrap.servers': "localhost:9092"}
     p.produce('my-topic',b'raw_bytes')
     msg = c.poll()
-
 
 API
 ___


### PR DESCRIPTION
### Description
Enable readthedocs auto-generated documentation to parse init.py doc
[1496](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1496)
### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  tox -e docs

### Does This PR Require a Core Repo Change?

- [ ]  Yes. - Link to PR:
- [x]  No.