### PR TITLE
Fix link to OpenTelemetry kafka-python Instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-kafka-python/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/README.rst
@@ -17,6 +17,6 @@ Installation
 References
 ----------
 
-* `OpenTelemetry kafka-python Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/kafka-python/kafka-python.html>`_
+* `OpenTelemetry kafka-python Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/kafka_python/kafka_python.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_


### PR DESCRIPTION
# Description

Fixes link to [OpenTelemetry kafka-python Integration](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/kafka_python/kafka_python.html) in `opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-kafka-python/README.rst`

## Type of change

- [X] Documentation fix

# How Has This Been Tested?

I clicked the link and checked it opened the correct documentation

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
