### PR TITLE
Fix UnboundLocalError local variable 'start' referenced before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `opentelemetry-instrumentation-asgi` Fix UnboundLocalError local variable 'start' referenced before assignment 
+  ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
+
 ## Version 1.19.0/0.40b0 (2023-07-13)
 - `opentelemetry-instrumentation-asgi` Add `http.server.request.size` metric
   ([#1867](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1867))

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -538,6 +538,7 @@ class OpenTelemetryMiddleware:
             receive: An awaitable callable yielding dictionaries
             send: An awaitable callable taking a single dictionary as argument.
         """
+        start = default_timer()
         if scope["type"] not in ("http", "websocket"):
             return await self.app(scope, receive, send)
 
@@ -591,7 +592,6 @@ class OpenTelemetryMiddleware:
                     send,
                     duration_attrs,
                 )
-                start = default_timer()
 
                 await self.app(scope, otel_receive, otel_send)
         finally:

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -809,7 +809,7 @@ class TestAsgiApplicationRaisingError(AsgiTestBase):
         self, mock_collect_custom_request_headers_attributes
     ):
         """
-        Test that exception UnboundLocalError local variable 'start' referenced before assignment is not raises
+        Test that exception UnboundLocalError local variable 'start' referenced before assignment is not raised
         See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1883
         """
         app = otel_asgi.OpenTelemetryMiddleware(simple_asgi)

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=too-many-lines
 
+import asyncio
 import sys
 import unittest
 from timeit import default_timer
@@ -794,6 +795,39 @@ class TestWrappedApplication(AsgiTestBase):
         self.assertEqual(
             span_list[4].context.span_id, span_list[3].parent.span_id
         )
+
+
+class TestAsgiApplicationRaisingError(AsgiTestBase):
+    def tearDown(self):
+        pass
+
+    @mock.patch(
+        "opentelemetry.instrumentation.asgi.collect_custom_request_headers_attributes",
+        side_effect=ValueError("whatever"),
+    )
+    def test_asgi_issue_1883(
+        self, mock_collect_custom_request_headers_attributes
+    ):
+        """
+        Test that exception UnboundLocalError local variable 'start' referenced before assignment is not raises
+        See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1883
+        """
+        app = otel_asgi.OpenTelemetryMiddleware(simple_asgi)
+        self.seed_app(app)
+        self.send_default_request()
+        try:
+            asyncio.get_event_loop().run_until_complete(
+                self.communicator.stop()
+            )
+        except ValueError as exc_info:
+            self.assertEqual(exc_info.args[0], "whatever")
+        except Exception as exc_info:  # pylint: disable=W0703
+            self.fail(
+                "expecting ValueError('whatever'), received instead: "
+                + str(exc_info)
+            )
+        else:
+            self.fail("expecting ValueError('whatever')")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This PR intends to fix a bug in opentelemetry-instrumentation-asgi where a variable in used before assignment in some corner cases.

Fixes #1883

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To trigger the bug, one must somehow raise an exception within the [OpentelemetryMiddleware try block](https://github.com/thomasleveil/opentelemetry-python-contrib/blob/db90ce38a2a9f48f225ea63bab1d295deeaff764/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L567) before the line that initializes the `start`  variable. 

- [x] added test test_asgi_issue_1883 with commit e12954118c97e9f50e1fee3c608f3d9497674126

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
