### PR TITLE
 Add ability to exclude some routes explicitly with Django Instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1613](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1613))
 - Fix aiohttp bug with unset `trace_configs` ([#1592](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1592))
 - `opentelemetry-instrumentation-django` Allow explicit `excluded_urls` configuration through `instrument()`
-  ([#1613](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1613))
+  ([#1618](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1618))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-aws-lambda` Flush `MeterProvider` at end of function invocation.
   ([#1613](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1613))
 - Fix aiohttp bug with unset `trace_configs` ([#1592](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1592))
+- `opentelemetry-instrumentation-django` Allow explicit `excluded_urls` configuration through `instrument()`
+  ([#1613](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1613))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -91,6 +91,7 @@ urlpatterns = [
 _django_instrumentor = DjangoInstrumentor()
 
 
+# pylint: disable=too-many-public-methods
 class TestMiddleware(WsgiTestBase):
     @classmethod
     def setUpClass(cls):

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -285,6 +285,18 @@ class TestMiddleware(WsgiTestBase):
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
 
+    def test_exclude_lists_through_instrument(self):
+        _django_instrumentor.uninstrument()
+        _django_instrumentor.instrument(excluded_urls="excluded_explicit")
+        client = Client()
+        client.get("/excluded_explicit")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+        client.get("/excluded_arg/123")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
     def test_span_name(self):
         # test no query_string
         Client().get("/span_name/1234/")


### PR DESCRIPTION
We have exclude_lists via `OTEL_PYTHON_DJANGO_EXCLUDED_URLS` environment variable but not explicitly passed in through `instrument()`.