### PR TITLE
Specify the topic arn as the span attribute messaging.destination.name in the botocore sns instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1800](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1800))
 
 ### Added
+- `opentelemetry-instrumentation-botocore` Include SNS topic ARN as a span attribute with name `messaging.destination.name` to uniquely identify the SNS topic
+  ([#1995](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1995))
 - `opentelemetry-instrumentation-system-metrics` Add support for collecting process metrics
   ([#1948](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1948))
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sns.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sns.py
@@ -81,6 +81,8 @@ class _OpPublish(_SnsOperation):
         ] = MessagingDestinationKindValues.TOPIC.value
         attributes[SpanAttributes.MESSAGING_DESTINATION] = destination_name
 
+        # TODO: Use SpanAttributes.MESSAGING_DESTINATION_NAME when opentelemetry-semantic-conventions 0.42b0 is released
+        attributes["messaging.destination.name"] = cls._extract_input_arn(call_context)
         call_context.span_name = (
             f"{'phone_number' if is_phone_number else destination_name} send"
         )

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sns.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sns.py
@@ -118,6 +118,12 @@ class TestSnsExtension(TestBase):
             self.topic_name,
             span.attributes[SpanAttributes.MESSAGING_DESTINATION],
         )
+        self.assertEqual(
+            target_arn,
+            # TODO: Use SpanAttributes.MESSAGING_DESTINATION_NAME when
+            #  opentelemetry-semantic-conventions 0.42b0 is released
+            span.attributes["messaging.destination.name"]
+        )
 
     @mock_sns
     def test_publish_to_phone_number(self):
@@ -183,6 +189,12 @@ class TestSnsExtension(TestBase):
         self.assertEqual(
             self.topic_name,
             span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+        )
+        self.assertEqual(
+            topic_arn,
+            # TODO: Use SpanAttributes.MESSAGING_DESTINATION_NAME when
+            #  opentelemetry-semantic-conventions 0.42b0 is released
+            span.attributes["messaging.destination.name"]
         )
 
         self.assert_injected_span(message1_attrs, span)


### PR DESCRIPTION
# Description

This PR addresses the scenario where the existing `messaging.destination` attribute may not uniquely identify the messaging destination when the same SNS topic name is present for multiple accounts. This PR includes the SNS topic arn as the span attribute `messaging.destination.name` to uniquely identify the messaging destination. Note that when `opentelemetry-semantic-conventions` version `0.42b0` is released, the constant `SpanAttributes.MESSAGING_DESTINATION_NAME` can be used instead of `messaging.destination.name`.

Fixes # [1989](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1989)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested that `messaging.destination.name` is present as a span attribute for SNS when a message is published to an SNS topic arn.
- [x] test-instrumentation-botocore

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project

@pavankrish123 @svrnm @noltak3 @alingamn