### PR TITLE
fix: elasticsearch `bulk` API produces lists

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -246,7 +246,7 @@ def _wrap_perform_request(
                     attributes["elasticsearch.method"] = method
                 if body:
                     # Don't set db.statement for bulk requests, as it can be very large
-                    if not isinstance(body, list):
+                    if isinstance(body, dict):
                         attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
                             body
                         )

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -245,9 +245,11 @@ def _wrap_perform_request(
                 if method:
                     attributes["elasticsearch.method"] = method
                 if body:
-                    attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
-                        body
-                    )
+                    # Don't set db.statement for bulk requests, as it can be very large
+                    if not isinstance(body, list):
+                        attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
+                            body
+                        )
                 if params:
                     attributes["elasticsearch.params"] = str(params)
                 if doc_id:


### PR DESCRIPTION
# Description

Fixes an issue seen in production where the elasticsearch bulk API would end up sending a list through this code path and not a dictionary.

For example:

```
File \"/code/platform_be/core/logic/ingest.py\", line 378, in update_source_doc_version_history
        bulk(es_client, bulk_es_updates)
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/helpers/actions.py\", line 521, in bulk
        for ok, item in streaming_bulk(
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/helpers/actions.py\", line 436, in streaming_bulk
        for data, (ok, info) in zip(
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/helpers/actions.py\", line 339, in _process_bulk_chunk
        resp = client.bulk(*args, operations=bulk_actions, **kwargs)  # type: ignore[arg-type]
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/_sync/client/utils.py\", line 414, in wrapped
        return api(*args, **kwargs)
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/_sync/client/__init__.py\", line 704, in bulk
        return self.perform_request(  # type: ignore[return-value]
      File \"/opt/python/lib/python3.10/site-packages/elasticsearch/_sync/client/_base.py\", line 285, in perform_request
        meta, resp_body = self.transport.perform_request(
      File \"/opt/python/lib/python3.10/site-packages/opentelemetry/instrumentation/elasticsearch/__init__.py\", line 242, in wrapper
        attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
      File \"/opt/python/lib/python3.10/site-packages/opentelemetry/instrumentation/elasticsearch/utils.py\", line 58, in sanitize_body
        flatten_body = _flatten_dict(body)
      File \"/opt/python/lib/python3.10/site-packages/opentelemetry/instrumentation/elasticsearch/utils.py\", line 31, in _flatten_dict
        for k, v in d.items():
    AttributeError: 'list' object has no attribute 'items'"
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
