### PR TITLE
fix: None does not implement middleware when there are no middlewares

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -245,6 +245,9 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
 
         # inject trace middleware
         self._middlewares_list = kwargs.pop("middleware", [])
+        if (self._middlewares_list is None):
+            self._middlewares_list = []
+
         tracer_provider = otel_opts.pop("tracer_provider", None)
         meter_provider = otel_opts.pop("meter_provider", None)
         if not isinstance(self._middlewares_list, (list, tuple)):


### PR DESCRIPTION
# Description

When no middlewares are registered falcon-instrumentation will throw following exception:
`TypeError: None does not implement the middleware interface`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

We are running a [Hug](http://hugapi.github.io/hug/) framework that built on top of Falcon.
Its enough to build a basic api without middlewares and instrument it with falcon instrumentation to encounter this error.
Application will exit immediately without this fix. As a workaround any middleware can be registered.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
