### PR TITLE
Bring SQS Propagation in line with the spec

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.12",
   "opentelemetry-instrumentation == 0.37b0.dev",
+  "opentelemetry-propagator-aws-xray == 1.0.1",
   "opentelemetry-semantic-conventions == 0.37b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
 ]


### PR DESCRIPTION
Opening as a draft because 1 test still fails. I'm hoping someone more familiar with the code might notice what I did wrong easily :)

The failure is in `TestBoto3SQSInstrumentation.test_receive_message`, no links are found:

```
>           self.assertEqual(1, len(span.links))
E           AssertionError: 1 != 0
```

I did some simple `printf` debugging to check what the `MessageSystemAttributes` were before calling `extract` and the `ctx` after calling `extract`:

```
        message_system_attributes = message.get("MessageSystemAttributes", {})
        print(message_system_attributes)
        links = []
        ctx = AwsXRayPropagator().extract(
            message_system_attributes, getter=boto3sqs_getter
        )
        print(ctx)
```

And the header is there as expected and it is extracted properly but the ctx is then empty:

`message_system_attributes`:

```
{'AWSTraceHeader': {'StringValue': 'root=1-00000000-00000000000000000000000a;parent=0000000000000001;sampled=1', 'DataType': 'String'}}
```

Value in `Boto3SQSGetter.get`:

```
root=1-00000000-00000000000000000000000a;parent=0000000000000001;sampled=1
```

`ctx`:

```
{}
```

# Description

The instrumentation spec for SQS defines that propagation is done with X-Ray to the key `AWSTraceHeader` in `MessageSystemAttributes`. This patch brings the propagation in line with the spec from what it was doing before of using the global propagator and `MessageAttributes`. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Existing tests were updated to extract/inject the propagated context with the new format. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
