### PR TITLE
Audit and test opentelemetry-instrumentation-django NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -22,6 +22,7 @@ from django import VERSION, conf
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
 from django.test.utils import setup_test_environment, teardown_test_environment
+
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.django import (
     DjangoInstrumentor,

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -36,6 +36,7 @@ from opentelemetry.sdk.trace import Span
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
+from opentelemetry import trace as trace_api
 from opentelemetry.trace import (
     SpanKind,
     StatusCode,
@@ -423,6 +424,14 @@ class TestMiddlewareAsgiWithTracerProvider(SimpleTestCase, TestBase):
         self.assertEqual(
             span.resource.attributes["resource-key"], "resource-value"
         )
+
+    async def test_no_op_tracer_provider(self):
+        _django_instrumentor.uninstrument()
+        _django_instrumentor.instrument(tracer_provider=trace_api.NoOpTracerProvider)
+
+        await self.async_client.post("/traced/")
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
 
 
 @patch.dict(

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -22,7 +22,7 @@ from django import VERSION, conf
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
 from django.test.utils import setup_test_environment, teardown_test_environment
-
+from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.django import (
     DjangoInstrumentor,
     _DjangoMiddleware,
@@ -36,7 +36,6 @@ from opentelemetry.sdk.trace import Span
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
-from opentelemetry import trace as trace_api
 from opentelemetry.trace import (
     SpanKind,
     StatusCode,

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -427,7 +427,9 @@ class TestMiddlewareAsgiWithTracerProvider(SimpleTestCase, TestBase):
 
     async def test_no_op_tracer_provider(self):
         _django_instrumentor.uninstrument()
-        _django_instrumentor.instrument(tracer_provider=trace_api.NoOpTracerProvider)
+        _django_instrumentor.instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
 
         await self.async_client.post("/traced/")
         spans = self.exporter.get_finished_spans()


### PR DESCRIPTION
Add test for django using NoOpTracerProvider

Fixes #985 

### How has this been tested?
tox -e test-instrumentation-django1
tox -e test-instrumentation-django2
tox -e test-instrumentation-django3
tox -e test-instrumentation-django4