### PR TITLE
asyncpg: fix AttributeError while using dsn-initialized connection

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -138,7 +138,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
     async def _do_execute(self, func, instance, args, kwargs):
         exception = None
         params = getattr(instance, "_params", {})
-        name = args[0] if args[0] else params.get("database", "postgresql")
+        name = args[0] if args[0] else getattr(params, "database", "postgresql")
 
         try:
             # Strip leading comments so we get the operation name.


### PR DESCRIPTION
# Description

Actual error:
```
AttributeError
'ConnectionParameters' object has no attribute 'get'
```

where ConnectionParameters is a namedtuple object, that doesn't have "get" attribute.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
```
import collections
>>> getattr(collections.namedtuple("abc","a")("a"), "b", "a")  # <-- OK
'a' 

>>> collections.namedtuple("abc","a")("a").get("a")  # <-- NOT OK 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'abc' object has no attribute 'get'
```

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
