### PR TITLE
Remove use of httpbin.org

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-httpx/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-httpx/README.rst
@@ -30,7 +30,7 @@ When using the instrumentor, all clients will automatically trace requests.
      import httpx
      from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-     url = "https://httpbin.org/get"
+     url = "https://some.url/get"
      HTTPXClientInstrumentor().instrument()
 
      with httpx.Client() as client:
@@ -51,7 +51,7 @@ use the `instrument_client` method.
     import httpx
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
 
     with httpx.Client(transport=telemetry_transport) as client:
         HTTPXClientInstrumentor.instrument_client(client)
@@ -96,7 +96,7 @@ If you don't want to use the instrumentor class, you can use the transport class
         SyncOpenTelemetryTransport,
     )
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
     transport = httpx.HTTPTransport()
     telemetry_transport = SyncOpenTelemetryTransport(transport)
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -25,7 +25,7 @@ When using the instrumentor, all clients will automatically trace requests.
      import httpx
      from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-     url = "https://httpbin.org/get"
+     url = "https://some.url/get"
      HTTPXClientInstrumentor().instrument()
 
      with httpx.Client() as client:
@@ -46,7 +46,7 @@ use the `instrument_client` method.
     import httpx
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
 
     with httpx.Client(transport=telemetry_transport) as client:
         HTTPXClientInstrumentor.instrument_client(client)
@@ -91,7 +91,7 @@ If you don't want to use the instrumentor class, you can use the transport class
         SyncOpenTelemetryTransport,
     )
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
     transport = httpx.HTTPTransport()
     telemetry_transport = SyncOpenTelemetryTransport(transport)
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -97,7 +97,7 @@ class BaseTestCases:
     class BaseTest(TestBase, metaclass=abc.ABCMeta):
         # pylint: disable=no-member
 
-        URL = "http://httpbin.org/status/200"
+        URL = "http://mock/status/200"
         response_hook = staticmethod(_response_hook)
         request_hook = staticmethod(_request_hook)
         no_update_request_hook = staticmethod(_no_update_request_hook)
@@ -165,7 +165,7 @@ class BaseTestCases:
             self.assert_span(num_spans=2)
 
         def test_not_foundbasic(self):
-            url_404 = "http://httpbin.org/status/404"
+            url_404 = "http://mock/status/404"
 
             with respx.mock:
                 respx.get(url_404).mock(httpx.Response(404))


### PR DESCRIPTION
This is done in order to prevent confusion. We are trying to stop using httpbin.org for our tests. Even when the tests for the httpx instrumentation do not actually perform any request to httpbin.org having the string httpbin.org in the tests can cause confusion and make the reader think the tests are actually using httpbin.org.

Fixes #1843