### PR TITLE
issue 1918: Ensure string values for span status and attribute values

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -139,7 +139,7 @@ class CommandTracer(monitoring.CommandListener):
                 )
                 span.set_attribute(SpanAttributes.DB_NAME, event.database_name)
                 span.set_attribute(SpanAttributes.DB_STATEMENT, statement)
-                if collection:
+                if collection and isinstance(collection, str):
                     span.set_attribute(
                         SpanAttributes.DB_MONGODB_COLLECTION, collection
                     )
@@ -193,7 +193,7 @@ class CommandTracer(monitoring.CommandListener):
         if span is None:
             return
         if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR, event.failure))
+            span.set_status(Status(StatusCode.ERROR, str(event.failure)))
             try:
                 self.failed_hook(span, event)
             except (


### PR DESCRIPTION
# Description

This aims to fix two cases where data types were deemed invalid, resulting in telemetry not being transmitted to our collector.  Specifically:
* don't set the `SpanAttributes.DB_MONGODB_COLLECTION` attribute unless the collection is already a string value.
* `str()`-ify the event failure details

Fixes #1918

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

So far, only adhoc testing has been done.  Without these changes, we fail to receive telemetry data and see these logged warnings:

```
opentelemetry.trace.status.py, line 54 "Invalid status description type, expected str"
opentelemetry.attributes._init_.py, line 70 "Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or None"
```

With the changes, the warnings are gone and telemetry data flows as expected.  We are using pymongo 4.5.0.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
