### PR TITLE
Remove use of httpbin

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -63,7 +63,7 @@ class RequestsIntegrationTestBase(abc.ABC):
     # pylint: disable=no-member
     # pylint: disable=too-many-public-methods
 
-    URL = "http://httpbin.org/status/200"
+    URL = "http://mock/status/200"
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -152,7 +152,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.attributes["response_hook_attr"], "value")
 
     def test_excluded_urls_explicit(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(
             httpretty.GET,
             url_404,
@@ -194,7 +194,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.name, "HTTP GET")
 
     def test_not_foundbasic(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(
             httpretty.GET,
             url_404,
@@ -460,7 +460,7 @@ class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
         return session.get(url)
 
     def test_credential_removal(self):
-        new_url = "http://username:password@httpbin.org/status/200"
+        new_url = "http://username:password@mock/status/200"
         self.perform_request(new_url)
         span = self.assert_span()
 


### PR DESCRIPTION
This is done in order to prevent confusion. We are trying to stop using httpbin.org for our tests. Even when the tests for the requests instrumentation do not actually perform any request to httpbin.org, because the test requests are being mocked with httpretty, having the string httpbin.org in the tests can cause confusion and make the reader think the tests are actually using httpbin.org.

Fixes #1844