### PR TITLE
Update runtime metrics to follow semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
+
 ### Added
 
 - Add `excluded_urls` functionality to `urllib` and `urllib3` instrumentations
@@ -43,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-requests` Replace `name_callback` and `span_callback` with standard `response_hook` and `request_hook` callbacks
   ([#670](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/670))
-- `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
 
 ## Version 1.16.0/0.37b0 (2023-02-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-requests` Replace `name_callback` and `span_callback` with standard `response_hook` and `request_hook` callbacks
   ([#670](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/670))
+- `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
 
 ## Version 1.16.0/0.37b0 (2023-02-17)
 

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -34,8 +34,8 @@ following metrics are configured:
         "system.network.io": ["transmit", "receive"],
         "system.network.connections": ["family", "type"],
         "system.thread_count": None
-        "runtime.memory": ["rss", "vms"],
-        "runtime.cpu.time": ["user", "system"],
+        "process.runtime.memory": ["rss", "vms"],
+        "process.runtime.cpu.time": ["user", "system"],
     }
 
 Usage
@@ -61,8 +61,8 @@ Usage
         "system.memory.usage": ["used", "free", "cached"],
         "system.cpu.time": ["idle", "user", "system", "irq"],
         "system.network.io": ["transmit", "receive"],
-        "runtime.memory": ["rss", "vms"],
-        "runtime.cpu.time": ["user", "system"],
+        "process.runtime.memory": ["rss", "vms"],
+        "process.runtime.cpu.time": ["user", "system"],
     }
     SystemMetricsInstrumentor(config=configuration).instrument()
 
@@ -102,9 +102,9 @@ _DEFAULT_CONFIG = {
     "system.network.io": ["transmit", "receive"],
     "system.network.connections": ["family", "type"],
     "system.thread_count": None,
-    "runtime.memory": ["rss", "vms"],
-    "runtime.cpu.time": ["user", "system"],
-    "runtime.gc_count": None,
+    "process.runtime.memory": ["rss", "vms"],
+    "process.runtime.cpu.time": ["user", "system"],
+    "process.runtime.gc_count": None,
 }
 
 
@@ -323,25 +323,25 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
                 description="System active threads count",
             )
 
-        if "runtime.memory" in self._config:
+        if "process.runtime.memory" in self._config:
             self._meter.create_observable_counter(
-                name=f"runtime.{self._python_implementation}.memory",
+                name=f"process.runtime.{self._python_implementation}.memory",
                 callbacks=[self._get_runtime_memory],
                 description=f"Runtime {self._python_implementation} memory",
                 unit="bytes",
             )
 
-        if "runtime.cpu.time" in self._config:
+        if "process.runtime.cpu.time" in self._config:
             self._meter.create_observable_counter(
-                name=f"runtime.{self._python_implementation}.cpu_time",
+                name=f"process.runtime.{self._python_implementation}.cpu_time",
                 callbacks=[self._get_runtime_cpu_time],
                 description=f"Runtime {self._python_implementation} CPU time",
                 unit="seconds",
             )
 
-        if "runtime.gc_count" in self._config:
+        if "process.runtime.gc_count" in self._config:
             self._meter.create_observable_counter(
-                name=f"runtime.{self._python_implementation}.gc_count",
+                name=f"process.runtime.{self._python_implementation}.gc_count",
                 callbacks=[self._get_runtime_gc_count],
                 description=f"Runtime {self._python_implementation} GC count",
                 unit="bytes",
@@ -618,7 +618,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
     ) -> Iterable[Observation]:
         """Observer callback for runtime memory"""
         proc_memory = self._proc.memory_info()
-        for metric in self._config["runtime.memory"]:
+        for metric in self._config["process.runtime.memory"]:
             if hasattr(proc_memory, metric):
                 self._runtime_memory_labels["type"] = metric
                 yield Observation(
@@ -631,7 +631,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
     ) -> Iterable[Observation]:
         """Observer callback for runtime CPU time"""
         proc_cpu = self._proc.cpu_times()
-        for metric in self._config["runtime.cpu.time"]:
+        for metric in self._config["process.runtime.cpu.time"]:
             if hasattr(proc_cpu, metric):
                 self._runtime_cpu_time_labels["type"] = metric
                 yield Observation(

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -324,7 +324,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
             )
 
         if "process.runtime.memory" in self._config:
-            self._meter.create_observable_counter(
+            self._meter.create_observable_gauge(
                 name=f"process.runtime.{self._python_implementation}.memory",
                 callbacks=[self._get_runtime_memory],
                 description=f"Runtime {self._python_implementation} memory",

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -324,7 +324,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
             )
 
         if "process.runtime.memory" in self._config:
-            self._meter.create_observable_gauge(
+            self._meter.create_observable_up_down_counter(
                 name=f"process.runtime.{self._python_implementation}.memory",
                 callbacks=[self._get_runtime_memory],
                 description=f"Runtime {self._python_implementation} memory",

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -114,9 +114,9 @@ class TestSystemMetrics(TestBase):
             "system.network.io",
             "system.network.connections",
             "system.thread_count",
-            f"runtime.{self.implementation}.memory",
-            f"runtime.{self.implementation}.cpu_time",
-            f"runtime.{self.implementation}.gc_count",
+            f"process.runtime.{self.implementation}.memory",
+            f"process.runtime.{self.implementation}.cpu_time",
+            f"process.runtime.{self.implementation}.gc_count",
         ]
 
         for observer in metric_names:
@@ -125,9 +125,9 @@ class TestSystemMetrics(TestBase):
 
     def test_runtime_metrics_instrument(self):
         runtime_config = {
-            "runtime.memory": ["rss", "vms"],
-            "runtime.cpu.time": ["user", "system"],
-            "runtime.gc_count": None,
+            "process.runtime.memory": ["rss", "vms"],
+            "process.runtime.cpu.time": ["user", "system"],
+            "process.runtime.gc_count": None,
         }
 
         reader = InMemoryMetricReader()
@@ -143,9 +143,9 @@ class TestSystemMetrics(TestBase):
         self.assertEqual(len(metric_names), 3)
 
         observer_names = [
-            f"runtime.{self.implementation}.memory",
-            f"runtime.{self.implementation}.cpu_time",
-            f"runtime.{self.implementation}.gc_count",
+            f"process.runtime.{self.implementation}.memory",
+            f"process.runtime.{self.implementation}.cpu_time",
+            f"process.runtime.{self.implementation}.gc_count",
         ]
 
         for observer in metric_names:
@@ -750,7 +750,7 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"type": "rss"}, 1),
             _SystemMetricsResult({"type": "vms"}, 2),
         ]
-        self._test_metrics(f"runtime.{self.implementation}.memory", expected)
+        self._test_metrics(f"process.runtime.{self.implementation}.memory", expected)
 
     @mock.patch("psutil.Process.cpu_times")
     def test_runtime_cpu_time(self, mock_process_cpu_times):
@@ -764,7 +764,7 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"type": "user"}, 1.1),
             _SystemMetricsResult({"type": "system"}, 2.2),
         ]
-        self._test_metrics(f"runtime.{self.implementation}.cpu_time", expected)
+        self._test_metrics(f"process.runtime.{self.implementation}.cpu_time", expected)
 
     @mock.patch("gc.get_count")
     def test_runtime_get_count(self, mock_gc_get_count):
@@ -775,4 +775,4 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"count": "1"}, 2),
             _SystemMetricsResult({"count": "2"}, 3),
         ]
-        self._test_metrics(f"runtime.{self.implementation}.gc_count", expected)
+        self._test_metrics(f"process.runtime.{self.implementation}.gc_count", expected)

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -750,7 +750,9 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"type": "rss"}, 1),
             _SystemMetricsResult({"type": "vms"}, 2),
         ]
-        self._test_metrics(f"process.runtime.{self.implementation}.memory", expected)
+        self._test_metrics(
+            f"process.runtime.{self.implementation}.memory", expected
+        )
 
     @mock.patch("psutil.Process.cpu_times")
     def test_runtime_cpu_time(self, mock_process_cpu_times):
@@ -764,7 +766,9 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"type": "user"}, 1.1),
             _SystemMetricsResult({"type": "system"}, 2.2),
         ]
-        self._test_metrics(f"process.runtime.{self.implementation}.cpu_time", expected)
+        self._test_metrics(
+            f"process.runtime.{self.implementation}.cpu_time", expected
+        )
 
     @mock.patch("gc.get_count")
     def test_runtime_get_count(self, mock_gc_get_count):
@@ -775,4 +779,6 @@ class TestSystemMetrics(TestBase):
             _SystemMetricsResult({"count": "1"}, 2),
             _SystemMetricsResult({"count": "2"}, 3),
         ]
-        self._test_metrics(f"process.runtime.{self.implementation}.gc_count", expected)
+        self._test_metrics(
+            f"process.runtime.{self.implementation}.gc_count", expected
+        )


### PR DESCRIPTION
# Description

This PR adds the `process.` prefix to the following runtime metrics:
- runtime.memory
- runtime.cpu.time
- runtime.gc_count

This PR also changes runtime.memory to be an UpDownCounter instead of a count, since the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#metric-instruments) list `process.memory.usage` as an UpDownCounter.

Fixes #1722 

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)