### PR TITLE
Fix install of Python 3.10 on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install tox
         run: pip install tox==3.27.1
       - name: Install libsnappy-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,10 @@ jobs:
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install tox
         run: pip install tox==3.27.1
       - name: Install libsnappy-dev

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/example/sampleapp.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/example/sampleapp.py
@@ -46,7 +46,7 @@ meter = metrics.get_meter(__name__)
 
 # Callback to gather cpu usage
 def get_cpu_usage_callback(observer):
-    for (number, percent) in enumerate(psutil.cpu_percent(percpu=True)):
+    for number, percent in enumerate(psutil.cpu_percent(percpu=True)):
         labels = {"cpu_number": str(number)}
         yield Observation(percent, labels)
 

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -300,7 +300,6 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         return sanitized
 
     def _parse_histogram_data_point(self, data_point, name):
-
         sample_attr_pairs = []
 
         base_attrs = list(data_point.attributes.items())
@@ -341,7 +340,6 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         return sample_attr_pairs
 
     def _parse_data_point(self, data_point, name=None):
-
         attrs = tuple(data_point.attributes.items()) + (
             ("__name__", self._sanitize_string(name, "name")),
         )

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/gen/remote_pb2.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/gen/remote_pb2.py
@@ -31,7 +31,6 @@ _builder.BuildTopDescriptorsAndMessages(
     globals(),
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"Z\006prompb"
     _WRITEREQUEST.fields_by_name["timeseries"]._options = None

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/gen/types_pb2.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/gen/types_pb2.py
@@ -28,7 +28,6 @@ _builder.BuildTopDescriptorsAndMessages(
     globals(),
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"Z\006prompb"
     _EXEMPLAR.fields_by_name["labels"]._options = None

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -56,7 +56,6 @@ def test_regex_invalid(prom_rw):
 
 
 def test_parse_data_point(prom_rw):
-
     attrs = {"Foo": "Bar", "Baz": 42}
     timestamp = 1641946016139533244
     value = 242.42

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -127,7 +127,6 @@ def get_traced_cursor_proxy(cursor, db_api_integration, *args, **kwargs):
 
     # pylint: disable=abstract-method
     class AsyncCursorTracerProxy(AsyncProxyObject):
-
         # pylint: disable=unused-argument
         def __init__(self, cursor, *args, **kwargs):
             super().__init__(cursor)

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -334,7 +334,8 @@ def collect_request_attributes(scope):
 
 def collect_custom_request_headers_attributes(scope):
     """returns custom HTTP request headers to be added into SERVER span as span attributes
-    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+    """
 
     sanitize = SanitizeValue(
         get_custom_headers(
@@ -359,7 +360,8 @@ def collect_custom_request_headers_attributes(scope):
 
 def collect_custom_response_headers_attributes(message):
     """returns custom HTTP response headers to be added into SERVER span as span attributes
-    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+    """
 
     sanitize = SanitizeValue(
         get_custom_headers(

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -131,7 +131,6 @@ class AsyncPGInstrumentor(BaseInstrumentor):
             unwrap(asyncpg.Connection, method)
 
     async def _do_execute(self, func, instance, args, kwargs):
-
         exception = None
         params = getattr(instance, "_params", {})
         name = args[0] if args[0] else params.get("database", "postgresql")

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -81,10 +81,7 @@ from opentelemetry.instrumentation.aws_lambda.package import _instruments
 from opentelemetry.instrumentation.aws_lambda.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.metrics import (
-    MeterProvider,
-    get_meter_provider,
-)
+from opentelemetry.metrics import MeterProvider, get_meter_provider
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.propagators.aws.aws_xray_propagator import (
     TRACE_HEADER_KEY,
@@ -282,7 +279,7 @@ def _instrument(
     disable_aws_context_propagation: bool = False,
     meter_provider: MeterProvider = None,
 ):
-    def _instrumented_lambda_handler_call(
+    def _instrumented_lambda_handler_call(  # noqa pylint: disable=too-many-branches
         call_wrapped, instance, args, kwargs
     ):
         orig_handler_name = ".".join(
@@ -366,23 +363,21 @@ def _instrument(
                 # NOTE: `force_flush` before function quit in case of Lambda freeze.
                 _tracer_provider.force_flush(flush_timeout)
             except Exception:  # pylint: disable=broad-except
-                logger.exception(
-                    f"TracerProvider failed to flush traces"
-                )
+                logger.exception("TracerProvider failed to flush traces")
         else:
-            logger.warning("TracerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation.")
+            logger.warning(
+                "TracerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
+            )
 
         _meter_provider = meter_provider or get_meter_provider()
         if hasattr(_meter_provider, "force_flush"):
-            rem = flush_timeout - (time.time()-now)*1000
+            rem = flush_timeout - (time.time() - now) * 1000
             if rem > 0:
                 try:
                     # NOTE: `force_flush` before function quit in case of Lambda freeze.
                     _meter_provider.force_flush(rem)
                 except Exception:  # pylint: disable=broad-except
-                    logger.exception(
-                        f"MeterProvider failed to flush metrics"
-                    )
+                    logger.exception("MeterProvider failed to flush metrics")
         else:
             logger.warning(
                 "MeterProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -302,7 +302,6 @@ class TestAwsLambdaInstrumentor(TestBase):
             test_env_patch.stop()
 
     def test_lambda_no_error_with_invalid_flush_timeout(self):
-
         test_env_patch = mock.patch.dict(
             "os.environ",
             {

--- a/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/__init__.py
@@ -119,7 +119,6 @@ class BotoInstrumentor(BaseInstrumentor):
         args,
         kwargs,
     ):
-
         endpoint_name = getattr(instance, "host").split(".")[0]
 
         with self._tracer.start_as_current_span(
@@ -166,7 +165,6 @@ class BotoInstrumentor(BaseInstrumentor):
             return result
 
     def _patched_query_request(self, original_func, instance, args, kwargs):
-
         return self._common_request(
             ("operation_name", "params", "path", "verb"),
             ["operation_name", "params", "path"],

--- a/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto/tests/test_boto_instrumentation.py
@@ -187,7 +187,6 @@ class TestBotoInstrumentor(TestBase):
 
     @mock_lambda_deprecated
     def test_unpatch(self):
-
         lamb = boto.awslambda.connect_to_region("us-east-2")
 
         BotoInstrumentor().uninstrument()

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -120,7 +120,6 @@ from .version import __version__
 
 
 class AutoInstrumentedProducer(Producer):
-
     # This method is deliberately implemented in order to allow wrapt to wrap this function
     def produce(
         self, topic, value=None, *args, **kwargs

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -73,7 +73,6 @@ def _enrich_span(
     offset: Optional[int] = None,
     operation: Optional[MessagingOperationValues] = None,
 ):
-
     if not span.is_recording():
         return
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -471,7 +471,6 @@ def get_traced_cursor_proxy(cursor, db_api_integration, *args, **kwargs):
 
     # pylint: disable=abstract-method
     class TracedCursorProxy(wrapt.ObjectProxy):
-
         # pylint: disable=unused-argument
         def __init__(self, cursor, *args, **kwargs):
             wrapt.ObjectProxy.__init__(self, cursor)

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -236,7 +236,6 @@ class TestDBApiIntegration(TestBase):
         )
 
     def test_executemany_comment(self):
-
         connect_module = mock.MagicMock()
         connect_module.__version__ = mock.MagicMock()
         connect_module.__libpq_version__ = 123
@@ -262,7 +261,6 @@ class TestDBApiIntegration(TestBase):
         )
 
     def test_executemany_flask_integration_comment(self):
-
         connect_module = mock.MagicMock()
         connect_module.__version__ = mock.MagicMock()
         connect_module.__libpq_version__ = 123

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -286,7 +286,6 @@ class DjangoInstrumentor(BaseInstrumentor):
         return _instruments
 
     def _instrument(self, **kwargs):
-
         # FIXME this is probably a pattern that will show up in the rest of the
         # ext. Find a better way of implementing this.
         if environ.get(OTEL_PYTHON_DJANGO_INSTRUMENT) == "False":

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -201,7 +201,6 @@ def _wrap_perform_request(
             op_name,
             kind=SpanKind.CLIENT,
         ) as span:
-
             if callable(request_hook):
                 request_hook(span, method, url, kwargs)
 

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -323,7 +323,6 @@ class TestElasticsearchIntegration(TestBase):
         request_hook_kwargs_attribute = "request_hook.kwargs"
 
         def request_hook(span, method, url, kwargs):
-
             attributes = {
                 request_hook_method_attribute: method,
                 request_hook_url_attribute: url,

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -456,7 +456,6 @@ def _wrapped_teardown_request(
 
 
 class _InstrumentedFlask(flask.Flask):
-
     _excluded_urls = None
     _tracer_provider = None
     _request_hook = None

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_sqlcommenter.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_sqlcommenter.py
@@ -36,7 +36,6 @@ class TestSQLCommenter(InstrumentationTest, WsgiTestBase):
             FlaskInstrumentor().uninstrument()
 
     def test_sqlcommenter_enabled_default(self):
-
         self.app = flask.Flask(__name__)
         self.app.route("/sqlcommenter")(self._sqlcommenter_endpoint)
         client = Client(self.app, Response)

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -221,7 +221,6 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
     def _start_span(
         self, handler_call_details, context, set_status_on_exception=False
     ):
-
         # standard attributes
         attributes = {
             SpanAttributes.RPC_SYSTEM: "grpc",
@@ -283,7 +282,6 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
 
         def telemetry_wrapper(behavior, request_streaming, response_streaming):
             def telemetry_interceptor(request_or_iterator, context):
-
                 # handle streaming responses specially
                 if response_streaming:
                     return self._intercept_server_stream(
@@ -327,7 +325,6 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
     def _intercept_server_stream(
         self, behavior, handler_call_details, request_or_iterator, context
     ):
-
         with self._set_remote_context(context):
             with self._start_span(
                 handler_call_details, context, set_status_on_exception=False

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/_server.py
@@ -46,7 +46,6 @@ class TestServer(test_server_pb2_grpc.GRPCTestServerServicer):
 
     def ServerStreamingMethod(self, request, context):
         if request.request_data == "error":
-
             context.abort(
                 code=grpc.StatusCode.INVALID_ARGUMENT,
                 details="server stream error",

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
@@ -205,7 +205,6 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
         class TwoSpanServicer(GRPCTestServerServicer):
             # pylint:disable=C0103
             async def SimpleMethod(self, request, context):
-
                 # create another span
                 tracer = trace.get_tracer(__name__)
                 with tracer.start_as_current_span("child") as child:

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -217,7 +217,6 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         class TwoSpanServicer(GRPCTestServerServicer):
             # pylint:disable=C0103
             def SimpleMethod(self, request, context):
-
                 # create another span
                 tracer = trace.get_tracer(__name__)
                 with tracer.start_as_current_span("child") as child:
@@ -347,7 +346,6 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         class TwoSpanServicer(GRPCTestServerServicer):
             # pylint:disable=C0103
             def ServerStreamingMethod(self, request, context):
-
                 # create another span
                 tracer = trace.get_tracer(__name__)
                 with tracer.start_as_current_span("child") as child:

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -425,7 +425,6 @@ class AsyncOpenTelemetryTransport(httpx.AsyncBaseTransport):
 
 
 class _InstrumentedClient(httpx.Client):
-
     _tracer_provider = None
     _request_hook = None
     _response_hook = None
@@ -445,7 +444,6 @@ class _InstrumentedClient(httpx.Client):
 
 
 class _InstrumentedAsyncClient(httpx.AsyncClient):
-
     _tracer_provider = None
     _request_hook = None
     _response_hook = None

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
@@ -204,7 +204,6 @@ def _wrap_next(
     consume_hook: ConsumeHookT,
 ) -> Callable:
     def _traced_next(func, instance, args, kwargs):
-
         record = func(*args, **kwargs)
 
         if record:

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -82,7 +82,6 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
         return _instruments
 
     def _instrument(self, **kwargs):
-
         provider = kwargs.get("tracer_provider", None) or get_tracer_provider()
         old_factory = logging.getLogRecordFactory()
         LoggingInstrumentor._old_factory = old_factory

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -24,7 +24,6 @@ from opentelemetry.test.test_base import TestBase
 
 
 class MockCursor:
-
     execute = mock.MagicMock(spec=types.MethodType)
     execute.__name__ = "execute"
 
@@ -47,7 +46,6 @@ class MockCursor:
 
 
 class MockConnection:
-
     commit = mock.MagicMock(spec=types.MethodType)
     commit.__name__ = "commit"
 

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/__init__.py
@@ -127,7 +127,6 @@ def _wrap_cmd(tracer, cmd, wrapped, instance, args, kwargs):
 
 
 def _get_query_string(arg):
-
     """Return the query values given the first argument to a pymemcache command.
 
     If there are multiple query values, they are joined together

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -152,7 +152,9 @@ class CommandTracer(monitoring.CommandListener):
                     )
             try:
                 self.start_hook(span, event)
-            except Exception as hook_exception:  # noqa pylint: disable=broad-except
+            except (
+                Exception  # noqa pylint: disable=broad-except
+            ) as hook_exception:  # noqa pylint: disable=broad-except
                 _LOG.exception(hook_exception)
 
             # Add Span to dictionary
@@ -175,7 +177,9 @@ class CommandTracer(monitoring.CommandListener):
         if span.is_recording():
             try:
                 self.success_hook(span, event)
-            except Exception as hook_exception:  # noqa pylint: disable=broad-except
+            except (
+                Exception  # noqa pylint: disable=broad-except
+            ) as hook_exception:  # noqa pylint: disable=broad-except
                 _LOG.exception(hook_exception)
         span.end()
 
@@ -192,7 +196,9 @@ class CommandTracer(monitoring.CommandListener):
             span.set_status(Status(StatusCode.ERROR, event.failure))
             try:
                 self.failed_hook(span, event)
-            except Exception as hook_exception:  # noqa pylint: disable=broad-except
+            except (
+                Exception  # noqa pylint: disable=broad-except
+            ) as hook_exception:  # noqa pylint: disable=broad-except
                 _LOG.exception(hook_exception)
         span.end()
 

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -207,7 +207,6 @@ def trace_tween_factory(handler, registry):
                     "PyramidInstrumentor().instrument_config(config) is called"
                 )
             elif enabled:
-
                 if status is not None:
                     otel_wsgi.add_response_attributes(
                         span,

--- a/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sklearn/src/opentelemetry/instrumentation/sklearn/__init__.py
@@ -198,7 +198,7 @@ def get_base_estimators(packages: List[str]) -> Dict[str, Type[BaseEstimator]]:
     for package_name in packages:
         lib = import_module(package_name)
         package_dir = os.path.dirname(lib.__file__)
-        for (_, module_name, _) in iter_modules([package_dir]):
+        for _, module_name, _ in iter_modules([package_dir]):
             # import the module and iterate through its attributes
             try:
                 module = import_module(package_name + "." + module_name)

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -255,7 +255,6 @@ class StarletteInstrumentor(BaseInstrumentor):
         applications.Starlette = _InstrumentedStarlette
 
     def _uninstrument(self, **kwargs):
-
         """uninstrumenting all created apps by user"""
         for instance in _InstrumentedStarlette._instrumented_starlette_apps:
             self.uninstrument_app(instance)

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -691,7 +691,6 @@ class TestSystemMetrics(TestBase):
 
     @mock.patch("psutil.Process.memory_info")
     def test_runtime_memory(self, mock_process_memory_info):
-
         PMem = namedtuple("PMem", ["rss", "vms"])
 
         mock_process_memory_info.configure_mock(
@@ -706,7 +705,6 @@ class TestSystemMetrics(TestBase):
 
     @mock.patch("psutil.Process.cpu_times")
     def test_runtime_cpu_time(self, mock_process_cpu_times):
-
         PCPUTimes = namedtuple("PCPUTimes", ["user", "system"])
 
         mock_process_cpu_times.configure_mock(
@@ -721,7 +719,6 @@ class TestSystemMetrics(TestBase):
 
     @mock.patch("gc.get_count")
     def test_runtime_get_count(self, mock_gc_get_count):
-
         mock_gc_get_count.configure_mock(**{"return_value": (1, 2, 3)})
 
         expected = [

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -400,7 +400,6 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
         )
 
     def test_handler_on_finish(self):
-
         response = self.fetch("/on_finish")
         self.assertEqual(response.code, 200)
 

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
@@ -260,7 +260,6 @@ class TortoiseORMInstrumentor(BaseInstrumentor):
         return span_attributes
 
     async def _do_execute(self, func, instance, args, kwargs):
-
         exception = None
         name = args[0].split()[0]
 
@@ -288,7 +287,6 @@ class TortoiseORMInstrumentor(BaseInstrumentor):
         return result
 
     async def _from_queryset(self, func, modelcls, args, kwargs):
-
         exception = None
         name = f"pydantic.{func.__name__}"
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -151,7 +151,6 @@ def _instrument(
 
     @functools.wraps(opener_open)
     def instrumented_open(opener, fullurl, data=None, timeout=None):
-
         if isinstance(fullurl, str):
             request_ = Request(fullurl, data)
         else:
@@ -211,7 +210,6 @@ def _instrument(
                 context.detach(token)
 
             if result is not None:
-
                 code_ = result.getcode()
                 labels[SpanAttributes.HTTP_STATUS_CODE] = str(code_)
 
@@ -249,7 +247,6 @@ def _uninstrument():
 
 
 def _uninstrument_from(instr_root, restore_as_bound_func=False):
-
     instr_func_name = "open"
     instr_func = getattr(instr_root, instr_func_name)
     if not getattr(

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -157,7 +157,6 @@ class RequestsIntegrationTestBase(abc.ABC):
 
     @patch("http.client.HTTPResponse.getcode", new=mock_get_code)
     def test_response_code_none(self):
-
         result = self.perform_request(self.URL)
 
         self.assertEqual(result.read(), b"Hello!")
@@ -290,7 +289,6 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertIs(span.resource, resource)
 
     def test_requests_exception_with_response(self, *_, **__):
-
         with self.assertRaises(HTTPError):
             self.perform_request("http://httpbin.org/status/500")
 

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -34,7 +34,6 @@ from opentelemetry.test.test_base import TestBase
 
 
 class TestURLLib3Instrumentor(TestBase):
-
     HTTP_URL = "http://httpbin.org/status/200"
     HTTPS_URL = "https://httpbin.org/status/200"
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -291,7 +291,8 @@ def setifnotnone(dic, key, value):
 
 def collect_request_attributes(environ):
     """Collects HTTP request attributes from the PEP3333-conforming
-    WSGI environ and returns a dictionary to be used as span creation attributes."""
+    WSGI environ and returns a dictionary to be used as span creation attributes.
+    """
 
     result = {
         SpanAttributes.HTTP_METHOD: environ.get("REQUEST_METHOD"),
@@ -340,7 +341,8 @@ def collect_request_attributes(environ):
 def collect_custom_request_headers_attributes(environ):
     """Returns custom HTTP request headers which are configured by the user
     from the PEP3333-conforming WSGI environ to be used as span creation attributes as described
-    in the specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+    in the specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+    """
 
     sanitize = SanitizeValue(
         get_custom_headers(
@@ -366,7 +368,8 @@ def collect_custom_request_headers_attributes(environ):
 def collect_custom_response_headers_attributes(response_headers):
     """Returns custom HTTP response headers which are configured by the user from the
     PEP3333-conforming WSGI environ as described in the specification
-    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers"""
+    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+    """
 
     sanitize = SanitizeValue(
         get_custom_headers(
@@ -414,7 +417,8 @@ def add_response_attributes(
     span, start_response_status, response_headers
 ):  # pylint: disable=unused-argument
     """Adds HTTP response attributes to span using the arguments
-    passed to a PEP3333-conforming start_response callable."""
+    passed to a PEP3333-conforming start_response callable.
+    """
     if not span.is_recording():
         return
     status_code, _ = start_response_status.split(" ", 1)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -29,7 +29,6 @@ _logger = getLogger(__name__)
 
 
 def run() -> None:
-
     parser = ArgumentParser(
         description="""
         opentelemetry-instrument automatically instruments a Python
@@ -57,9 +56,7 @@ def run() -> None:
         environment_variable_module = entry_point.load()
 
         for attribute in dir(environment_variable_module):
-
             if attribute.startswith("OTEL_"):
-
                 argument = sub(r"OTEL_(PYTHON_)?", "", attribute).lower()
 
                 parser.add_argument(
@@ -88,7 +85,6 @@ def run() -> None:
     ).items():
         value = getattr(args, argument)
         if value is not None:
-
             environ[otel_environment_variable] = value
 
     python_path = environ.get("PYTHONPATH")

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -46,7 +46,6 @@ class BaseInstrumentor(ABC):
     _is_instrumented_by_opentelemetry = False
 
     def __new__(cls, *args, **kwargs):
-
         if cls._instance is None:
             cls._instance = object.__new__(cls, *args, **kwargs)
 

--- a/opentelemetry-instrumentation/tests/test_bootstrap.py
+++ b/opentelemetry-instrumentation/tests/test_bootstrap.py
@@ -30,7 +30,6 @@ def sample_packages(packages, rate):
 
 
 class TestBootstrap(TestCase):
-
     installed_libraries = {}
     installed_instrumentations = {}
 

--- a/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
+++ b/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py
@@ -95,7 +95,6 @@ class OTTracePropagator(TextMapPropagator):
             baggage = get_all(context) or {}
 
             for key in getter.keys(carrier):
-
                 if not key.startswith(OT_BAGGAGE_PREFIX):
                     continue
 
@@ -114,7 +113,6 @@ class OTTracePropagator(TextMapPropagator):
         context: Optional[Context] = None,
         setter: Setter[CarrierT] = default_setter,
     ) -> None:
-
         span_context = get_current_span(context).get_span_context()
 
         if span_context.trace_id == INVALID_TRACE_ID:
@@ -142,7 +140,6 @@ class OTTracePropagator(TextMapPropagator):
             return
 
         for header_name, header_value in baggage.items():
-
             if (
                 _valid_header_name.fullmatch(header_name) is None
                 or _valid_header_value.fullmatch(header_value) is None

--- a/propagator/opentelemetry-propagator-ot-trace/tests/test_ot_trace_propagator.py
+++ b/propagator/opentelemetry-propagator-ot-trace/tests/test_ot_trace_propagator.py
@@ -34,11 +34,9 @@ from opentelemetry.trace.propagation import get_current_span
 
 
 class TestOTTracePropagator(TestCase):
-
     ot_trace_propagator = OTTracePropagator()
 
     def carrier_inject(self, trace_id, span_id, is_remote, trace_flags):
-
         carrier = {}
 
         self.ot_trace_propagator.inject(

--- a/tests/opentelemetry-docker-tests/tests/celery/conftest.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/conftest.py
@@ -47,6 +47,7 @@ def celery_worker_parameters():
 @pytest.fixture(autouse=True)
 def patch_celery_app(celery_app, celery_worker):
     """Patch task decorator on app fixture to reload worker"""
+
     # See https://github.com/celery/celery/issues/3642
     def wrap_task(fn):
         @wraps(fn)

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
@@ -152,7 +152,6 @@ class TestFunctionalPsycopg(TestBase):
         )
 
     def test_commenter_enabled(self):
-
         stmt = "CREATE TABLE IF NOT EXISTS users (id integer, name varchar)"
         with self._tracer.start_as_current_span("rootSpan"):
             self._cursor.execute(stmt)

--- a/tox.ini
+++ b/tox.ini
@@ -541,12 +541,12 @@ basepython: python3.10
 deps =
   pip >= 20.3.3
   pytest
-  asyncpg==0.20.1
+  asyncpg==0.27.0
   docker-compose >= 1.25.2
   mysql-connector-python ~=  8.0
   pymongo >= 3.1, < 5.0
   PyMySQL ~= 0.10.1
-  psycopg2 ~= 2.8.4
+  psycopg2 ~= 2.9.5
   aiopg >= 0.13.0, < 1.3.0
   sqlalchemy ~= 1.4
   redis ~= 4.3


### PR DESCRIPTION
# Description

In PR #1604 the Python version was upgraded to Python 3.10 to fix a local issue on M1 MacBooks.

The GitHub Action workflows now exit with the following message for the docker-tests, spellcheck and lint checks, skipping these checks.

```
lint create: /home/runner/work/opentelemetry-python-contrib/opentelemetry-python-contrib/.tox/lint
SKIPPED: InterpreterNotFound: python3.10
___________________________________ summary ____________________________________
SKIPPED:  lint: InterpreterNotFound: python3.10
  congratulations :)
```

Upgrade the Python version in the GitHub Actions workflow to fix this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running the CI in full

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:


- [x] Followed the style guidelines of this project
