### PR TITLE
Make Django request span attributes available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1645](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1645))
 - Add `excluded_urls` functionality to `urllib` and `urllib3` instrumentations
   ([#1733](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1733))
+- Make Django request span attributes available for `start_span`. 
+  ([#1730](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1730))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -212,6 +212,7 @@ class _DjangoMiddleware(MiddlewareMixin):
             carrier_getter = wsgi_getter
             collect_request_attributes = wsgi_collect_request_attributes
 
+        attributes = collect_request_attributes(carrier)
         span, token = _start_internal_or_server_span(
             tracer=self._tracer,
             span_name=self._get_span_name(request),
@@ -220,9 +221,9 @@ class _DjangoMiddleware(MiddlewareMixin):
             ),
             context_carrier=carrier,
             context_getter=carrier_getter,
+            attributes=attributes,
         )
 
-        attributes = collect_request_attributes(carrier)
         active_requests_count_attrs = _parse_active_request_count_attrs(
             attributes
         )


### PR DESCRIPTION
# Description

I would like to be able not to instrument certain requests within Django. E.g. when HTTP `http.method=OPTIONS`.

To be able to do this, I'd need to be able to access request data through `attributes`, which at the moment is unused:

```
class DjangoSampler(Sampler):
    # ...
    def should_sample(
        self,
        parent_context,
        trace_id,
        name,
        kind=None,  # noqa
        attributes=None,
        links=None,  # noqa
        trace_state=None,
    ):
        decision = Decision.RECORD_AND_SAMPLE
        if attributes and attributes.get("http.method") == "OPTIONS":
            # Do not instrument OPTIONS requests
            decision = Decision.DROP
            attributes = None
        return SamplingResult(
            decision,
            attributes,
            self._get_parent_trace_state(parent_context),
        )

    resource = Resource(
        attributes={
            "service.name": "myapp",
        }
    )
    trace.set_tracer_provider(
        TracerProvider(
            sampler=DjangoSampler(),
            resource=resource,
        )
    )
```

Fixes partially #936


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the code in the description.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
