### PR TITLE
Add aiobotocore instrumentation

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -6,6 +6,9 @@ components:
   instrumentation/opentelemetry-instrumentation-aio-pika:
     - ofek1weiss
 
+  instrumentation/opentelemetry-instrumentation-aiobotocore:
+    - dacevedo12
+
   instrumentation/opentelemetry-instrumentation-boto3sqs:
     - oxeye-nikolay
     - nikosokolik

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `opentelemetry-instrumentation-aiobotocore` Initial release
+  ([#1709](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1709))
+
 ## Version 1.17.0/0.38b0 (2023-03-22)
 
 ### Added

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -19,6 +19,7 @@ django>=2.2
 
 # Required by instrumentation and exporter packages
 aio_pika~=7.2.0
+aiobotocore~=2.0
 aiohttp~=3.0
 aiopg>=0.13.0,<1.3.0
 asyncpg>=0.12.0

--- a/docs/instrumentation/aiobotocore/aiobotocore.rst
+++ b/docs/instrumentation/aiobotocore/aiobotocore.rst
@@ -1,0 +1,7 @@
+OpenTelemetry AioBotocore Instrumentation
+=========================================
+
+.. automodule:: opentelemetry.instrumentation.aiobotocore
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -2,6 +2,7 @@
 | Instrumentation | Supported Packages | Metrics support |
 | --------------- | ------------------ | --------------- |
 | [opentelemetry-instrumentation-aio-pika](./opentelemetry-instrumentation-aio-pika) | aio_pika >= 7.2.0, < 10.0.0 | No
+| [opentelemetry-instrumentation-aiobotocore](./opentelemetry-instrumentation-aiobotocore) | aiobotocore ~= 2.0 | No
 | [opentelemetry-instrumentation-aiohttp-client](./opentelemetry-instrumentation-aiohttp-client) | aiohttp ~= 3.0 | No
 | [opentelemetry-instrumentation-aiopg](./opentelemetry-instrumentation-aiopg) | aiopg >= 0.13.0, < 2.0.0 | No
 | [opentelemetry-instrumentation-asgi](./opentelemetry-instrumentation-asgi) | asgiref ~= 3.0 | No

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry AioBotocore Tracing
+=================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-aiobotocore.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-aiobotocore/
+
+This library allows tracing requests made by the AioBotocore library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-aiobotocore
+
+
+References
+----------
+
+* `OpenTelemetry AioBotocore Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/aiobotocore/aiobotocore.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-aiobotocore"
+dynamic = ["version"]
+description = "OpenTelemetry AioBotocore instrumentation"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.7"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation == 0.39b0.dev",
+  "opentelemetry-instrumentation-botocore == 0.39b0.dev",
+  "opentelemetry-semantic-conventions == 0.39b0.dev",
+]
+
+[project.optional-dependencies]
+instruments = [
+  "aiobotocore ~= 2.0",
+]
+test = [
+  "opentelemetry-instrumentation-aiobotocore[instruments]",
+  "moto[all] ~= 2.2.6",
+  "opentelemetry-test-utils == 0.39b0.dev",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+aiobotocore = "opentelemetry.instrumentation.aiobotocore:AioBotocoreInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiobotocore"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/aiobotocore/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/__init__.py
@@ -1,0 +1,133 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Instrument `AioBotocore`_ to trace service requests.
+
+There are two options for instrumenting code. The first option is to use the
+``opentelemetry-instrument`` executable which will automatically
+instrument your AioBotocore client. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _AioBotocore: https://pypi.org/project/aiobotocore/
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+    import aiobotocore.session
+
+
+    # Instrument AioBotocore
+    AioBotocoreInstrumentor().instrument()
+
+    # This will create a span with AioBotocore-specific attributes
+    session = aiobotocore.session.get_session()
+    session.set_credentials(
+        access_key="access-key", secret_key="secret-key"
+    )
+    with session.create_client("ec2", region_name="us-west-2") as ec2:
+        await ec2.describe_instances()
+
+API
+---
+
+The `instrument` method accepts the following keyword args:
+
+tracer_provider (TracerProvider) - an optional tracer provider
+request_hook (Callable) - a function with extra user-defined logic to be performed before performing the request
+this function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, api_params: dict) -> None
+response_hook (Callable) - a function with extra user-defined logic to be performed after performing the request
+this function signature is:  def request_hook(span: Span, service_name: str, operation_name: str, result: dict) -> None
+
+for example:
+
+.. code:: python
+
+    from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+    import aiobotocore.session
+
+    def request_hook(span, service_name, operation_name, api_params):
+        # request hook logic
+
+    def response_hook(span, service_name, operation_name, result):
+        # response hook logic
+
+    # Instrument AioBotocore with hooks
+    AioBotocoreInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook)
+
+    # This will create a span with AioBotocore-specific attributes, including custom attributes added from the hooks
+    session = aiobotocore.session.get_session()
+    session.set_credentials(
+        access_key="access-key", secret_key="secret-key"
+    )
+    with session.create_client("ec2", region_name="us-west-2") as ec2:
+        await ec2.describe_instances()
+"""
+
+from typing import Collection
+
+from aiobotocore.client import AioBaseClient
+from aiobotocore.endpoint import AioEndpoint
+from wrapt import wrap_function_wrapper
+
+from opentelemetry.instrumentation.aiobotocore.package import _instruments
+from opentelemetry.instrumentation.aiobotocore.version import __version__
+from opentelemetry.instrumentation.botocore import (
+    BotocoreInstrumentor,
+    _patched_endpoint_prepare_request,
+    _trace_api_call,
+)
+from opentelemetry.instrumentation.utils import unwrap
+
+
+class AioBotocoreInstrumentor(BotocoreInstrumentor):
+    """An instrumentor for AioBotocore.
+
+    See `BotocoreInstrumentor`
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        self._init_instrument(__name__, __version__, **kwargs)
+
+        wrap_function_wrapper(
+            "aiobotocore.client",
+            "AioBaseClient._make_api_call",
+            self._patched_api_call,
+        )
+
+        wrap_function_wrapper(
+            "aiobotocore.endpoint",
+            "AioEndpoint.prepare_request",
+            _patched_endpoint_prepare_request,
+        )
+
+    def _uninstrument(self, **kwargs):
+        unwrap(AioBaseClient, "_make_api_call")
+        unwrap(AioEndpoint, "prepare_request")
+
+    async def _patched_api_call(self, original_func, instance, args, kwargs):
+        with _trace_api_call(self, instance, args) as trace_context:
+            if trace_context is None:
+                return await original_func(*args, **kwargs)
+
+            result = await original_func(*args, **kwargs)
+            trace_context["result"] = result
+
+            return result

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/package.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("aiobotocore ~= 2.0",)

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/version.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/src/opentelemetry/instrumentation/aiobotocore/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.39b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/conftest.py
@@ -1,0 +1,43 @@
+import aiobotocore.awsrequest
+import aiobotocore.endpoint
+import pytest
+
+
+class MockedAWSResponse(aiobotocore.awsrequest.AioAWSResponse):
+    """
+    Patch aiobotocore to work with moto
+    See https://github.com/aio-libs/aiobotocore/issues/755
+    """
+
+    def __init__(self, response):
+        self._response = response
+        self.headers = response.headers
+        self.raw = response.raw
+        self.raw.raw_headers = {
+            k.encode("utf-8"): str(v).encode("utf-8")
+            for k, v in response.headers.items()
+        }.items()
+        self.status_code = response.status_code
+
+    async def _content_prop(self):
+        return self._response.content
+
+
+@pytest.fixture(autouse=True, scope="session")
+def patch_aiobotocore_endpoint():
+    original = aiobotocore.endpoint.convert_to_response_dict
+
+    def patched(http_response, operation_model):
+        return original(MockedAWSResponse(http_response), operation_model)
+
+    aiobotocore.endpoint.convert_to_response_dict = patched
+
+
+@pytest.fixture(autouse=True, scope="session")
+def patch_aiobotocore_retryhandler():
+    original = aiobotocore.retryhandler.AioCRC32Checker._check_response
+
+    def patched(self, attempt_number, response):
+        return original(self, attempt_number, [MockedAWSResponse(response[0])])
+
+    aiobotocore.retryhandler.AioCRC32Checker._check_response = patched

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_dynamodb.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_dynamodb.py
@@ -1,0 +1,512 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+
+import aiobotocore.session
+from moto import mock_dynamodb2
+
+from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.span import Span
+
+# pylint: disable=too-many-public-methods
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+class TestDynamoDbExtension(TestBase):
+    def setUp(self):
+        super().setUp()
+        AioBotocoreInstrumentor().instrument()
+
+        session = aiobotocore.session.get_session()
+        session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+        self.client = async_call(
+            session.create_client(
+                "dynamodb", region_name="us-west-2"
+            ).__aenter__()
+        )
+        self.default_table_name = "test_table"
+
+    def tearDown(self):
+        super().tearDown()
+        AioBotocoreInstrumentor().uninstrument()
+
+    def _create_table(self, **kwargs):
+        create_args = {
+            "TableName": self.default_table_name,
+            "AttributeDefinitions": [
+                {"AttributeName": "id", "AttributeType": "S"},
+                {"AttributeName": "idl", "AttributeType": "S"},
+                {"AttributeName": "idg", "AttributeType": "S"},
+            ],
+            "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 5,
+                "WriteCapacityUnits": 5,
+            },
+            "LocalSecondaryIndexes": [
+                {
+                    "IndexName": "lsi",
+                    "KeySchema": [{"AttributeName": "idl", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                }
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "gsi",
+                    "KeySchema": [{"AttributeName": "idg", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                }
+            ],
+        }
+        create_args.update(kwargs)
+
+        async_call(self.client.create_table(**create_args))
+
+    def _create_prepared_table(self, **kwargs):
+        self._create_table(**kwargs)
+
+        table = kwargs.get("TableName", self.default_table_name)
+        async_call(
+            self.client.put_item(
+                TableName=table,
+                Item={"id": {"S": "1"}, "idl": {"S": "2"}, "idg": {"S": "3"}},
+            )
+        )
+
+        self.memory_exporter.clear()
+
+    def assert_span(self, operation: str) -> Span:
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+
+        self.assertEqual("dynamodb", span.attributes[SpanAttributes.DB_SYSTEM])
+        self.assertEqual(
+            operation, span.attributes[SpanAttributes.DB_OPERATION]
+        )
+        self.assertEqual(
+            "dynamodb.us-west-2.amazonaws.com",
+            span.attributes[SpanAttributes.NET_PEER_NAME],
+        )
+        return span
+
+    def assert_table_names(self, span: Span, *table_names):
+        self.assertEqual(
+            tuple(table_names),
+            span.attributes[SpanAttributes.AWS_DYNAMODB_TABLE_NAMES],
+        )
+
+    def assert_consumed_capacity(self, span: Span, *table_names):
+        cap = span.attributes[SpanAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]
+        self.assertEqual(len(cap), len(table_names))
+        cap_tables = set()
+        for item in cap:
+            # should be like {"TableName": name, "CapacityUnits": number, ...}
+            deserialized = json.loads(item)
+            cap_tables.add(deserialized["TableName"])
+        for table_name in table_names:
+            self.assertIn(table_name, cap_tables)
+
+    def assert_item_col_metrics(self, span: Span):
+        actual = span.attributes[
+            SpanAttributes.AWS_DYNAMODB_ITEM_COLLECTION_METRICS
+        ]
+        self.assertIsNotNone(actual)
+        json.loads(actual)
+
+    def assert_provisioned_read_cap(self, span: Span, expected: int):
+        actual = span.attributes[
+            SpanAttributes.AWS_DYNAMODB_PROVISIONED_READ_CAPACITY
+        ]
+        self.assertEqual(expected, actual)
+
+    def assert_provisioned_write_cap(self, span: Span, expected: int):
+        actual = span.attributes[
+            SpanAttributes.AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY
+        ]
+        self.assertEqual(expected, actual)
+
+    def assert_consistent_read(self, span: Span, expected: bool):
+        actual = span.attributes[SpanAttributes.AWS_DYNAMODB_CONSISTENT_READ]
+        self.assertEqual(expected, actual)
+
+    def assert_projection(self, span: Span, expected: str):
+        actual = span.attributes[SpanAttributes.AWS_DYNAMODB_PROJECTION]
+        self.assertEqual(expected, actual)
+
+    def assert_attributes_to_get(self, span: Span, *attrs):
+        self.assertEqual(
+            tuple(attrs),
+            span.attributes[SpanAttributes.AWS_DYNAMODB_ATTRIBUTES_TO_GET],
+        )
+
+    def assert_index_name(self, span: Span, expected: str):
+        self.assertEqual(
+            expected, span.attributes[SpanAttributes.AWS_DYNAMODB_INDEX_NAME]
+        )
+
+    def assert_limit(self, span: Span, expected: int):
+        self.assertEqual(
+            expected, span.attributes[SpanAttributes.AWS_DYNAMODB_LIMIT]
+        )
+
+    def assert_select(self, span: Span, expected: str):
+        self.assertEqual(
+            expected, span.attributes[SpanAttributes.AWS_DYNAMODB_SELECT]
+        )
+
+    @mock_dynamodb2
+    def test_batch_get_item(self):
+        table_name1 = "test_table1"
+        table_name2 = "test_table2"
+        self._create_prepared_table(TableName=table_name1)
+        self._create_prepared_table(TableName=table_name2)
+
+        async_call(
+            self.client.batch_get_item(
+                RequestItems={
+                    table_name1: {"Keys": [{"id": {"S": "test_key"}}]},
+                    table_name2: {"Keys": [{"id": {"S": "test_key2"}}]},
+                },
+                ReturnConsumedCapacity="TOTAL",
+            )
+        )
+
+        span = self.assert_span("BatchGetItem")
+        self.assert_table_names(span, table_name1, table_name2)
+        self.assert_consumed_capacity(span, table_name1, table_name2)
+
+    @mock_dynamodb2
+    def test_batch_write_item(self):
+        table_name1 = "test_table1"
+        table_name2 = "test_table2"
+        self._create_prepared_table(TableName=table_name1)
+        self._create_prepared_table(TableName=table_name2)
+
+        async_call(
+            self.client.batch_write_item(
+                RequestItems={
+                    table_name1: [
+                        {"PutRequest": {"Item": {"id": {"S": "123"}}}}
+                    ],
+                    table_name2: [
+                        {"PutRequest": {"Item": {"id": {"S": "456"}}}}
+                    ],
+                },
+                ReturnConsumedCapacity="TOTAL",
+                ReturnItemCollectionMetrics="SIZE",
+            )
+        )
+
+        span = self.assert_span("BatchWriteItem")
+        self.assert_table_names(span, table_name1, table_name2)
+        self.assert_consumed_capacity(span, table_name1, table_name2)
+        self.assert_item_col_metrics(span)
+
+    @mock_dynamodb2
+    def test_create_table(self):
+        local_sec_idx = {
+            "IndexName": "local_sec_idx",
+            "KeySchema": [{"AttributeName": "value", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "KEYS_ONLY"},
+        }
+        global_sec_idx = {
+            "IndexName": "global_sec_idx",
+            "KeySchema": [{"AttributeName": "value", "KeyType": "HASH"}],
+            "Projection": {"ProjectionType": "KEYS_ONLY"},
+        }
+
+        async_call(
+            self.client.create_table(
+                AttributeDefinitions=[
+                    {"AttributeName": "id", "AttributeType": "S"},
+                    {"AttributeName": "value", "AttributeType": "S"},
+                ],
+                KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+                LocalSecondaryIndexes=[local_sec_idx],
+                GlobalSecondaryIndexes=[global_sec_idx],
+                ProvisionedThroughput={
+                    "ReadCapacityUnits": 42,
+                    "WriteCapacityUnits": 17,
+                },
+                TableName=self.default_table_name,
+            )
+        )
+
+        span = self.assert_span("CreateTable")
+        self.assert_table_names(span, self.default_table_name)
+        self.assertEqual(
+            (json.dumps(global_sec_idx),),
+            span.attributes[
+                SpanAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES
+            ],
+        )
+        self.assertEqual(
+            (json.dumps(local_sec_idx),),
+            span.attributes[
+                SpanAttributes.AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES
+            ],
+        )
+        self.assert_provisioned_read_cap(span, 42)
+
+    @mock_dynamodb2
+    def test_delete_item(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.delete_item(
+                TableName=self.default_table_name,
+                Key={"id": {"S": "1"}},
+                ReturnConsumedCapacity="TOTAL",
+                ReturnItemCollectionMetrics="SIZE",
+            )
+        )
+
+        span = self.assert_span("DeleteItem")
+        self.assert_table_names(span, self.default_table_name)
+        # moto does not seem to return these:
+        # self.assert_consumed_capacity(span, self.default_table_name)
+        # self.assert_item_coll_metrics(span)
+
+    @mock_dynamodb2
+    def test_delete_table(self):
+        self._create_prepared_table()
+
+        async_call(self.client.delete_table(TableName=self.default_table_name))
+
+        span = self.assert_span("DeleteTable")
+        self.assert_table_names(span, self.default_table_name)
+
+    @mock_dynamodb2
+    def test_describe_table(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.describe_table(TableName=self.default_table_name)
+        )
+
+        span = self.assert_span("DescribeTable")
+        self.assert_table_names(span, self.default_table_name)
+
+    @mock_dynamodb2
+    def test_get_item(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.get_item(
+                TableName=self.default_table_name,
+                Key={"id": {"S": "1"}},
+                ConsistentRead=True,
+                AttributesToGet=["id"],
+                ProjectionExpression="1,2",
+                ReturnConsumedCapacity="TOTAL",
+            )
+        )
+
+        span = self.assert_span("GetItem")
+        self.assert_table_names(span, self.default_table_name)
+        self.assert_consistent_read(span, True)
+        self.assert_projection(span, "1,2")
+        self.assert_consumed_capacity(span, self.default_table_name)
+
+    @mock_dynamodb2
+    def test_list_tables(self):
+        self._create_table(TableName="my_table")
+        self._create_prepared_table()
+
+        async_call(
+            self.client.list_tables(
+                ExclusiveStartTableName="my_table", Limit=5
+            )
+        )
+
+        span = self.assert_span("ListTables")
+        self.assertEqual(
+            "my_table",
+            span.attributes[SpanAttributes.AWS_DYNAMODB_EXCLUSIVE_START_TABLE],
+        )
+        self.assertEqual(
+            1, span.attributes[SpanAttributes.AWS_DYNAMODB_TABLE_COUNT]
+        )
+        self.assertEqual(5, span.attributes[SpanAttributes.AWS_DYNAMODB_LIMIT])
+
+    @mock_dynamodb2
+    def test_put_item(self):
+        table = "test_table"
+        self._create_prepared_table(TableName=table)
+
+        async_call(
+            self.client.put_item(
+                TableName=table,
+                Item={"id": {"S": "1"}, "idl": {"S": "2"}, "idg": {"S": "3"}},
+                ReturnConsumedCapacity="TOTAL",
+                ReturnItemCollectionMetrics="SIZE",
+            )
+        )
+
+        span = self.assert_span("PutItem")
+        self.assert_table_names(span, table)
+        self.assert_consumed_capacity(span, table)
+        # moto does not seem to return these:
+        # self.assert_item_coll_metrics(span)
+
+    @mock_dynamodb2
+    def test_query(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.query(
+                TableName=self.default_table_name,
+                IndexName="lsi",
+                Select="ALL_ATTRIBUTES",
+                AttributesToGet=["id"],
+                Limit=42,
+                ConsistentRead=True,
+                KeyConditions={
+                    "id": {
+                        "AttributeValueList": [{"S": "123"}],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+                ScanIndexForward=True,
+                ProjectionExpression="1,2",
+                ReturnConsumedCapacity="TOTAL",
+            )
+        )
+
+        span = self.assert_span("Query")
+        self.assert_table_names(span, self.default_table_name)
+        self.assertTrue(
+            span.attributes[SpanAttributes.AWS_DYNAMODB_SCAN_FORWARD]
+        )
+        self.assert_attributes_to_get(span, "id")
+        self.assert_consistent_read(span, True)
+        self.assert_index_name(span, "lsi")
+        self.assert_limit(span, 42)
+        self.assert_projection(span, "1,2")
+        self.assert_select(span, "ALL_ATTRIBUTES")
+        self.assert_consumed_capacity(span, self.default_table_name)
+
+    @mock_dynamodb2
+    def test_scan(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.scan(
+                TableName=self.default_table_name,
+                IndexName="lsi",
+                AttributesToGet=["id", "idl"],
+                Limit=42,
+                Select="ALL_ATTRIBUTES",
+                TotalSegments=17,
+                Segment=21,
+                ProjectionExpression="1,2",
+                ConsistentRead=True,
+                ReturnConsumedCapacity="TOTAL",
+            )
+        )
+
+        span = self.assert_span("Scan")
+        self.assert_table_names(span, self.default_table_name)
+        self.assertEqual(
+            21, span.attributes[SpanAttributes.AWS_DYNAMODB_SEGMENT]
+        )
+        self.assertEqual(
+            17, span.attributes[SpanAttributes.AWS_DYNAMODB_TOTAL_SEGMENTS]
+        )
+        self.assertEqual(1, span.attributes[SpanAttributes.AWS_DYNAMODB_COUNT])
+        self.assertEqual(
+            1, span.attributes[SpanAttributes.AWS_DYNAMODB_SCANNED_COUNT]
+        )
+        self.assert_attributes_to_get(span, "id", "idl")
+        self.assert_consistent_read(span, True)
+        self.assert_index_name(span, "lsi")
+        self.assert_limit(span, 42)
+        self.assert_projection(span, "1,2")
+        self.assert_select(span, "ALL_ATTRIBUTES")
+        self.assert_consumed_capacity(span, self.default_table_name)
+
+    @mock_dynamodb2
+    def test_update_item(self):
+        self._create_prepared_table()
+
+        async_call(
+            self.client.update_item(
+                TableName=self.default_table_name,
+                Key={"id": {"S": "123"}},
+                AttributeUpdates={
+                    "id": {"Value": {"S": "456"}, "Action": "PUT"}
+                },
+                ReturnConsumedCapacity="TOTAL",
+                ReturnItemCollectionMetrics="SIZE",
+            )
+        )
+
+        span = self.assert_span("UpdateItem")
+        self.assert_table_names(span, self.default_table_name)
+        self.assert_consumed_capacity(span, self.default_table_name)
+        # moto does not seem to return these:
+        # self.assert_item_coll_metrics(span)
+
+    @mock_dynamodb2
+    def test_update_table(self):
+        self._create_prepared_table()
+
+        global_sec_idx_updates = {
+            "Update": {
+                "IndexName": "gsi",
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": 777,
+                    "WriteCapacityUnits": 666,
+                },
+            }
+        }
+        attr_definition = {"AttributeName": "id", "AttributeType": "N"}
+
+        async_call(
+            self.client.update_table(
+                TableName=self.default_table_name,
+                AttributeDefinitions=[attr_definition],
+                ProvisionedThroughput={
+                    "ReadCapacityUnits": 23,
+                    "WriteCapacityUnits": 19,
+                },
+                GlobalSecondaryIndexUpdates=[global_sec_idx_updates],
+            )
+        )
+
+        span = self.assert_span("UpdateTable")
+        self.assert_table_names(span, self.default_table_name)
+        self.assert_provisioned_read_cap(span, 23)
+        self.assert_provisioned_write_cap(span, 19)
+        self.assertEqual(
+            (json.dumps(attr_definition),),
+            span.attributes[SpanAttributes.AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS],
+        )
+        self.assertEqual(
+            (json.dumps(global_sec_idx_updates),),
+            span.attributes[
+                SpanAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
+            ],
+        )

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_instrumentation.py
@@ -1,0 +1,433 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import json
+from unittest.mock import Mock, patch
+
+import aiobotocore.session
+from botocore.exceptions import ParamValidationError
+from moto import (  # pylint: disable=import-error
+    mock_ec2,
+    mock_kinesis,
+    mock_kms,
+    mock_s3,
+    mock_sqs,
+    mock_sts,
+    mock_xray,
+)
+
+from opentelemetry import trace as trace_api
+from opentelemetry.context import (
+    _SUPPRESS_HTTP_INSTRUMENTATION_KEY,
+    attach,
+    detach,
+    set_value,
+)
+from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
+from opentelemetry.propagate import get_global_textmap, set_global_textmap
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.test.mock_textmap import MockTextMapPropagator
+from opentelemetry.test.test_base import TestBase
+
+_REQUEST_ID_REGEX_MATCH = r"[A-Z0-9]{52}"
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+# pylint:disable=too-many-public-methods
+class TestAioBotocoreInstrumentor(TestBase):
+    """AioBotocore integration testsuite"""
+
+    def setUp(self):
+        super().setUp()
+        AioBotocoreInstrumentor().instrument()
+
+        self.session = aiobotocore.session.get_session()
+        self.session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+        self.region = "us-west-2"
+
+    def tearDown(self):
+        super().tearDown()
+        AioBotocoreInstrumentor().uninstrument()
+
+    def _make_client(self, service: str):
+        return async_call(
+            self.session.create_client(
+                service, region_name=self.region
+            ).__aenter__()
+        )
+
+    def _default_span_attributes(self, service: str, operation: str):
+        return {
+            SpanAttributes.RPC_SYSTEM: "aws-api",
+            SpanAttributes.RPC_SERVICE: service,
+            SpanAttributes.RPC_METHOD: operation,
+            "aws.region": self.region,
+            "retry_attempts": 0,
+            SpanAttributes.HTTP_STATUS_CODE: 200,
+        }
+
+    def assert_only_span(self):
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+        return spans[0]
+
+    def assert_span(
+        self,
+        service: str,
+        operation: str,
+        request_id=None,
+        attributes=None,
+    ):
+        span = self.assert_only_span()
+        expected = self._default_span_attributes(service, operation)
+        if attributes:
+            expected.update(attributes)
+
+        span_attributes_request_id = "aws.request_id"
+        if request_id is _REQUEST_ID_REGEX_MATCH:
+            actual_request_id = span.attributes[span_attributes_request_id]
+            self.assertRegex(actual_request_id, _REQUEST_ID_REGEX_MATCH)
+            expected[span_attributes_request_id] = actual_request_id
+        elif request_id is not None:
+            expected[span_attributes_request_id] = request_id
+
+        self.assertSpanHasAttributes(span, expected)
+        self.assertEqual(f"{service}.{operation}", span.name)
+        return span
+
+    @mock_ec2
+    def test_traced_client(self):
+        ec2 = self._make_client("ec2")
+
+        async_call(ec2.describe_instances())
+
+        request_id = "fdcdcab1-ae5c-489e-9c33-4637c5dda355"
+        self.assert_span("EC2", "DescribeInstances", request_id=request_id)
+
+    @mock_ec2
+    def test_not_recording(self):
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.is_recording.return_value = False
+        mock_tracer.start_span.return_value = mock_span
+        with patch("opentelemetry.trace.get_tracer") as tracer:
+            tracer.return_value = mock_tracer
+            ec2 = self._make_client("ec2")
+            async_call(ec2.describe_instances())
+            self.assertFalse(mock_span.is_recording())
+            self.assertTrue(mock_span.is_recording.called)
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
+
+    @mock_s3
+    def test_exception(self):
+        s3 = self._make_client("s3")
+
+        with self.assertRaises(ParamValidationError):
+            async_call(s3.list_objects(bucket="mybucket"))
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+
+        expected = self._default_span_attributes("S3", "ListObjects")
+        expected.pop(SpanAttributes.HTTP_STATUS_CODE)
+        expected.pop("retry_attempts")
+        self.assertEqual(expected, span.attributes)
+        self.assertIs(span.status.status_code, trace_api.StatusCode.ERROR)
+
+        self.assertEqual(1, len(span.events))
+        event = span.events[0]
+        self.assertIn(SpanAttributes.EXCEPTION_STACKTRACE, event.attributes)
+        self.assertIn(SpanAttributes.EXCEPTION_TYPE, event.attributes)
+        self.assertIn(SpanAttributes.EXCEPTION_MESSAGE, event.attributes)
+
+    @mock_s3
+    def test_s3_client(self):
+        s3 = self._make_client("s3")
+
+        async_call(s3.list_buckets())
+        self.assert_span("S3", "ListBuckets")
+
+    @mock_s3
+    def test_s3_put(self):
+        s3 = self._make_client("s3")
+
+        location = {"LocationConstraint": "us-west-2"}
+        async_call(
+            s3.create_bucket(
+                Bucket="mybucket", CreateBucketConfiguration=location
+            )
+        )
+        self.assert_span(
+            "S3", "CreateBucket", request_id=_REQUEST_ID_REGEX_MATCH
+        )
+        self.memory_exporter.clear()
+
+        async_call(s3.put_object(Key="foo", Bucket="mybucket", Body=b"bar"))
+        self.assert_span("S3", "PutObject", request_id=_REQUEST_ID_REGEX_MATCH)
+        self.memory_exporter.clear()
+
+        async_call(s3.get_object(Bucket="mybucket", Key="foo"))
+        self.assert_span("S3", "GetObject", request_id=_REQUEST_ID_REGEX_MATCH)
+
+    @mock_sqs
+    def test_sqs_client(self):
+        sqs = self._make_client("sqs")
+
+        async_call(sqs.list_queues())
+
+        self.assert_span(
+            "SQS", "ListQueues", request_id=_REQUEST_ID_REGEX_MATCH
+        )
+
+    @mock_sqs
+    def test_sqs_send_message(self):
+        sqs = self._make_client("sqs")
+        test_queue_name = "test_queue_name"
+
+        response = async_call(sqs.create_queue(QueueName=test_queue_name))
+        self.assert_span(
+            "SQS", "CreateQueue", request_id=_REQUEST_ID_REGEX_MATCH
+        )
+        self.memory_exporter.clear()
+
+        queue_url = response["QueueUrl"]
+        async_call(
+            sqs.send_message(
+                QueueUrl=queue_url, MessageBody="Test SQS MESSAGE!"
+            )
+        )
+
+        self.assert_span(
+            "SQS",
+            "SendMessage",
+            request_id=_REQUEST_ID_REGEX_MATCH,
+            attributes={"aws.queue_url": queue_url},
+        )
+
+    @mock_kinesis
+    def test_kinesis_client(self):
+        kinesis = self._make_client("kinesis")
+
+        async_call(kinesis.list_streams())
+        self.assert_span("Kinesis", "ListStreams")
+
+    @mock_kinesis
+    def test_unpatch(self):
+        kinesis = self._make_client("kinesis")
+
+        AioBotocoreInstrumentor().uninstrument()
+
+        async_call(kinesis.list_streams())
+        self.assertEqual(0, len(self.memory_exporter.get_finished_spans()))
+
+    @mock_ec2
+    def test_uninstrument_does_not_inject_headers(self):
+        headers = {}
+        previous_propagator = get_global_textmap()
+        try:
+            set_global_textmap(MockTextMapPropagator())
+
+            def intercept_headers(**kwargs):
+                headers.update(kwargs["request"].headers)
+
+            ec2 = self._make_client("ec2")
+
+            AioBotocoreInstrumentor().uninstrument()
+
+            ec2.meta.events.register_first(
+                "before-send.ec2.DescribeInstances", intercept_headers
+            )
+            with self.tracer_provider.get_tracer("test").start_span("parent"):
+                async_call(ec2.describe_instances())
+
+            self.assertNotIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
+            self.assertNotIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
+        finally:
+            set_global_textmap(previous_propagator)
+
+    @mock_sqs
+    def test_double_patch(self):
+        sqs = self._make_client("sqs")
+
+        AioBotocoreInstrumentor().instrument()
+        AioBotocoreInstrumentor().instrument()
+
+        async_call(sqs.list_queues())
+        self.assert_span(
+            "SQS", "ListQueues", request_id=_REQUEST_ID_REGEX_MATCH
+        )
+
+    @mock_kms
+    def test_kms_client(self):
+        kms = self._make_client("kms")
+
+        async_call(kms.list_keys(Limit=21))
+
+        span = self.assert_only_span()
+        # check for exact attribute set to make sure not to leak any kms secrets
+        self.assertEqual(
+            self._default_span_attributes("KMS", "ListKeys"), span.attributes
+        )
+
+    @mock_sts
+    def test_sts_client(self):
+        sts = self._make_client("sts")
+
+        async_call(sts.get_caller_identity())
+
+        span = self.assert_only_span()
+        expected = self._default_span_attributes("STS", "GetCallerIdentity")
+        expected["aws.request_id"] = "c6104cbe-af31-11e0-8154-cbc7ccf896c7"
+        # check for exact attribute set to make sure not to leak any sts secrets
+        self.assertEqual(expected, span.attributes)
+
+    @mock_ec2
+    def test_propagator_injects_into_request(self):
+        headers = {}
+        previous_propagator = get_global_textmap()
+
+        def check_headers(**kwargs):
+            nonlocal headers
+            headers = kwargs["request"].headers
+
+        try:
+            set_global_textmap(MockTextMapPropagator())
+
+            ec2 = self._make_client("ec2")
+            ec2.meta.events.register_first(
+                "before-send.ec2.DescribeInstances", check_headers
+            )
+            async_call(ec2.describe_instances())
+
+            request_id = "fdcdcab1-ae5c-489e-9c33-4637c5dda355"
+            span = self.assert_span(
+                "EC2", "DescribeInstances", request_id=request_id
+            )
+
+            self.assertIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().trace_id),
+                headers[MockTextMapPropagator.TRACE_ID_KEY],
+            )
+            self.assertIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
+            self.assertEqual(
+                str(span.get_span_context().span_id),
+                headers[MockTextMapPropagator.SPAN_ID_KEY],
+            )
+
+        finally:
+            set_global_textmap(previous_propagator)
+
+    @mock_xray
+    def test_suppress_instrumentation_xray_client(self):
+        xray_client = self._make_client("xray")
+        token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+        try:
+            async_call(
+                xray_client.put_trace_segments(TraceSegmentDocuments=["str1"])
+            )
+            async_call(
+                xray_client.put_trace_segments(TraceSegmentDocuments=["str2"])
+            )
+        finally:
+            detach(token)
+        self.assertEqual(0, len(self.get_finished_spans()))
+
+    @mock_xray
+    def test_suppress_http_instrumentation_xray_client(self):
+        xray_client = self._make_client("xray")
+        token = attach(set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True))
+        try:
+            async_call(
+                xray_client.put_trace_segments(TraceSegmentDocuments=["str1"])
+            )
+            async_call(
+                xray_client.put_trace_segments(TraceSegmentDocuments=["str2"])
+            )
+        finally:
+            detach(token)
+        self.assertEqual(2, len(self.get_finished_spans()))
+
+    @mock_s3
+    def test_request_hook(self):
+        request_hook_service_attribute_name = "request_hook.service_name"
+        request_hook_operation_attribute_name = "request_hook.operation_name"
+        request_hook_api_params_attribute_name = "request_hook.api_params"
+
+        def request_hook(span, service_name, operation_name, api_params):
+            hook_attributes = {
+                request_hook_service_attribute_name: service_name,
+                request_hook_operation_attribute_name: operation_name,
+                request_hook_api_params_attribute_name: json.dumps(api_params),
+            }
+
+            span.set_attributes(hook_attributes)
+
+        AioBotocoreInstrumentor().uninstrument()
+        AioBotocoreInstrumentor().instrument(request_hook=request_hook)
+
+        s3 = self._make_client("s3")
+
+        params = {
+            "Bucket": "mybucket",
+            "CreateBucketConfiguration": {"LocationConstraint": "us-west-2"},
+        }
+        async_call(s3.create_bucket(**params))
+        self.assert_span(
+            "S3",
+            "CreateBucket",
+            attributes={
+                request_hook_service_attribute_name: "s3",
+                request_hook_operation_attribute_name: "CreateBucket",
+                request_hook_api_params_attribute_name: json.dumps(params),
+            },
+        )
+
+    @mock_s3
+    def test_response_hook(self):
+        response_hook_service_attribute_name = "request_hook.service_name"
+        response_hook_operation_attribute_name = "response_hook.operation_name"
+        response_hook_result_attribute_name = "response_hook.result"
+
+        def response_hook(span, service_name, operation_name, result):
+            hook_attributes = {
+                response_hook_service_attribute_name: service_name,
+                response_hook_operation_attribute_name: operation_name,
+                response_hook_result_attribute_name: len(result["Buckets"]),
+            }
+            span.set_attributes(hook_attributes)
+
+        AioBotocoreInstrumentor().uninstrument()
+        AioBotocoreInstrumentor().instrument(response_hook=response_hook)
+
+        s3 = self._make_client("s3")
+        async_call(s3.list_buckets())
+        self.assert_span(
+            "S3",
+            "ListBuckets",
+            attributes={
+                response_hook_service_attribute_name: "s3",
+                response_hook_operation_attribute_name: "ListBuckets",
+                response_hook_result_attribute_name: 0,
+            },
+        )

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_lambda.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_lambda.py
@@ -1,0 +1,178 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import io
+import json
+import sys
+import zipfile
+
+import aiobotocore.session
+from moto import mock_iam, mock_lambda  # pylint: disable=import-error
+from pytest import mark
+
+from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+from opentelemetry.propagate import get_global_textmap, set_global_textmap
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.test.mock_textmap import MockTextMapPropagator
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace.span import Span
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+def get_as_zip_file(file_name, content):
+    zip_output = io.BytesIO()
+    with zipfile.ZipFile(zip_output, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr(file_name, content)
+    zip_output.seek(0)
+    return zip_output.read()
+
+
+def return_headers_lambda_str():
+    pfunc = """
+def lambda_handler(event, context):
+    print("custom log event")
+    headers = event.get('headers', event.get('attributes', {}))
+    return headers
+"""
+    return pfunc
+
+
+class TestLambdaExtension(TestBase):
+    def setUp(self):
+        super().setUp()
+        AioBotocoreInstrumentor().instrument()
+
+        session = aiobotocore.session.get_session()
+        session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+        self.region = "us-west-2"
+        self.client = async_call(
+            session.create_client(
+                "lambda", region_name=self.region
+            ).__aenter__()
+        )
+        self.iam_client = async_call(
+            session.create_client("iam", region_name=self.region).__aenter__()
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        AioBotocoreInstrumentor().uninstrument()
+
+    def assert_span(self, operation: str) -> Span:
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+
+        span = spans[0]
+        self.assertEqual(operation, span.attributes[SpanAttributes.RPC_METHOD])
+        self.assertEqual("Lambda", span.attributes[SpanAttributes.RPC_SERVICE])
+        self.assertEqual("aws-api", span.attributes[SpanAttributes.RPC_SYSTEM])
+        return span
+
+    def assert_invoke_span(self, function_name: str) -> Span:
+        span = self.assert_span("Invoke")
+        self.assertEqual(
+            "aws", span.attributes[SpanAttributes.FAAS_INVOKED_PROVIDER]
+        )
+        self.assertEqual(
+            self.region, span.attributes[SpanAttributes.FAAS_INVOKED_REGION]
+        )
+        self.assertEqual(
+            function_name, span.attributes[SpanAttributes.FAAS_INVOKED_NAME]
+        )
+        return span
+
+    @mock_lambda
+    def test_list_functions(self):
+        async_call(self.client.list_functions())
+        self.assert_span("ListFunctions")
+
+    @mock_iam
+    def _create_role_and_get_arn(self) -> str:
+        return async_call(
+            self.iam_client.create_role(
+                RoleName="my-role",
+                AssumeRolePolicyDocument="some policy",
+                Path="/my-path/",
+            )
+        )["Role"]["Arn"]
+
+    def _create_lambda_function(self, function_name: str, function_code: str):
+        role_arn = self._create_role_and_get_arn()
+
+        async_call(
+            self.client.create_function(
+                FunctionName=function_name,
+                Runtime="python3.8",
+                Role=role_arn,
+                Handler="lambda_function.lambda_handler",
+                Code={
+                    "ZipFile": get_as_zip_file(
+                        "lambda_function.py", function_code
+                    )
+                },
+                Description="test lambda function",
+                Timeout=3,
+                MemorySize=128,
+                Publish=True,
+            )
+        )
+
+    @mark.skip(reason="Docker error, unblocking builds for now.")
+    @mark.skipif(
+        sys.platform == "win32",
+        reason="requires docker and Github CI Windows does not have docker installed by default",
+    )
+    @mock_lambda
+    def test_invoke(self):
+        previous_propagator = get_global_textmap()
+        try:
+            set_global_textmap(MockTextMapPropagator())
+            function_name = "testFunction"
+            self._create_lambda_function(
+                function_name, return_headers_lambda_str()
+            )
+            # 2 spans for create IAM + create lambda
+            self.assertEqual(2, len(self.memory_exporter.get_finished_spans()))
+            self.memory_exporter.clear()
+
+            response = async_call(
+                self.client.invoke(
+                    Payload=json.dumps({}),
+                    FunctionName=function_name,
+                    InvocationType="RequestResponse",
+                )
+            )
+
+            span = self.assert_invoke_span(function_name)
+            span_context = span.get_span_context()
+
+            # # assert injected span
+            headers = json.loads(response["Payload"].read().decode("utf-8"))
+            self.assertEqual(
+                str(span_context.trace_id),
+                headers[MockTextMapPropagator.TRACE_ID_KEY],
+            )
+            self.assertEqual(
+                str(span_context.span_id),
+                headers[MockTextMapPropagator.SPAN_ID_KEY],
+            )
+        finally:
+            set_global_textmap(previous_propagator)

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_sns.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_sns.py
@@ -1,0 +1,205 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import contextlib
+from typing import Any, Dict
+from unittest import mock
+
+import aiobotocore.session
+from aiobotocore.awsrequest import AioAWSResponse
+from moto import mock_sns
+
+from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+from opentelemetry.semconv.trace import (
+    MessagingDestinationKindValues,
+    SpanAttributes,
+)
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.span import Span
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+class TestSnsExtension(TestBase):
+    def setUp(self):
+        super().setUp()
+        AioBotocoreInstrumentor().instrument()
+
+        session = aiobotocore.session.get_session()
+        session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+        self.client = async_call(
+            session.create_client("sns", region_name="us-west-2").__aenter__()
+        )
+        self.topic_name = "my-topic"
+
+    def tearDown(self):
+        super().tearDown()
+        AioBotocoreInstrumentor().uninstrument()
+
+    def _create_topic(self, name: str = None) -> str:
+        if name is None:
+            name = self.topic_name
+
+        response = async_call(self.client.create_topic(Name=name))
+
+        self.memory_exporter.clear()
+        return response["TopicArn"]
+
+    @contextlib.contextmanager
+    def _mocked_aws_endpoint(self, response):
+        response_func = self._make_aws_response_func(response)
+        with mock.patch(
+            "aiobotocore.endpoint.AioEndpoint.make_request", new=response_func
+        ):
+            yield
+
+    @staticmethod
+    def _make_aws_response_func(response):
+        async def _response_func(*args, **kwargs):
+            return AioAWSResponse("http://127.0.0.1", 200, {}, "{}"), response
+
+        return _response_func
+
+    def assert_span(self, name: str) -> Span:
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+
+        self.assertEqual(SpanKind.PRODUCER, span.kind)
+        self.assertEqual(name, span.name)
+        self.assertEqual(
+            "aws.sns", span.attributes[SpanAttributes.MESSAGING_SYSTEM]
+        )
+
+        return span
+
+    def assert_injected_span(self, message_attrs: Dict[str, Any], span: Span):
+        # traceparent: <ver>-<trace-id>-<span-id>-<flags>
+        trace_parent = message_attrs["traceparent"]["StringValue"].split("-")
+        span_context = span.get_span_context()
+
+        self.assertEqual(span_context.trace_id, int(trace_parent[1], 16))
+        self.assertEqual(span_context.span_id, int(trace_parent[2], 16))
+
+    @mock_sns
+    def test_publish_to_topic_arn(self):
+        self._test_publish_to_arn("TopicArn")
+
+    @mock_sns
+    def test_publish_to_target_arn(self):
+        self._test_publish_to_arn("TargetArn")
+
+    def _test_publish_to_arn(self, arg_name: str):
+        target_arn = self._create_topic(self.topic_name)
+
+        async_call(
+            self.client.publish(
+                **{
+                    arg_name: target_arn,
+                    "Message": "Hello message",
+                }
+            )
+        )
+
+        span = self.assert_span(f"{self.topic_name} send")
+        self.assertEqual(
+            MessagingDestinationKindValues.TOPIC.value,
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION_KIND],
+        )
+        self.assertEqual(
+            self.topic_name,
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+        )
+
+    @mock_sns
+    def test_publish_to_phone_number(self):
+        phone_number = "+10000000000"
+        async_call(
+            self.client.publish(
+                PhoneNumber=phone_number,
+                Message="Hello SNS",
+            )
+        )
+
+        span = self.assert_span("phone_number send")
+        self.assertEqual(
+            phone_number, span.attributes[SpanAttributes.MESSAGING_DESTINATION]
+        )
+
+    @mock_sns
+    def test_publish_injects_span(self):
+        message_attrs = {}
+        topic_arn = self._create_topic()
+        async_call(
+            self.client.publish(
+                TopicArn=topic_arn,
+                Message="Hello Message",
+                MessageAttributes=message_attrs,
+            )
+        )
+
+        span = self.assert_span(f"{self.topic_name} send")
+        self.assert_injected_span(message_attrs, span)
+
+    def test_publish_batch_to_topic(self):
+        topic_arn = f"arn:aws:sns:region:000000000:{self.topic_name}"
+        message1_attrs = {}
+        message2_attrs = {}
+        mock_response = {
+            "Successful": [
+                {"Id": "1", "MessageId": "11", "SequenceNumber": "1"},
+                {"Id": "2", "MessageId": "22", "SequenceNumber": "2"},
+            ],
+            "Failed": [],
+        }
+
+        # publish_batch not implemented by moto so mock the endpoint instead
+        with self._mocked_aws_endpoint(mock_response):
+            async_call(
+                self.client.publish_batch(
+                    TopicArn=topic_arn,
+                    PublishBatchRequestEntries=[
+                        {
+                            "Id": "1",
+                            "Message": "Hello message 1",
+                            "MessageAttributes": message1_attrs,
+                        },
+                        {
+                            "Id": "2",
+                            "Message": "Hello message 2",
+                            "MessageAttributes": message2_attrs,
+                        },
+                    ],
+                )
+            )
+
+        span = self.assert_span(f"{self.topic_name} send")
+        self.assertEqual(
+            MessagingDestinationKindValues.TOPIC.value,
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION_KIND],
+        )
+        self.assertEqual(
+            self.topic_name,
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+        )
+
+        self.assert_injected_span(message1_attrs, span)
+        self.assert_injected_span(message2_attrs, span)

--- a/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-aiobotocore/tests/test_aiobotocore_sqs.py
@@ -1,0 +1,153 @@
+import asyncio
+
+import aiobotocore.session
+from moto import mock_sqs
+
+from opentelemetry.instrumentation.aiobotocore import AioBotocoreInstrumentor
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.test.test_base import TestBase
+
+
+def async_call(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+class TestSqsExtension(TestBase):
+    def setUp(self):
+        super().setUp()
+        AioBotocoreInstrumentor().instrument()
+
+        session = aiobotocore.session.get_session()
+        session.set_credentials(
+            access_key="access-key", secret_key="secret-key"
+        )
+        self.region = "us-west-2"
+        self.client = async_call(
+            session.create_client("sqs", region_name=self.region).__aenter__()
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        AioBotocoreInstrumentor().uninstrument()
+
+    @mock_sqs
+    def test_sqs_messaging_send_message(self):
+        create_queue_result = async_call(
+            self.client.create_queue(QueueName="test_queue_name")
+        )
+        queue_url = create_queue_result["QueueUrl"]
+        response = async_call(
+            self.client.send_message(QueueUrl=queue_url, MessageBody="content")
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 2)
+        span = spans[1]
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+            "test_queue_name",
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            response["MessageId"],
+        )
+
+    @mock_sqs
+    def test_sqs_messaging_send_message_batch(self):
+        create_queue_result = async_call(
+            self.client.create_queue(QueueName="test_queue_name")
+        )
+        queue_url = create_queue_result["QueueUrl"]
+        response = async_call(
+            self.client.send_message_batch(
+                QueueUrl=queue_url,
+                Entries=[
+                    {"Id": "1", "MessageBody": "content"},
+                    {"Id": "2", "MessageBody": "content2"},
+                ],
+            )
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 2)
+        span = spans[1]
+        self.assertEqual(span.attributes["rpc.method"], "SendMessageBatch")
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+            "test_queue_name",
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            response["Successful"][0]["MessageId"],
+        )
+
+    @mock_sqs
+    def test_sqs_messaging_receive_message(self):
+        create_queue_result = async_call(
+            self.client.create_queue(QueueName="test_queue_name")
+        )
+        queue_url = create_queue_result["QueueUrl"]
+        async_call(
+            self.client.send_message(QueueUrl=queue_url, MessageBody="content")
+        )
+        message_result = async_call(
+            self.client.receive_message(
+                QueueUrl=create_queue_result["QueueUrl"]
+            )
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 3)
+        span = spans[-1]
+        self.assertEqual(span.attributes["rpc.method"], "ReceiveMessage")
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_URL], queue_url
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+            "test_queue_name",
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            message_result["Messages"][0]["MessageId"],
+        )
+
+    @mock_sqs
+    def test_sqs_messaging_failed_operation(self):
+        with self.assertRaises(Exception):
+            async_call(
+                self.client.send_message(
+                    QueueUrl="non-existing", MessageBody="content"
+                )
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.attributes["rpc.method"], "SendMessage")
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs"
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.MESSAGING_URL], "non-existing"
+        )

--- a/opentelemetry-contrib-instrumentations/pyproject.toml
+++ b/opentelemetry-contrib-instrumentations/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "opentelemetry-instrumentation-aio-pika==0.39b0.dev",
+    "opentelemetry-instrumentation-aiobotocore==0.39b0.dev",
     "opentelemetry-instrumentation-aiohttp-client==0.39b0.dev",
     "opentelemetry-instrumentation-aiopg==0.39b0.dev",
     "opentelemetry-instrumentation-asgi==0.39b0.dev",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -20,6 +20,10 @@ libraries = {
         "library": "aio_pika >= 7.2.0, < 10.0.0",
         "instrumentation": "opentelemetry-instrumentation-aio-pika==0.39b0.dev",
     },
+    "aiobotocore": {
+        "library": "aiobotocore ~= 2.0",
+        "instrumentation": "opentelemetry-instrumentation-aiobotocore==0.39b0.dev",
+    },
     "aiohttp": {
         "library": "aiohttp ~= 3.0",
         "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.39b0.dev",

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ envlist =
     py3{7,8,9,10,11}-test-instrumentation-aio-pika
     pypy3-test-instrumentation-aio-pika
 
+    ; opentelemetry-instrumentation-aiobotocore
+    py3{7,8,9,10,11}-test-instrumentation-aiobotocore
+    pypy3-test-instrumentation-aiobotocore
+
     ; opentelemetry-instrumentation-aiohttp-client
     py3{7,8,9,10,11}-test-instrumentation-aiohttp-client
     pypy3-test-instrumentation-aiohttp-client
@@ -282,6 +286,7 @@ changedir =
   test-distro: opentelemetry-distro/tests
   test-opentelemetry-instrumentation: opentelemetry-instrumentation/tests
   test-instrumentation-aio-pika: instrumentation/opentelemetry-instrumentation-aio-pika/tests
+  test-instrumentation-aiobotocore: instrumentation/opentelemetry-instrumentation-aiobotocore/tests
   test-instrumentation-aiohttp-client: instrumentation/opentelemetry-instrumentation-aiohttp-client/tests
   test-instrumentation-aiopg: instrumentation/opentelemetry-instrumentation-aiopg/tests
   test-instrumentation-asgi: instrumentation/opentelemetry-instrumentation-asgi/tests
@@ -364,7 +369,7 @@ commands_pre =
 
   aws-lambda: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aws-lambda[test]
 
-  boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
+  aiobotocore,boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
   boto: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-boto[test]
 
   boto3sqs: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-boto3sqs[test]
@@ -418,6 +423,8 @@ commands_pre =
   logging: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-logging[test]
 
   aio-pika: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika[test]
+
+  aiobotocore: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiobotocore[test]
 
   aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
 
@@ -522,6 +529,7 @@ commands_pre =
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-logging[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-psycopg2[test]
+  python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aiobotocore[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlite3[test]


### PR DESCRIPTION
# Description

Added instrumentor for aiobotocore, an async client for amazon services.

It's based on the sync botocore instrumentor, overriding the methods to patch the async codepaths

Fixes #553

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- I've been using it on production for a while with no problems.
- workflow tests should pass to be sure

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
