### PR TITLE
Remove use of httpbin

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -705,11 +705,11 @@ class TestAsgiAttributes(unittest.TestCase):
         self.assertEqual(self.span.set_status.call_count, 1)
 
     def test_credential_removal(self):
-        self.scope["server"] = ("username:password@httpbin.org", 80)
+        self.scope["server"] = ("username:password@mock", 80)
         self.scope["path"] = "/status/200"
         attrs = otel_asgi.collect_request_attributes(self.scope)
         self.assertEqual(
-            attrs[SpanAttributes.HTTP_URL], "http://httpbin.org/status/200"
+            attrs[SpanAttributes.HTTP_URL], "http://mock/status/200"
         )
 
     def test_collect_target_attribute_missing(self):

--- a/instrumentation/opentelemetry-instrumentation-httpx/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-httpx/README.rst
@@ -30,7 +30,7 @@ When using the instrumentor, all clients will automatically trace requests.
      import httpx
      from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-     url = "https://httpbin.org/get"
+     url = "https://some.url/get"
      HTTPXClientInstrumentor().instrument()
 
      with httpx.Client() as client:
@@ -51,7 +51,7 @@ use the `instrument_client` method.
     import httpx
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
 
     with httpx.Client(transport=telemetry_transport) as client:
         HTTPXClientInstrumentor.instrument_client(client)
@@ -96,7 +96,7 @@ If you don't want to use the instrumentor class, you can use the transport class
         SyncOpenTelemetryTransport,
     )
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
     transport = httpx.HTTPTransport()
     telemetry_transport = SyncOpenTelemetryTransport(transport)
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -25,7 +25,7 @@ When using the instrumentor, all clients will automatically trace requests.
      import httpx
      from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-     url = "https://httpbin.org/get"
+     url = "https://some.url/get"
      HTTPXClientInstrumentor().instrument()
 
      with httpx.Client() as client:
@@ -46,7 +46,7 @@ use the `instrument_client` method.
     import httpx
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
 
     with httpx.Client(transport=telemetry_transport) as client:
         HTTPXClientInstrumentor.instrument_client(client)
@@ -91,7 +91,7 @@ If you don't want to use the instrumentor class, you can use the transport class
         SyncOpenTelemetryTransport,
     )
 
-    url = "https://httpbin.org/get"
+    url = "https://some.url/get"
     transport = httpx.HTTPTransport()
     telemetry_transport = SyncOpenTelemetryTransport(transport)
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -97,7 +97,7 @@ class BaseTestCases:
     class BaseTest(TestBase, metaclass=abc.ABCMeta):
         # pylint: disable=no-member
 
-        URL = "http://httpbin.org/status/200"
+        URL = "http://mock/status/200"
         response_hook = staticmethod(_response_hook)
         request_hook = staticmethod(_request_hook)
         no_update_request_hook = staticmethod(_no_update_request_hook)
@@ -165,7 +165,7 @@ class BaseTestCases:
             self.assert_span(num_spans=2)
 
         def test_not_foundbasic(self):
-            url_404 = "http://httpbin.org/status/404"
+            url_404 = "http://mock/status/404"
 
             with respx.mock:
                 respx.get(url_404).mock(httpx.Response(404))

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -63,7 +63,7 @@ class RequestsIntegrationTestBase(abc.ABC):
     # pylint: disable=no-member
     # pylint: disable=too-many-public-methods
 
