### PR TITLE
Audit and test opentelemetry-instrumentation-aiohttp-client NoOpTrace…

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -441,7 +441,7 @@ class TestAioHttpClientInstrumentor(TestBase):
             tracer_provider=trace_api.NoOpTracerProvider()
         )
 
-        host, port = run_with_test_server(
+        run_with_test_server(
             self.get_default_request(), self.URL, self.default_handler
         )
         spans_list = self.memory_exporter.get_finished_spans()

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -437,14 +437,15 @@ class TestAioHttpClientInstrumentor(TestBase):
 
     def test_no_op_tracer_provider(self):
         AioHttpClientInstrumentor().uninstrument()
-        AioHttpClientInstrumentor().instrument(tracer_provider=trace_api.NoOpTracerProvider())
+        AioHttpClientInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
 
         host, port = run_with_test_server(
             self.get_default_request(), self.URL, self.default_handler
         )
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 0)
-
 
     def test_uninstrument(self):
         AioHttpClientInstrumentor().uninstrument()


### PR DESCRIPTION
Add test for aiohttp-client using NoOpTracerProvider

Fixes #994  

### How has this been tested?
tox -e test-instrumentation-aiohttp-client