### PR TITLE
Add commit method for ConfluentKafkaInstrumentor's ProxiedConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1435](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1435))
 - mongo db - fix db statement capturing
   ([#1512](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1512))
+- Add commit method for ConfluentKafkaInstrumentor's ProxiedConsumer
+  ([#1656](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1656))
 
 ## Version 1.15.0/0.36b0 (2022-12-10)
 

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -173,6 +173,9 @@ class ProxiedConsumer(Consumer):
     def committed(self, partitions, timeout=-1):
         return self._consumer.committed(partitions, timeout)
 
+    def commit(self, *args, **kwargs):
+        return self._consumer.commit(*args, **kwargs)
+
     def consume(
         self, num_messages=1, *args, **kwargs
     ):  # pylint: disable=keyword-arg-before-vararg

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
@@ -58,3 +58,18 @@ class TestConfluentKafka(TestCase):
 
         consumer = instrumentation.uninstrument_consumer(consumer)
         self.assertEqual(consumer.__class__, Consumer)
+
+    def test_consumer_commit_method_exists(self) -> None:
+        instrumentation = ConfluentKafkaInstrumentor()
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": "localhost:29092",
+                "group.id": "mygroup",
+                "auto.offset.reset": "earliest",
+            }
+        )
+
+        consumer = instrumentation.instrument_consumer(consumer)
+        self.assertEqual(consumer.__class__, ProxiedConsumer)
+        self.assertTrue(hasattr(consumer, "commit"))


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1506

The package confluent-kafka has a class Consumer, which has a method called commit (Ref: https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Consumer.commit)

The package opentelemetry-instrumentation-confluent-kafka offers a wrapper around confluent-kafka's Consumer, called ProxiedConsumer. However ProxiedConsumer does not support `commit` method. This leads to an exception with the message "Consumer closed" when ProxiedConsumer.commit is called.

This PR fixes this by adding a method `commit` on ProxiedConsumer, which accepts the same args as confluent-kafka's Consumer's commit method and makes a call to that method.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Previously calling `commit` on the ProxiedConsumer would lead to an exception. With the changes in this PR, calling `commit` ensures the message is committed since it calls the underlying Consumer's commit method.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
