### PR TITLE
Fix exporter example docker-compose path

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/example/Dockerfile
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/example/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /code
 COPY . .
 
 RUN pip install -e .
-RUN pip install -r ./examples/requirements.txt
+RUN pip install -r ./example/requirements.txt
 
-CMD ["python", "./examples/sampleapp.py"]
+CMD ["python", "./example/sampleapp.py"]

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/example/README.md
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/example/README.md
@@ -14,7 +14,7 @@ data
 *Users do not need to install Python as the app will be run in the Docker Container*
 
 ## Instructions
-1. Run `docker-compose up -d` in the the `examples/` directory
+1. Run `docker-compose up -d` in the the `example/` directory
 
 The `-d` flag causes all services to run in detached mode and frees up your
 terminal session. This also causes no logs to show up. Users can attach themselves to the service's logs manually using `docker logs ${CONTAINER_ID} --follow`
@@ -39,4 +39,4 @@ terminal session. This also causes no logs to show up. Users can attach themselv
    * Click the refresh button and data should show up on the graph
 
 6. Shutdown the services when finished
-   * Run `docker-compose down` in the examples directory
+   * Run `docker-compose down` in the example directory

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/example/docker-compose.yml
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/example/docker-compose.yml
@@ -30,4 +30,4 @@ services:
   sample_app:
     build:
       context: ../
-      dockerfile: ./examples/Dockerfile
+      dockerfile: ./example/Dockerfile


### PR DESCRIPTION
# Description

This PR fixes a typo in the [exporter/opentelemetry-exporter-prometheus-remote-write/example](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/exporter/opentelemetry-exporter-prometheus-remote-write)

Failures:

1. Error 1:
```
❯ docker-compose up
[+] Running 14/14
 ⠿ grafana Pulled                                                                                                                                                                                                                
 ⠿ cortex Pulled                                                                                                                                                                                                                 
[+] Building 0.0s (0/0)
could not find /Users/sraradhy/cisco/eti/sre/opentelemetry-python-contrib/exporter/opentelemetry-exporter-prometheus-remote-write/examples: stat /Users/sraradhy/cisco/eti/sre/opentelemetry-python-contrib/exporter/opentelemetry-exporter-prometheus-remote-write/examples: no such file or directory
```

2. Error 2:
```
❯ docker-compose up
FROM python:3.8
[+] Building 200.5s (10/10) FINISHED
<SOME OUTPUT SKIPPED>
 => [5/6] RUN pip install -e .                                                                                                                                                                                                   14.4s
 => ERROR [6/6] RUN pip install -r ./examples/requirements.txt                                                                                                                                                                    ```
 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Successfully running `docker-compose up -d`
- [x ] docker-compose up

```
❯ docker-compose up -d
[+] Running 3/0
 ⠿ Container example-grafana-1     Running                                                                                                                                                                                        0.0s
 ⠿ Container example-cortex-1      Running                                                                                                                                                                                        0.0s
 ⠿ Container example-sample_app-1  Running                                                                                                                                                                                        0.0s
 ```

# Does This PR Require a Core Repo Change?

- [ x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated

