### PR TITLE
Add sqlalchemy db.statement sanitization flag

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -134,6 +134,7 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
                 ``engine``: a SQLAlchemy engine instance
                 ``engines``: a list of SQLAlchemy engine instances
                 ``tracer_provider``: a TracerProvider, defaults to global
+                ``sanitize_query``: bool to enable/disable query sanitization, defaults to False
 
         Returns:
             An instrumented engine if passed in as an argument or list of instrumented engines, None otherwise.
@@ -151,16 +152,22 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
         )
 
         enable_commenter = kwargs.get("enable_commenter", False)
+        sanitize_query = kwargs.get("sanitize_query", False)
+        commenter_options = kwargs.get("commenter_options", {})
 
         _w(
             "sqlalchemy",
             "create_engine",
-            _wrap_create_engine(tracer, connections_usage, enable_commenter),
+            _wrap_create_engine(
+                tracer, connections_usage, sanitize_query, enable_commenter
+            ),
         )
         _w(
             "sqlalchemy.engine",
             "create_engine",
-            _wrap_create_engine(tracer, connections_usage, enable_commenter),
+            _wrap_create_engine(
+                tracer, connections_usage, sanitize_query, enable_commenter
+            ),
         )
         _w(
             "sqlalchemy.engine.base",
@@ -180,8 +187,9 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
                 tracer,
                 kwargs.get("engine"),
                 connections_usage,
-                kwargs.get("enable_commenter", False),
-                kwargs.get("commenter_options", {}),
+                sanitize_query,
+                enable_commenter,
+                commenter_options,
             )
         if kwargs.get("engines") is not None and isinstance(
             kwargs.get("engines"), Sequence
@@ -191,8 +199,9 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
                     tracer,
                     engine,
                     connections_usage,
-                    kwargs.get("enable_commenter", False),
-                    kwargs.get("commenter_options", {}),
+                    sanitize_query,
+                    enable_commenter,
+                    commenter_options,
                 )
                 for engine in kwargs.get("engines")
             ]

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_engine.py
@@ -1,0 +1,43 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry.instrumentation.sqlalchemy.engine import (
+    _normalize_vendor,
+    _sanitize_query,
+)
+from opentelemetry.test.test_base import TestBase
+
+
+class TestSQLAlchemyEngine(TestBase):
+    def test_sql_query_sanitization(self):
+        sanitized = "SELECT ? ?"
+        select1 = "SELECT * FROM users WHERE name = 'John'"
+        select2 = "SELECT  * FROM users WHERE name = 'John'"
+        select3 = "SELECT\t*\tFROM\tusers\tWHERE\tname\t=\t'John'"
+
+        self.assertEqual(_sanitize_query(select1), sanitized)
+        self.assertEqual(_sanitize_query(select2), sanitized)
+        self.assertEqual(_sanitize_query(select3), sanitized)
+        self.assertEqual(_sanitize_query(""), "")
+        self.assertEqual(_sanitize_query(None), "")
+
+    def test_normalize_vendor(self):
+        self.assertEqual(_normalize_vendor("mysql"), "mysql")
+        self.assertEqual(_normalize_vendor("sqlite"), "sqlite")
+        self.assertEqual(_normalize_vendor("sqlite~12345"), "sqlite")
+        self.assertEqual(_normalize_vendor("postgres"), "postgresql")
+        self.assertEqual(_normalize_vendor("postgres 12345"), "postgresql")
+        self.assertEqual(_normalize_vendor("psycopg2"), "postgresql")
+        self.assertEqual(_normalize_vendor(""), "db")
+        self.assertEqual(_normalize_vendor(None), "db")


### PR DESCRIPTION
# Description

Added an optional query sanitizer to the SQLAlchemy instrumentation.
Usage
SQLAlchemyInstrumentor().instrument(sanitize_query=True)

This will affect the DB_STATEMENT value to contain the original query or sanitized one.

Fixes #1549    
Following the specification discussion [here](https://github.com/open-telemetry/opentelemetry-specification/issues/3104)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Test A db.statement has been sanitized
- [x] Test B no side affects occurred on a query without a db.statement attribute 

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
