### PR TITLE
Add explicit deps for otel instrumentation and semconv

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation == 0.41b0.dev",
+  "opentelemetry-semantic-conventions == 0.41b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
 ]
 


### PR DESCRIPTION
# Description
The project readme says that only depending on the specific instrumentation and `opentelemetry-api` should be enough. However this was not the case for confluent kafka instrumentation and it required explicitly listing semantic convetion and instrumentation from its users.

I've honestly just replicated the way it's done for `kafka-python` but I'm not sure that's entirely correct.

Fixes #1894

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually using the steps from #1894. Any hints as to how to reproduce that programatically as part of unit tests would be welcome, but I think a more elaborate change to the test suite would be needed where each instrumentation would be installed in isolated environment...

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project

