### PR TITLE
Add an exclude_paths config like exclude_urls, …

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -24,6 +24,10 @@ from opentelemetry import context, trace
 
 class InstrumentationTest:
     @staticmethod
+    def _ping_endpoint():
+        return "Ping"
+
+    @staticmethod
     def _hello_endpoint(helloid):
         if helloid == 500:
             raise ValueError(":-(")

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -136,6 +136,17 @@ def get_excluded_urls(instrumentation: str) -> ExcludeList:
     return parse_excluded_urls(excluded_urls)
 
 
+def get_excluded_paths(instrumentation: str) -> ExcludeList:
+    # Get instrumentation-specific excluded URLs. If not set, retrieve them
+    # from generic variable.
+    excluded_urls = environ.get(
+        _root.format(f"{instrumentation}_EXCLUDED_PATHS"),
+        environ.get(_root.format("EXCLUDED_PATHS"), ""),
+    )
+
+    return parse_excluded_urls(excluded_urls)
+
+
 def parse_excluded_urls(excluded_urls: str) -> ExcludeList:
     """
     Small helper to put an arbitrary url list inside an ExcludeList


### PR DESCRIPTION
…but avoiding the problem of having to match full URLs using regular expressions.

# Description

exclude_urls, because it matches the full URL including protocol/domain at the beginning and query at the end, is very difficult to reliably match on with a regular expression. This leaves the common pattern to just use bare/unanchored configurations such as exclude_urls="ping" which could easily match other URLs like "/housekeeping". This PR allows matching just against the path portion of a URL, so that you can anchor the regex more reliably, e.g. "^/ping$" or "^/ping".

I have currently implemented this only for the Flask integration, because that's my use-case, but I think this could be valuable for all of the inbound server integrations.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] added automated tests to the flask integration, and existing tests continue to run correctly.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

I don't think so, but I'm not sure what "core repo" means. This does affect the opentelemetry-util-http repository.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

I think I've followed the style guide, but I'm not sure if there's a checker I can use to validate that. I haven't yet modified the changelog, because I wanted to get feedback on the PR first and my experience is that changelog updates tend to bitrot quickly.