### PR TITLE
Add direct/explicit dependencies on yarl

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aio-pika/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aio-pika/pyproject.toml
@@ -38,6 +38,7 @@ test = [
   "opentelemetry-test-utils == 0.40b0.dev",
   "pytest",
   "wrapt >= 1.0.0, < 2.0.0",
+  "yarl",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "opentelemetry-semantic-conventions == 0.40b0.dev",
   "opentelemetry-util-http == 0.40b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
+  "yarl >= 1.9.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

This makes the actual dependencies explicit and avoids relying on indirect or implicit dependencies.

In some environments, with some combinations of packages, this can prevent an `ImportError` when `yarl` is imported but was never required.

No issue was filed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Run the normal tests and observe no regressions. (I did this by applying this PR as a patch to the Fedora Linux package.)
- [x] Test B: Compare the added dependencies against the actual imports (see the bottom of this PR text).

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/cae6ce46ecf834d959929f20e095f10a55f3b9d0/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py#L25

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/cae6ce46ecf834d959929f20e095f10a55f3b9d0/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py#L89

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/cae6ce46ecf834d959929f20e095f10a55f3b9d0/instrumentation/opentelemetry-instrumentation-aio-pika/tests/consts.py#L4