### PR TITLE
Add support for pymemcache version > 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-system-metrics` Add `process.` prefix to `runtime.memory`, `runtime.cpu.time`, and `runtime.gc_count`. Change `runtime.memory` from count to UpDownCounter. ([#1735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1735))
 - Add request and response hooks for GRPC instrumentation (client only)
   ([#1706](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1706))
+- `opentelemetry-instrumentation-pymemcache` Update instrumentation to support pymemcache >4
+  ([#1764](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1764))
 
 ### Added
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -26,7 +26,7 @@
 | [opentelemetry-instrumentation-mysql](./opentelemetry-instrumentation-mysql) | mysql-connector-python ~= 8.0 | No
 | [opentelemetry-instrumentation-pika](./opentelemetry-instrumentation-pika) | pika >= 0.12.0 | No
 | [opentelemetry-instrumentation-psycopg2](./opentelemetry-instrumentation-psycopg2) | psycopg2 >= 2.7.3.1 | No
-| [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache >= 1.3.5, < 4 | No
+| [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache >= 1.3.5, < 5 | No
 | [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 | No
 | [opentelemetry-instrumentation-pymysql](./opentelemetry-instrumentation-pymysql) | PyMySQL < 2 | No
 | [opentelemetry-instrumentation-pyramid](./opentelemetry-instrumentation-pyramid) | pyramid >= 1.7 | Yes

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "pymemcache >= 1.3.5, < 4",
+  "pymemcache >= 1.3.5, < 5",
 ]
 test = [
   "opentelemetry-instrumentation-pymemcache[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("pymemcache >= 1.3.5, < 4",)
+_instruments = ("pymemcache >= 1.3.5, < 5",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -105,7 +105,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-psycopg2==0.39b0.dev",
     },
     "pymemcache": {
-        "library": "pymemcache >= 1.3.5, < 4",
+        "library": "pymemcache >= 1.3.5, < 5",
         "instrumentation": "opentelemetry-instrumentation-pymemcache==0.39b0.dev",
     },
     "pymongo": {

--- a/tox.ini
+++ b/tox.ini
@@ -122,8 +122,8 @@ envlist =
     ; ext-psycopg2 intentionally excluded from pypy3
 
     ; opentelemetry-instrumentation-pymemcache
-    py3{7,8,9,10,11}-test-instrumentation-pymemcache{135,200,300,342}
-    pypy3-test-instrumentation-pymemcache{135,200,300,342}
+    py3{7,8,9,10,11}-test-instrumentation-pymemcache{135,200,300,342,400}
+    pypy3-test-instrumentation-pymemcache{135,200,300,342,400}
 
     ; opentelemetry-instrumentation-pymongo
     py3{7,8,9,10,11}-test-instrumentation-pymongo
@@ -267,6 +267,7 @@ deps =
   pymemcache200: pymemcache >2.0.0,<3.0.0
   pymemcache300: pymemcache >3.0.0,<3.4.2
   pymemcache342: pymemcache ==3.4.2
+  pymemcache400: pymemcache ==4.0.0
   httpx18: httpx>=0.18.0,<0.19.0
   httpx18: respx~=0.17.0
   httpx21: httpx>=0.19.0
@@ -311,7 +312,7 @@ changedir =
   test-instrumentation-pika{0,1}: instrumentation/opentelemetry-instrumentation-pika/tests
   test-instrumentation-aio-pika{7,8,9}: instrumentation/opentelemetry-instrumentation-aio-pika/tests
   test-instrumentation-psycopg2: instrumentation/opentelemetry-instrumentation-psycopg2/tests
-  test-instrumentation-pymemcache{135,200,300,342}: instrumentation/opentelemetry-instrumentation-pymemcache/tests
+  test-instrumentation-pymemcache{135,200,300,342,400}: instrumentation/opentelemetry-instrumentation-pymemcache/tests
   test-instrumentation-pymongo: instrumentation/opentelemetry-instrumentation-pymongo/tests
   test-instrumentation-pymysql: instrumentation/opentelemetry-instrumentation-pymysql/tests
   test-instrumentation-pyramid: instrumentation/opentelemetry-instrumentation-pyramid/tests
@@ -390,7 +391,7 @@ commands_pre =
 
   mysql: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql[test]
 
-  pymemcache{135,200,300,342}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
+  pymemcache{135,200,300,342,400}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
 
   pymongo: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo[test]
 


### PR DESCRIPTION
# Description

Adds support for pymemcache versions >4.0.0,<5.0.0

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] All current tests pass

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
