### PR TITLE
Fixing typing for _ResponseHookT for requests instrumentation.

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -87,7 +87,7 @@ from opentelemetry.util.http.httplib import set_ip_on_next_http_connection
 _excluded_urls_from_env = get_excluded_urls("REQUESTS")
 
 _RequestHookT = Optional[Callable[[Span, PreparedRequest], None]]
-_ResponseHookT = Optional[Callable[[Span, PreparedRequest], None]]
+_ResponseHookT = Optional[Callable[[Span, PreparedRequest, Response], None]]
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
# Description

This PR fixes a typing error for the request hook of the requests instrumentation.

The type for this callable is defined here: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/eb6024ca3171072daa5d842d9363e41d72ee64a6/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py#L90

But as we can see on this line: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/eb6024ca3171072daa5d842d9363e41d72ee64a6/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py#L211C24-L211C24, the number of arguments don't match. This PR fixes the problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This PR was not tested, it's only about type hinting. It's a trivial one-liner. Moreover, the request and response hooks for the requests library aren't mentioned in the docs (AFAIK) so I don't think this PR needs a doc update.


# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
