### PR TITLE
Add better debugging if hatch subprocess fails during bootstrap_gen

### DIFF
--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess
+from subprocess import CalledProcessError
 
 import tomli
 
@@ -28,12 +29,18 @@ def get_instrumentation_packages():
         if not os.path.isdir(pkg_path):
             continue
 
-        version = subprocess.check_output(
-            "hatch version",
-            shell=True,
-            cwd=pkg_path,
-            universal_newlines=True,
-        )
+        try:
+            version = subprocess.check_output(
+                "hatch version",
+                shell=True,
+                cwd=pkg_path,
+                universal_newlines=True,
+            )
+        except CalledProcessError as exc:
+            print(f"Could not get hatch version from path {pkg_path}")
+            print(exc.output)
+            raise exc
+
         pyproject_toml_path = os.path.join(pkg_path, "pyproject.toml")
 
         with open(pyproject_toml_path, "rb") as file:


### PR DESCRIPTION
# Description

This has been bugging me for a while, I could not run the `tox -e generate` command. It turns out that the problem was I had an empty directory in the `instrumentations` folder for an instrumentation I had started but never completed.

The problem is I had no indication as to where the problem was, or how I could fix it.

To reproduce, just `mkdir instrumentation/opentelemetry-instrumentation-somelib` and run `tox -e generate`.

<details>
<summary>Current output</summary>

```
(3.9.5/envs/opentelemetry-python-contrib) ~/opentelemetry-python-contrib ‹main*› » tox -e generate                                                                                          [15:08:14]
generate installed: anyio==3.6.2,astor==0.8.1,black==22.12.0,certifi==2022.12.7,charset-normalizer==3.0.1,click==8.1.3,commonmark==0.9.1,distlib==0.3.6,editables==0.3,filelock==3.9.0,h11==0.14.0,hatch==1.6.3,hatchling==1.12.2,httpcore==0.16.3,httpx==0.23.3,hyperlink==21.0.0,idna==3.4,importlib-metadata==6.0.0,isort==5.11.4,jaraco.classes==3.2.3,Jinja2==2.11.3,keyring==23.13.1,MarkupSafe==2.0.1,more-itertools==9.0.0,mypy-extensions==0.4.3,packaging==23.0,pathspec==0.10.3,pexpect==4.8.0,platformdirs==2.6.2,pluggy==1.0.0,ptyprocess==0.7.0,Pygments==2.14.0,pyperclip==1.8.2,requests==2.28.2,rfc3986==1.5.0,rich==13.1.0,shellingham==1.5.0.post1,sniffio==1.3.0,tomli==2.0.1,tomli_w==1.0.0,tomlkit==0.11.6,typing_extensions==4.4.0,urllib3==1.26.14,userpath==1.8.0,virtualenv==20.17.1,zipp==3.11.0
generate run-test-pre: PYTHONHASHSEED='418181719'
generate run-test: commands[0] | /Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py
Traceback (most recent call last):
  File "/Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py", line 104, in <module>
    main()
  File "/Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py", line 62, in main
    for pkg in get_instrumentation_packages():
  File "/Users/phillip/opentelemetry-python-contrib/scripts/otel_packaging.py", line 31, in get_instrumentation_packages
    version = subprocess.check_output(
  File "/Users/phillip/.pyenv/versions/3.9.5/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/Users/phillip/.pyenv/versions/3.9.5/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'hatch version' returned non-zero exit status 1.
ERROR: InvocationError for command /Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py (exited with code 1)
_______________________________________________________________________________________________ summary ________________________________________________________________________________________________
ERROR:   generate: commands failed
```
</details>

With my change, this is the output of the failure:

<details>
<summary>Modified output</summary>

