### PR TITLE
Fix contrib build

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
@@ -38,6 +38,7 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-botocore[instruments]",
   "markupsafe==2.0.1",
+  "botocore ~= 1.0, < 1.31.82",
   "moto[all] ~= 2.2.6",
   "opentelemetry-test-utils == 0.43b0.dev",
 ]

--- a/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
@@ -38,7 +38,7 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-botocore[instruments]",
   "markupsafe==2.0.1",
-  "botocore ~= 1.0, < 1.31.82",
+  "botocore ~= 1.0, < 1.31.81",
   "moto[all] ~= 2.2.6",
   "opentelemetry-test-utils == 0.43b0.dev",
 ]


### PR DESCRIPTION
Contrib builds are failing due to new version of [botobore](https://pypi.org/project/botocore/1.31.82/). Limit version for now.

https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/6805934958/job/18508673741?pr=2049