### PR TITLE
Relaxed the version range in opentelemetry-instrumentation-starlette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
+- `opentelemetry-instrumentation-starlette` Removed upper version bound for `starlette` dependency, fix \_instrumented_by_opentelemetry flag
+  ([#1933](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1933))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1959](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1959))
 - `opentelemetry-resource-detector-azure` Added dependency for Cloud Resource ID attribute
   ([#2072](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2072))
-  
+
 ## Version 1.21.0/0.42b0 (2023-11-01)
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "starlette ~= 0.13.0",
+  "starlette >= 0.13.0",
 ]
 test = [
   "opentelemetry-instrumentation-starlette[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -224,7 +224,7 @@ class StarletteInstrumentor(BaseInstrumentor):
                 tracer_provider=tracer_provider,
                 meter=meter,
             )
-            app.is_instrumented_by_opentelemetry = True
+            app._is_instrumented_by_opentelemetry = True
 
             # adding apps to set for uninstrumenting
             if app not in _InstrumentedStarlette._instrumented_starlette_apps:

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-_instruments = ("starlette ~= 0.13.0",)
+_instruments = ("starlette >= 0.13.0",)
 
 _supports_metrics = True


### PR DESCRIPTION
# Description

The Signature of `Starlette.add_middleware()` seems to be quite stable and hasn't changed since version 0.13 (from mid 2020). The current version as of today is 0.31.1. So we can assume that add_middleware Signature won't change in a meaningful way until 1.x or beyond. 

That's why I think relaxing the version range to only set a minimum version would be best for future proofness.

BUGFIXES: 
- I found a bug in a missing leading underscore of `_is_instrumented_by_opentelemetry`.
- Fixed DeprecationWarnings in tests for route decorators


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added checks for the `_is_instrumented_by_opentelemetry` in one test.
I ran the tox test env.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
