### PR TITLE
Fix errors introduced in regression

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -3,6 +3,7 @@ components:
   docs/instrumentation:
     - nemoshlag
 
+
   instrumentation/opentelemetry-instrumentation-aio-pika:
     - ofek1weiss
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-asgi` Fix UnboundLocalError local variable 'start' referenced before assignment
   ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
-- Fixed union typing error not compatible with Python 3.7 introduced in `opentelemetry-util-http`
-  ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
+- Fixed union typing error not compatible with Python 3.7 introduced in `opentelemetry-util-http`, fix tests introduced by patch related to sanitize method for wsgi
+  ([#1913](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1913))
 
 ## Version 1.19.0/0.40b0 (2023-07-13)
 - `opentelemetry-instrumentation-asgi` Add `http.server.request.size` metric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `opentelemetry-instrumentation-asgi` Fix UnboundLocalError local variable 'start' referenced before assignment 
+- `opentelemetry-instrumentation-asgi` Fix UnboundLocalError local variable 'start' referenced before assignment
+  ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
+- Fixed union typing error not compatible with Python 3.7 introduced in `opentelemetry-util-http`
   ([#1889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1889))
 
 ## Version 1.19.0/0.40b0 (2023-07-13)

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -289,7 +289,7 @@ class TestWsgiApplication(WsgiTestBase):
         self.environ["REQUEST_METHOD"]= "NONSTANDARD"
         app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
         response = app(self.environ, self.start_response)
-        self.validate_response(response, span_name="HTTP UNKNOWN", http_method="UNKNOWN")
+        self.validate_response(response, span_name="UNKNOWN /", http_method="UNKNOWN")
 
     @mock.patch.dict(
     "os.environ",
@@ -301,7 +301,7 @@ class TestWsgiApplication(WsgiTestBase):
         self.environ["REQUEST_METHOD"]= "NONSTANDARD"
         app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
         response = app(self.environ, self.start_response)
-        self.validate_response(response, span_name="HTTP NONSTANDARD", http_method="NONSTANDARD")
+        self.validate_response(response, span_name="NONSTANDARD /", http_method="NONSTANDARD")
 
     def test_default_span_name_missing_path_info(self):
         """Test that default span_names with missing path info."""

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -16,7 +16,7 @@ from os import environ
 from re import IGNORECASE as RE_IGNORECASE
 from re import compile as re_compile
 from re import search
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 from urllib.parse import urlparse, urlunparse
 
 from opentelemetry.semconv.trace import SpanAttributes
@@ -190,7 +190,7 @@ def normalise_response_header_name(header: str) -> str:
     key = header.lower().replace("-", "_")
     return f"http.response.header.{key}"
 
-def sanitize_method(method: str | None) -> str | None:
+def sanitize_method(method: Optional[str]) -> Optional[str]:
     if method is None:
         return None
     method = method.upper()

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -198,7 +198,7 @@ def sanitize_method(method: Optional[str]) -> Optional[str]:
         # Based on https://www.rfc-editor.org/rfc/rfc7231#section-4.1 and https://www.rfc-editor.org/rfc/rfc5789#section-2.
         method in ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]):
         return method
-    return "NONSTANDARD"
+    return "UNKNOWN"
 
 def get_custom_headers(env_var: str) -> List[str]:
     custom_headers = environ.get(env_var, [])


### PR DESCRIPTION
CI was not able to run successfully for security change: https://github.com/open-telemetry/opentelemetry-python-contrib-ghsa-5rv5-6h4r-h22v/pull/2

1. Fixing typing errors introduced by the above pr for Python 3.7
2. Change fix, name is required to be UNKNOWN instead of NONSTANDARD
3. Fix tests