### PR TITLE
Fix python path to support both windows and linux

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import subprocess
 
 from argparse import REMAINDER, ArgumentParser
 from logging import getLogger
@@ -112,4 +113,4 @@ def run() -> None:
     environ["PYTHONPATH"] = pathsep.join(python_path)
 
     executable = which(args.command)
-    execl(executable, executable, *args.command_args)
+    subprocess.run([executable, *args.command_args])


### PR DESCRIPTION
# Description

The library had a bug regarding the execution of the python path in windows context.
When there trying to execute a python executable containing a space character in the path it actually tried to execute just the first path.
i.e 'C:\Program Files\Python311' there is a space the in program files, tried to execute C:\Program.exe and use the rest as arguments.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Tested against both windows and linux operating systems.

# Does This PR Require a Core Repo Change?

- [ ] No.

