### PR TITLE
fix(auto-instrumentation): Python path no longer required

### DIFF
--- a/.github/workflows/instrumentations_0.yml
+++ b/.github/workflows/instrumentations_0.yml
@@ -57,7 +57,7 @@ jobs:
           - "logging"
           - "mysql"
           - "mysqlclient"
-          - "pika"
+          - "sio-pika"
           - "psycopg2"
           - "pymemcache"
           - "pymongo"

--- a/.github/workflows/instrumentations_1.yml
+++ b/.github/workflows/instrumentations_1.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: [py37, py38, py39, py310, py311, pypy3]
         package:
           - "urllib"
-          - "urllib3"
+          - "urllib3v"
           - "wsgi"
           - "distro"
           - "richconsole"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1967](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1967))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
+- `opentelemetry-resource-detector-azure` Changed timeout to 4 seconds due to [timeout bug](https://github.com/open-telemetry/opentelemetry-python/issues/3644)
+  ([#2136](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2136))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-resource-detector-azure` Add resource detectors for Azure App Service and VM
   ([#1901](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1901))
+- `opentelemetry-instrumentation-flask` Add support for Flask 3.0.0
+  ([#152](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2013))
 
 ## Version 1.19.0/0.40b0 (2023-07-13)
 - `opentelemetry-instrumentation-asgi` Add `http.server.request.size` metric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1967](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1967))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
+- `opentelemetry-instrumentation-confluent-kafka` Add support for higher versions until 2.3.0 of confluent_kafka
+  ([#2132](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2132))
 - `opentelemetry-resource-detector-azure` Changed timeout to 4 seconds due to [timeout bug](https://github.com/open-telemetry/opentelemetry-python/issues/3644)
   ([#2136](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2136))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-instrumentation` Fix bug that happens when PYTHONPATH is not set.
+  ([#1967](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1967))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1948](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1948))
 - Added schema_url (`"https://opentelemetry.io/schemas/1.11.0"`) to all metrics and traces
   ([#1977](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1977))
+- Add support for configuring ASGI middleware header extraction via runtime constructor parameters
+  ([#2026](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2026))
 
 ### Fixed
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -27,7 +27,7 @@ botocore~=1.0
 boto3~=1.0
 cassandra-driver~=3.25
 celery>=4.0
-confluent-kafka>= 1.8.2,<= 2.2.0
+confluent-kafka>= 1.8.2,<= 2.3.0
 elasticsearch>=2.0,<9.0
 flask~=2.0
 falcon~=2.0

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -13,7 +13,7 @@
 | [opentelemetry-instrumentation-botocore](./opentelemetry-instrumentation-botocore) | botocore ~= 1.0 | No
 | [opentelemetry-instrumentation-cassandra](./opentelemetry-instrumentation-cassandra) | cassandra-driver ~= 3.25,scylla-driver ~= 3.25 | No
 | [opentelemetry-instrumentation-celery](./opentelemetry-instrumentation-celery) | celery >= 4.0, < 6.0 | No
-| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.2.0 | No
+| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.3.0 | No
 | [opentelemetry-instrumentation-dbapi](./opentelemetry-instrumentation-dbapi) | dbapi | No
 | [opentelemetry-instrumentation-django](./opentelemetry-instrumentation-django) | django >= 1.10 | Yes
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 2.0 | No

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -19,7 +19,7 @@
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 2.0 | No
 | [opentelemetry-instrumentation-falcon](./opentelemetry-instrumentation-falcon) | falcon >= 1.4.1, < 4.0.0 | Yes
 | [opentelemetry-instrumentation-fastapi](./opentelemetry-instrumentation-fastapi) | fastapi ~= 0.58 | Yes
-| [opentelemetry-instrumentation-flask](./opentelemetry-instrumentation-flask) | flask >= 1.0, < 3.0 | Yes
+| [opentelemetry-instrumentation-flask](./opentelemetry-instrumentation-flask) | flask >= 1.0 | Yes
 | [opentelemetry-instrumentation-grpc](./opentelemetry-instrumentation-grpc) | grpcio ~= 1.27 | No
 | [opentelemetry-instrumentation-httpx](./opentelemetry-instrumentation-httpx) | httpx >= 0.18.0 | No
 | [opentelemetry-instrumentation-jinja2](./opentelemetry-instrumentation-jinja2) | jinja2 >= 2.7, < 4.0 | No

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -189,11 +189,13 @@ API
 ---
 """
 
+from __future__ import annotations
+
 import typing
 import urllib
 from functools import wraps
 from timeit import default_timer
-from typing import Tuple
+from typing import Any, Awaitable, Callable, Tuple, cast
 
 from asgiref.compatibility import guarantee_single_callable
 
@@ -332,55 +334,28 @@ def collect_request_attributes(scope):
     return result
 
 
-def collect_custom_request_headers_attributes(scope):
-    """returns custom HTTP request headers to be added into SERVER span as span attributes
-    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+def collect_custom_headers_attributes(
+    scope_or_response_message: dict[str, Any],
+    sanitize: SanitizeValue,
+    header_regexes: list[str],
+    normalize_names: Callable[[str], str],
+) -> dict[str, str]:
     """
+    Returns custom HTTP request or response headers to be added into SERVER span as span attributes.
 
-    sanitize = SanitizeValue(
-        get_custom_headers(
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS
-        )
-    )
-
+    Refer specifications:
+     - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
+    """
     # Decode headers before processing.
-    headers = {
+    headers: dict[str, str] = {
         _key.decode("utf8"): _value.decode("utf8")
-        for (_key, _value) in scope.get("headers")
+        for (_key, _value) in scope_or_response_message.get("headers")
+        or cast("list[tuple[bytes, bytes]]", [])
     }
-
     return sanitize.sanitize_header_values(
         headers,
-        get_custom_headers(
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST
-        ),
-        normalise_request_header_name,
-    )
-
-
-def collect_custom_response_headers_attributes(message):
-    """returns custom HTTP response headers to be added into SERVER span as span attributes
-    Refer specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers
-    """
-
-    sanitize = SanitizeValue(
-        get_custom_headers(
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS
-        )
-    )
-
-    # Decode headers before processing.
-    headers = {
-        _key.decode("utf8"): _value.decode("utf8")
-        for (_key, _value) in message.get("headers")
-    }
-
-    return sanitize.sanitize_header_values(
-        headers,
-        get_custom_headers(
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE
-        ),
-        normalise_response_header_name,
+        header_regexes,
+        normalize_names,
     )
 
 
@@ -493,6 +468,9 @@ class OpenTelemetryMiddleware:
         tracer_provider=None,
         meter_provider=None,
         meter=None,
+        http_capture_headers_server_request: list[str] | None = None,
+        http_capture_headers_server_response: list[str] | None = None,
+        http_capture_headers_sanitize_fields: list[str] | None = None,
     ):
         self.app = guarantee_single_callable(app)
         self.tracer = trace.get_tracer(
@@ -540,7 +518,41 @@ class OpenTelemetryMiddleware:
         self.client_response_hook = client_response_hook
         self.content_length_header = None
 
-    async def __call__(self, scope, receive, send):
+        # Environment variables as constructor parameters
+        self.http_capture_headers_server_request = (
+            http_capture_headers_server_request
+            or (
+                get_custom_headers(
+                    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST
+                )
+            )
+            or None
+        )
+        self.http_capture_headers_server_response = (
+            http_capture_headers_server_response
+            or (
+                get_custom_headers(
+                    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE
+                )
+            )
+            or None
+        )
+        self.http_capture_headers_sanitize_fields = SanitizeValue(
+            http_capture_headers_sanitize_fields
+            or (
+                get_custom_headers(
+                    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS
+                )
+            )
+            or []
+        )
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
         """The ASGI application
 
         Args:
@@ -583,7 +595,14 @@ class OpenTelemetryMiddleware:
 
                     if current_span.kind == trace.SpanKind.SERVER:
                         custom_attributes = (
-                            collect_custom_request_headers_attributes(scope)
+                            collect_custom_headers_attributes(
+                                scope,
+                                self.http_capture_headers_sanitize_fields,
+                                self.http_capture_headers_server_request,
+                                normalise_request_header_name,
+                            )
+                            if self.http_capture_headers_server_request
+                            else {}
                         )
                         if len(custom_attributes) > 0:
                             current_span.set_attributes(custom_attributes)
@@ -658,7 +677,7 @@ class OpenTelemetryMiddleware:
         expecting_trailers = False
 
         @wraps(send)
-        async def otel_send(message):
+        async def otel_send(message: dict[str, Any]):
             nonlocal expecting_trailers
             with self.tracer.start_as_current_span(
                 " ".join((server_span_name, scope["type"], "send"))
@@ -685,7 +704,14 @@ class OpenTelemetryMiddleware:
                         and "headers" in message
                     ):
                         custom_response_attributes = (
-                            collect_custom_response_headers_attributes(message)
+                            collect_custom_headers_attributes(
+                                message,
+                                self.http_capture_headers_sanitize_fields,
+                                self.http_capture_headers_server_response,
+                                normalise_response_header_name,
+                            )
+                            if self.http_capture_headers_server_response
+                            else {}
                         )
                         if len(custom_response_attributes) > 0:
                             server_span.set_attributes(

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_custom_headers.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_custom_headers.py
@@ -1,4 +1,4 @@
-from unittest import mock
+import os
 
 import opentelemetry.instrumentation.asgi as otel_asgi
 from opentelemetry.test.asgitestutil import AsgiTestBase
@@ -72,21 +72,22 @@ async def websocket_app_with_custom_headers(scope, receive, send):
             break
 
 
-@mock.patch.dict(
-    "os.environ",
-    {
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
-    },
-)
 class TestCustomHeaders(AsgiTestBase, TestBase):
+    constructor_params = {}
+    __test__ = False
+
+    def __init_subclass__(cls) -> None:
+        if cls is not TestCustomHeaders:
+            cls.__test__ = True
+
     def setUp(self):
         super().setUp()
         self.tracer_provider, self.exporter = TestBase.create_tracer_provider()
         self.tracer = self.tracer_provider.get_tracer(__name__)
         self.app = otel_asgi.OpenTelemetryMiddleware(
-            simple_asgi, tracer_provider=self.tracer_provider
+            simple_asgi,
+            tracer_provider=self.tracer_provider,
+            **self.constructor_params,
         )
 
     def test_http_custom_request_headers_in_span_attributes(self):
@@ -148,7 +149,9 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
 
     def test_http_custom_response_headers_in_span_attributes(self):
         self.app = otel_asgi.OpenTelemetryMiddleware(
-            http_app_with_custom_headers, tracer_provider=self.tracer_provider
+            http_app_with_custom_headers,
+            tracer_provider=self.tracer_provider,
+            **self.constructor_params,
         )
         self.seed_app(self.app)
         self.send_default_request()
@@ -175,7 +178,9 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
 
     def test_http_custom_response_headers_not_in_span_attributes(self):
         self.app = otel_asgi.OpenTelemetryMiddleware(
-            http_app_with_custom_headers, tracer_provider=self.tracer_provider
+            http_app_with_custom_headers,
+            tracer_provider=self.tracer_provider,
+            **self.constructor_params,
         )
         self.seed_app(self.app)
         self.send_default_request()
@@ -277,6 +282,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.app = otel_asgi.OpenTelemetryMiddleware(
             websocket_app_with_custom_headers,
             tracer_provider=self.tracer_provider,
+            **self.constructor_params,
         )
         self.seed_app(self.app)
         self.send_input({"type": "websocket.connect"})
@@ -317,6 +323,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.app = otel_asgi.OpenTelemetryMiddleware(
             websocket_app_with_custom_headers,
             tracer_provider=self.tracer_provider,
+            **self.constructor_params,
         )
         self.seed_app(self.app)
         self.send_input({"type": "websocket.connect"})
@@ -333,3 +340,46 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
             if span.kind == SpanKind.SERVER:
                 for key, _ in not_expected.items():
                     self.assertNotIn(key, span.attributes)
+
+
+SANITIZE_FIELDS_TEST_VALUE = ".*my-secret.*"
+SERVER_REQUEST_TEST_VALUE = "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*"
+SERVER_RESPONSE_TEST_VALUE = "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*"
+
+
+class TestCustomHeadersEnv(TestCustomHeaders):
+    def setUp(self):
+        os.environ.update(
+            {
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: SANITIZE_FIELDS_TEST_VALUE,
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: SERVER_REQUEST_TEST_VALUE,
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: SERVER_RESPONSE_TEST_VALUE,
+            }
+        )
+        super().setUp()
+
+    def tearDown(self):
+        os.environ.pop(
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS, None
+        )
+        os.environ.pop(
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST, None
+        )
+        os.environ.pop(
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE, None
+        )
+        super().tearDown()
+
+
+class TestCustomHeadersConstructor(TestCustomHeaders):
+    constructor_params = {
+        "http_capture_headers_sanitize_fields": SANITIZE_FIELDS_TEST_VALUE.split(
+            ","
+        ),
+        "http_capture_headers_server_request": SERVER_REQUEST_TEST_VALUE.split(
+            ","
+        ),
+        "http_capture_headers_server_response": SERVER_RESPONSE_TEST_VALUE.split(
+            ","
+        ),
+    }

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -983,18 +983,16 @@ class TestAsgiApplicationRaisingError(AsgiTestBase):
     def tearDown(self):
         pass
 
-    @mock.patch(
-        "opentelemetry.instrumentation.asgi.collect_custom_request_headers_attributes",
-        side_effect=ValueError("whatever"),
-    )
-    def test_asgi_issue_1883(
-        self, mock_collect_custom_request_headers_attributes
-    ):
+    def test_asgi_issue_1883(self):
         """
         Test that exception UnboundLocalError local variable 'start' referenced before assignment is not raised
         See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1883
         """
-        app = otel_asgi.OpenTelemetryMiddleware(simple_asgi)
+
+        async def bad_app(_scope, _receive, _send):
+            raise ValueError("whatever")
+
+        app = otel_asgi.OpenTelemetryMiddleware(bad_app)
         self.seed_app(app)
         self.send_default_request()
         try:

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "confluent-kafka >= 1.8.2, <= 2.2.0",
+  "confluent-kafka >= 1.8.2, <= 2.3.0",
 ]
 test = [
   "opentelemetry-instrumentation-confluent-kafka[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("confluent-kafka >= 1.8.2, <= 2.2.0",)
+_instruments = ("confluent-kafka >= 1.8.2, <= 2.3.0",)

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -43,10 +43,17 @@ from opentelemetry.instrumentation.wsgi import wsgi_getter
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, use_span
 from opentelemetry.util.http import (
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS,
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST,
+    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE,
+    SanitizeValue,
     _parse_active_request_count_attrs,
     _parse_duration_attrs,
+    get_custom_headers,
     get_excluded_urls,
     get_traced_request_attrs,
+    normalise_request_header_name,
+    normalise_response_header_name,
 )
 
 try:
@@ -91,10 +98,7 @@ else:
 try:
     from opentelemetry.instrumentation.asgi import asgi_getter, asgi_setter
     from opentelemetry.instrumentation.asgi import (
-        collect_custom_request_headers_attributes as asgi_collect_custom_request_attributes,
-    )
-    from opentelemetry.instrumentation.asgi import (
-        collect_custom_response_headers_attributes as asgi_collect_custom_response_attributes,
+        collect_custom_headers_attributes as asgi_collect_custom_headers_attributes,
     )
     from opentelemetry.instrumentation.asgi import (
         collect_request_attributes as asgi_collect_request_attributes,
@@ -107,7 +111,6 @@ except ImportError:
     asgi_collect_request_attributes = None
     set_status_code = None
     _is_asgi_supported = False
-
 
 _logger = getLogger(__name__)
 _attributes_by_preference = [
@@ -249,7 +252,18 @@ class _DjangoMiddleware(MiddlewareMixin):
                 )
                 if span.is_recording() and span.kind == SpanKind.SERVER:
                     attributes.update(
-                        asgi_collect_custom_request_attributes(carrier)
+                        asgi_collect_custom_headers_attributes(
+                            carrier,
+                            SanitizeValue(
+                                get_custom_headers(
+                                    OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS
+                                )
+                            ),
+                            get_custom_headers(
+                                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST
+                            ),
+                            normalise_request_header_name,
+                        )
                     )
             else:
                 if span.is_recording() and span.kind == SpanKind.SERVER:
@@ -336,8 +350,17 @@ class _DjangoMiddleware(MiddlewareMixin):
                     for key, value in response.items():
                         asgi_setter.set(custom_headers, key, value)
 
-                    custom_res_attributes = (
-                        asgi_collect_custom_response_attributes(custom_headers)
+                    custom_res_attributes = asgi_collect_custom_headers_attributes(
+                        custom_headers,
+                        SanitizeValue(
+                            get_custom_headers(
+                                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS
+                            )
+                        ),
+                        get_custom_headers(
+                            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE
+                        ),
+                        normalise_response_header_name,
                     )
                     for key, value in custom_res_attributes.items():
                         span.set_attribute(key, value)

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/sqlcommenter_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/sqlcommenter_middleware.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "flask >= 1.0, < 3.0",
-  "werkzeug < 3.0.0"
+  "werkzeug < 3.0.0",
+  "flask >= 1.0",
 ]
 test = [
   "opentelemetry-instrumentation-flask[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -251,6 +251,16 @@ import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.flask.package import _instruments
 from opentelemetry.instrumentation.flask.version import __version__
+
+try:
+    flask_version = flask.__version__
+except AttributeError:
+    try:
+        from importlib import metadata
+    except ImportError:
+        import importlib_metadata as metadata
+    flask_version = metadata.version("flask")
+
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.propagators import (
     get_global_response_propagator,
@@ -271,7 +281,7 @@ _ENVIRON_TOKEN = "opentelemetry-flask.token"
 
 _excluded_urls_from_env = get_excluded_urls("FLASK")
 
-if package_version.parse(flask.__version__) >= package_version.parse("2.2.0"):
+if package_version.parse(flask_version) >= package_version.parse("2.2.0"):
 
     def _request_ctx_ref() -> weakref.ReferenceType:
         return weakref.ref(flask.globals.request_ctx._get_current_object())
@@ -420,7 +430,7 @@ def _wrapped_before_request(
             # https://flask.palletsprojects.com/en/1.1.x/api/#flask.has_request_context
             if flask and flask.request:
                 if commenter_options.get("framework", True):
-                    flask_info["framework"] = f"flask:{flask.__version__}"
+                    flask_info["framework"] = f"flask:{flask_version}"
                 if (
                     commenter_options.get("controller", True)
                     and flask.request.endpoint

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/package.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/package.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-_instruments = ("flask >= 1.0, < 3.0",)
+_instruments = ("flask >= 1.0",)
 
 _supports_metrics = True

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -467,15 +467,18 @@ class TestBaseWithCustomHeaders(TestBase):
         return app
 
 
-@patch.dict(
-    "os.environ",
-    {
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
-    },
-)
 class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
+        },
+    )
+    def setUp(self) -> None:
+        super().setUp()
+
     def test_custom_request_headers_in_span_attributes(self):
         expected = {
             "http.request.header.custom_test_header_1": (
@@ -590,15 +593,18 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
             self.assertNotIn(key, server_span.attributes)
 
 
-@patch.dict(
-    "os.environ",
-    {
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
-        OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
-    },
-)
 class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
+            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
+        },
+    )
+    def setUp(self) -> None:
+        super().setUp()
+
     def test_custom_request_headers_in_span_attributes(self):
         expected = {
             "http.request.header.custom_test_header_1": (

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -14,7 +14,7 @@ Installation
     pip install opentelemetry-instrumentation
 
 
-This package provides a couple of commands that help automatically instruments a program:
+This package provides commands that help automatically instrument a program:
 
 .. note::
     You need to install a distro package to get auto instrumentation working. The ``opentelemetry-distro``
@@ -22,7 +22,7 @@ This package provides a couple of commands that help automatically instruments a
     For more info about ``opentelemetry-distro`` check `here <https://opentelemetry-python.readthedocs.io/en/latest/examples/distro/README.html>`__
     ::
 
-        pip install opentelemetry-distro[otlp]
+        pip install "opentelemetry-distro[otlp]"
 
     When creating a custom distro and/or configurator, be sure to add entry points for each under `opentelemetry_distro` and `opentelemetry_configurator` respectfully.
     If you have entry points for multiple distros or configurators present in your environment, you should specify the entry point name of the distro and configurator you want to be used via the `OTEL_PYTHON_DISTRO` and `OTEL_PYTHON_CONFIGURATOR` environment variables.
@@ -33,13 +33,14 @@ opentelemetry-bootstrap
 
 ::
 
-    opentelemetry-bootstrap --action=install|requirements
+    opentelemetry-bootstrap [-a |--action=][install|requirements]
 
-This commands inspects the active Python site-packages and figures out which
-instrumentation packages the user might want to install. By default it prints out
-a list of the suggested instrumentation packages which can be added to a requirements.txt
-file. It also supports installing the suggested packages when run with :code:`--action=install`
-flag.
+This command install default instrumentation packages and detects active Python site-packages
+to figure out which instrumentation packages the user might want to install. By default, it
+prints out a list of the default and detected instrumentation packages that can be added to a
+requirements.txt file. It also supports installing the packages when run with
+:code:`--action=install` or :code:`-a install` flag. All default and detectable
+instrumentation packages are defined `here <https://github.com/flands/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py>`.
 
 
 opentelemetry-instrument
@@ -51,12 +52,12 @@ opentelemetry-instrument
 
 The instrument command will try to automatically detect packages used by your python program
 and when possible, apply automatic tracing instrumentation on them. This means your program
-will get automatic distributed tracing for free without having to make any code changes
-at all. This will also configure a global tracer and tracing exporter without you having to
-make any code changes. By default, the instrument command will use the OTLP exporter but
-this can be overridden when needed.
+will get automatic distributed tracing without having to make any code changes. This will
+also configure a global tracer and tracing exporter as well as a meter and meter exporter.
+By default, the instrument command will use the OTLP exporter but this can be overridden.
 
-The command supports the following configuration options as CLI arguments and environment vars:
+The command supports the following configuration options as CLI arguments and environment
+variables:
 
 
 * ``--traces_exporter`` or ``OTEL_TRACES_EXPORTER``
@@ -64,27 +65,32 @@ The command supports the following configuration options as CLI arguments and en
 * ``--distro`` or ``OTEL_PYTHON_DISTRO``
 * ``--configurator`` or ``OTEL_PYTHON_CONFIGURATOR``
 
-Used to specify which trace exporter to use. Can be set to one or more of the well-known exporter
-names (see below).
+The exporter options define what exporter destination to use and can be set to one or more
+exporter names (see below). You can pass multiple values to configure multiple exporters
+(e.g., ``zipkin_json,otlp``).
 
     - Defaults to `otlp`.
     - Can be set to `none` to disable automatic tracer initialization.
+    - Can be set to 'console` to display JSON results locally.
 
-You can pass multiple values to configure multiple exporters e.g, ``zipkin,prometheus``
-
-Well known trace exporter names:
+Trace exporter names:
 
     - jaeger_proto
     - jaeger_thrift
     - opencensus
-    - zipkin_json
-    - zipkin_proto
     - otlp
     - otlp_proto_grpc (`deprecated`)
     - otlp_proto_http (`deprecated`)
+    - zipkin_json
+    - zipkin_proto
+
+Metric exporter names:
+
+    - otlp
+    - otlp_proto_grpc (`deprecated`)
+    - prometheus
 
 Note: The default transport protocol for ``otlp`` is gRPC.
-HTTP is currently supported for traces only, and should be set using ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf``
 
 * ``--id-generator`` or ``OTEL_PYTHON_ID_GENERATOR``
 
@@ -106,9 +112,9 @@ Examples
 
 ::
 
-    opentelemetry-instrument --traces_exporter otlp flask run --port=3000
+    opentelemetry-instrument --traces_exporter console flask run --port=3000
 
-The above command will pass ``--traces_exporter otlp`` to the instrument command and ``--port=3000`` to ``flask run``.
+The above command will pass ``--traces_exporter console`` to the instrument command and ``--port=3000`` to ``flask run``.
 
 ::
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -28,9 +28,11 @@ logger = getLogger(__name__)
 
 def initialize():
     # prevents auto-instrumentation of subprocesses if code execs another python process
-    environ["PYTHONPATH"] = _python_path_without_directory(
-        environ.get("PYTHONPATH", ""), dirname(abspath(__file__)), pathsep
-    )
+
+    if environ.get("PYTHONPATH") is not None:
+        environ["PYTHONPATH"] = _python_path_without_directory(
+            environ["PYTHONPATH"], dirname(abspath(__file__)), pathsep
+        )
 
     try:
         distro = _load_distro()

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -29,7 +29,7 @@ logger = getLogger(__name__)
 def initialize():
     # prevents auto-instrumentation of subprocesses if code execs another python process
     environ["PYTHONPATH"] = _python_path_without_directory(
-        environ["PYTHONPATH"], dirname(abspath(__file__)), pathsep
+        environ.get("PYTHONPATH", ""), dirname(abspath(__file__)), pathsep
     )
 
     try:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -65,7 +65,7 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-celery==0.44b0.dev",
     },
     {
-        "library": "confluent-kafka >= 1.8.2, <= 2.2.0",
+        "library": "confluent-kafka >= 1.8.2, <= 2.3.0",
         "instrumentation": "opentelemetry-instrumentation-confluent-kafka==0.44b0.dev",
     },
     {

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -85,11 +85,11 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-fastapi==0.44b0.dev",
     },
     {
-        "library": "flask >= 1.0, < 3.0",
+        "library": "werkzeug < 3.0.0",
         "instrumentation": "opentelemetry-instrumentation-flask==0.44b0.dev",
     },
     {
-        "library": "werkzeug < 3.0.0",
+        "library": "flask >= 1.0",
         "instrumentation": "opentelemetry-instrumentation-flask==0.44b0.dev",
     },
     {

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_run.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_run.py
@@ -43,6 +43,16 @@ class TestRun(TestCase):
         cls.which_patcher.stop()
 
     @patch("sys.argv", ["instrument", ""])
+    def test_unset(self):
+        if environ.get("PYTHONPATH"):
+            del environ["PYTHONPATH"]  # enforce remove key/value from environ
+        auto_instrumentation.run()
+        self.assertEqual(
+            environ.get("PYTHONPATH"),
+            pathsep.join([self.auto_instrumentation_path, getcwd()]),
+        )
+
+    @patch("sys.argv", ["instrument", ""])
     @patch.dict("os.environ", {"PYTHONPATH": ""})
     def test_empty(self):
         auto_instrumentation.run()

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
@@ -24,7 +24,7 @@ class TestSiteCustomize(TestCase):
     def test_unset(self):
         if environ.get("PYTHONPATH"):
             del environ["PYTHONPATH"]  # enforce remove key/value from environ
-        from opentelemetry.instrumentation.auto_instrumentation import (
+        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
             sitecustomize,
         )
 
@@ -32,7 +32,7 @@ class TestSiteCustomize(TestCase):
 
     @patch.dict("os.environ", {"PYTHONPATH": ""})
     def test_empty(self):
-        from opentelemetry.instrumentation.auto_instrumentation import (
+        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
             sitecustomize,
         )
 
@@ -40,7 +40,7 @@ class TestSiteCustomize(TestCase):
 
     @patch.dict("os.environ", {"PYTHONPATH": "abc"})
     def test_set(self):
-        from opentelemetry.instrumentation.auto_instrumentation import (
+        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
             sitecustomize,
         )
 

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
@@ -1,0 +1,38 @@
+from os import environ
+from unittest import TestCase
+from unittest.mock import patch
+
+class TestSiteCustomize(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.load_configurators = patch(
+            "opentelemetry.instrumentation.auto_instrumentation._load._load_configurators"
+        )
+        cls.load_instrumentors = patch(
+            "opentelemetry.instrumentation.auto_instrumentation._load._load_instrumentors"
+        )
+
+        cls.load_configurators.start()
+        cls.load_instrumentors.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.load_configurators.stop()
+        cls.load_instrumentors.stop()
+
+    def test_unset(self):
+        if environ.get("PYTHONPATH"):
+            del environ["PYTHONPATH"]  # enforce remove key/value from environ
+        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        self.assertEqual(environ.get("PYTHONPATH"), None)
+
+    @patch.dict("os.environ", {"PYTHONPATH": ""})
+    def test_empty(self):
+        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        self.assertEqual(environ["PYTHONPATH"], "")
+
+    @patch.dict("os.environ", {"PYTHONPATH": "abc"})
+    def test_set(self):
+        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        self.assertEqual(environ["PYTHONPATH"], "abc")

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
@@ -2,8 +2,8 @@ from os import environ
 from unittest import TestCase
 from unittest.mock import patch
 
-class TestSiteCustomize(TestCase):
 
+class TestSiteCustomize(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.load_configurators = patch(
@@ -24,15 +24,24 @@ class TestSiteCustomize(TestCase):
     def test_unset(self):
         if environ.get("PYTHONPATH"):
             del environ["PYTHONPATH"]  # enforce remove key/value from environ
-        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        from opentelemetry.instrumentation.auto_instrumentation import (
+            sitecustomize,
+        )
+
         self.assertEqual(environ.get("PYTHONPATH"), None)
 
     @patch.dict("os.environ", {"PYTHONPATH": ""})
     def test_empty(self):
-        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        from opentelemetry.instrumentation.auto_instrumentation import (
+            sitecustomize,
+        )
+
         self.assertEqual(environ["PYTHONPATH"], "")
 
     @patch.dict("os.environ", {"PYTHONPATH": "abc"})
     def test_set(self):
-        from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
+        from opentelemetry.instrumentation.auto_instrumentation import (
+            sitecustomize,
+        )
+
         self.assertEqual(environ["PYTHONPATH"], "abc")

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_sitecustomize.py
@@ -24,24 +24,24 @@ class TestSiteCustomize(TestCase):
     def test_unset(self):
         if environ.get("PYTHONPATH"):
             del environ["PYTHONPATH"]  # enforce remove key/value from environ
-        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
-            sitecustomize,
+        from opentelemetry.instrumentation.auto_instrumentation.sitecustomize import (  # noqa
+            initialize,
         )
 
         self.assertEqual(environ.get("PYTHONPATH"), None)
 
     @patch.dict("os.environ", {"PYTHONPATH": ""})
     def test_empty(self):
-        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
-            sitecustomize,
+        from opentelemetry.instrumentation.auto_instrumentation.sitecustomize import (  # noqa
+            initialize,
         )
 
         self.assertEqual(environ["PYTHONPATH"], "")
 
     @patch.dict("os.environ", {"PYTHONPATH": "abc"})
     def test_set(self):
-        from opentelemetry.instrumentation.auto_instrumentation import (  # noqa
-            sitecustomize,
+        from opentelemetry.instrumentation.auto_instrumentation.sitecustomize import (  # noqa
+            initialize,
         )
 
         self.assertEqual(environ["PYTHONPATH"], "abc")

--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/version.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
@@ -68,7 +68,10 @@ class _AzureVMMetadataServiceRequestor:
         request = Request(_AZURE_VM_METADATA_ENDPOINT)
         request.add_header("Metadata", "True")
         try:
-            with urlopen(request, timeout=10) as response:
+            # TODO: Changed to 4s to fit into OTel SDK's 5 second timeout.
+            # Lengthen or allow user input if issue is resolved.
+            # See https://github.com/open-telemetry/opentelemetry-python/issues/3644
+            with urlopen(request, timeout=4) as response:
                 return loads(response.read())
         except URLError:
             # Not on Azure VM

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ envlist =
 
     ; opentelemetry-instrumentation-flask
     py3{7,8,9,10,11}-test-instrumentation-flask{213,220}
+    py3{8,9,10,11}-test-instrumentation-flask{300}
     pypy3-test-instrumentation-flask{213,220}
 
     ; opentelemetry-instrumentation-urllib
@@ -273,7 +274,11 @@ deps =
   falcon2: falcon >=2.0.0,<3.0.0
   falcon3: falcon >=3.0.0,<4.0.0
   flask213: Flask ==2.1.3
-  flask220: Flask >=2.2.0
+  flask213: Werkzeug <3.0.0
+  flask220: Flask ==2.2.0
+  flask220: Werkzeug <3.0.0
+  flask300: Flask >=3.0.0
+  flask300: Werkzeug >=3.0.0
   grpc: pytest-asyncio
   sqlalchemy11: sqlalchemy>=1.1,<1.2
   sqlalchemy14: aiosqlite
@@ -324,7 +329,7 @@ changedir =
   test-instrumentation-elasticsearch{2,5,6}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
   test-instrumentation-falcon{1,2,3}: instrumentation/opentelemetry-instrumentation-falcon/tests
   test-instrumentation-fastapi: instrumentation/opentelemetry-instrumentation-fastapi/tests
-  test-instrumentation-flask{213,220}: instrumentation/opentelemetry-instrumentation-flask/tests
+  test-instrumentation-flask{213,220,300}: instrumentation/opentelemetry-instrumentation-flask/tests
   test-instrumentation-urllib: instrumentation/opentelemetry-instrumentation-urllib/tests
   test-instrumentation-urllib3v{1,2}: instrumentation/opentelemetry-instrumentation-urllib3/tests
   test-instrumentation-grpc: instrumentation/opentelemetry-instrumentation-grpc/tests
@@ -386,8 +391,8 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,httpx{18,21},requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
-  wsgi,falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
+  falcon{1,2,3},flask{213,220,300},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,httpx{18,21},requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  wsgi,falcon{1,2,3},flask{213,220,300},django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   asgi,django{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 
   asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg[test]
@@ -401,7 +406,7 @@ commands_pre =
 
   falcon{1,2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
 
-  flask{213,220}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
+  flask{213,220,300}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
 
   urllib: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib[test]
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,6 @@ envlist =
     py3{7,8,9,10,11}-test-opentelemetry-instrumentation
     pypy3-test-opentelemetry-instrumentation
 
-    py3{7,8,9,10,11}-test-instrumentation-aio-pika
-    pypy3-test-instrumentation-aio-pika
-
     ; opentelemetry-instrumentation-aiohttp-client
     py3{7,8,9,10,11}-test-instrumentation-aiohttp-client
     pypy3-test-instrumentation-aiohttp-client
@@ -54,11 +51,11 @@ envlist =
     ; Only officially supported Python versions are tested for each Django
     ; major release. Updated list can be found at:
     ; https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-    py3{7}-test-instrumentation-django1
-    py3{7,8,9}-test-instrumentation-django2
-    py3{7,8,9,10,11}-test-instrumentation-django3
-    py3{8,9,10,11}-test-instrumentation-django4
-    pypy3-test-instrumentation-django{1,2,3}
+    py3{7}-test-instrumentation-django-1
+    py3{7,8,9}-test-instrumentation-django-2
+    py3{7,8,9,10,11}-test-instrumentation-django-3
+    py3{8,9,10,11}-test-instrumentation-django-4
+    pypy3-test-instrumentation-django-{1,2,3}
 
     ; opentelemetry-instrumentation-dbapi
     py3{7,8,9,10,11}-test-instrumentation-dbapi
@@ -70,41 +67,39 @@ envlist =
     ; pypy3-test-instrumentation-boto
 
     ; opentelemetry-instrumentation-elasticsearch
-    py3{7,8,9,10,11}-test-instrumentation-elasticsearch{2,6}
-    pypy3-test-instrumentation-elasticsearch{2,6}
-
-    ; opentelemetry-instrumentation-elasticsearch5
-    py3{7,8,9}-test-instrumentation-elasticsearch5
-    pypy3-test-instrumentation-elasticsearch5
+    py3{7,8,9,10,11}-test-instrumentation-elasticsearch-{2,6}
+    pypy3-test-instrumentation-elasticsearch-{2,6}
+    py3{7,8,9}-test-instrumentation-elasticsearch-5
+    pypy3-test-instrumentation-elasticsearch-5
 
     ; opentelemetry-instrumentation-falcon
     ; py310 does not work with falcon 1
-    py3{7,8,9}-test-instrumentation-falcon1
-    py3{7,8,9,10,11}-test-instrumentation-falcon{2,3}
-    pypy3-test-instrumentation-falcon{1,2,3}
+    py3{7,8,9}-test-instrumentation-falcon-1
+    py3{7,8,9,10,11}-test-instrumentation-falcon-{2,3}
+    pypy3-test-instrumentation-falcon-{1,2,3}
 
     ; opentelemetry-instrumentation-fastapi
     py3{7,8,9,10,11}-test-instrumentation-fastapi
     pypy3-test-instrumentation-fastapi
 
     ; opentelemetry-instrumentation-flask
-    py3{7,8,9,10,11}-test-instrumentation-flask{213,220}
-    py3{8,9,10,11}-test-instrumentation-flask{300}
-    pypy3-test-instrumentation-flask{213,220}
+    py3{7,8,9,10,11}-test-instrumentation-flask-{213,220}
+    py3{8,9,10,11}-test-instrumentation-flask-{300}
+    pypy3-test-instrumentation-flask-{213,220}
 
     ; opentelemetry-instrumentation-urllib
     py3{7,8,9,10,11}-test-instrumentation-urllib
     pypy3-test-instrumentation-urllib
 
     ; opentelemetry-instrumentation-urllib3
-    py3{7,8,9,10,11}-test-instrumentation-urllib3v{1,2}
-    ;pypy3-test-instrumentation-urllib3v{1,2}
+    py3{7,8,9,10,11}-test-instrumentation-urllib3v-{1,2}
+    ;pypy3-test-instrumentation-urllib3v-{1,2}
 
     ; opentelemetry-instrumentation-requests
     py3{7,8,9,10,11}-test-instrumentation-requests
     ;pypy3-test-instrumentation-requests
 
-    ; opentelemetry-instrumentation-starlette.
+    ; opentelemetry-instrumentation-starlette
     py3{7,8,9,10,11}-test-instrumentation-starlette
     pypy3-test-instrumentation-starlette
 
@@ -135,8 +130,8 @@ envlist =
     ; ext-psycopg2 intentionally excluded from pypy3
 
     ; opentelemetry-instrumentation-pymemcache
-    py3{7,8,9,10,11}-test-instrumentation-pymemcache{135,200,300,342,400}
-    pypy3-test-instrumentation-pymemcache{135,200,300,342,400}
+    py3{7,8,9,10,11}-test-instrumentation-pymemcache-{135,200,300,342,400}
+    pypy3-test-instrumentation-pymemcache-{135,200,300,342,400}
 
     ; opentelemetry-instrumentation-pymongo
     py3{7,8,9,10,11}-test-instrumentation-pymongo
@@ -170,9 +165,9 @@ envlist =
     py3{7,8,9,10,11}-test-instrumentation-grpc
 
     ; opentelemetry-instrumentation-sqlalchemy
-    py3{7}-test-instrumentation-sqlalchemy{11}
-    py3{7,8,9,10,11}-test-instrumentation-sqlalchemy{14}
-    pypy3-test-instrumentation-sqlalchemy{11,14}
+    py3{7}-test-instrumentation-sqlalchemy-{11}
+    py3{7,8,9,10,11}-test-instrumentation-sqlalchemy-{14}
+    pypy3-test-instrumentation-sqlalchemy-{11,14}
 
     ; opentelemetry-instrumentation-redis
     py3{7,8,9,10,11}-test-instrumentation-redis
@@ -206,8 +201,8 @@ envlist =
     pypy3-test-instrumentation-tortoiseorm
 
     ; opentelemetry-instrumentation-httpx
-    py3{7,8,9,10,11}-test-instrumentation-httpx{18,21}
-    pypy3-test-instrumentation-httpx{18,21}
+    py3{7,8,9,10,11}-test-instrumentation-httpx-{18,21}
+    pypy3-test-instrumentation-httpx-{18,21}
 
     ; opentelemetry-util-http
     py3{7,8,9,10,11}-test-util-http
@@ -221,13 +216,13 @@ envlist =
     py3{7,8,9,10,11}-test-propagator-ot-trace
     pypy3-test-propagator-ot-trace
 
-    ; opentelemetry-instrumentation-pika
-    py3{7,8,9,10,11}-test-instrumentation-pika{0,1}
-    pypy3-test-instrumentation-pika{0,1}
+    ; opentelemetry-instrumentation-sio-pika
+    py3{7,8,9,10,11}-test-instrumentation-sio-pika-{0,1}
+    pypy3-test-instrumentation-sio-pika-{0,1}
 
     ; opentelemetry-instrumentation-aio-pika
-    py3{7,8,9,10,11}-test-instrumentation-aio-pika{7,8,9}
-    pypy3-test-instrumentation-aio-pika{7,8,9}
+    py3{7,8,9,10,11}-test-instrumentation-aio-pika-{7,8,9}
+    pypy3-test-instrumentation-aio-pika-{7,8,9}
 
     ; opentelemetry-instrumentation-kafka-python
     py3{7,8,9,10,11}-test-instrumentation-kafka-python
@@ -255,50 +250,50 @@ deps =
   test: pytest-benchmark
   coverage: pytest
   coverage: pytest-cov
-  django1: django~=1.0
-  django2: django~=2.0
-  django3: django~=3.0
-  django4: django>=4.0b1,<5.0
-  elasticsearch2: elasticsearch-dsl>=2.0,<3.0
-  elasticsearch2: elasticsearch>=2.0,<3.0
-  elasticsearch5: elasticsearch-dsl>=5.0,<6.0
-  elasticsearch5: elasticsearch>=5.0,<6.0
-  elasticsearch6: elasticsearch-dsl>=6.0,<7.0
-  elasticsearch6: elasticsearch>=6.0,<7.0
+  django-1: django~=1.0
+  django-2: django~=2.0
+  django-3: django~=3.0
+  django-4: django>=4.0b1,<5.0
+  elasticsearch-2: elasticsearch-dsl>=2.0,<3.0
+  elasticsearch-2: elasticsearch>=2.0,<3.0
+  elasticsearch-5: elasticsearch-dsl>=5.0,<6.0
+  elasticsearch-5: elasticsearch>=5.0,<6.0
+  elasticsearch-6: elasticsearch-dsl>=6.0,<7.0
+  elasticsearch-6: elasticsearch>=6.0,<7.0
   ; FIXME: Elasticsearch >=7 causes CI workflow tests to hang, see open-telemetry/opentelemetry-python-contrib#620
-  ; elasticsearch7: elasticsearch-dsl>=7.0,<8.0
-  ; elasticsearch7: elasticsearch>=7.0,<8.0
-  ; elasticsearch8: elasticsearch-dsl>=8.0,<9.0
-  ; elasticsearch8: elasticsearch>=8.0,<9.0
-  falcon1: falcon ==1.4.1
-  falcon2: falcon >=2.0.0,<3.0.0
-  falcon3: falcon >=3.0.0,<4.0.0
-  flask213: Flask ==2.1.3
-  flask213: Werkzeug <3.0.0
-  flask220: Flask ==2.2.0
-  flask220: Werkzeug <3.0.0
-  flask300: Flask >=3.0.0
-  flask300: Werkzeug >=3.0.0
+  ; elasticsearch-7: elasticsearch-dsl>=7.0,<8.0
+  ; elasticsearch-7: elasticsearch>=7.0,<8.0
+  ; elasticsearch-8: elasticsearch-dsl>=8.0,<9.0
+  ; elasticsearch-8: elasticsearch>=8.0,<9.0
+  falcon-1: falcon ==1.4.1
+  falcon-2: falcon >=2.0.0,<3.0.0
+  falcon-3: falcon >=3.0.0,<4.0.0
+  flask-213: Flask ==2.1.3
+  flask-213: Werkzeug <3.0.0
+  flask-220: Flask ==2.2.0
+  flask-220: Werkzeug <3.0.0
+  flask-300: Flask >=3.0.0
+  flask-300: Werkzeug >=3.0.0
   grpc: pytest-asyncio
-  sqlalchemy11: sqlalchemy>=1.1,<1.2
-  sqlalchemy14: aiosqlite
-  sqlalchemy14: sqlalchemy~=1.4
-  pika0: pika>=0.12.0,<1.0.0
-  pika1: pika>=1.0.0
-  aio-pika7: aio_pika~=7.2.0
-  aio-pika8: aio_pika>=8.0.0,<9.0.0
-  aio-pika9: aio_pika>=9.0.0,<10.0.0
-  pymemcache135: pymemcache ==1.3.5
-  pymemcache200: pymemcache >2.0.0,<3.0.0
-  pymemcache300: pymemcache >3.0.0,<3.4.2
-  pymemcache342: pymemcache ==3.4.2
-  pymemcache400: pymemcache ==4.0.0
-  httpx18: httpx>=0.18.0,<0.19.0
-  httpx18: respx~=0.17.0
-  httpx21: httpx>=0.19.0
-  httpx21: respx~=0.20.1
-  urllib3v1: urllib3 >=1.0.0,<2.0.0
-  urllib3v2: urllib3 >=2.0.0,<3.0.0
+  sqlalchemy-11: sqlalchemy>=1.1,<1.2
+  sqlalchemy-14: aiosqlite
+  sqlalchemy-14: sqlalchemy~=1.4
+  sio-pika-0: pika>=0.12.0,<1.0.0
+  sio-pika-1: pika>=1.0.0
+  aio-pika-7: aio_pika~=7.2.0
+  aio-pika-8: aio_pika>=8.0.0,<9.0.0
+  aio-pika-9: aio_pika>=9.0.0,<10.0.0
+  pymemcache-135: pymemcache ==1.3.5
+  pymemcache-200: pymemcache >2.0.0,<3.0.0
+  pymemcache-300: pymemcache >3.0.0,<3.4.2
+  pymemcache-342: pymemcache ==3.4.2
+  pymemcache-400: pymemcache ==4.0.0
+  httpx-18: httpx>=0.18.0,<0.19.0
+  httpx-18: respx~=0.17.0
+  httpx-21: httpx>=0.19.0
+  httpx-21: respx~=0.20.1
+  urllib3v-1: urllib3 >=1.0.0,<2.0.0
+  urllib3v-2: urllib3 >=2.0.0,<3.0.0
 
   ; FIXME: add coverage testing
   ; FIXME: add mypy testing
@@ -312,7 +307,6 @@ setenv =
 changedir =
   test-distro: opentelemetry-distro/tests
   test-opentelemetry-instrumentation: opentelemetry-instrumentation/tests
-  test-instrumentation-aio-pika: instrumentation/opentelemetry-instrumentation-aio-pika/tests
   test-instrumentation-aiohttp-client: instrumentation/opentelemetry-instrumentation-aiohttp-client/tests
   test-instrumentation-aiohttp-server: instrumentation/opentelemetry-instrumentation-aiohttp-server/tests
   test-instrumentation-aiopg: instrumentation/opentelemetry-instrumentation-aiopg/tests
@@ -325,13 +319,13 @@ changedir =
   test-instrumentation-cassandra: instrumentation/opentelemetry-instrumentation-cassandra/tests
   test-instrumentation-celery: instrumentation/opentelemetry-instrumentation-celery/tests
   test-instrumentation-dbapi: instrumentation/opentelemetry-instrumentation-dbapi/tests
-  test-instrumentation-django{1,2,3,4}: instrumentation/opentelemetry-instrumentation-django/tests
-  test-instrumentation-elasticsearch{2,5,6}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
-  test-instrumentation-falcon{1,2,3}: instrumentation/opentelemetry-instrumentation-falcon/tests
+  test-instrumentation-django-{1,2,3,4}: instrumentation/opentelemetry-instrumentation-django/tests
+  test-instrumentation-elasticsearch-{2,5,6}: instrumentation/opentelemetry-instrumentation-elasticsearch/tests
+  test-instrumentation-falcon-{1,2,3}: instrumentation/opentelemetry-instrumentation-falcon/tests
   test-instrumentation-fastapi: instrumentation/opentelemetry-instrumentation-fastapi/tests
-  test-instrumentation-flask{213,220,300}: instrumentation/opentelemetry-instrumentation-flask/tests
+  test-instrumentation-flask-{213,220,300}: instrumentation/opentelemetry-instrumentation-flask/tests
   test-instrumentation-urllib: instrumentation/opentelemetry-instrumentation-urllib/tests
-  test-instrumentation-urllib3v{1,2}: instrumentation/opentelemetry-instrumentation-urllib3/tests
+  test-instrumentation-urllib3v-{1,2}: instrumentation/opentelemetry-instrumentation-urllib3/tests
   test-instrumentation-grpc: instrumentation/opentelemetry-instrumentation-grpc/tests
   test-instrumentation-jinja2: instrumentation/opentelemetry-instrumentation-jinja2/tests
   test-instrumentation-kafka-python: instrumentation/opentelemetry-instrumentation-kafka-python/tests
@@ -339,10 +333,10 @@ changedir =
   test-instrumentation-logging: instrumentation/opentelemetry-instrumentation-logging/tests
   test-instrumentation-mysql: instrumentation/opentelemetry-instrumentation-mysql/tests
   test-instrumentation-mysqlclient: instrumentation/opentelemetry-instrumentation-mysqlclient/tests
-  test-instrumentation-pika{0,1}: instrumentation/opentelemetry-instrumentation-pika/tests
-  test-instrumentation-aio-pika{7,8,9}: instrumentation/opentelemetry-instrumentation-aio-pika/tests
+  test-instrumentation-sio-pika-{0,1}: instrumentation/opentelemetry-instrumentation-pika/tests
+  test-instrumentation-aio-pika-{7,8,9}: instrumentation/opentelemetry-instrumentation-aio-pika/tests
   test-instrumentation-psycopg2: instrumentation/opentelemetry-instrumentation-psycopg2/tests
-  test-instrumentation-pymemcache{135,200,300,342,400}: instrumentation/opentelemetry-instrumentation-pymemcache/tests
+  test-instrumentation-pymemcache-{135,200,300,342,400}: instrumentation/opentelemetry-instrumentation-pymemcache/tests
   test-instrumentation-pymongo: instrumentation/opentelemetry-instrumentation-pymongo/tests
   test-instrumentation-pymysql: instrumentation/opentelemetry-instrumentation-pymysql/tests
   test-instrumentation-pyramid: instrumentation/opentelemetry-instrumentation-pyramid/tests
@@ -350,14 +344,14 @@ changedir =
   test-instrumentation-remoulade: instrumentation/opentelemetry-instrumentation-remoulade/tests
   test-instrumentation-requests: instrumentation/opentelemetry-instrumentation-requests/tests
   test-instrumentation-sklearn: instrumentation/opentelemetry-instrumentation-sklearn/tests
-  test-instrumentation-sqlalchemy{11,14}: instrumentation/opentelemetry-instrumentation-sqlalchemy/tests
+  test-instrumentation-sqlalchemy-{11,14}: instrumentation/opentelemetry-instrumentation-sqlalchemy/tests
   test-instrumentation-sqlite3: instrumentation/opentelemetry-instrumentation-sqlite3/tests
   test-instrumentation-starlette: instrumentation/opentelemetry-instrumentation-starlette/tests
   test-instrumentation-system-metrics: instrumentation/opentelemetry-instrumentation-system-metrics/tests
   test-instrumentation-tornado: instrumentation/opentelemetry-instrumentation-tornado/tests
   test-instrumentation-tortoiseorm: instrumentation/opentelemetry-instrumentation-tortoiseorm/tests
   test-instrumentation-wsgi: instrumentation/opentelemetry-instrumentation-wsgi/tests
-  test-instrumentation-httpx{18,21}: instrumentation/opentelemetry-instrumentation-httpx/tests
+  test-instrumentation-httpx-{18,21}: instrumentation/opentelemetry-instrumentation-httpx/tests
   test-util-http: util/opentelemetry-util-http/tests
   test-sdkextension-aws: sdk-extension/opentelemetry-sdk-extension-aws/tests
   test-resource-detector-container: resource/opentelemetry-resource-detector-container/tests
@@ -381,9 +375,9 @@ commands_pre =
 
   celery: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-celery[test]
 
-  pika{0,1}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pika[test]
+  sio-pika-{0,1}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pika[test]
 
-  aio-pika{7,8,9}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika[test]
+  aio-pika-{7,8,9}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika[test]
 
   kafka-python: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python[test]
 
@@ -391,9 +385,9 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon{1,2,3},flask{213,220,300},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,httpx{18,21},requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
-  wsgi,falcon{1,2,3},flask{213,220,300},django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
-  asgi,django{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
+  falcon-{1,2,3},flask-{213,220,300},django-{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,httpx-{18,21},requests,urllib,urllib3v-{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http
+  wsgi,falcon-{1,2,3},flask-{213,220,300},django-{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
+  asgi,django-{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 
   asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg[test]
 
@@ -404,13 +398,13 @@ commands_pre =
 
   boto3sqs: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-boto3sqs[test]
 
-  falcon{1,2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
+  falcon-{1,2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
 
-  flask{213,220,300}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
+  flask-{213,220,300}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
 
   urllib: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib[test]
 
-  urllib3v{1,2}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib3[test]
+  urllib3v-{1,2}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib3[test]
 
   botocore: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-botocore[test]
 
@@ -418,7 +412,7 @@ commands_pre =
 
   dbapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi[test]
 
-  django{1,2,3,4}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-django[test]
+  django-{1,2,3,4}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-django[test]
 
   fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-fastapi[test]
 
@@ -426,7 +420,7 @@ commands_pre =
 
   mysqlclient: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient[test]
 
-  pymemcache{135,200,300,342,400}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
+  pymemcache-{135,200,300,342,400}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymemcache[test]
 
   pymongo: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-pymongo[test]
 
@@ -456,7 +450,7 @@ commands_pre =
 
   logging: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-logging[test]
 
-  aio-pika: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika[test]
+  aio-pika-{7,8,9}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika[test]
 
   aiohttp-client: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[test]
 
@@ -470,17 +464,17 @@ commands_pre =
 
   sklearn: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sklearn[test]
 
-  sqlalchemy{11,14}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy[test]
+  sqlalchemy-{11,14}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy[test]
 
-  elasticsearch{2,5,6}: pip install {toxinidir}/opentelemetry-instrumentation[test] {toxinidir}/instrumentation/opentelemetry-instrumentation-elasticsearch[test]
+  elasticsearch-{2,5,6}: pip install {toxinidir}/opentelemetry-instrumentation[test] {toxinidir}/instrumentation/opentelemetry-instrumentation-elasticsearch[test]
 
-  httpx{18,21}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-httpx[test]
+  httpx-{18,21}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-httpx[test]
 
   sdkextension-aws: pip install {toxinidir}/sdk-extension/opentelemetry-sdk-extension-aws[test]
 
   resource-detector-container: pip install {toxinidir}/resource/opentelemetry-resource-detector-container[test]
 
-  http: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  http: pip install {toxinidir}/util/opentelemetry-util-http
 ; In order to get a health coverage report,
   propagator-ot-trace: pip install {toxinidir}/propagator/opentelemetry-propagator-ot-trace[test]
 
@@ -531,7 +525,7 @@ commands_pre =
   python -m pip install "{env:CORE_REPO}#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions"
   python -m pip install "{env:CORE_REPO}#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk"
   python -m pip install "{env:CORE_REPO}#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils"
-  python -m pip install -e {toxinidir}/util/opentelemetry-util-http[test]
+  python -m pip install -e {toxinidir}/util/opentelemetry-util-http
   python -m pip install -e {toxinidir}/opentelemetry-instrumentation[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-dbapi[test]

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from os import environ
 from re import IGNORECASE as RE_IGNORECASE
 from re import compile as re_compile
 from re import search
-from typing import Iterable, List, Optional
+from typing import Callable, Iterable, Optional
 from urllib.parse import urlparse, urlunparse
 
 from opentelemetry.semconv.trace import SpanAttributes
@@ -84,9 +86,12 @@ class SanitizeValue:
         )
 
     def sanitize_header_values(
-        self, headers: dict, header_regexes: list, normalize_function: callable
-    ) -> dict:
-        values = {}
+        self,
+        headers: dict[str, str],
+        header_regexes: list[str],
+        normalize_function: Callable[[str], str],
+    ) -> dict[str, str]:
+        values: dict[str, str] = {}
 
         if header_regexes:
             header_regexes_compiled = re_compile(
@@ -216,14 +221,14 @@ def sanitize_method(method: Optional[str]) -> Optional[str]:
     return "UNKNOWN"
 
 
-def get_custom_headers(env_var: str) -> List[str]:
-    custom_headers = environ.get(env_var, [])
+def get_custom_headers(env_var: str) -> list[str]:
+    custom_headers = environ.get(env_var, None)
     if custom_headers:
-        custom_headers = [
+        return [
             custom_headers.strip()
             for custom_headers in custom_headers.split(",")
         ]
-    return custom_headers
+    return []
 
 
 def _parse_active_request_count_attrs(req_attrs):


### PR DESCRIPTION
# Description

When we implemented the gunicorn.py configuration with a post fork, we wanted to use OTEL auto-instrumentation easily.
But a bug appeared when using `sitecustomize`.

Here is an example of a gunicorn post fork to load auto-instrumentation.
```py
def post_fork(server, worker):
    from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
```

if we run gunicorn like this
```sh
gunicorn my-app.wsgi -c gunicorn.py
```

An error appear :
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/gunicorn/arbiter.py", line 608, in spawn_worker
    self.cfg.post_fork(self, worker)
  File "gunicorn.py", line 15, in post_fork
    from opentelemetry.instrumentation.auto_instrumentation import sitecustomize
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 44, in <module>
    initialize()
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 32, in initialize
    environ["PYTHONPATH"], dirname(abspath(__file__)), pathsep
  File "/usr/local/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'PYTHONPATH'
```

**PYTHONPATH should not be required to use this auto-instrument feature.**