### PR TITLE
Fix dependency for azure resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2020](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2020))
 - `opentelemetry-instrumentation-urllib`/`opentelemetry-instrumentation-urllib3` Fix metric descriptions to match semantic conventions
   ([#1959](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1959))
+- `opentelemetry-resource-detector-azure` Added dependency for Cloud Resource ID attribute
+  ([#2072](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2072))
   
 ## Version 1.21.0/0.42b0 (2023-11-01)
 

--- a/resource/opentelemetry-resource-detector-azure/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-azure/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "opentelemetry-sdk ~= 1.19",
+  "opentelemetry-sdk ~= 1.21",
 ]
 
 [project.optional-dependencies]

--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
@@ -24,7 +24,6 @@ from opentelemetry.semconv.resource import (
     ResourceAttributes,
 )
 
-# TODO: Remove when cloud resource id is no longer missing in Resource Attributes
 _AZURE_VM_METADATA_ENDPOINT = "http://169.254.169.254/metadata/instance/compute?api-version=2021-12-13&format=json"
 _AZURE_VM_SCALE_SET_NAME_ATTRIBUTE = "azure.vm.scaleset.name"
 _AZURE_VM_SKU_ATTRIBUTE = "azure.vm.sku"


### PR DESCRIPTION
# Description

VM Resource Detector's dependencies allowed for a version of semantic conventions that did not include the CLOUD_RESOURCE_ID constant it needs.

Fixes possible source of # [azure-sdk-for-python/issues/33301](https://github.com/Azure/azure-sdk-for-python/issues/33301)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests for new top level try catch for both resource detectors.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
