### PR TITLE
Add http.server.request.size for ASGI metric implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- `opentelemetry-instrumentation-asgi` Add `http.server.request.size` metric
+  ([#](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - `opentelemetry-instrumentation-asgi` Add `http.server.request.size` metric
-  ([#](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/))
+  ([#1867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1867))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -609,8 +609,6 @@ class OpenTelemetryMiddleware:
                         self.content_length_header, duration_attrs
                     )
                 request_size = asgi_getter.get(scope, "content-length")
-                print(scope)
-                print(request_size)
                 if request_size:
                     try:
                         self.server_request_size_histogram.record(

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -511,6 +511,11 @@ class OpenTelemetryMiddleware:
             unit="By",
             description="measures the size of HTTP response messages (compressed).",
         )
+        self.server_request_size_histogram = self.meter.create_histogram(
+            name=MetricInstruments.HTTP_SERVER_REQUEST_SIZE,
+            unit="By",
+            description="Measures the size of HTTP request messages (compressed).",
+        )
         self.active_requests_counter = self.meter.create_up_down_counter(
             name=MetricInstruments.HTTP_SERVER_ACTIVE_REQUESTS,
             unit="requests",
@@ -603,6 +608,16 @@ class OpenTelemetryMiddleware:
                     self.server_response_size_histogram.record(
                         self.content_length_header, duration_attrs
                     )
+                request_size = asgi_getter.get(scope, "content-length")
+                print(scope)
+                print(request_size)
+                if request_size:
+                    try:
+                        self.server_request_size_histogram.record(
+                            int(request_size[0]), duration_attrs
+                        )
+                    except ValueError:
+                        pass
             if token:
                 context.detach(token)
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -611,11 +611,13 @@ class OpenTelemetryMiddleware:
                 request_size = asgi_getter.get(scope, "content-length")
                 if request_size:
                     try:
-                        self.server_request_size_histogram.record(
-                            int(request_size[0]), duration_attrs
-                        )
+                        request_size_amount = int(request_size[0])
                     except ValueError:
                         pass
+                    else:
+                        self.server_request_size_histogram.record(
+                            request_size_amount, duration_attrs
+                        )
             if token:
                 context.detach(token)
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -45,11 +45,16 @@ _expected_metric_names = [
     "http.server.active_requests",
     "http.server.duration",
     "http.server.response.size",
+    "http.server.request.size",
 ]
 _recommended_attrs = {
     "http.server.active_requests": _active_requests_count_attrs,
     "http.server.duration": {*_duration_attrs, SpanAttributes.HTTP_TARGET},
     "http.server.response.size": {
+        *_duration_attrs,
+        SpanAttributes.HTTP_TARGET,
+    },
+    "http.server.request.size": {
         *_duration_attrs,
         SpanAttributes.HTTP_TARGET,
     },
@@ -251,8 +256,13 @@ class TestFastAPIManualInstrumentation(TestBase):
 
     def test_basic_post_request_metric_success(self):
         start = default_timer()
-        self._client.post("/foobar")
+        response = self._client.post(
+            "/foobar",
+            json={"foo": "bar"},
+        )
         duration = max(round((default_timer() - start) * 1000), 0)
+        response_size = int(response.headers.get("content-length"))
+        request_size = int(response.request.headers.get("content-length"))
         metrics_list = self.memory_metrics_reader.get_metrics_data()
         for metric in (
             metrics_list.resource_metrics[0].scope_metrics[0].metrics
@@ -260,7 +270,12 @@ class TestFastAPIManualInstrumentation(TestBase):
             for point in list(metric.data.data_points):
                 if isinstance(point, HistogramDataPoint):
                     self.assertEqual(point.count, 1)
-                    self.assertAlmostEqual(duration, point.sum, delta=30)
+                    if metric.name == "http.server.duration":
+                        self.assertAlmostEqual(duration, point.sum, delta=30)
+                    elif metric.name == "http.server.response.size":
+                        self.assertEqual(response_size, point.sum)
+                    elif metric.name == "http.server.request.size":
+                        self.assertEqual(request_size, point.sum)
                 if isinstance(point, NumberDataPoint):
                     self.assertEqual(point.value, 0)
 


### PR DESCRIPTION
# Description

This PR adds http.server.request.size to ASGI instrumentation logic.

It follows naming/conventions from here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverrequestsize

Fixes #1865 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated the current unit tests to support content-length and test http.server.request.size.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
