### PR TITLE
Expand sqlalchemy pool.name to follow the semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expand sqlalchemy pool.name to follow the semantic conventions
+  ([#1778](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1778))
 - Add `excluded_urls` functionality to `urllib` and `urllib3` instrumentations
   ([#1733](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1733))
 - Make Django request span attributes available for `start_span`. 

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -121,12 +121,12 @@ class EngineTracer:
     def _get_pool_name(self):
         if self.engine.pool.logging_name is not None:
             return self.engine.pool.logging_name
-        else:
-            drivername = self.engine.url.drivername or ""
-            host = self.engine.url.host or ""
-            port = self.engine.url.port or ""
-            database = self.engine.url.database or ""
-            return f"{drivername}://{host}:{port}/{database}"
+
+        drivername = self.engine.url.drivername or ""
+        host = self.engine.url.host or ""
+        port = self.engine.url.port or ""
+        database = self.engine.url.database or ""
+        return f"{drivername}://{host}:{port}/{database}"
 
     def _add_idle_to_connection_usage(self, value):
         self.connections_usage.add(

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -119,7 +119,14 @@ class EngineTracer:
         self._register_event_listener(engine, "checkout", self._pool_checkout)
 
     def _get_pool_name(self):
-        return self.engine.pool.logging_name or ""
+        if self.engine.pool.logging_name is not None:
+            return self.engine.pool.logging_name
+        else:
+            drivername = self.engine.url.drivername or ""
+            host = self.engine.url.host or ""
+            port = self.engine.url.port or ""
+            database = self.engine.url.database or ""
+            return f"{drivername}://{host}:{port}/{database}"
 
     def _add_idle_to_connection_usage(self, value):
         self.connections_usage.add(

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -118,15 +118,17 @@ class EngineTracer:
         self._register_event_listener(engine, "checkin", self._pool_checkin)
         self._register_event_listener(engine, "checkout", self._pool_checkout)
 
-    def _get_pool_name(self):
-        if self.engine.pool.logging_name is not None:
-            return self.engine.pool.logging_name
-
+    def _get_connection_string(self):
         drivername = self.engine.url.drivername or ""
         host = self.engine.url.host or ""
         port = self.engine.url.port or ""
         database = self.engine.url.database or ""
         return f"{drivername}://{host}:{port}/{database}"
+
+    def _get_pool_name(self):
+        if self.engine.pool.logging_name is not None:
+            return self.engine.pool.logging_name
+        return self._get_connection_string()
 
     def _add_idle_to_connection_usage(self, value):
         self.connections_usage.add(

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy_metrics.py
@@ -70,11 +70,12 @@ class TestSqlalchemyMetricsInstrumentation(TestBase):
         )
 
     def test_metrics_without_pool_name(self):
-        pool_name = ""
+        pool_name = "pool_test_name"
         engine = sqlalchemy.create_engine(
             "sqlite:///:memory:",
             pool_size=5,
             poolclass=QueuePool,
+            pool_logging_name=pool_name,
         )
 
         metrics = self.get_sorted_metrics()


### PR DESCRIPTION
Expand sqlalchemy pool.name to follow the semantic conventions

Fixes #1777 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] tox -e test-instrumentation-sqlalchemy14

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
