### PR TITLE
Remove [test] package from flask instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -37,11 +37,6 @@ dependencies = [
 instruments = [
   "flask >= 1.0",
 ]
-test = [
-  "opentelemetry-instrumentation-flask[instruments]",
-  "markupsafe==2.1.2",
-  "opentelemetry-test-utils == 0.45b0.dev",
-]
 
 [project.entry-points.opentelemetry_instrumentor]
 flask = "opentelemetry.instrumentation.flask:FlaskInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-flask/test-requirements-0.txt
+++ b/instrumentation/opentelemetry-instrumentation-flask/test-requirements-0.txt
@@ -1,0 +1,25 @@
+asgiref==3.7.2
+attrs==23.2.0
+click==8.1.7
+Deprecated==1.2.14
+Flask==2.1.3
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.3
+MarkupSafe==2.1.2
+packaging==23.2
+pluggy==1.4.0
+py==1.11.0
+py-cpuinfo==9.0.0
+pytest==7.1.3
+pytest-benchmark==4.0.0
+tomli==2.0.1
+typing_extensions==4.9.0
+Werkzeug==2.3.8
+wrapt==1.16.0
+zipp==3.17.0
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-wsgi
+-e util/opentelemetry-util-http
+-e instrumentation/opentelemetry-instrumentation-flask

--- a/instrumentation/opentelemetry-instrumentation-flask/test-requirements-1.txt
+++ b/instrumentation/opentelemetry-instrumentation-flask/test-requirements-1.txt
@@ -1,0 +1,25 @@
+asgiref==3.7.2
+attrs==23.2.0
+click==8.1.7
+Deprecated==1.2.14
+Flask==2.2.0
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.3
+MarkupSafe==2.1.2
+packaging==23.2
+pluggy==1.4.0
+py==1.11.0
+py-cpuinfo==9.0.0
+pytest==7.1.3
+pytest-benchmark==4.0.0
+tomli==2.0.1
+typing_extensions==4.9.0
+Werkzeug==2.3.8
+wrapt==1.16.0
+zipp==3.17.0
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-wsgi
+-e util/opentelemetry-util-http
+-e instrumentation/opentelemetry-instrumentation-flask

--- a/instrumentation/opentelemetry-instrumentation-flask/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-flask/test-requirements-2.txt
@@ -1,0 +1,26 @@
+asgiref==3.7.2
+attrs==23.2.0
+blinker==1.7.0
+click==8.1.7
+Deprecated==1.2.14
+Flask==3.0.2
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.3
+MarkupSafe==2.1.2
+packaging==23.2
+pluggy==1.4.0
+py==1.11.0
+py-cpuinfo==9.0.0
+pytest==7.1.3
+pytest-benchmark==4.0.0
+tomli==2.0.1
+typing_extensions==4.9.0
+Werkzeug==3.0.1
+wrapt==1.16.0
+zipp==3.17.0
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-wsgi
+-e util/opentelemetry-util-http
+-e instrumentation/opentelemetry-instrumentation-flask

--- a/tox.ini
+++ b/tox.ini
@@ -83,9 +83,14 @@ envlist =
     pypy3-test-instrumentation-fastapi
 
     ; opentelemetry-instrumentation-flask
-    py3{8,9,10,11}-test-instrumentation-flask-{213,220}
-    py3{8,9,10,11}-test-instrumentation-flask-{300}
-    pypy3-test-instrumentation-flask-{213,220}
+    ; The numbers at the end of the environment names
+    ; below mean these dependencies are being used:
+    ; 0: Flask ==2.1.3 Werkzeug <3.0.0
+    ; 1: Flask ==2.2.0 Werkzeug <3.0.0
+    ; 2: Flask >=3.0.0 Werkzeug >=3.0.0
+    py3{8,9,10,11}-test-instrumentation-flask-{0,1}
+    py3{8,9,10,11}-test-instrumentation-flask-{2}
+    pypy3-test-instrumentation-flask-{0,1}
 
     ; opentelemetry-instrumentation-urllib
     py3{8,9,10,11}-test-instrumentation-urllib
@@ -277,12 +282,6 @@ deps =
   falcon-1: falcon ==1.4.1
   falcon-2: falcon >=2.0.0,<3.0.0
   falcon-3: falcon >=3.0.0,<4.0.0
-  flask-213: Flask ==2.1.3
-  flask-213: Werkzeug <3.0.0
-  flask-220: Flask ==2.2.0
-  flask-220: Werkzeug <3.0.0
-  flask-300: Flask >=3.0.0
-  flask-300: Werkzeug >=3.0.0
   grpc: pytest-asyncio
   sqlalchemy-11: sqlalchemy>=1.1,<1.2
   sqlalchemy-14: aiosqlite
@@ -339,8 +338,8 @@ commands_pre =
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
 
-  falcon-{1,2,3},flask-{213,220,300},django-{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,httpx-{18,21},requests,urllib,urllib3v-{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http
-  wsgi,falcon-{1,2,3},flask-{213,220,300},django-{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
+  falcon-{1,2,3},django-{1,2,3,4},pyramid,tornado,starlette,fastapi,aiohttp,httpx-{18,21},requests,urllib,urllib3v-{1,2},wsgi: pip install {toxinidir}/util/opentelemetry-util-http
+  wsgi,falcon-{1,2,3},django-{1,2,3,4},pyramid: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi[test]
   django-{3,4},starlette,fastapi: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asgi
 
   asyncpg: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncpg[test]
@@ -354,7 +353,9 @@ commands_pre =
 
   falcon-{1,2,3}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
 
-  flask-{213,220,300}: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
+  flask-0: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-flask/test-requirements-0.txt
+  flask-1: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-flask/test-requirements-1.txt
+  flask-2: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-flask/test-requirements-2.txt
 
   urllib: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-urllib[test]
 
@@ -548,7 +549,7 @@ commands_pre =
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-boto[test]
-  python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-flask[test]
+  pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-flask/test-requirements-2.txt
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlalchemy[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-cassandra[test]
   python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-celery[test]


### PR DESCRIPTION
Fixes #2126

~I am not a fan of using additional executable `bash` scripts but this exemplifies what I am trying to do (remove the `[test]` packages and separate the testing requirements for every package into a file in each package).~

If we agree on this strategy I will add the changes for the rest of the packages in this PR. For the time being I am adding only one since I want to make it easy for others to review and understand this strategy.

For the record, I would prefer not to use `tox` but [`nox`](https://nox.thea.codes/en/stable/) which has the advantage of using a Python file instead of an `ini` file. I think that by using `nox` we can find a pure-Python way of handing our test dependencies. In fact, I would prefer if we had one noxfile for every package and a Python script that just calls `nox` in every package directory.