### PR TITLE
Fix wrong package/project name for opentelemetry-resource-detector-azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `opentelemetry-resource-detector-azure` Fix incorrect project name in metadata
+
 ## Version 1.20.0/0.41b0 (2023-09-01)
 
 ### Fixed

--- a/resource/opentelemetry-resource-detector-azure/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-azure/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "opentelemetry-resource-detector-container"
+name = "opentelemetry-resource-detector-azure"
 dynamic = ["version"]
 description = "Container Resource Detector for OpenTelemetry"
 readme = "README.rst"


### PR DESCRIPTION
# Description

This fixes package/project name for `opentelemetry-resource-detector-azure`. It looks like the `pyproject.toml` was copied from `opentelemetry-resource-detector-container` without updating the project name.

Fixes # (issue)

(No issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By inspection only.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added **N/A**
- [ ] Documentation has been updated **N/A**
