### PR TITLE
Reference link fix in confluent-kafka instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/README.rst
@@ -19,5 +19,5 @@ Installation
 References
 ----------
 
-* `OpenTelemetry confluent-kafka/ Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/confluent-kafka/confluent-kafka.html>`_
+* `OpenTelemetry confluent-kafka/ Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/confluent_kafka/confluent_kafka.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_


### PR DESCRIPTION
# Description

The link in readme is broken.

