### PR TITLE
Remove httpbin.org

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -35,8 +35,8 @@ from opentelemetry.util.http import get_excluded_urls
 
 
 class TestURLLib3Instrumentor(TestBase):
-    HTTP_URL = "http://httpbin.org/status/200"
-    HTTPS_URL = "https://httpbin.org/status/200"
+    HTTP_URL = "http://mock/status/200"
+    HTTPS_URL = "https://mock/status/200"
 
     def setUp(self):
         super().setUp()
@@ -123,7 +123,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTP_URL)
 
     def test_basic_http_success_using_connection_pool(self):
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.request("GET", "/status/200")
 
         self.assert_success_span(response, self.HTTP_URL)
@@ -133,13 +133,13 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTPS_URL)
 
     def test_basic_https_success_using_connection_pool(self):
-        pool = urllib3.HTTPSConnectionPool("httpbin.org")
+        pool = urllib3.HTTPSConnectionPool("mock")
         response = pool.request("GET", "/status/200")
 
         self.assert_success_span(response, self.HTTPS_URL)
 
     def test_basic_not_found(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(httpretty.GET, url_404, status=404)
 
         response = self.perform_request(url_404)
@@ -152,30 +152,30 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     def test_basic_http_non_default_port(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
 
         response = self.perform_request(url)
         self.assert_success_span(response, url)
 
     def test_basic_http_absolute_url(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
-        pool = urllib3.HTTPConnectionPool("httpbin.org", port=666)
+        pool = urllib3.HTTPConnectionPool("mock", port=666)
         response = pool.request("GET", url)
 
         self.assert_success_span(response, url)
 
     def test_url_open_explicit_arg_parameters(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
-        pool = urllib3.HTTPConnectionPool("httpbin.org", port=666)
+        pool = urllib3.HTTPConnectionPool("mock", port=666)
         response = pool.urlopen(method="GET", url="/status/200")
 
         self.assert_success_span(response, url)
 
     def test_excluded_urls_explicit(self):
-        url_201 = "http://httpbin.org/status/201"
+        url_201 = "http://mock/status/201"
         httpretty.register_uri(
             httpretty.GET,
             url_201,
@@ -301,7 +301,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTP_URL)
 
     def test_credential_removal(self):
-        url = "http://username:password@httpbin.org/status/200"
+        url = "http://username:password@mock/status/200"
 
         response = self.perform_request(url)
         self.assert_success_span(response, self.HTTP_URL)
@@ -339,7 +339,7 @@ class TestURLLib3Instrumentor(TestBase):
         headers = {"header1": "value1", "header2": "value2"}
         body = "param1=1&param2=2"
 
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.request(
             "POST", "/status/200", body=body, headers=headers
         )
@@ -366,7 +366,7 @@ class TestURLLib3Instrumentor(TestBase):
 
         body = "param1=1&param2=2"
 
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.urlopen("POST", "/status/200", body)
 
         self.assertEqual(b"Hello!", response.data)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
@@ -26,7 +26,7 @@ from opentelemetry.test.test_base import TestBase
 
 
 class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
-    HTTP_URL = "http://httpbin.org/status/200"
+    HTTP_URL = "http://mock/status/200"
 
     def setUp(self):
         super().setUp()
@@ -68,11 +68,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=client_duration_estimated,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -91,11 +91,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=0,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -116,11 +116,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=expected_size,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -144,11 +144,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -172,11 +172,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -201,11 +201,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=expected_value,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -229,11 +229,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )


### PR DESCRIPTION
This is done in order to avoid confusion. Even when urllib3 tests do not actually make external requests to httpbin.org, having httpbin.org in the tests is confusing for the reader and may make it look like external requests to httpbin.org are actually being made.

Fixes #1846