-    URL = "http://httpbin.org/status/200"
+    URL = "http://mock/status/200"
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -152,7 +152,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.attributes["response_hook_attr"], "value")
 
     def test_excluded_urls_explicit(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(
             httpretty.GET,
             url_404,
@@ -194,7 +194,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.name, "HTTP GET")
 
     def test_not_foundbasic(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(
             httpretty.GET,
             url_404,
@@ -460,7 +460,7 @@ class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
         return session.get(url)
 
     def test_credential_removal(self):
-        new_url = "http://username:password@httpbin.org/status/200"
+        new_url = "http://username:password@mock/status/200"
         self.perform_request(new_url)
         span = self.assert_span()
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
@@ -27,8 +27,8 @@ from opentelemetry.test.test_base import TestBase
 
 
 class TestUrllibMetricsInstrumentation(TestBase):
-    URL = "http://httpbin.org/status/200"
-    URL_POST = "http://httpbin.org/post"
+    URL = "http://mock/status/200"
+    URL_POST = "http://mock/post"
 
     def setUp(self):
         super().setUp()

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -46,9 +46,9 @@ from opentelemetry.util.http import get_excluded_urls
 class RequestsIntegrationTestBase(abc.ABC):
     # pylint: disable=no-member
 
-    URL = "http://httpbin.org/status/200"
-    URL_TIMEOUT = "http://httpbin.org/timeout/0"
-    URL_EXCEPTION = "http://httpbin.org/exception/0"
+    URL = "http://mock/status/200"
+    URL_TIMEOUT = "http://mock/timeout/0"
+    URL_EXCEPTION = "http://mock/exception/0"
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -83,7 +83,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         )
         httpretty.register_uri(
             httpretty.GET,
-            "http://httpbin.org/status/500",
+            "http://mock/status/500",
             status=500,
         )
 
@@ -142,7 +142,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         )
 
     def test_excluded_urls_explicit(self):
-        url_201 = "http://httpbin.org/status/201"
+        url_201 = "http://mock/status/201"
         httpretty.register_uri(
             httpretty.GET,
             url_201,
@@ -172,7 +172,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assert_span(num_spans=1)
 
     def test_not_foundbasic(self):
-        url_404 = "http://httpbin.org/status/404/"
+        url_404 = "http://mock/status/404/"
         httpretty.register_uri(
             httpretty.GET,
             url_404,
@@ -336,14 +336,14 @@ class RequestsIntegrationTestBase(abc.ABC):
 
     def test_requests_exception_with_response(self, *_, **__):
         with self.assertRaises(HTTPError):
-            self.perform_request("http://httpbin.org/status/500")
+            self.perform_request("http://mock/status/500")
 
         span = self.assert_span()
         self.assertEqual(
             dict(span.attributes),
             {
                 SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: "http://httpbin.org/status/500",
+                SpanAttributes.HTTP_URL: "http://mock/status/500",
                 SpanAttributes.HTTP_STATUS_CODE: 500,
             },
         )
@@ -365,7 +365,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
     def test_credential_removal(self):
-        url = "http://username:password@httpbin.org/status/200"
+        url = "http://username:password@mock/status/200"
 
         with self.assertRaises(Exception):
             self.perform_request(url)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -35,8 +35,8 @@ from opentelemetry.util.http import get_excluded_urls
 
 
 class TestURLLib3Instrumentor(TestBase):
-    HTTP_URL = "http://httpbin.org/status/200"
-    HTTPS_URL = "https://httpbin.org/status/200"
+    HTTP_URL = "http://mock/status/200"
+    HTTPS_URL = "https://mock/status/200"
 
     def setUp(self):
         super().setUp()
@@ -123,7 +123,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTP_URL)
 
     def test_basic_http_success_using_connection_pool(self):
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.request("GET", "/status/200")
 
         self.assert_success_span(response, self.HTTP_URL)
@@ -133,13 +133,13 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTPS_URL)
 
     def test_basic_https_success_using_connection_pool(self):
-        pool = urllib3.HTTPSConnectionPool("httpbin.org")
+        pool = urllib3.HTTPSConnectionPool("mock")
         response = pool.request("GET", "/status/200")
 
         self.assert_success_span(response, self.HTTPS_URL)
 
     def test_basic_not_found(self):
-        url_404 = "http://httpbin.org/status/404"
+        url_404 = "http://mock/status/404"
         httpretty.register_uri(httpretty.GET, url_404, status=404)
 
         response = self.perform_request(url_404)
@@ -152,30 +152,30 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     def test_basic_http_non_default_port(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
 
         response = self.perform_request(url)
         self.assert_success_span(response, url)
 
     def test_basic_http_absolute_url(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
-        pool = urllib3.HTTPConnectionPool("httpbin.org", port=666)
+        pool = urllib3.HTTPConnectionPool("mock", port=666)
         response = pool.request("GET", url)
 
         self.assert_success_span(response, url)
 
     def test_url_open_explicit_arg_parameters(self):
-        url = "http://httpbin.org:666/status/200"
+        url = "http://mock:666/status/200"
         httpretty.register_uri(httpretty.GET, url, body="Hello!")
-        pool = urllib3.HTTPConnectionPool("httpbin.org", port=666)
+        pool = urllib3.HTTPConnectionPool("mock", port=666)
         response = pool.urlopen(method="GET", url="/status/200")
 
         self.assert_success_span(response, url)
 
     def test_excluded_urls_explicit(self):
-        url_201 = "http://httpbin.org/status/201"
+        url_201 = "http://mock/status/201"
         httpretty.register_uri(
             httpretty.GET,
             url_201,
@@ -301,7 +301,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_success_span(response, self.HTTP_URL)
 
     def test_credential_removal(self):
-        url = "http://username:password@httpbin.org/status/200"
+        url = "http://username:password@mock/status/200"
 
         response = self.perform_request(url)
         self.assert_success_span(response, self.HTTP_URL)
@@ -339,7 +339,7 @@ class TestURLLib3Instrumentor(TestBase):
         headers = {"header1": "value1", "header2": "value2"}
         body = "param1=1&param2=2"
 
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.request(
             "POST", "/status/200", body=body, headers=headers
         )
@@ -366,7 +366,7 @@ class TestURLLib3Instrumentor(TestBase):
 
         body = "param1=1&param2=2"
 
-        pool = urllib3.HTTPConnectionPool("httpbin.org")
+        pool = urllib3.HTTPConnectionPool("mock")
         response = pool.urlopen("POST", "/status/200", body)
 
         self.assertEqual(b"Hello!", response.data)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
@@ -26,7 +26,7 @@ from opentelemetry.test.test_base import TestBase
 
 
 class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
-    HTTP_URL = "http://httpbin.org/status/200"
+    HTTP_URL = "http://mock/status/200"
 
     def setUp(self):
         super().setUp()
@@ -68,11 +68,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=client_duration_estimated,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -91,11 +91,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=0,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -116,11 +116,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=expected_size,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "GET",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -144,11 +144,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -172,11 +172,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -201,11 +201,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=expected_value,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )
@@ -229,11 +229,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     min_data_point=6,
                     attributes={
                         "http.flavor": "1.1",
-                        "http.host": "httpbin.org",
+                        "http.host": "mock",
                         "http.method": "POST",
                         "http.scheme": "http",
                         "http.status_code": 200,
-                        "net.peer.name": "httpbin.org",
+                        "net.peer.name": "mock",
                         "net.peer.port": 80,
                     },
                 )

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -437,10 +437,10 @@ class TestWsgiAttributes(unittest.TestCase):
         self.span.set_attribute.assert_has_calls(expected, any_order=True)
 
     def test_credential_removal(self):
-        self.environ["HTTP_HOST"] = "username:password@httpbin.com"
+        self.environ["HTTP_HOST"] = "username:password@mock"
         self.environ["PATH_INFO"] = "/status/200"
         expected = {
-            SpanAttributes.HTTP_URL: "http://httpbin.com/status/200",
+            SpanAttributes.HTTP_URL: "http://mock/status/200",
             SpanAttributes.NET_HOST_PORT: 80,
         }
         self.assertGreaterEqual(


### PR DESCRIPTION
This is done in order to prevent confusion. We are trying to stop using httpbin.org for our tests. Even when the tests for the requests instrumentation do not actually perform any request to httpbin.org, because the test requests are being mocked somehow having the string httpbin.org in the tests can cause confusion and make the reader think the tests are actually making external requests to  httpbin.org.

Fixes #1844 #1843 #1845 #1846 #1847 #1848