### PR TITLE
Exclude background task execution from root server span in ASGI middleware 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1824](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1824))
 - Fix sqlalchemy instrumentation wrap methods to accept sqlcommenter options
   ([#1873](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1873))
+- Exclude background task execution from root server span in ASGI middleware
+  ([#1952](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1952))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -576,7 +576,7 @@ class OpenTelemetryMiddleware:
         if scope["type"] == "http":
             self.active_requests_counter.add(1, active_requests_count_attrs)
         try:
-            with trace.use_span(span, end_on_exit=True) as current_span:
+            with trace.use_span(span, end_on_exit=False) as current_span:
                 if current_span.is_recording():
                     for key, value in attributes.items():
                         current_span.set_attribute(key, value)
@@ -703,5 +703,8 @@ class OpenTelemetryMiddleware:
                         pass
 
                 await send(message)
+            if message["type"] == "http.response.body":
+                if not message.get("more_body", False):
+                    server_span.end()
 
         return otel_send

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -630,6 +630,8 @@ class OpenTelemetryMiddleware:
                         )
             if token:
                 context.detach(token)
+            if span.is_recording():
+                span.end()
 
     # pylint: enable=too-many-branches
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -119,10 +119,18 @@ async def long_response_asgi(scope, receive, send):
                 ],
             }
         )
-        await send({"type": "http.response.body", "body": b"*", "more_body": True})
-        await send({"type": "http.response.body", "body": b"*", "more_body": True})
-        await send({"type": "http.response.body", "body": b"*", "more_body": True})
-        await send({"type": "http.response.body", "body": b"*", "more_body": False})
+        await send(
+            {"type": "http.response.body", "body": b"*", "more_body": True}
+        )
+        await send(
+            {"type": "http.response.body", "body": b"*", "more_body": True}
+        )
+        await send(
+            {"type": "http.response.body", "body": b"*", "more_body": True}
+        )
+        await send(
+            {"type": "http.response.body", "body": b"*", "more_body": False}
+        )
 
 
 async def background_execution_asgi(scope, receive, send):
@@ -142,7 +150,12 @@ async def background_execution_asgi(scope, receive, send):
                 ],
             }
         )
-        await send({"type": "http.response.body", "body": b"*", })
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"*",
+            }
+        )
         time.sleep(simulated_background_task_execution_time_s)
 
 
@@ -280,7 +293,11 @@ class TestAsgiApplication(AsgiTestBase):
         self.validate_outputs(outputs, error=ValueError)
 
     def test_long_response(self):
-        """Test that the server span is ended on the final response body message. If the server span is ended early then this test will fail due discrepancies in the expected list of spans and the emitted list of spans."""
+        """Test that the server span is ended on the final response body message.
+
+        If the server span is ended early then this test will fail due
+        to discrepancies in the expected list of spans and the emitted list of spans.
+        """
         app = otel_asgi.OpenTelemetryMiddleware(long_response_asgi)
         self.seed_app(app)
         self.send_default_request()
@@ -312,7 +329,8 @@ class TestAsgiApplication(AsgiTestBase):
         print(span_duration_nanos)
         self.assertLessEqual(
             span_duration_nanos,
-            simulated_background_task_execution_time_s * 10**9)
+            simulated_background_task_execution_time_s * 10**9,
+        )
 
     def test_override_span_name(self):
         """Test that default span_names can be overwritten by our callback function."""

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import sys
+import time
 import unittest
 from timeit import default_timer
 from unittest import mock
@@ -56,6 +57,8 @@ _recommended_attrs = {
     "http.server.response.size": _duration_attrs,
     "http.server.request.size": _duration_attrs,
 }
+
+simulated_background_task_execution_time_s = 0.01
 
 
 async def http_app(scope, receive, send):
@@ -99,6 +102,50 @@ async def simple_asgi(scope, receive, send):
         await websocket_app(scope, receive, send)
 
 
+async def long_response_asgi(scope, receive, send):
+    assert isinstance(scope, dict)
+    assert scope["type"] == "http"
+    message = await receive()
+    scope["headers"] = [(b"content-length", b"128")]
+    assert scope["type"] == "http"
+    if message.get("type") == "http.request":
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    [b"Content-Type", b"text/plain"],
+                    [b"content-length", b"1024"],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"*", "more_body": True})
+        await send({"type": "http.response.body", "body": b"*", "more_body": True})
+        await send({"type": "http.response.body", "body": b"*", "more_body": True})
+        await send({"type": "http.response.body", "body": b"*", "more_body": False})
+
+
+async def background_execution_asgi(scope, receive, send):
+    assert isinstance(scope, dict)
+    assert scope["type"] == "http"
+    message = await receive()
+    scope["headers"] = [(b"content-length", b"128")]
+    assert scope["type"] == "http"
+    if message.get("type") == "http.request":
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    [b"Content-Type", b"text/plain"],
+                    [b"content-length", b"1024"],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"*", })
+        time.sleep(simulated_background_task_execution_time_s)
+
+
 async def error_asgi(scope, receive, send):
     assert isinstance(scope, dict)
     assert scope["type"] == "http"
@@ -127,14 +174,14 @@ class TestAsgiApplication(AsgiTestBase):
         # Ensure modifiers is a list
         modifiers = modifiers or []
         # Check for expected outputs
-        self.assertEqual(len(outputs), 2)
         response_start = outputs[0]
-        response_body = outputs[1]
+        response_final_body = outputs[-1]
         self.assertEqual(response_start["type"], "http.response.start")
-        self.assertEqual(response_body["type"], "http.response.body")
+        self.assertEqual(response_final_body["type"], "http.response.body")
+        self.assertEqual(response_final_body.get("more_body", False), False)
 
         # Check http response body
