### PR TITLE
Fix AWS Lambda documentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -24,11 +24,11 @@ Usage
     # Copy this snippet into an AWS Lambda function
 
     import boto3
-    from opentelemetry.instrumentation.botocore import AwsBotocoreInstrumentor
+    from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
     from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
 
     # Enable instrumentation
-    AwsBotocoreInstrumentor().instrument()
+    BotocoreInstrumentor().instrument()
     AwsLambdaInstrumentor().instrument()
 
     # Lambda function


### PR DESCRIPTION
# Description

Fix documentation to avoid the error `ImportError: cannot import name 'AwsBotocoreInstrumentor' from 'opentelemetry.instrumentation.botocore'`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentaion fix

# How Has This Been Tested?

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [X] Documentation has been updated
