### PR TITLE
Drop obsolete parameterized test dependency

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-falcon/pyproject.toml
@@ -40,7 +40,6 @@ instruments = [
 test = [
   "opentelemetry-instrumentation-falcon[instruments]",
   "opentelemetry-test-utils == 0.44b0.dev",
-  "parameterized == 0.7.4",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]


### PR DESCRIPTION
# Description

In the test dependencies for `opentelemetry-instrumentation-falcon`, don’t depend on `parametrized` because `pytest.mark.parametrize` is now included in `pytest`.

Fixes # (issue) **N/A**

## Type of change

Please delete options that are not relevant.

**no relevant options**

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I tested this in a virtual environment as follows:

```
python3 -m venv _e
. _e/bin/activate
cd opentelemetry-instrumentation
pip install .
cd ../../opentelemetry-python/opentelemetry-semantic-conventions
pip install .
cd ../../opentelemetry-api
pip install .
cd ../opentelemetry-sdk
pip install .
cd ../tests/opentelemetry-test-utils
pip install .
cd ../../opentelemetry-python-contrib/util/opentelemetry-util-http
pip install .
cd ../../instrumentation/opentelemetry-instrumentation-wsgi
pip install .
cd ../opentelemetry-instrumentation-falcon
pip install -e '.[test]'
pip install pytest
python -m pytest
```

All tests passed.

```
=============================== warnings summary ===============================
../../_e/lib64/python3.12/site-packages/falcon/media/__init__.py:4
  /home/ben/src/forks/opentelemetry-python-contrib/_e/lib64/python3.12/site-packages/falcon/media/__init__.py:4: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    from .handlers import Handlers

../../_e/lib64/python3.12/site-packages/opentelemetry/instrumentation/dependencies.py:4
  /home/ben/src/forks/opentelemetry-python-contrib/_e/lib64/python3.12/site-packages/opentelemetry/instrumentation/dependencies.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import (

instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py::TestFalconInstrumentation::test_url_template
  /home/ben/src/forks/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py:379: DeprecatedWarning: Call to deprecated property body. Please use text instead.
    return super().__call__(env, _start_response)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 25 passed, 3 warnings in 0.47s ========================
```

The `parameterized` package is not installed in the virtual environment.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project 
- [ ] Changelogs have been updated **This doesn’t seem like it deserves a changelog entry. Let me know if I need to add one.**
- [ ] Unit tests have been added **N/A, covered by existing tests**
- [ ] Documentation has been updated **N/A**
