### PR TITLE
Unwrap Celery's `ExceptionInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
 - Fixed union typing error not compatible with Python 3.7 introduced in `opentelemetry-util-http`, fix tests introduced by patch related to sanitize method for wsgi
   ([#1913](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1913))
+- `opentelemetry-instrumentation-celery` Unwrap Celery's `ExceptionInfo` errors and report the actual exception that was raised. ([#1863](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1863))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -76,8 +76,13 @@ from opentelemetry.propagate import extract, inject
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
+from billiard import VERSION
 
-ExceptionWithTraceback = utils.import_exception_with_traceback()
+
+if VERSION >= (4, 0, 1):
+    from billiard.einfo import ExceptionWithTraceback
+else:
+    ExceptionWithTraceback = None
 
 logger = logging.getLogger(__name__)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -66,13 +66,6 @@ from typing import Collection, Iterable
 from billiard.einfo import ExceptionInfo
 from celery import signals  # pylint: disable=no-name-in-module
 
-try:
-    from billiard.einfo import (  # pylint: disable=no-name-in-module
-        ExceptionWithTraceback,
-    )
-except ImportError:
-    ExceptionWithTraceback = None
-
 from opentelemetry import trace
 from opentelemetry.instrumentation.celery import utils
 from opentelemetry.instrumentation.celery.package import _instruments
@@ -83,6 +76,8 @@ from opentelemetry.propagate import extract, inject
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
+
+ExceptionWithTraceback = utils.import_exception_with_traceback()
 
 logger = logging.getLogger(__name__)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -64,6 +64,12 @@ from timeit import default_timer
 from typing import Collection, Iterable
 
 from celery import signals  # pylint: disable=no-name-in-module
+from billiard.einfo import ExceptionInfo
+
+try:
+    from billiard.einfo import ExceptionWithTraceback # pylint: disable=no-name-in-module
+except ImportError:
+    ExceptionWithTraceback = None
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.celery import utils
@@ -271,6 +277,21 @@ class CeleryInstrumentor(BaseInstrumentor):
             return
 
         if ex is not None:
+            # Unwrap the actual exception wrapped by billiard's
+            # `ExceptionInfo` and `ExceptionWithTraceback`.
+            if (
+                isinstance(ex, ExceptionInfo)
+                and ex.exception is not None
+            ):
+                ex = ex.exception
+
+            if (
+                ExceptionWithTraceback is not None
+                and isinstance(ex, ExceptionWithTraceback)
+                and ex.exc is not None
+            ):
+                ex = ex.exc
+
             status_kwargs["description"] = str(ex)
             span.record_exception(ex)
         span.set_status(Status(**status_kwargs))

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -63,11 +63,13 @@ import logging
 from timeit import default_timer
 from typing import Collection, Iterable
 
-from celery import signals  # pylint: disable=no-name-in-module
 from billiard.einfo import ExceptionInfo
+from celery import signals  # pylint: disable=no-name-in-module
 
 try:
-    from billiard.einfo import ExceptionWithTraceback # pylint: disable=no-name-in-module
+    from billiard.einfo import (  # pylint: disable=no-name-in-module
+        ExceptionWithTraceback,
+    )
 except ImportError:
     ExceptionWithTraceback = None
 
@@ -279,10 +281,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         if ex is not None:
             # Unwrap the actual exception wrapped by billiard's
             # `ExceptionInfo` and `ExceptionWithTraceback`.
-            if (
-                isinstance(ex, ExceptionInfo)
-                and ex.exception is not None
-            ):
+            if isinstance(ex, ExceptionInfo) and ex.exception is not None:
                 ex = ex.exception
 
             if (

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -48,15 +48,6 @@ CELERY_CONTEXT_ATTRIBUTES = (
 )
 
 
-def import_exception_with_traceback():
-    if VERSION >= (4, 0, 1):
-        from billiard.einfo import ExceptionWithTraceback
-
-        return ExceptionWithTraceback
-
-    return None
-
-
 # pylint:disable=too-many-branches
 def set_attributes_from_context(span, context):
     """Helper to extract meta values from a Celery Context"""

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -15,6 +15,7 @@
 import logging
 
 from celery import registry  # pylint: disable=no-name-in-module
+from billiard import VERSION
 
 from opentelemetry.semconv.trace import SpanAttributes
 
@@ -45,6 +46,15 @@ CELERY_CONTEXT_ATTRIBUTES = (
     "origin",
     "state",
 )
+
+
+def import_exception_with_traceback():
+    if VERSION >= (4, 0, 1):
+        from billiard.einfo import ExceptionWithTraceback
+
+        return ExceptionWithTraceback
+
+    return None
 
 
 # pylint:disable=too-many-branches

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
@@ -24,6 +24,15 @@ app = Celery(broker="memory:///")
 app.config_from_object(Config)
 
 
+class CustomError(Exception):
+    pass
+
+
 @app.task
 def task_add(num_a, num_b):
     return num_a + num_b
+
+
+@app.task
+def task_raises():
+    raise CustomError("The task failed!")

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -18,9 +18,9 @@ import time
 from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, StatusCode
 
-from .celery_test_tasks import app, task_add
+from .celery_test_tasks import app, task_add, task_raises
 
 
 class TestCeleryInstrumentation(TestBase):
@@ -66,6 +66,10 @@ class TestCeleryInstrumentation(TestBase):
             },
         )
 
+        self.assertEqual(consumer.status.status_code, StatusCode.UNSET)
+
+        self.assertEqual(0, len(consumer.events))
+
         self.assertEqual(
             producer.name, "apply_async/tests.celery_test_tasks.task_add"
         )
@@ -75,6 +79,70 @@ class TestCeleryInstrumentation(TestBase):
             {
                 "celery.action": "apply_async",
                 "celery.task_name": "tests.celery_test_tasks.task_add",
+                SpanAttributes.MESSAGING_DESTINATION_KIND: "queue",
+                SpanAttributes.MESSAGING_DESTINATION: "celery",
+            },
+        )
+
+        self.assertNotEqual(consumer.parent, producer.context)
+        self.assertEqual(consumer.parent.span_id, producer.context.span_id)
+        self.assertEqual(consumer.context.trace_id, producer.context.trace_id)
+
+    def test_task_raises(self):
+        CeleryInstrumentor().instrument()
+
+        result = task_raises.delay()
+
+        timeout = time.time() + 60 * 1  # 1 minutes from now
+        while not result.ready():
+            if time.time() > timeout:
+                break
+            time.sleep(0.05)
+
+        spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
+        self.assertEqual(len(spans), 2)
+
+        consumer, producer = spans
+
+        self.assertEqual(
+            consumer.name, "run/tests.celery_test_tasks.task_raises"
+        )
+        self.assertEqual(consumer.kind, SpanKind.CONSUMER)
+        self.assertSpanHasAttributes(
+            consumer,
+            {
+                "celery.action": "run",
+                "celery.state": "FAILURE",
+                SpanAttributes.MESSAGING_DESTINATION: "celery",
+                "celery.task_name": "tests.celery_test_tasks.task_raises",
+            },
+        )
+
+        self.assertEqual(consumer.status.status_code, StatusCode.ERROR)
+
+        self.assertEqual(1, len(consumer.events))
+        event = consumer.events[0]
+
+        self.assertIn(SpanAttributes.EXCEPTION_STACKTRACE, event.attributes)
+
+        self.assertEqual(
+            event.attributes[SpanAttributes.EXCEPTION_TYPE], "CustomError"
+        )
+
+        self.assertEqual(
+            event.attributes[SpanAttributes.EXCEPTION_MESSAGE],
+            "The task failed!",
+        )
+
+        self.assertEqual(
+            producer.name, "apply_async/tests.celery_test_tasks.task_raises"
+        )
+        self.assertEqual(producer.kind, SpanKind.PRODUCER)
+        self.assertSpanHasAttributes(
+            producer,
+            {
+                "celery.action": "apply_async",
+                "celery.task_name": "tests.celery_test_tasks.task_raises",
                 SpanAttributes.MESSAGING_DESTINATION_KIND: "queue",
                 SpanAttributes.MESSAGING_DESTINATION: "celery",
             },

--- a/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
@@ -279,7 +279,7 @@ def test_fn_exception(celery_app, memory_exporter):
     assert len(span.events) == 1
     event = span.events[0]
     assert event.name == "exception"
-    assert event.attributes[SpanAttributes.EXCEPTION_TYPE] == "ExceptionInfo"
+    assert event.attributes[SpanAttributes.EXCEPTION_TYPE] == "Exception"
     assert SpanAttributes.EXCEPTION_MESSAGE in event.attributes
     assert (
         span.attributes.get(SpanAttributes.MESSAGING_MESSAGE_ID)

--- a/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
@@ -420,7 +420,7 @@ def test_class_task_exception(celery_app, memory_exporter):
     assert "Task class is failing" in span.status.description
 
 
-def test_class_task_exception_excepted(celery_app, memory_exporter):
+def test_class_task_exception_expected(celery_app, memory_exporter):
     class BaseTask(celery_app.Task):
         throws = (MyException,)
 


### PR DESCRIPTION
# Description

When a task fails and Celery reports an exception, the exception reported is an `ExceptionInfo` wrapper that Celery provides to the signal handler. The actual exception that was raised is a property of this exception.

This PR changes the instrumentation's behaviour to report the actual exception that is wrapped inside `ExceptionInfo`, ensuring that the resulting exception has a type and traceback that are meaningful and relevant to the application's developer.

Fixes appsignal/appsignal-python#76.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

(I consider this a bug fix, in that the useful exception to report is the one that was raised in the task, not its Celery wrapper -- please let me know if you disagree that this is a non-breaking change)

# How Has This Been Tested?

The instrumentation's functional tests have been amended.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added (and functional tests have been amended)
- [x] ~Documentation has been updated~ N/A
