### PR TITLE
Add an entry for sqlalchemy component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -46,3 +46,6 @@ components:
 
   instrumentation/opentelemetry-instrumentation-urllib3:
     - shalevr
+
+  instrumentation/opentelemetry-instrumentation-sqlalchemy:
+    - shalevr


### PR DESCRIPTION
# Description

Add an entry for sqlalchemy component owner:

I contributed metrics instrumentation(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1645) 
and fixed a bug in the uninstrument logic(https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1163)
