### PR TITLE
Refactor bootstrap generation

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -22,7 +22,7 @@ libraries = [
     },
     {
         "library": "aiohttp ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.45b0.dev",
+        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.46b0.dev",
     },
     {
         "library": "aiopg >= 0.13.0, < 2.0.0",
@@ -187,7 +187,6 @@ default_instrumentations = [
     "opentelemetry-instrumentation-dbapi==0.46b0.dev",
     "opentelemetry-instrumentation-logging==0.46b0.dev",
     "opentelemetry-instrumentation-sqlite3==0.46b0.dev",
-    "opentelemetry-instrumentation-threading==0.46b0.dev",
     "opentelemetry-instrumentation-urllib==0.46b0.dev",
     "opentelemetry-instrumentation-wsgi==0.46b0.dev",
 ]

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -21,6 +21,10 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-aio-pika==0.46b0.dev",
     },
     {
+        "library": "aiohttp ~= 3.0",
+        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.45b0.dev",
+    },
+    {
         "library": "aiopg >= 0.13.0, < 2.0.0",
         "instrumentation": "opentelemetry-instrumentation-aiopg==0.46b0.dev",
     },

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -21,14 +21,6 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-aio-pika==0.46b0.dev",
     },
     {
-        "library": "aiohttp ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.46b0.dev",
-    },
-    {
-        "library": "aiohttp ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiohttp-server==0.46b0.dev",
-    },
-    {
         "library": "aiopg >= 0.13.0, < 2.0.0",
         "instrumentation": "opentelemetry-instrumentation-aiopg==0.46b0.dev",
     },

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -12,23 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-import tomli
+from tomli import load
+from os import path, listdir
+from subprocess import check_output, CalledProcessError
 from requests import get
 
-scripts_path = os.path.dirname(os.path.abspath(__file__))
-root_path = os.path.dirname(scripts_path)
-instrumentations_path = os.path.join(root_path, "instrumentation")
+scripts_path = path.dirname(path.abspath(__file__))
+root_path = path.dirname(scripts_path)
+instrumentations_path = path.join(root_path, "instrumentation")
 
 
 def get_instrumentation_packages():
-    for pkg in sorted(os.listdir(instrumentations_path)):
-        pkg_path = os.path.join(instrumentations_path, pkg)
-        if not os.path.isdir(pkg_path):
+    for pkg in sorted(listdir(instrumentations_path)):
+        pkg_path = path.join(instrumentations_path, pkg)
+        if not path.isdir(pkg_path):
             continue
 
         error = f"Could not get version for package {pkg}"
+
+        try:
+            hatch_version = check_output(
+                "hatch version",
+                shell=True,
+                cwd=pkg_path,
+                universal_newlines=True
+            )
+
+        except CalledProcessError as exc:
+            print(f"Could not get hatch version from path {pkg_path}")
+            print(exc.output)
+
         try:
             response = get(f"https://pypi.org/pypi/{pkg}/json", timeout=10)
 
@@ -40,16 +53,14 @@ def get_instrumentation_packages():
             print(error)
             continue
 
-        version = response.json()["info"]["version"]
-
-        pyproject_toml_path = os.path.join(pkg_path, "pyproject.toml")
+        pyproject_toml_path = path.join(pkg_path, "pyproject.toml")
 
         with open(pyproject_toml_path, "rb") as file:
-            pyproject_toml = tomli.load(file)
+            pyproject_toml = load(file)
 
         instrumentation = {
             "name": pyproject_toml["project"]["name"],
-            "version": version.strip(),
+            "version": hatch_version.strip(),
             "instruments": pyproject_toml["project"]["optional-dependencies"][
                 "instruments"
             ],

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -18,7 +18,6 @@ from subprocess import CalledProcessError
 import tomli
 from requests import get
 
-
 scripts_path = os.path.dirname(os.path.abspath(__file__))
 root_path = os.path.dirname(scripts_path)
 instrumentations_path = os.path.join(root_path, "instrumentation")
@@ -32,9 +31,7 @@ def get_instrumentation_packages():
 
         error = f"Could not get version for package {pkg}"
         try:
-            response = get(
-                f"https://pypi.org/pypi/{pkg}/json"
-            )
+            response = get(f"https://pypi.org/pypi/{pkg}/json")
 
         except Exception as exc:
             print(error)

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
-import subprocess
 from subprocess import CalledProcessError
 
 import tomli
+from requests import get
+
 
 scripts_path = os.path.dirname(os.path.abspath(__file__))
 root_path = os.path.dirname(scripts_path)
@@ -29,17 +30,21 @@ def get_instrumentation_packages():
         if not os.path.isdir(pkg_path):
             continue
 
+        error = f"Could not get version for package {pkg}"
         try:
-            version = subprocess.check_output(
-                "hatch version",
-                shell=True,
-                cwd=pkg_path,
-                universal_newlines=True,
+            response = get(
+                f"https://pypi.org/pypi/{pkg}/json"
             )
-        except CalledProcessError as exc:
-            print(f"Could not get hatch version from path {pkg_path}")
-            print(exc.output)
-            raise exc
+
+        except Exception as exc:
+            print(error)
+            continue
+
+        if response.status_code != 200:
+            print(error)
+            continue
+
+        version = response.json()["info"]["version"]
 
         pyproject_toml_path = os.path.join(pkg_path, "pyproject.toml")
 

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-from subprocess import CalledProcessError
 
 import tomli
 from requests import get
@@ -31,9 +30,9 @@ def get_instrumentation_packages():
 
         error = f"Could not get version for package {pkg}"
         try:
-            response = get(f"https://pypi.org/pypi/{pkg}/json")
+            response = get(f"https://pypi.org/pypi/{pkg}/json", timeout=10)
 
-        except Exception as exc:
+        except Exception:
             print(error)
             continue
 


### PR DESCRIPTION
This makes the bootstrap script get the package version directly from pypi instead of from our lists of packages. This makes sure that the packages are actually available for the end user to install.