### PR TITLE
Remove pinned version importlib-metadata

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
@@ -37,7 +37,6 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-celery[instruments]",
   "opentelemetry-test-utils == 0.38b0.dev",
-  "importlib-metadata==4.13.0",
   "pytest",
 ]
 


### PR DESCRIPTION
# Description

Because this conflicts with https://github.com/open-telemetry/opentelemetry-python/blob/d77ca16badd5197d66b9b4dfac1221a5fb09c028/opentelemetry-api/pyproject.toml#L32 and fails