### PR TITLE
Update wsgi __init__.py to include HTTP_TARGET.  

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -321,12 +321,16 @@ def collect_request_attributes(environ):
         target = environ.get("REQUEST_URI")
     if target is not None:
         result[SpanAttributes.HTTP_TARGET] = target
-        result[SpanAttributes.HTTP_ROUTE] = environ.get("PATH_INFO")
     else:
         result[SpanAttributes.HTTP_URL] = remove_url_credentials(
             wsgiref_util.request_uri(environ)
         )
-
+    route = environ.get("PATH_INFO")
+    if route is None:  
+        route = environ.get("PATH_INFO")
+    if target is not None:
+        result[SpanAttributes.HTTP_ROUTE] = route
+        
     remote_addr = environ.get("REMOTE_ADDR")
     if remote_addr:
         result[SpanAttributes.NET_PEER_IP] = remote_addr

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -249,6 +249,7 @@ _duration_attrs = [
     SpanAttributes.HTTP_SERVER_NAME,
     SpanAttributes.NET_HOST_NAME,
     SpanAttributes.NET_HOST_PORT,
+    SpanAttributes.HTTP_TARGET,
 ]
 
 _active_requests_count_attrs = [
@@ -257,6 +258,7 @@ _active_requests_count_attrs = [
     SpanAttributes.HTTP_SCHEME,
     SpanAttributes.HTTP_FLAVOR,
     SpanAttributes.HTTP_SERVER_NAME,
+    SpanAttributes.HTTP_TARGET,
 ]
 
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -249,7 +249,7 @@ _duration_attrs = [
     SpanAttributes.HTTP_SERVER_NAME,
     SpanAttributes.NET_HOST_NAME,
     SpanAttributes.NET_HOST_PORT,
-    SpanAttributes.HTTP_TARGET,
+    SpanAttributes.HTTP_ROUTE,
 ]
 
 _active_requests_count_attrs = [
@@ -258,7 +258,7 @@ _active_requests_count_attrs = [
     SpanAttributes.HTTP_SCHEME,
     SpanAttributes.HTTP_FLAVOR,
     SpanAttributes.HTTP_SERVER_NAME,
-    SpanAttributes.HTTP_TARGET,
+    SpanAttributes.HTTP_ROUTE,
 ]
 
 
@@ -321,6 +321,7 @@ def collect_request_attributes(environ):
         target = environ.get("REQUEST_URI")
     if target is not None:
         result[SpanAttributes.HTTP_TARGET] = target
+        result[SpanAttributes.HTTP_ROUTE] = environ.get("PATH_INFO")
     else:
         result[SpanAttributes.HTTP_URL] = remove_url_credentials(
             wsgiref_util.request_uri(environ)


### PR DESCRIPTION
Add HTTP_TARGET to server duration and active requests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # Currently metrics exclude the HTTP_TARGET.  This does not allow use to get specific resource counts or durations for visited endpoints.  By adding HTTP_TARGET, we can now get detailed stats for individual page access.  This will create additional metrics and increase cardinality.  I feel like the granularity is needed to make the metric useful.  It also brings this metric in-line with the spanmetrics connector. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Test A

Changed package and ran locally using auto-instrumentation->local collector with Prometheus exporter.  Adding variables allowed prometheus to create correct metrics with targets.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
