### PR TITLE
WIP: fix: making grpc aio instrumentation robust to non-list interceptors

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -385,20 +385,18 @@ class GrpcAioInstrumentorServer(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
 
         def server(*args, **kwargs):
+            # set our interceptor as the first
+            interceptor = aio_server_interceptor(
+                tracer_provider=tracer_provider, filter_=self._filter
+            )
+            interceptors = [interceptor]
+
             if "interceptors" in kwargs:
-                # add our interceptor as the first
-                kwargs["interceptors"].insert(
-                    0,
-                    aio_server_interceptor(
-                        tracer_provider=tracer_provider, filter_=self._filter
-                    ),
-                )
-            else:
-                kwargs["interceptors"] = [
-                    aio_server_interceptor(
-                        tracer_provider=tracer_provider, filter_=self._filter
-                    )
-                ]
+                # Add existing interceptors to the end
+                # CAUTION: `kwargs["interceptors"]` may be a tuple
+                interceptors.extend(kwargs["interceptors"])
+
+            kwargs["interceptors"] = interceptors
             return self._original_func(*args, **kwargs)
 
         grpc.aio.server = server


### PR DESCRIPTION
# Description 
`kwargs["interceptors"]` is just assumed to always be a list, and it's not guaranteed. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't - I'm struggling to figure out how to run the unittests locally. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated <-- This shouldn't be necessary, right?