```
(3.9.5/envs/opentelemetry-python-contrib) ~/opentelemetry-python-contrib ‹hatch-version-debug*› » tox -e generate                                                                           [15:05:55]
generate installed: anyio==3.6.2,astor==0.8.1,black==22.12.0,certifi==2022.12.7,charset-normalizer==3.0.1,click==8.1.3,commonmark==0.9.1,distlib==0.3.6,editables==0.3,filelock==3.9.0,h11==0.14.0,hatch==1.6.3,hatchling==1.12.2,httpcore==0.16.3,httpx==0.23.3,hyperlink==21.0.0,idna==3.4,importlib-metadata==6.0.0,isort==5.11.4,jaraco.classes==3.2.3,Jinja2==2.11.3,keyring==23.13.1,MarkupSafe==2.0.1,more-itertools==9.0.0,mypy-extensions==0.4.3,packaging==23.0,pathspec==0.10.3,pexpect==4.8.0,platformdirs==2.6.2,pluggy==1.0.0,ptyprocess==0.7.0,Pygments==2.14.0,pyperclip==1.8.2,requests==2.28.2,rfc3986==1.5.0,rich==13.1.0,shellingham==1.5.0.post1,sniffio==1.3.0,tomli==2.0.1,tomli_w==1.0.0,tomlkit==0.11.6,typing_extensions==4.4.0,urllib3==1.26.14,userpath==1.8.0,virtualenv==20.17.1,zipp==3.11.0
generate run-test-pre: PYTHONHASHSEED='2056460220'
generate run-test: commands[0] | /Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py
Could not get hatch version from path /Users/phillip/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-somelib
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/hatch/cli/ │
│ __init__.py:205 in main                                                                          │
│                                                                                                  │
│   202                                                                                            │
│   203 def main():  # no cov                                                                      │
│   204 │   try:                                                                                   │
│ ❱ 205 │   │   return hatch(windows_expand_args=False)                                            │
│   206 │   except Exception:                                                                      │
│   207 │   │   from rich.console import Console                                                   │
│   208                                                                                            │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/core │
│ .py:1130 in __call__                                                                             │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/core │
│ .py:1055 in main                                                                                 │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/core │
│ .py:1657 in invoke                                                                               │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/core │
│ .py:1404 in invoke                                                                               │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/core │
│ .py:760 in invoke                                                                                │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/click/deco │
│ rators.py:38 in new_func                                                                         │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/hatch/cli/ │
│ version/__init__.py:20 in version                                                                │
│                                                                                                  │
│   17 │                                                                                           │
│   18 │   with app.project.location.as_cwd():                                                     │
│   19 │   │   if not (                                                                            │
│ ❱ 20 │   │   │   'version' in app.project.metadata.dynamic or app.project.metadata.hatch.meta    │
│   21 │   │   ) or dependencies_in_sync(app.project.metadata.build.requires_complex):             │
│   22 │   │   │   source = app.project.metadata.hatch.version.source                              │
│   23                                                                                             │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/hatchling/ │
│ metadata/core.py:94 in dynamic                                                                   │
│                                                                                                  │
│     91 │   def dynamic(self) -> list[str]:                                                       │
│     92 │   │   # Keep track of the original dynamic fields before depopulation                   │
│     93 │   │   if self._dynamic is None:                                                         │
│ ❱   94 │   │   │   dynamic = self.core_raw_metadata.get('dynamic', [])                           │
│     95 │   │   │   if not isinstance(dynamic, list):                                             │
│     96 │   │   │   │   message = 'Field `project.dynamic` must be an array'                      │
│     97 │   │   │   │   raise TypeError(message)                                                  │
│                                                                                                  │
│ /Users/phillip/opentelemetry-python-contrib/.tox/generate/lib/python3.9/site-packages/hatchling/ │
│ metadata/core.py:79 in core_raw_metadata                                                         │
│                                                                                                  │
│     76 │   │   if self._core_raw_metadata is None:                                               │
│     77 │   │   │   if 'project' not in self.config:                                              │
│     78 │   │   │   │   message = 'Missing `project` metadata table in configuration'             │
│ ❱   79 │   │   │   │   raise ValueError(message)                                                 │
│     80 │   │   │                                                                                 │
│     81 │   │   │   core_raw_metadata = self.config['project']                                    │
│     82 │   │   │   if not isinstance(core_raw_metadata, dict):                                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: Missing `project` metadata table in configuration

Traceback (most recent call last):
  File "/Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py", line 104, in <module>
    main()
  File "/Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py", line 62, in main
    for pkg in get_instrumentation_packages():
  File "/Users/phillip/opentelemetry-python-contrib/scripts/otel_packaging.py", line 42, in get_instrumentation_packages
    raise e
  File "/Users/phillip/opentelemetry-python-contrib/scripts/otel_packaging.py", line 33, in get_instrumentation_packages
    version = subprocess.check_output(
  File "/Users/phillip/.pyenv/versions/3.9.5/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/Users/phillip/.pyenv/versions/3.9.5/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'hatch version' returned non-zero exit status 1.
ERROR: InvocationError for command /Users/phillip/opentelemetry-python-contrib/scripts/generate_instrumentation_bootstrap.py (exited with code 1)
_______________________________________________________________________________________________ summary ________________________________________________________________________________________________
ERROR:   generate: commands failed
```
</details>

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local observation

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
