### PR TITLE
added request and response hooks for grpc client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
+- Add request and response hooks for GRPC instrumentation (client only)
+  ([#1706](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1706))
 
 ### Added
 
@@ -23,9 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Version 1.17.0/0.38b0 (2023-03-22)
-
-- Add request and response hooks for GRPC instrumentation (client only)
-  ([#1706](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1706))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 1.17.0/0.38b0 (2023-03-22)
 
+- Add request and response hooks for GRPC instrumentation (client only)
+  ([#1706](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1706))
+
 ### Added
 
 - Add connection attributes to sqlalchemy connect span

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
@@ -1,0 +1,120 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    from unittest import IsolatedAsyncioTestCase
+except ImportError:
+    # unittest.IsolatedAsyncioTestCase was introduced in Python 3.8. It's use
+    # simplifies the following tests. Without it, the amount of test code
+    # increases significantly, with most of the additional code handling
+    # the asyncio set up.
+    from unittest import TestCase
+
+    class IsolatedAsyncioTestCase(TestCase):
+        def run(self, result=None):
+            self.skipTest(
+                "This test requires Python 3.8 for unittest.IsolatedAsyncioTestCase"
+            )
+
+
+import grpc
+import pytest
+
+from opentelemetry.instrumentation.grpc import GrpcAioInstrumentorClient
+from opentelemetry.test.test_base import TestBase
+
+from ._aio_client import simple_method
+from ._server import create_test_server
+from .protobuf import test_server_pb2_grpc  # pylint: disable=no-name-in-module
+
+
+def request_hook(span, request):
+    span.set_attribute("request_data", request.request_data)
+
+
+def response_hook(span, response):
+    span.set_attribute("response_data", response)
+
+
+def request_hook_with_exception(_span, _request):
+    raise Exception()
+
+
+def response_hook_with_exception(_span, _response):
+    raise Exception()
+
+
+@pytest.mark.asyncio
+class TestAioClientInterceptorWithHooks(TestBase, IsolatedAsyncioTestCase):
+    def setUp(self):
+        super().setUp()
+        self.server = create_test_server(25565)
+        self.server.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.server.stop(None)
+
+    async def test_request_and_response_hooks(self):
+        instrumentor = GrpcAioInstrumentorClient()
+
+        try:
+            instrumentor.instrument(
+                request_hook=request_hook,
+                response_hook=response_hook,
+            )
+
+            channel = grpc.aio.insecure_channel(
+                "localhost:25565",
+            )
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            response = await simple_method(stub)
+            assert response.response_data == "data"
+
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+
+            self.assertIn("request_data", span.attributes)
+            self.assertEqual(span.attributes["request_data"], "data")
+
+            self.assertIn("response_data", span.attributes)
+            self.assertEqual(span.attributes["response_data"], "")
+        finally:
+            instrumentor.uninstrument()
+
+    async def test_hooks_with_exception(self):
+        instrumentor = GrpcAioInstrumentorClient()
+
+        try:
+            instrumentor.instrument(
+                request_hook=request_hook_with_exception,
+                response_hook=response_hook_with_exception,
+            )
+
+            channel = grpc.aio.insecure_channel(
+                "localhost:25565",
+            )
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            response = await simple_method(stub)
+            assert response.response_data == "data"
+
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+
+            self.assertEqual(span.name, "/GRPCTestServer/SimpleMethod")
+        finally:
+            instrumentor.uninstrument()

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor_hooks.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor_hooks.py
@@ -1,0 +1,149 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grpc
+from tests.protobuf import (  # pylint: disable=no-name-in-module
+    test_server_pb2_grpc,
+)
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+from opentelemetry.test.test_base import TestBase
+
+from ._client import simple_method
+from ._server import create_test_server
+
+
+# User defined interceptor. Is used in the tests along with the opentelemetry client interceptor.
+class Interceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
+    def __init__(self):
+        pass
+
+    def intercept_unary_unary(
+        self, continuation, client_call_details, request
+    ):
+        return self._intercept_call(continuation, client_call_details, request)
+
+    def intercept_unary_stream(
+        self, continuation, client_call_details, request
+    ):
+        return self._intercept_call(continuation, client_call_details, request)
+
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return self._intercept_call(
+            continuation, client_call_details, request_iterator
+        )
+
+    def intercept_stream_stream(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return self._intercept_call(
+            continuation, client_call_details, request_iterator
+        )
+
+    @staticmethod
+    def _intercept_call(
+        continuation, client_call_details, request_or_iterator
+    ):
+        return continuation(client_call_details, request_or_iterator)
+
+
+def request_hook(span, request):
+    span.set_attribute("request_data", request.request_data)
+
+
+def response_hook(span, response):
+    span.set_attribute("response_data", response.response_data)
+
+
+def request_hook_with_exception(_span, _request):
+    raise Exception()
+
+
+def response_hook_with_exception(_span, _response):
+    raise Exception()
+
+
+class TestHooks(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.server = create_test_server(25565)
+        self.server.start()
+        # use a user defined interceptor along with the opentelemetry client interceptor
+        self.interceptors = [Interceptor()]
+
+    def tearDown(self):
+        super().tearDown()
+        self.server.stop(None)
+
+    def test_response_and_request_hooks(self):
+        instrumentor = GrpcInstrumentorClient()
+
+        try:
+            instrumentor.instrument(
+                request_hook=request_hook,
+                response_hook=response_hook,
+            )
+
+            channel = grpc.insecure_channel("localhost:25565")
+            channel = grpc.intercept_channel(channel, *self.interceptors)
+
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            simple_method(stub)
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+
+            self.assertEqual(span.name, "/GRPCTestServer/SimpleMethod")
+            self.assertIs(span.kind, trace.SpanKind.CLIENT)
+
+            self.assertIn("request_data", span.attributes)
+            self.assertEqual(span.attributes["request_data"], "data")
+
+            self.assertIn("response_data", span.attributes)
+            self.assertEqual(span.attributes["response_data"], "data")
+        finally:
+            instrumentor.uninstrument()
+
+    def test_hooks_with_exception(self):
+        instrumentor = GrpcInstrumentorClient()
+
+        try:
+            instrumentor.instrument(
+                request_hook=request_hook_with_exception,
+                response_hook=response_hook_with_exception,
+            )
+
+            channel = grpc.insecure_channel("localhost:25565")
+            channel = grpc.intercept_channel(channel, *self.interceptors)
+
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            simple_method(stub)
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+
+            self.assertEqual(span.name, "/GRPCTestServer/SimpleMethod")
+            self.assertIs(span.kind, trace.SpanKind.CLIENT)
+        finally:
+            instrumentor.uninstrument()


### PR DESCRIPTION
# Description

Added an option to configure request and response hooks for GRPC clients.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A added request and response hooks which add span attributes
- [x] Test B added faulty request and response hooks and verified they do not break the instrumentation nor the application.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
