### PR TITLE
Audit and test opentelemetry-instrumentation-flask NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
@@ -82,7 +82,9 @@ class TestAutomatic(InstrumentationTest, WsgiTestBase):
 
     def test_no_op_tracer_provider(self):
         FlaskInstrumentor().uninstrument()
-        FlaskInstrumentor().instrument(tracer_provider=trace_api.NoOpTracerProvider())
+        FlaskInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
 
         self.app = flask.Flask(__name__)
         self.app.route("/hello/<int:helloid>")(self._hello_endpoint)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_automatic.py
@@ -16,6 +16,7 @@ import flask
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
+from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 
@@ -78,3 +79,16 @@ class TestAutomatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual([b"Hello: 456"], list(resp.response))
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
+
+    def test_no_op_tracer_provider(self):
+        FlaskInstrumentor().uninstrument()
+        FlaskInstrumentor().instrument(tracer_provider=trace_api.NoOpTracerProvider())
+
+        self.app = flask.Flask(__name__)
+        self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        # pylint: disable=attribute-defined-outside-init
+        self.client = Client(self.app, Response)
+        self.client.get("/hello/123")
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)


### PR DESCRIPTION
Add test for flask using NoOpTracerProvider

Fixes #981 

### How has this been tested?
tox -e test-instrumentation-flask