### PR TITLE
Pass args and kwargs to confluent-kafka Consumer superclass

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -130,8 +130,8 @@ class AutoInstrumentedProducer(Producer):
 
 
 class AutoInstrumentedConsumer(Consumer):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
         self._current_consume_span = None
 
     # This method is deliberately implemented in order to allow wrapt to wrap this function


### PR DESCRIPTION
# Description

This PR fixes an issue in `AutoInstrumentedConsumer` which wasn't passing extra args and kwargs to superclass `Consumer`. This was causing issues when a caller need to pass extra arguments like `logger`. 

The use of `logger` is tested here: https://github.com/confluentinc/confluent-kafka-python/blob/master/tests/test_log.py#L28-L30

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce the issue we instantiate a `Consumer` object with extra arguments (e.g. `logger`) before and after instrumenting by `ConfluentKafkaInstrumentor().instrument()`

Instantiating the uninstrumented Consumer:
```
In [1]: from confluent_kafka import Consumer

In [2]: conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}

In [3]: Consumer(conf2, logger=55)
Out[3]: <cimpl.Consumer at 0x7fa3462567c0>
```
We can pass keyword arguments. Below is the same after we instrument `Consumer`:
```
In [1]: from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor

In [2]: ConfluentKafkaInstrumentor().instrument()

In [3]: from confluent_kafka import Consumer

In [4]: conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}

In [5]: Consumer(conf2, logger=55)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 1
----> 1 Consumer(conf2, logger=55)

TypeError: __init__() got an unexpected keyword argument 'logger'
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
