### PR TITLE
Remove URL credentials (httpx integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-httpx` Remove URL credentials
+  ([#2020](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2020))
 - `opentelemetry-instrumentation-urllib`/`opentelemetry-instrumentation-urllib3` Fix metric descriptions to match semantic conventions
   ([#1959](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1959))
   

--- a/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.12",
   "opentelemetry-instrumentation == 0.44b0.dev",
   "opentelemetry-semantic-conventions == 0.44b0.dev",
+  "opentelemetry-util-http == 0.44b0.dev",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -206,6 +206,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import SpanKind, TracerProvider, get_tracer
 from opentelemetry.trace.span import Span
 from opentelemetry.trace.status import Status
+from opentelemetry.util.http import remove_url_credentials
 
 _logger = logging.getLogger(__name__)
 
@@ -269,7 +270,7 @@ def _extract_parameters(args, kwargs):
         # In httpx >= 0.20.0, handle_request receives a Request object
         request: httpx.Request = args[0]
         method = request.method.encode()
-        url = request.url
+        url = remove_url_credentials(str(request.url))
         headers = request.headers
         stream = request.stream
         extensions = request.extensions

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -604,6 +604,13 @@ class TestSyncIntegration(BaseTestCases.BaseManualTest):
             return self.client.request(method, url, headers=headers)
         return client.request(method, url, headers=headers)
 
+    def test_credential_removal(self):
+        new_url = "http://username:password@mock/status/200"
+        self.perform_request(new_url)
+        span = self.assert_span()
+
+        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
+
 
 class TestAsyncIntegration(BaseTestCases.BaseManualTest):
     response_hook = staticmethod(_async_response_hook)
@@ -663,6 +670,13 @@ class TestAsyncIntegration(BaseTestCases.BaseManualTest):
             self.URL, client=self.create_client(self.transport)
         )
         self.assert_span(num_spans=2)
+
+    def test_credential_removal(self):
+        new_url = "http://username:password@mock/status/200"
+        self.perform_request(new_url)
+        span = self.assert_span()
+
+        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
 
 
 class TestSyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):

--- a/tox.ini
+++ b/tox.ini
@@ -386,7 +386,7 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
+  falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,asgi,httpx{18,21},requests,urllib,urllib3v{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http[test]
   wsgi,falcon{1,2,3},flask{213,220},django{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   asgi,django{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi[test]
 


### PR DESCRIPTION
# Description

This PR fixes issue #367 for `httpx` instrumentation. This would ensure that URLs passed in the form of `https://username:password@example.com/` would result in a http span attribute value of `https://example.com/`.

Based on https://github.com/open-telemetry/opentelemetry-python-contrib/pull/538

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Additional tests are provided:

- [x] `test_httpx_integration.py::TestSyncIntegration::test_credential_removal`
- [x] `test_httpx_integration.py::TestAsyncIntegration::test_credential_removal`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
