### PR TITLE
Instrument boto3 Session client

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -33,6 +33,7 @@ from typing import Any, Collection, Dict, Generator, List, Mapping, Optional
 
 import boto3
 import botocore.client
+import boto3.session
 from wrapt import wrap_function_wrapper
 
 from opentelemetry import context, propagate, trace
@@ -383,6 +384,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
             return retval
 
         wrap_function_wrapper(boto3, "client", client_wrapper)
+        wrap_function_wrapper(boto3.session.Session, "client", client_wrapper)
 
     def _decorate_sqs(self, sqs_class: type) -> None:
         """

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -46,6 +46,15 @@ def _make_sqs_client():
     )
 
 
+def _make_sqs_session_client():
+    return boto3.session.Session().client(
+        "sqs",
+        region_name="us-east-1",
+        aws_access_key_id="dummy",
+        aws_secret_access_key="dummy",
+    )
+
+
 class TestBoto3SQSInstrumentor(TestCase):
     def _assert_instrumented(self, client):
         self.assertIsInstance(boto3.client, FunctionWrapper)
@@ -81,6 +90,20 @@ class TestBoto3SQSInstrumentor(TestCase):
             self._assert_instrumented(_make_sqs_client())
             self._assert_instrumented(_make_sqs_client())
 
+    def test_instrument_api_before_session_client_init(self) -> None:
+        with self._active_instrumentor():
+            client = _make_sqs_session_client()
+            self._assert_instrumented(client)
+
+    def test_instrument_api_after_session_client_init(self) -> None:
+        client = _make_sqs_session_client()
+        with self._active_instrumentor():
+            self._assert_instrumented(client)
+
+    def test_instrument_multiple_clients(self):
+        with self._active_instrumentor():
+            self._assert_instrumented(_make_sqs_session_client())
+            self._assert_instrumented(_make_sqs_session_client())
 
 class TestBoto3SQSGetter(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
# Description

This aims to address #1996 by instrumenting `boto3.session.Session`. I'm not very familiar with how instrumentation works in detail, so I'm not sure if this is the right approach, but it does seem to work.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- tox for this module
- using the reproduction script in the issue and copying in the changed module file
    ```
    COPY __init__.py /usr/local/lib/python3.8/site-packages/opentelemetry/instrumentation/boto3sqs/__init__.py
    ```

# Does This PR Require a Core Repo Change?

- No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
