### PR TITLE
Add 10 second timeout to VM Resource Detector

### DIFF
--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
@@ -68,7 +68,7 @@ class _AzureVMMetadataServiceRequestor:
         request = Request(_AZURE_VM_METADATA_ENDPOINT)
         request.add_header("Metadata", "True")
         try:
-            with urlopen(request).read() as response:
+            with urlopen(request, timeout=10).read() as response:
                 return loads(response)
         except URLError:
             # Not on Azure VM


### PR DESCRIPTION
# Description

urlopen has no default timeout.

Fixes https://github.com/Azure/azure-sdk-for-python/issues/33441

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
