### PR TITLE
Fix error in build for README in Cassandra instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-cassandra/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Cassandra Instrumentation
-===================================
+=======================================
 
 |pypi|
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/6791421783/job/18463633098

Release job failed due to README not rendering properly for cassandra instrumentation. Title underline is too short.

```
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 2: Warning: Title underline too short.
```