-        self.assertEqual(response_body["body"], b"*")
+        self.assertEqual(response_final_body["body"], b"*")
 
         # Check http response start
         self.assertEqual(response_start["status"], 200)
@@ -153,7 +200,6 @@ class TestAsgiApplication(AsgiTestBase):
 
         # Check spans
         span_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(span_list), 4)
         expected = [
             {
                 "name": "GET / http receive",
@@ -194,6 +240,7 @@ class TestAsgiApplication(AsgiTestBase):
         for modifier in modifiers:
             expected = modifier(expected)
         # Check that output matches
+        self.assertEqual(len(span_list), len(expected))
         for span, expected in zip(span_list, expected):
             self.assertEqual(span.name, expected["name"])
             self.assertEqual(span.kind, expected["kind"])
@@ -231,6 +278,41 @@ class TestAsgiApplication(AsgiTestBase):
         self.send_default_request()
         outputs = self.get_all_output()
         self.validate_outputs(outputs, error=ValueError)
+
+    def test_long_response(self):
+        """Test that the server span is ended on the final response body message. If the server span is ended early then this test will fail due discrepancies in the expected list of spans and the emitted list of spans."""
+        app = otel_asgi.OpenTelemetryMiddleware(long_response_asgi)
+        self.seed_app(app)
+        self.send_default_request()
+        outputs = self.get_all_output()
+
+        def add_more_body_spans(expected: list):
+            more_body_span = {
+                "name": "GET / http send",
+                "kind": trace_api.SpanKind.INTERNAL,
+                "attributes": {"type": "http.response.body"},
+            }
+            extra_spans = [more_body_span] * 3
+            expected[2:2] = extra_spans
+            return expected
+
+        self.validate_outputs(outputs, modifiers=[add_more_body_spans])
+
+    def test_background_execution(self):
+        """Test that the server span is ended BEFORE the background task is finished."""
+        app = otel_asgi.OpenTelemetryMiddleware(background_execution_asgi)
+        self.seed_app(app)
+        self.send_default_request()
+        outputs = self.get_all_output()
+        self.validate_outputs(outputs)
+        span_list = self.memory_exporter.get_finished_spans()
+        server_span = span_list[-1]
+        assert server_span.kind == SpanKind.SERVER
+        span_duration_nanos = server_span.end_time - server_span.start_time
+        print(span_duration_nanos)
+        self.assertLessEqual(
+            span_duration_nanos,
+            simulated_background_task_execution_time_s * 10**9)
 
     def test_override_span_name(self):
         """Test that default span_names can be overwritten by our callback function."""

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -58,7 +58,7 @@ _recommended_attrs = {
     "http.server.request.size": _duration_attrs,
 }
 
-simulated_background_task_execution_time_s = 0.01
+_SIMULATED_BACKGROUND_TASK_EXECUTION_TIME_S = 0.01
 
 
 async def http_app(scope, receive, send):
@@ -156,7 +156,7 @@ async def background_execution_asgi(scope, receive, send):
                 "body": b"*",
             }
         )
-        time.sleep(simulated_background_task_execution_time_s)
+        time.sleep(_SIMULATED_BACKGROUND_TASK_EXECUTION_TIME_S)
 
 
 async def error_asgi(scope, receive, send):
@@ -326,10 +326,9 @@ class TestAsgiApplication(AsgiTestBase):
         server_span = span_list[-1]
         assert server_span.kind == SpanKind.SERVER
         span_duration_nanos = server_span.end_time - server_span.start_time
-        print(span_duration_nanos)
         self.assertLessEqual(
             span_duration_nanos,
-            simulated_background_task_execution_time_s * 10**9,
+            _SIMULATED_BACKGROUND_TASK_EXECUTION_TIME_S * 10**9,
         )
 
     def test_override_span_name(self):


### PR DESCRIPTION
# Description

Some ASGI web frameworks, like FastAPI, support scheduling of background tasks that execute after the server has sent a response to the client. Currently, the root server span doesn't end when the response is dispatched but rather when the server has completely processed the request. This can skew aggregate statistics, potentially making it appear as if the server has high latency when, in reality, it's only executing background tasks that don't impact the actual latency.

To address this, I've made changes to end the `server_span` upon sending the final response body. To ensure there are no duplicate attempts at ending the `server_span`, the span is initialized with `end_on_exit=False` and then ended manually if it's still recording.

**However**, one challenge with my solution pertains to error reporting. In the original implementation, exceptions in background tasks get reported on the top-level server span. With the changes in this PR, errors won't be reported unless a tracing context is active within the background task. Perhaps the FastAPI instrumentation should introduce a broader span for background task execution to ensure errors are reported within some span.

The solution is heavily inspired by the Datadog PR for this exact same problem https://github.com/DataDog/dd-trace-py/pull/3799

Before
![image](https://github.com/open-telemetry/opentelemetry-python-contrib/assets/106159316/580aea4f-dc84-487b-b17b-8b541a386678)

After
![image](https://github.com/open-telemetry/opentelemetry-python-contrib/assets/106159316/baca649c-ce06-40f9-80f1-4506c5f76a7c)




Fixes #1684



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Ran in production for months (Python 3.11 FastAPI)
- [X] Manually tested with FastApi(0.103.1) in matrix [Normal Request, Request with background execution] x [No Exceptions, Exception before response, Exception in background task*]
- [X] Ran ASGI instrumentation tests
- [X] Ran FastAPI instrumentation tests
- [X] Added additional tests to the ASGI instrumentation

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] ~~Documentation has been updated~~
