### PR TITLE
Add support for confluent_kafka until 2.3.0 version;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
+- `opentelemetry-instrumentation-confluent-kafka` Add support for higher versions until 2.3.0 of confluent_kafka
+  ([#2132](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2132))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -27,7 +27,7 @@ botocore~=1.0
 boto3~=1.0
 cassandra-driver~=3.25
 celery>=4.0
-confluent-kafka>= 1.8.2,<= 2.2.0
+confluent-kafka>= 1.8.2,<= 2.3.0
 elasticsearch>=2.0,<9.0
 flask~=2.0
 falcon~=2.0

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -13,7 +13,7 @@
 | [opentelemetry-instrumentation-botocore](./opentelemetry-instrumentation-botocore) | botocore ~= 1.0 | No
 | [opentelemetry-instrumentation-cassandra](./opentelemetry-instrumentation-cassandra) | cassandra-driver ~= 3.25,scylla-driver ~= 3.25 | No
 | [opentelemetry-instrumentation-celery](./opentelemetry-instrumentation-celery) | celery >= 4.0, < 6.0 | No
-| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.2.0 | No
+| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.3.0 | No
 | [opentelemetry-instrumentation-dbapi](./opentelemetry-instrumentation-dbapi) | dbapi | No
 | [opentelemetry-instrumentation-django](./opentelemetry-instrumentation-django) | django >= 1.10 | Yes
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 2.0 | No

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "confluent-kafka >= 1.8.2, <= 2.2.0",
+  "confluent-kafka >= 1.8.2, <= 2.3.0",
 ]
 test = [
   "opentelemetry-instrumentation-confluent-kafka[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("confluent-kafka >= 1.8.2, <= 2.2.0",)
+_instruments = ("confluent-kafka >= 1.8.2, <= 2.3.0",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -65,7 +65,7 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-celery==0.44b0.dev",
     },
     {
-        "library": "confluent-kafka >= 1.8.2, <= 2.2.0",
+        "library": "confluent-kafka >= 1.8.2, <= 2.3.0",
         "instrumentation": "opentelemetry-instrumentation-confluent-kafka==0.44b0.dev",
     },
     {


### PR DESCRIPTION
# Description

Add support for confluent_kafka instrumentation until 2.3.0 version.

Fixes #2095

## Type of change

Add support for higher version.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ]  `tox -e test-instrumentation-confluent-kafka`

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
