### PR TITLE
Add a test for aws lambda using NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -38,7 +38,7 @@ from opentelemetry.propagators.aws.aws_xray_propagator import (
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace import SpanKind, NoOpTracerProvider
+from opentelemetry.trace import NoOpTracerProvider, SpanKind
 from opentelemetry.trace.propagation.tracecontext import (
     TraceContextTextMapPropagator,
 )

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -38,7 +38,7 @@ from opentelemetry.propagators.aws.aws_xray_propagator import (
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, NoOpTracerProvider
 from opentelemetry.trace.propagation.tracecontext import (
     TraceContextTextMapPropagator,
 )
@@ -412,5 +412,14 @@ class TestAwsLambdaInstrumentor(TestBase):
         AwsLambdaInstrumentor().uninstrument()
 
         mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+    def test_no_op_tracer_provider(self):
+        tracer_provider = NoOpTracerProvider()
+        AwsLambdaInstrumentor().instrument(tracer_provider=tracer_provider)
+
+        mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT)
+
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -420,6 +420,6 @@ class TestAwsLambdaInstrumentor(TestBase):
         AwsLambdaInstrumentor().instrument(tracer_provider=tracer_provider)
 
         mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT)
-
         spans = self.memory_exporter.get_finished_spans()
+        assert spans is not None
         self.assertEqual(len(spans), 0)


### PR DESCRIPTION
# Description

Add a test for aws lambda instrumentation to ensure that NoOpTracerProvider works

Fixes #990 

# How Has This Been Tested?

- Instrument the library using a NoOpTracerProvider. the test validates that no spans are being produced.

# Does This PR Require a Core Repo Change?

- No.
