### PR TITLE
Add/botocore sanitization

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
@@ -560,6 +560,7 @@ class TestDynamoDbExtension(TestBase):
             ],
         )
 
+    # pylint: disable=expression-not-assigned
     def test_db_statement_sanitization(self):
         sanitized_value = {"?": "?"}
         self.assertEqual(

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
@@ -157,7 +157,9 @@ class TestDynamoDbExtension(TestBase):
 
         self.assertEqual("dynamodb", span.attributes[SpanAttributes.DB_SYSTEM])
         self.assertIn(SpanAttributes.DB_STATEMENT, span.attributes)
-        self.assertNotIn(SpanAttributes.DB_STATEMENT + ".sanitized", span.attributes)
+        self.assertNotIn(
+            SpanAttributes.DB_STATEMENT + ".sanitized", span.attributes
+        )
         self.assertEqual(
             operation, span.attributes[SpanAttributes.DB_OPERATION]
         )
@@ -562,7 +564,7 @@ class TestDynamoDbExtension(TestBase):
         sanitized_value = {"?": "?"}
         self.assertEqual(
             _conv_params_to_sanitized_str(key_value_query),
-            str({"Key": sanitized_value})
+            str({"Key": sanitized_value}),
         ),
         self.assertEqual(
             _conv_params_to_sanitized_str(secondary_index_query),
@@ -572,7 +574,7 @@ class TestDynamoDbExtension(TestBase):
                     "KeyConditionExpression": sanitized_value,
                     "ExpressionAttributeValues": sanitized_value,
                 }
-            )
+            ),
         ),
         self.assertEqual(
             _conv_params_to_sanitized_str(scan_query),
@@ -581,9 +583,9 @@ class TestDynamoDbExtension(TestBase):
                     "FilterExpression": sanitized_value,
                     "ExpressionAttributeValues": sanitized_value,
                 }
-            )
+            ),
         ),
         self.assertNotEqual(
             _conv_params_to_sanitized_str(projection_expression_query),
-            projection_expression_query
+            projection_expression_query,
         )


### PR DESCRIPTION
# Description

Added an optional query sanitizer to the botocore dynamoDB instrumentation.
Usage
BotocoreInstrumentor().instrument(sanitize_query=True)

This will affect the DB_STATEMENT value to contain the original query or sanitized one.

Fixes #1544   
Following the specification discussion [here](https://github.com/open-telemetry/opentelemetry-specification/issues/3104)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Test A db.statement has been sanitized
- [x] Test B no side affects occurred on a query without a db.statement attribute 

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
