### PR TITLE
Enable requests tests for pypy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ envlist =
 
     ; opentelemetry-instrumentation-requests
     py3{7,8,9,10,11}-test-instrumentation-requests
-    ;pypy3-test-instrumentation-requests
+    pypy3-test-instrumentation-requests
 
     ; opentelemetry-instrumentation-starlette.
     py3{7,8,9,10,11}-test-instrumentation-starlette


### PR DESCRIPTION
Enable pypy3-test-instrumentation-requests due to the new request version 2.31.0
