### PR TITLE
Add sqlcommenter fields

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/sqlcommenter_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/sqlcommenter_middleware.py
@@ -78,9 +78,16 @@ class _QueryWrapper:
         with_db_driver = getattr(
             conf.settings, "SQLCOMMENTER_WITH_DB_DRIVER", True
         )
+        with_action = getattr(
+            conf.settings, "SQLCOMMENTER_WITH_ACTION", True
+        )
 
         db_driver = context["connection"].settings_dict.get("ENGINE", "")
         resolver_match = self.request.resolver_match
+
+        # app_name is the application namespace for the URL pattern that matches the URL.
+        # See https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.app_name
+        app_name = (resolver_match.app_name or None) if resolver_match and with_app_name else None
 
         sql = _add_sql_comment(
             sql,
@@ -88,17 +95,15 @@ class _QueryWrapper:
             controller=resolver_match.view_name
             if resolver_match and with_controller
             else None,
+            action=self.request.method if with_action else None,
             # route is the pattern that matched a request with a controller i.e. the regex
             # See https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.route
             # getattr() because the attribute doesn't exist in Django < 2.2.
             route=getattr(resolver_match, "route", None)
             if resolver_match and with_route
             else None,
-            # app_name is the application namespace for the URL pattern that matches the URL.
-            # See https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.app_name
-            app_name=(resolver_match.app_name or None)
-            if resolver_match and with_app_name
-            else None,
+            app_name=app_name,
+            application=app_name,
             # Framework centric information.
             framework=f"django:{_django_version}" if with_framework else None,
             # Information about the database and driver.

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_sqlcommenter.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_sqlcommenter.py
@@ -76,28 +76,29 @@ class TestMiddleware(WsgiTestBase):
         "opentelemetry.instrumentation.django.middleware.sqlcommenter_middleware._get_opentelemetry_values"
     )
     def test_query_wrapper(self, trace_capture):
-        requests_mock = MagicMock()
-        requests_mock.resolver_match.view_name = "view"
-        requests_mock.resolver_match.route = "route"
-        requests_mock.resolver_match.app_name = "app"
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.resolver_match.view_name = "view"
+        mock_request.resolver_match.route = "route"
+        mock_request.resolver_match.app_name = "app"
 
         trace_capture.return_value = {
             "traceparent": "*traceparent='00-000000000000000000000000deadbeef-000000000000beef-00"
         }
-        qw_instance = _QueryWrapper(requests_mock)
-        execute_mock_obj = MagicMock()
+        qw_instance = _QueryWrapper(request=mock_request)
+        mock_execute = MagicMock()
         qw_instance(
-            execute_mock_obj,
-            "Select 1;",
-            MagicMock("test"),
-            MagicMock("test1"),
-            MagicMock(),
+            execute=mock_execute,
+            sql="Select 1;",
+            params=MagicMock("test"),
+            many=MagicMock("test1"),
+            context=MagicMock(),
         )
-        output_sql = execute_mock_obj.call_args[0][0]
+        output_sql = mock_execute.call_args[0][0]
         self.assertEqual(
             output_sql,
-            "Select 1 /*app_name='app',controller='view',route='route',traceparent='%%2Atraceparent%%3D%%2700-0000000"
-            "00000000000000000deadbeef-000000000000beef-00'*/;",
+            "Select 1 /*action='GET',app_name='app',application='app',controller='view',route='route',"
+            "traceparent='%%2Atraceparent%%3D%%2700-000000000000000000000000deadbeef-000000000000beef-00'*/;",
         )
 
     @patch(


### PR DESCRIPTION
# Description

Add new fields for SQLCommenter:
- `"application"`, which should contain the name of the application
- `"action"`, which should contain the HTTP verb in the request

Both are documented in the [spec](https://google.github.io/sqlcommenter/spec/#format) for SQLCommenter, and (for example) both are [accepted by Google Cloud](https://cloud.google.com/sql/docs/postgres/using-query-insights#adding-tags-to-sql-queries) when displaying Query Insights.

Note that `"app_name"` is already included, but `"application"` is the field expected in the spec.

Open questions:
[ ] Should I remove the original `app_name` field? I can't see this one described in the spec.
[ ] Should I copy these changes over to the other implementations for SQLCommenter in this library (dbapi, flask, psycopg2, sqlalchemy)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by:
- using this modified copy of the library in a production app
- updated unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
