### PR TITLE
urllib3: Add instrumentation support for version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1833](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1833))
 - Fix elasticsearch `Transport.perform_request` instrument wrap for elasticsearch >= 8
   ([#1810](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1810))
+- `opentelemetry-instrumentation-urllib3` Add support for urllib3 version 2
+  ([#1879](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1879))
 
 ## Version 1.18.0/0.39b0 (2023-05-10)
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -41,5 +41,5 @@
 | [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | Yes
 | [opentelemetry-instrumentation-tortoiseorm](./opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | No
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib | Yes
-| [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 2.0.0 | Yes
+| [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 3.0.0 | Yes
 | [opentelemetry-instrumentation-wsgi](./opentelemetry-instrumentation-wsgi) | wsgi | Yes

--- a/instrumentation/opentelemetry-instrumentation-urllib3/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "urllib3 >= 1.0.0, < 2.0.0",
+  "urllib3 >= 1.0.0, < 3.0.0",
 ]
 test = [
   "opentelemetry-instrumentation-urllib3[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-_instruments = ("urllib3 >= 1.0.0, < 2.0.0",)
+_instruments = ("urllib3 >= 1.0.0, < 3.0.0",)
 
 _supports_metrics = True

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -328,7 +328,9 @@ class TestURLLib3Instrumentor(TestBase):
 
     def test_request_hook_params(self):
         def request_hook(span, request, headers, body):
-            span.set_attribute("request_hook_headers", json.dumps(headers))
+            span.set_attribute(
+                "request_hook_headers", json.dumps(dict(headers))
+            )
             span.set_attribute("request_hook_body", body)
 
         URLLib3Instrumentor().uninstrument()

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
@@ -18,7 +18,7 @@ from timeit import default_timer
 import httpretty
 import urllib3
 import urllib3.exceptions
-from urllib3.request import encode_multipart_formdata
+from urllib3 import encode_multipart_formdata
 
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
 from opentelemetry.test.httptest import HttpTestBase

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -161,7 +161,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-tortoiseorm==0.40b0.dev",
     },
     "urllib3": {
-        "library": "urllib3 >= 1.0.0, < 2.0.0",
+        "library": "urllib3 >= 1.0.0, < 3.0.0",
         "instrumentation": "opentelemetry-instrumentation-urllib3==0.40b0.dev",
     },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -92,8 +92,8 @@ envlist =
     pypy3-test-instrumentation-urllib
 
     ; opentelemetry-instrumentation-urllib3
-    py3{7,8,9,10,11}-test-instrumentation-urllib3
-    ;pypy3-test-instrumentation-urllib3
+    py3{7,8,9,10,11}-test-instrumentation-urllib3v{1,2}
+    ;pypy3-test-instrumentation-urllib3v{1,2}
 
     ; opentelemetry-instrumentation-requests
     py3{7,8,9,10,11}-test-instrumentation-requests
@@ -280,6 +280,8 @@ deps =
   httpx18: respx~=0.17.0
   httpx21: httpx>=0.19.0
   httpx21: respx~=0.20.1
+  urllib3v1: urllib3 >=1.0.0,<2.0.0
+  urllib3v2: urllib3 >=2.0.0,<3.0.0
 
   ; FIXME: add coverage testing
   ; FIXME: add mypy testing
@@ -310,7 +312,7 @@ changedir =
   test-instrumentation-fastapi: instrumentation/opentelemetry-instrumentation-fastapi/tests
   test-instrumentation-flask{213,220}: instrumentation/opentelemetry-instrumentation-flask/tests
   test-instrumentation-urllib: instrumentation/opentelemetry-instrumentation-urllib/tests
-  test-instrumentation-urllib3: instrumentation/opentelemetry-instrumentation-urllib3/tests
+  test-instrumentation-urllib3v{1,2}: instrumentation/opentelemetry-instrumentation-urllib3/tests
   test-instrumentation-grpc: instrumentation/opentelemetry-instrumentation-grpc/tests
   test-instrumentation-jinja2: instrumentation/opentelemetry-instrumentation-jinja2/tests
   test-instrumentation-kafka-python: instrumentation/opentelemetry-instrumentation-kafka-python/tests
@@ -369,7 +371,7 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,requests,urllib,urllib3,wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
   wsgi,falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   asgi,django{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 
@@ -388,7 +390,7 @@ commands_pre =
 
   urllib: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib[test]
 
-  urllib3: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib3[test]
+  urllib3v{1,2}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib3[test]
 
   botocore: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
 


### PR DESCRIPTION
# Description

Adds support for the recently released urllib3 version 2. Basically nothing changed in the instrumentation, just some tests needed to be adapted.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

all tests are running for urllib3 version 1 and 2.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
