### PR TITLE
skip urllib3 test on pypy3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ envlist =
 
     ; opentelemetry-instrumentation-urllib3
     py3{7,8,9,10,11}-test-instrumentation-urllib3
-    pypy3-test-instrumentation-urllib3
+    ;pypy3-test-instrumentation-urllib3
 
     ; opentelemetry-instrumentation-requests
     py3{7,8,9,10,11}-test-instrumentation-requests


### PR DESCRIPTION
There is an issue with the new urllib3 version(1.26.16) on pypy3, the [test_basic_http_success_using_connection_pool](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/a6797541721af72e6feab400e24ceaabc08cb31e/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_ip_support.py#L51) test doesn't finish.

This issue will be handled here #1827 , in the meantime we skipped the urlib3 tests on pypy3
