### PR TITLE
Using importlib_metadata for entry points instead of pkg_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix version of Flask dependency `werkzeug`
   ([#1980](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1980))
+- `opentelemetry-instrumentation`, `opentelemetry-instrumentation-aiohttp-client` Use importlib-metadata for entry points instead of pkg_resources
+  ([#1973](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1973))
 
 ## Version 1.20.0/0.41b0 (2023-09-01)
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -22,9 +22,9 @@ from unittest import mock
 
 import aiohttp
 import aiohttp.test_utils
+import importlib_metadata
 import yarl
 from http_server_mock import HttpServerMock
-from pkg_resources import iter_entry_points
 
 from opentelemetry import context
 from opentelemetry import trace as trace_api
@@ -574,8 +574,8 @@ class TestAioHttpClientInstrumentor(TestBase):
 
 class TestLoadingAioHttpInstrumentor(unittest.TestCase):
     def test_loading_instrumentor(self):
-        entry_points = iter_entry_points(
-            "opentelemetry_instrumentor", "aiohttp-client"
+        entry_points = importlib_metadata.entry_points(
+            group="opentelemetry_instrumentor", name="aiohttp-client"
         )
 
         instrumentor = next(entry_points).load()()

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -21,7 +21,7 @@ from os.path import abspath, dirname, pathsep
 from re import sub
 from shutil import which
 
-from pkg_resources import iter_entry_points
+from importlib_metadata import entry_points
 
 from opentelemetry.instrumentation.version import __version__
 
@@ -50,8 +50,8 @@ def run() -> None:
 
     argument_otel_environment_variable = {}
 
-    for entry_point in iter_entry_points(
-        "opentelemetry_environment_variables"
+    for entry_point in entry_points(
+        group="opentelemetry_environment_variables"
     ):
         environment_variable_module = entry_point.load()
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -15,7 +15,7 @@
 from logging import getLogger
 from os import environ
 
-from pkg_resources import iter_entry_points
+from importlib_metadata import entry_points
 
 from opentelemetry.instrumentation.dependencies import (
     get_dist_dependency_conflicts,
@@ -33,7 +33,7 @@ _logger = getLogger(__name__)
 
 def _load_distro() -> BaseDistro:
     distro_name = environ.get(OTEL_PYTHON_DISTRO, None)
-    for entry_point in iter_entry_points("opentelemetry_distro"):
+    for entry_point in entry_points(group="opentelemetry_distro"):
         try:
             # If no distro is specified, use first to come up.
             if distro_name is None or distro_name == entry_point.name:
@@ -63,10 +63,10 @@ def _load_instrumentors(distro):
         # to handle users entering "requests , flask" or "requests, flask" with spaces
         package_to_exclude = [x.strip() for x in package_to_exclude]
 
-    for entry_point in iter_entry_points("opentelemetry_pre_instrument"):
+    for entry_point in entry_points(group="opentelemetry_pre_instrument"):
         entry_point.load()()
 
-    for entry_point in iter_entry_points("opentelemetry_instrumentor"):
+    for entry_point in entry_points(group="opentelemetry_instrumentor"):
         if entry_point.name in package_to_exclude:
             _logger.debug(
                 "Instrumentation skipped for library %s", entry_point.name
@@ -90,14 +90,14 @@ def _load_instrumentors(distro):
             _logger.exception("Instrumenting of %s failed", entry_point.name)
             raise exc
 
-    for entry_point in iter_entry_points("opentelemetry_post_instrument"):
+    for entry_point in entry_points(group="opentelemetry_post_instrument"):
         entry_point.load()()
 
 
 def _load_configurators():
     configurator_name = environ.get(OTEL_PYTHON_CONFIGURATOR, None)
     configured = None
-    for entry_point in iter_entry_points("opentelemetry_configurator"):
+    for entry_point in entry_points(group="opentelemetry_configurator"):
         if configured is not None:
             _logger.warning(
                 "Configuration of %s not loaded, %s already loaded",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
@@ -20,7 +20,7 @@ OpenTelemetry Base Distribution (Distro)
 from abc import ABC, abstractmethod
 from logging import getLogger
 
-from pkg_resources import EntryPoint
+from importlib_metadata import EntryPoint
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -30,7 +30,7 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_configurators(self, iter_mock):
         # Add multiple entry points but only specify the 2nd in the environment variable.
@@ -59,7 +59,7 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_configurators_no_ep(
         self,
@@ -73,7 +73,7 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_configurators_error(self, iter_mock):
         # Add multiple entry points but only specify the 2nd in the environment variable.
@@ -100,7 +100,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.isinstance"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_distro(self, iter_mock, isinstance_mock):
         # Add multiple entry points but only specify the 2nd in the environment variable.
@@ -133,7 +133,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.DefaultDistro"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_distro_not_distro(
         self, iter_mock, default_distro_mock, isinstance_mock
@@ -165,7 +165,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.DefaultDistro"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_distro_no_ep(self, iter_mock, default_distro_mock):
         iter_mock.return_value = ()
@@ -180,7 +180,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.isinstance"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_distro_error(self, iter_mock, isinstance_mock):
         ep_mock1 = Mock()
@@ -210,7 +210,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_instrumentors(self, iter_mock, dep_mock):
         # Mock opentelemetry_pre_instrument entry points
@@ -283,7 +283,7 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_instrumentors_dep_conflict(self, iter_mock, dep_mock):
         ep_mock1 = Mock()

--- a/opentelemetry-instrumentation/tests/test_distro.py
+++ b/opentelemetry-instrumentation/tests/test_distro.py
@@ -15,7 +15,7 @@
 
 from unittest import TestCase
 
-from pkg_resources import EntryPoint
+from importlib_metadata import EntryPoint
 
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor


### PR DESCRIPTION
# Description

pkg_resources is deprecated. Following example of https://github.com/open-telemetry/opentelemetry-python/pull/3217/files

Helps to fix #1970

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
