### PR TITLE
Measure http server durations in seconds

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -503,7 +503,7 @@ class OpenTelemetryMiddleware:
         )
         self.duration_histogram = self.meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration of the inbound HTTP request",
         )
         self.server_response_size_histogram = self.meter.create_histogram(
@@ -599,7 +599,7 @@ class OpenTelemetryMiddleware:
                 target = _collect_target_attribute(scope)
                 if target:
                     duration_attrs[SpanAttributes.HTTP_TARGET] = target
-                duration = max(round((default_timer() - start) * 1000), 0)
+                duration = max(default_timer() - start, 0)
                 self.duration_histogram.record(duration, duration_attrs)
                 self.active_requests_counter.add(
                     -1, active_requests_count_attrs

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -315,7 +315,7 @@ class DjangoInstrumentor(BaseInstrumentor):
         )
         _DjangoMiddleware._duration_histogram = meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration of the inbound http request",
         )
         _DjangoMiddleware._active_request_counter = meter.create_up_down_counter(

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -377,9 +377,7 @@ class _DjangoMiddleware(MiddlewareMixin):
                 activation.__exit__(None, None, None)
 
         if request_start_time is not None:
-            duration = max(
-                round((default_timer() - request_start_time) * 1000), 0
-            )
+            duration = max(default_timer() - request_start_time, 0)
             self._duration_histogram.record(duration, duration_attrs)
         self._active_request_counter.add(-1, active_requests_count_attrs)
         if request.META.get(self._environ_token, None) is not None:

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -259,7 +259,7 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
         self._otel_meter = get_meter(__name__, __version__, meter_provider)
         self.duration_histogram = self._otel_meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration of the inbound HTTP request",
         )
         self.active_requests_counter = self._otel_meter.create_up_down_counter(
@@ -377,7 +377,7 @@ class _InstrumentedFalconAPI(getattr(falcon, _instrument_app)):
                 duration_attrs[
                     SpanAttributes.HTTP_STATUS_CODE
                 ] = span.attributes.get(SpanAttributes.HTTP_STATUS_CODE)
-            duration = max(round((default_timer() - start) * 1000), 0)
+            duration = max(default_timer() - start, 0)
             self.duration_histogram.record(duration, duration_attrs)
             self.active_requests_counter.add(-1, active_requests_count_attrs)
             if exception is None:

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -354,7 +354,7 @@ def _rewrapped_app(
             return start_response(status, response_headers, *args, **kwargs)
 
         result = wsgi_app(wrapped_app_environ, _start_response)
-        duration = max(round((default_timer() - start) * 1000), 0)
+        duration = max((default_timer() - start), 0)
         duration_histogram.record(duration, duration_attrs)
         active_requests_counter.add(-1, active_requests_count_attrs)
         return result
@@ -499,7 +499,7 @@ class _InstrumentedFlask(flask.Flask):
         )
         duration_histogram = meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration of the inbound HTTP request",
         )
         active_requests_counter = meter.create_up_down_counter(
@@ -597,7 +597,7 @@ class FlaskInstrumentor(BaseInstrumentor):
             meter = get_meter(__name__, __version__, meter_provider)
             duration_histogram = meter.create_histogram(
                 name=MetricInstruments.HTTP_SERVER_DURATION,
-                unit="ms",
+                unit="s",
                 description="measures the duration of the inbound HTTP request",
             )
             active_requests_counter = meter.create_up_down_counter(

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -131,7 +131,7 @@ def trace_tween_factory(handler, registry):
     meter = get_meter(__name__, __version__)
     duration_histogram = meter.create_histogram(
         name=MetricInstruments.HTTP_SERVER_DURATION,
-        unit="ms",
+        unit="s",
         description="measures the duration of the inbound HTTP request",
     )
     active_requests_counter = meter.create_up_down_counter(
@@ -189,7 +189,7 @@ def trace_tween_factory(handler, registry):
             status = "500 InternalServerError"
             raise
         finally:
-            duration = max(round((default_timer() - start) * 1000), 0)
+            duration = max(default_timer() - start, 0)
             status = getattr(response, "status", status)
             status_code = otel_wsgi._parse_status_code(status)
             if status_code is not None:

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -285,7 +285,7 @@ def _create_server_histograms(meter) -> Dict[str, Histogram]:
     histograms = {
         MetricInstruments.HTTP_SERVER_DURATION: meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration outbound HTTP requests",
         ),
         MetricInstruments.HTTP_SERVER_REQUEST_SIZE: meter.create_histogram(
@@ -582,9 +582,7 @@ def _record_prepare_metrics(server_histograms, handler):
 
 
 def _record_on_finish_metrics(server_histograms, handler, error=None):
-    elapsed_time = round(
-        (default_timer() - server_histograms[_START_TIME]) * 1000
-    )
+    elapsed_time = (default_timer() - server_histograms[_START_TIME])
 
     response_size = int(handler._headers.get("Content-Length", 0))
     metric_attributes = _create_metric_attributes(handler)

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -494,7 +494,7 @@ class OpenTelemetryMiddleware:
         self.meter = get_meter(__name__, __version__, meter_provider)
         self.duration_histogram = self.meter.create_histogram(
             name=MetricInstruments.HTTP_SERVER_DURATION,
-            unit="ms",
+            unit="s",
             description="measures the duration of the inbound HTTP request",
         )
         self.active_requests_counter = self.meter.create_up_down_counter(
@@ -580,7 +580,7 @@ class OpenTelemetryMiddleware:
                 context.detach(token)
             raise
         finally:
-            duration = max(round((default_timer() - start) * 1000), 0)
+            duration = max(default_timer() - start, 0)
             self.duration_histogram.record(duration, duration_attrs)
             self.active_requests_counter.add(-1, active_requests_count_attrs)
 


### PR DESCRIPTION
See: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpserverrequestduration

I couldn't figure out how to set the histograms' buckets though :(

# Description

The unit for `http.server.request.duration` should be seconds and not milliseconds.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

_This has not been tested yet. I want to start the discussion around this before doing more work._

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
