### PR TITLE
Ensure httpx.get etc. get instrumented

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -527,11 +527,11 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedClient._tracer_provider = tracer_provider
         _InstrumentedAsyncClient._tracer_provider = tracer_provider
-        httpx.Client = _InstrumentedClient
+        httpx.Client = httpx._api.Client = _InstrumentedClient
         httpx.AsyncClient = _InstrumentedAsyncClient
 
     def _uninstrument(self, **kwargs):
-        httpx.Client = self._original_client
+        httpx.Client = httpx._api.Client = self._original_client
         httpx.AsyncClient = self._original_async_client
         _InstrumentedClient._tracer_provider = None
         _InstrumentedClient._request_hook = None


### PR DESCRIPTION
# Description

This closes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1742 — "httpx instrumentation doesn't work for httpx.get, httpx.post, etc.".

The `httpx.get`, `httpx.post`, etc. methods ultimately use `httpx._api.request`, which makes instantiates `httpx._api.Client`. But `httpx.Client` is modified during instrumentation without updating the value imported in the `httpx._api` module.

Fixing this was as easy as also patching the `Client` value in `httpx._api`.

Fixes #1742

## Type of change

I am not sure if it counts as a feature or bug fix. I'm sure it could be argued both ways, but I decided to call it a bug fix.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I made this change and confirmed that it caused spans from the HTTPX instrumentation to be nested properly in my observability backend. I can add tests with a bit of guidance about where to look/modify/what would be desired. But I'd like to get confirmation that this is likely to be accepted before putting in the effort.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [X] Documentation has been updated

I don't think a documentation change is necessary; I'll update changelogs after adding unit tests once confirmed this is desirable.