### PR TITLE
Add auto-instrumentation for karapace

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-karapace/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-karapace/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-karapace/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-karapace/README.rst
@@ -1,0 +1,30 @@
+OpenTelemetry karapace Instrumentation
+=============================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-karapace.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-karapace/
+
+This library allows tracing requests made by karapace.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-karapace
+    pip install opentelemetry-distro
+    
+    in pyproject.toml: "opentelemetry-distro", # IMPORTANT without this the default configuration is missing and nothing is exported
+    to facilitat auto-isntrumentation PYTHONPATH must start with opentelemetry/instrumentation/auto-isntrumentation/
+
+
+::python
+    add to main():     KarapaceInstrumentor().instrument() 
+
+References
+----------
+
+* `OpenTelemetry karapace/ Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/karapace/karapace.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-karapace/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-karapace/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-karapace"
+dynamic = ["version"]
+description = "OpenTelemetry Karapace instrumentation"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.7"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation",
+  "opentelemetry-sdk",
+  "opentelemetry-semantic-conventions",
+
+  "wrapt >= 1.0.0, < 2.0.0",
+]
+
+[project.optional-dependencies]
+instruments = [
+]
+
+test = [
+  "opentelemetry-instrumentation-karapace[instruments]",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+karapace = "opentelemetry.instrumentation.karapace:KarapaceInstrumentor"
+
+
+[project.scripts]
+karapace = "opentelemetry.instrumentation.karapace:KarapaceInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-karapace"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/karapace/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+[tool.black]
+line-length = 120
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/__init__.py
@@ -1,0 +1,241 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Instrument karapace-python to report instrumentation-karapace produced and consumed messages
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.confluent_kafka import KarapaceInstrumentor
+    from confluent_kafka import Producer, Consumer
+
+    # Instrument kafka
+    KarapaceInstrumentor().instrument()
+
+    # report a span of type producer with the default settings
+    conf1 = {'bootstrap.servers': "localhost:9092"}
+    producer = Producer(conf1)
+    producer.produce('my-topic',b'raw_bytes')
+    conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}
+    # report a span of type consumer with the default settings
+    consumer = Consumer(conf2)
+
+    def basic_consume_loop(consumer, topics):
+        try:
+            consumer.subscribe(topics)
+            running = True
+            while running:
+                msg = consumer.poll(timeout=1.0)
+                if msg is None: continue
+                if msg.error():
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+                        # End of partition event
+                        sys.stderr.write(f"{msg.topic() [{msg.partition()}] reached end at offset {msg.offset()}}")
+                    elif msg.error():
+                        raise KafkaException(msg.error())
+                else:
+                    msg_process(msg)
+        finally:
+            # Close down consumer to commit final offsets.
+            consumer.close()
+
+    basic_consume_loop(consumer, "my-topic")
+    ---
+
+The _instrument method accepts the following keyword args:
+  tracer_provider (TracerProvider) - an optional tracer provider
+
+  instrument_producer (Callable) - a function with extra user-defined logic to be performed before sending the message
+    this function signature is:
+
+  def instrument_producer(producer: Producer, tracer_provider=None)
+
+    instrument_consumer (Callable) - a function with extra user-defined logic to be performed after consuming a message
+        this function signature is:
+
+  def instrument_consumer(consumer: Consumer, tracer_provider=None)
+    for example:
+
+.. code:: python
+
+    from opentelemetry.instrumentation.confluent_kafka import KarapaceInstrumentor
+
+    from confluent_kafka import Producer, Consumer
+
+    inst = KarapaceInstrumentor()
+
+    p = confluent_kafka.Producer({'bootstrap.servers': 'localhost:29092'})
+    c = confluent_kafka.Consumer({
+        'bootstrap.servers': 'localhost:29092',
+        'group.id': 'mygroup',
+        'auto.offset.reset': 'earliest'
+    })
+
+    # instrument karapace with produce and consume hooks
+    p = inst.instrument_producer(p, tracer_provider)
+    c = inst.instrument_consumer(c, tracer_provider=tracer_provider)
+
+    # Using kafka as normal now will automatically generate spans,
+    # including user custom attributes added from the hooks
+    conf = {'bootstrap.servers': "localhost:9092"}
+    p.produce('my-topic',b'raw_bytes')
+    msg = c.poll()
+
+___
+"""
+import cgi
+import json
+import logging
+
+import re
+from typing import Collection, Optional
+import os
+from requests import options
+import sys
+import os
+import asyncio
+
+sys.path += [
+    os.getcwd(),
+]
+import karapace
+import wrapt
+from karapace.kafka_rest_apis import UserRestProxy
+from karapace.rapu import HTTPRequest, HTTPResponse
+
+from opentelemetry import context, propagate, trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.trace import MessagingOperationValues
+from opentelemetry.trace import Link, SpanKind, Tracer
+from opentelemetry.trace.span import Span
+
+from .package import _instruments
+from .utils import (
+    KafkaPropertiesExtractor,
+    _enrich_span,
+    _get_span_name,
+    _kafka_getter,
+    _kafka_setter,
+)
+from .version import __version__
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger().setLevel("DEBUG")
+log = logging.getLogger(__name__)
+
+from opentelemetry import trace
+
+
+class AutoInstrumentedUserRestProxy(UserRestProxy):
+    def __init__(self, config, kafka_timeout, serializer):
+        super().__init__(config, kafka_timeout, serializer)
+        log.debug("AutoInstrumentedUserRestProxy#__init__")
+
+    async def publish(
+        self,
+        topic: str,
+        partition_id: Optional[str],
+        content_type: str,
+        request: HTTPRequest,
+    ) -> None:  # pylint: disable=keyword-arg-before-vararg,useless-super-delegation
+        log.debug("AutoInstrumentedUserRestProxy#publish")
+
+        span_name = _get_span_name("send", topic)
+        result = None
+        with self._tracer.start_as_current_span(name=span_name, kind=trace.SpanKind.PRODUCER) as span:
+            headers = KafkaPropertiesExtractor.extract_produce_headers(request, None)
+            if headers is None:
+                raise NotImplementedError
+
+            _enrich_span(
+                span,
+                topic,
+            )  # Replace
+            propagate.inject(
+                headers,
+                setter=_kafka_setter,
+            )
+
+            # karapace seems to use exceptions as fast return
+            try:
+                await super().publish(topic, partition_id, content_type, request)
+            except HTTPResponse as response:
+                result = response
+                _enrich_span(span, topic, result.body["offsets"][0]["partition"], result.body["offsets"][0]["offset"])
+
+        # close span
+        raise result
+
+    async def fetch(self, group_name: str, instance: str, content_type: str, *, request: HTTPRequest) -> None:
+        log.debug("AutoInstrumentedUserRestProxy#_fetch")
+
+        result = None
+        with self._tracer.start_as_current_span("recv", end_on_exit=True, kind=trace.SpanKind.CONSUMER) as span:
+            try:
+                # karapace seems to use exceptions as fast return
+                await super().fetch(
+                    group_name=group_name, instance=instance, content_type=content_type, request=request
+                )
+            except HTTPResponse as response:
+                record = response.body
+                result = response
+                if record:
+                    links = []
+                    ctx = propagate.extract(response.headers, getter=_kafka_getter)
+                    if ctx:
+                        for item in ctx.values():
+                            if hasattr(item, "get_span_context"):
+                                links.append(Link(context=item.get_span_context()))
+
+                    span_name = _get_span_name("recv", record[0]["topic"])
+                    span.update_name(span_name)
+                    _enrich_span(
+                        span,
+                        record[0]["topic"],
+                        record[0]["partition"],
+                        record[0]["offset"],
+                        operation=MessagingOperationValues.PROCESS,
+                    )
+        # close span
+        raise result
+
+
+class KarapaceInstrumentor(BaseInstrumentor):
+    """
+    An instrumentor for karapace module see `BaseInstrumentor`
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        self._original_userrestproxy = karapace.kafka_rest_apis.UserRestProxy
+
+        karapace.kafka_rest_apis.UserRestProxy = AutoInstrumentedUserRestProxy
+
+        # we use the global defined tracer.
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = trace.get_tracer(__name__, __version__, tracer_provider=tracer_provider)
+        self._tracer = tracer
+
+        log.debug("KarapaceInstrumentor#_instrument")
+
+        karapace.kafka_rest_apis.UserRestProxy._tracer = self._tracer
+
+    def _uninstrument(self, **kwargs):
+        karapace.kafka_rest_apis.UserRestProxy = self._original_userrestproxy

--- a/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/package.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/package.py
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# karapace is instrumented in itself. it does not show as dependendcy
+# empty depedency is not possible. use something thtat is always present in karapace
+# _instruments = ("karapace >= 1.8.0, < 5.0.0",)
+_instruments = ("opentelemetry-sdk",)

--- a/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/utils.py
@@ -1,0 +1,122 @@
+from logging import getLogger
+from typing import List, Optional
+
+from opentelemetry.propagators import textmap
+import requests
+from opentelemetry.semconv.trace import (
+    MessagingDestinationKindValues,
+    MessagingOperationValues,
+    SpanAttributes,
+)
+
+_LOG = getLogger(__name__)
+
+
+class KafkaPropertiesExtractor:
+    @staticmethod
+    def extract_bootstrap_servers(instance):
+        return instance.config.get("bootstrap_servers")
+
+    @staticmethod
+    def _extract_argument(key, position, default_value, args, kwargs):
+        if len(args) > position:
+            return args[position]
+        return kwargs.get(key, default_value)
+
+    @staticmethod
+    def extract_produce_topic(args):
+        """extract topic from `produce` method arguments in Producer class"""
+        if len(args) > 0:
+            return args[0]
+        return "unknown"
+
+    @staticmethod
+    def extract_produce_headers(request: requests.request, kwargs):
+        """extract headers from `produce` method arguments in Producer class"""
+        return request.headers
+
+
+class KafkaContextGetter(textmap.Getter):
+    def get(self, carrier: textmap.CarrierT, key: str) -> Optional[List[str]]:
+        if carrier is None:
+            return None
+
+        carrier_items = carrier
+        if isinstance(carrier, dict):
+            carrier_items = carrier.items()
+
+        for item_key, value in carrier_items:
+            if item_key == key:
+                if value is not None:
+                    return [value.decode()]
+
+        return None
+
+    def keys(self, carrier: textmap.CarrierT) -> List[str]:
+        if carrier is None:
+            return []
+
+        carrier_items = carrier
+        if isinstance(carrier, dict):
+            carrier_items = carrier.items()
+        return [key for (key, value) in carrier_items]
+
+
+class KafkaContextSetter(textmap.Setter):
+    def set(self, carrier: textmap.CarrierT, key: str, value: str) -> None:
+        if carrier is None or key is None:
+            return
+
+        if value:
+            value = value.encode()
+
+        if isinstance(carrier, list):
+            carrier.append((key, value))
+
+        if isinstance(carrier, dict):
+            carrier[key] = value
+
+
+_kafka_getter = KafkaContextGetter()
+
+
+def _enrich_span(
+    span,
+    topic,
+    partition: Optional[int] = None,
+    offset: Optional[int] = None,
+    operation: Optional[MessagingOperationValues] = None,
+):
+    if not span.is_recording():
+        return
+
+    span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "kafka")
+    span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
+
+    if partition is not None:
+        span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)
+
+    span.set_attribute(
+        SpanAttributes.MESSAGING_DESTINATION_KIND,
+        MessagingDestinationKindValues.QUEUE.value,
+    )
+
+    if operation:
+        span.set_attribute(SpanAttributes.MESSAGING_OPERATION, operation.value)
+    else:
+        span.set_attribute(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)
+
+    # https://stackoverflow.com/questions/65935155/identify-and-find-specific-message-in-kafka-topic
+    # A message within Kafka is uniquely defined by its topic name, topic partition and offset.
+    if (partition is not None) and (offset is not None) and topic:
+        span.set_attribute(
+            SpanAttributes.MESSAGING_MESSAGE_ID,
+            f"{topic}.{partition}.{offset}",
+        )
+
+
+_kafka_setter = KafkaContextSetter()
+
+
+def _get_span_name(operation: str, topic: str):
+    return f"{operation} {topic}"

--- a/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/version.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/src/opentelemetry/instrumentation/karapace/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.39b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-karapace/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/tests/test_instrumentation.py
@@ -1,0 +1,30 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import TestCase
+
+from karapace.kafka_rest_apis import UserRestProxy
+from wrapt import BoundFunctionWrapper
+
+from opentelemetry.instrumentation.karapace import KarapaceInstrumentor
+
+
+class TestKafka(TestCase):
+    def test_instrument_api(self) -> None:
+        instrumentation = KarapaceInstrumentor()
+
+        instrumentation.instrument()
+        self.assertTrue(isinstance(UserRestProxy.publish, BoundFunctionWrapper))
+
+        instrumentation.uninstrument()
+        self.assertFalse(isinstance(UserRestProxy.pulish, BoundFunctionWrapper))

--- a/instrumentation/opentelemetry-instrumentation-karapace/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-karapace/tests/test_utils.py
@@ -1,0 +1,189 @@
+from unittest import TestCase, mock
+
+from opentelemetry.instrumentation.karapace.utils import *
+from opentelemetry.trace import SpanKind
+
+
+class TestUtils(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.topic_name = "test_topic"
+        self.args = [self.topic_name]
+        self.headers = []
+        self.kwargs = {"partition": 0, "headers": self.headers}
+
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.trace.set_span_in_context")
+    @mock.patch("opentelemetry.propagate.inject")
+    def test_wrap_send_with_topic_as_arg(
+        self,
+        inject: mock.MagicMock,
+        set_span_in_context: mock.MagicMock,
+        enrich_span: mock.MagicMock,
+        extract_send_partition: mock.MagicMock,
+        extract_bootstrap_servers: mock.MagicMock,
+    ) -> None:
+        self.wrap_send_helper(
+            inject,
+            set_span_in_context,
+            enrich_span,
+            extract_send_partition,
+            extract_bootstrap_servers,
+        )
+
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.trace.set_span_in_context")
+    @mock.patch("opentelemetry.propagate.inject")
+    def test_wrap_send_with_topic_as_kwarg(
+        self,
+        inject: mock.MagicMock,
+        set_span_in_context: mock.MagicMock,
+        enrich_span: mock.MagicMock,
+        extract_send_partition: mock.MagicMock,
+        extract_bootstrap_servers: mock.MagicMock,
+    ) -> None:
+        self.args = []
+        self.kwargs["topic"] = self.topic_name
+        self.wrap_send_helper(
+            inject,
+            set_span_in_context,
+            enrich_span,
+            extract_send_partition,
+            extract_bootstrap_servers,
+        )
+
+    def wrap_send_helper(
+        self,
+        inject: mock.MagicMock,
+        set_span_in_context: mock.MagicMock,
+        enrich_span: mock.MagicMock,
+        extract_send_partition: mock.MagicMock,
+        extract_bootstrap_servers: mock.MagicMock,
+    ) -> None:
+        tracer = mock.MagicMock()
+        produce_hook = mock.MagicMock()
+        original_send_callback = mock.MagicMock()
+        kafka_producer = mock.MagicMock()
+        expected_span_name = _get_span_name("send", self.topic_name)
+
+        wrapped_send = _wrap_send(tracer, produce_hook)
+        retval = wrapped_send(original_send_callback, kafka_producer, self.args, self.kwargs)
+
+        extract_bootstrap_servers.assert_called_once_with(kafka_producer)
+        extract_send_partition.assert_called_once_with(kafka_producer, self.args, self.kwargs)
+        tracer.start_as_current_span.assert_called_once_with(expected_span_name, kind=SpanKind.PRODUCER)
+
+        span = tracer.start_as_current_span().__enter__.return_value
+        enrich_span.assert_called_once_with(
+            span,
+            extract_bootstrap_servers.return_value,
+            self.topic_name,
+            extract_send_partition.return_value,
+        )
+
+        set_span_in_context.assert_called_once_with(span)
+        context = set_span_in_context.return_value
+        inject.assert_called_once_with(self.headers, context=context, setter=_kafka_setter)
+
+        produce_hook.assert_called_once_with(span, self.args, self.kwargs)
+
+        original_send_callback.assert_called_once_with(*self.args, **self.kwargs)
+        self.assertEqual(retval, original_send_callback.return_value)
+
+    @mock.patch("opentelemetry.propagate.extract")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._create_consumer_span")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
+    def test_wrap_next(
+        self,
+        extract_bootstrap_servers: mock.MagicMock,
+        _create_consumer_span: mock.MagicMock,
+        extract: mock.MagicMock,
+    ) -> None:
+        tracer = mock.MagicMock()
+        consume_hook = mock.MagicMock()
+        original_next_callback = mock.MagicMock()
+        kafka_consumer = mock.MagicMock()
+
+        wrapped_next = _wrap_next(tracer, consume_hook)
+        record = wrapped_next(original_next_callback, kafka_consumer, self.args, self.kwargs)
+
+        extract_bootstrap_servers.assert_called_once_with(kafka_consumer)
+        bootstrap_servers = extract_bootstrap_servers.return_value
+
+        original_next_callback.assert_called_once_with(*self.args, **self.kwargs)
+        self.assertEqual(record, original_next_callback.return_value)
+
+        extract.assert_called_once_with(record.headers, getter=_kafka_getter)
+        context = extract.return_value
+
+        _create_consumer_span.assert_called_once_with(
+            tracer,
+            consume_hook,
+            record,
+            context,
+            bootstrap_servers,
+            self.args,
+            self.kwargs,
+        )
+
+    @mock.patch("opentelemetry.trace.set_span_in_context")
+    @mock.patch("opentelemetry.context.attach")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.context.detach")
+    def test_create_consumer_span(
+        self,
+        detach: mock.MagicMock,
+        enrich_span: mock.MagicMock,
+        attach: mock.MagicMock,
+        set_span_in_context: mock.MagicMock,
+    ) -> None:
+        tracer = mock.MagicMock()
+        consume_hook = mock.MagicMock()
+        bootstrap_servers = mock.MagicMock()
+        extracted_context = mock.MagicMock()
+        record = mock.MagicMock()
+
+        _create_consumer_span(
+            tracer,
+            consume_hook,
+            record,
+            extracted_context,
+            bootstrap_servers,
+            self.args,
+            self.kwargs,
+        )
+
+        expected_span_name = _get_span_name("receive", record.topic)
+
+        tracer.start_as_current_span.assert_called_once_with(
+            expected_span_name,
+            context=extracted_context,
+            kind=SpanKind.CONSUMER,
+        )
+        span = tracer.start_as_current_span.return_value.__enter__()
+        set_span_in_context.assert_called_once_with(span, extracted_context)
+        attach.assert_called_once_with(set_span_in_context.return_value)
+
+        enrich_span.assert_called_once_with(span, bootstrap_servers, record.topic, record.partition)
+        consume_hook.assert_called_once_with(span, record, self.args, self.kwargs)
+        detach.assert_called_once_with(attach.return_value)
+
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor")
+    def test_kafka_properties_extractor(
+        self,
+        kafka_properties_extractor: mock.MagicMock,
+    ):
+        kafka_properties_extractor._serialize.return_value = None
+        kafka_properties_extractor._partition.return_value = "partition"
+        assert (
+            KafkaPropertiesExtractor.extract_send_partition(kafka_properties_extractor, self.args, self.kwargs)
+            == "partition"
+        )
+        kafka_properties_extractor._wait_on_metadata.side_effect = Exception("mocked error")
+        assert (
+            KafkaPropertiesExtractor.extract_send_partition(kafka_properties_extractor, self.args, self.kwargs) is None
+        )


### PR DESCRIPTION
adds basic instrumentation to karapace for produce and fetch operations. 
Only supports trace, no metrics

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [x ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x ] Unit tests have been added
- [x ] Documentation has been updated
