### PR TITLE
Add otelTraceSampled to instrumetation-logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make ASGI request span attributes available for `start_span`. 
   ([#1762](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1762))
 - `opentelemetry-instrumentation-celery` Add support for anonymous tasks.
-  ([#1407](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1407)
+  ([#1407](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1407))
+- `opentelemetry-instrumentation-logging` Add `otelTraceSampled` to instrumetation-logging
+  ([#1773](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1773))
 
 
 ### Fixed

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -94,6 +94,7 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
 
             record.otelSpanID = "0"
             record.otelTraceID = "0"
+            record.otelTraceSampled = False
 
             nonlocal service_name
             if service_name is None:
@@ -113,6 +114,7 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
                 if ctx != INVALID_SPAN_CONTEXT:
                     record.otelSpanID = format(ctx.span_id, "016x")
                     record.otelTraceID = format(ctx.trace_id, "032x")
+                    record.otelTraceSampled = ctx.trace_flags.sampled
                     if callable(LoggingInstrumentor._log_hook):
                         try:
                             LoggingInstrumentor._log_hook(  # pylint: disable=E1102

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/constants.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/constants.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_LOGGING_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s] - %(message)s"
+DEFAULT_LOGGING_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s trace_sampled=%(otelTraceSampled)s] - %(message)s"
 
 
 _MODULE_DOC = """
@@ -27,6 +27,7 @@ The following keys are injected into log record objects by the factory:
 - ``otelSpanID``
 - ``otelTraceID``
 - ``otelServiceName``
+- ``otelTraceSampled``
 
 The integration uses the following logging format by default:
 
@@ -113,7 +114,7 @@ adding the following placeholders to your logging format:
 
 .. code-block::
 
-    %(otelSpanID)s %(otelTraceID)s %(otelServiceName)s
+    %(otelSpanID)s %(otelTraceID)s %(otelServiceName)s %(otelTraceSampled)s
 
 
 

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -99,7 +99,9 @@ class TestLoggingInstrumentor(TestBase):
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
             trace_sampled = span.get_span_context().trace_flags.sampled
-            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
+            self.assert_trace_context_injected(
+                span_id, trace_id, trace_sampled
+            )
 
     def test_trace_context_injection_without_span(self):
         self.assert_trace_context_injected("0", "0", False)
@@ -185,7 +187,9 @@ class TestLoggingInstrumentor(TestBase):
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
             trace_sampled = span.get_span_context().trace_flags.sampled
-            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
+            self.assert_trace_context_injected(
+                span_id, trace_id, trace_sampled
+            )
 
         LoggingInstrumentor().uninstrument()
 

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -62,6 +62,7 @@ class TestLoggingInstrumentorProxyTracerProvider(TestBase):
             self.assertEqual(record.otelSpanID, "0")
             self.assertEqual(record.otelTraceID, "0")
             self.assertEqual(record.otelServiceName, "")
+            self.assertEqual(record.otelTraceSampled, False)
 
 
 def log_hook(span, record):
@@ -82,7 +83,7 @@ class TestLoggingInstrumentor(TestBase):
         super().tearDown()
         LoggingInstrumentor().uninstrument()
 
-    def assert_trace_context_injected(self, span_id, trace_id):
+    def assert_trace_context_injected(self, span_id, trace_id, trace_sampled):
         with self.caplog.at_level(level=logging.INFO):
             logger = logging.getLogger("test logger")
             logger.info("hello")
@@ -90,16 +91,18 @@ class TestLoggingInstrumentor(TestBase):
             record = self.caplog.records[0]
             self.assertEqual(record.otelSpanID, span_id)
             self.assertEqual(record.otelTraceID, trace_id)
+            self.assertEqual(record.otelTraceSampled, trace_sampled)
             self.assertEqual(record.otelServiceName, "unknown_service")
 
     def test_trace_context_injection(self):
         with self.tracer.start_as_current_span("s1") as span:
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
-            self.assert_trace_context_injected(span_id, trace_id)
+            trace_sampled = span.get_span_context().trace_flags.sampled
+            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
 
     def test_trace_context_injection_without_span(self):
-        self.assert_trace_context_injected("0", "0")
+        self.assert_trace_context_injected("0", "0", False)
 
     @mock.patch("logging.basicConfig")
     def test_basic_config_called(self, basic_config_mock):
@@ -163,6 +166,7 @@ class TestLoggingInstrumentor(TestBase):
         with self.tracer.start_as_current_span("s1") as span:
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
+            trace_sampled = span.get_span_context().trace_flags.sampled
             with self.caplog.at_level(level=logging.INFO):
                 logger = logging.getLogger("test logger")
                 logger.info("hello")
@@ -171,6 +175,7 @@ class TestLoggingInstrumentor(TestBase):
                 self.assertEqual(record.otelSpanID, span_id)
                 self.assertEqual(record.otelTraceID, trace_id)
                 self.assertEqual(record.otelServiceName, "unknown_service")
+                self.assertEqual(record.otelTraceSampled, trace_sampled)
                 self.assertEqual(
                     record.custom_user_attribute_from_log_hook, "some-value"
                 )
@@ -179,7 +184,8 @@ class TestLoggingInstrumentor(TestBase):
         with self.tracer.start_as_current_span("s1") as span:
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
-            self.assert_trace_context_injected(span_id, trace_id)
+            trace_sampled = span.get_span_context().trace_flags.sampled
+            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
 
         LoggingInstrumentor().uninstrument()
 
@@ -187,6 +193,7 @@ class TestLoggingInstrumentor(TestBase):
         with self.tracer.start_as_current_span("s1") as span:
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
+            trace_sampled = span.get_span_context().trace_flags.sampled
             with self.caplog.at_level(level=logging.INFO):
                 logger = logging.getLogger("test logger")
                 logger.info("hello")
@@ -195,3 +202,4 @@ class TestLoggingInstrumentor(TestBase):
                 self.assertFalse(hasattr(record, "otelSpanID"))
                 self.assertFalse(hasattr(record, "otelTraceID"))
                 self.assertFalse(hasattr(record, "otelServiceName"))
+                self.assertFalse(hasattr(record, "otelTraceSampled"))


### PR DESCRIPTION
# Description

Add otelTraceSampled field to LogEntry for OLTP Logging Instrumentation module

Fixes #1765 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tox tests. 

- [x] py37-test-instrumentation-logging
- [x] py38-test-instrumentation-logging
- [x] py39-test-instrumentation-logging
- [x] py310-test-instrumentation-logging
- [x] py311-test-instrumentation-logging
- [x] pypy3-test-instrumentation-logging

```
================================================== 8 passed, 1 warning in 0.47s ==================================================
____________________________________________________________ summary _____________________________________________________________
  py37-test-instrumentation-logging: commands succeeded
  py38-test-instrumentation-logging: commands succeeded
  py39-test-instrumentation-logging: commands succeeded
  py310-test-instrumentation-logging: commands succeeded
  py311-test-instrumentation-logging: commands succeeded
  pypy3-test-instrumentation-logging: commands succeeded
  congratulations :)
  ```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

```
# From the root directory
python -m black --config pyproject.toml instrumentation/opentelemetry-instrumentation-logging
python -m isort --settings-path ./.isort.cfg --profile black instrumentation/opentelemetry-instrumentation-logging
python scripts/check_for_valid_readme.py instrumentation/opentelemetry-instrumentation-logging/
```
