### PR TITLE
Relaxed version range for opentelemetry-instrument-fastapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation` Added Otel semantic convention opt-in mechanism
   ([#1987](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1987))
 
+### Fixed
+
+- `opentelemetry-instrumentation-fastapi` Removed upper version bound for fastapi.
+  ([#1934](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1934))
+
 ## Version 1.21.0/0.42b0 (2023-11-01)
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "fastapi ~= 0.58",
+  "fastapi >= 0.58",
 ]
 test = [
   "opentelemetry-instrumentation-fastapi[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-_instruments = ("fastapi ~= 0.58",)
+_instruments = ("fastapi >= 0.58",)
 
 _supports_metrics = True


### PR DESCRIPTION
# Description

Relaxed version range for fastapi to >= 0.58. `add_middleware` signature hasn't changed meaningfully since 2020. It probably will not for the forseeable future. So removing the upper bound makes sense, to be able to use autoinstrumentation for more versions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the tox env.

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
