### PR TITLE
Support SQLAlchemy 2 (in tests and doc strings)

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -40,7 +40,7 @@ Usage
 For example,
 ::
 
-    Invoking engine.execute("select * from auth_users") will lead to sql query "select * from auth_users" but when SQLCommenter is enabled
+    Invoking engine.execute(text("select * from auth_users")) will lead to sql query "select * from auth_users" but when SQLCommenter is enabled
     the query will get appended with some configurable tags like "select * from auth_users /*tag=value*/;"
 
 SQLCommenter Configurations

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 import pytest
 import sqlalchemy
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -43,12 +43,12 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
-        cnx.execute("/* leading comment */ SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
+        cnx.execute(text("/* leading comment */ SELECT	1 + 1;")).fetchall()
         cnx.execute(
-            "/* leading comment */ SELECT	1 + 1; /* trailing comment */"
+            text("/* leading comment */ SELECT	1 + 1; /* trailing comment */")
         ).fetchall()
-        cnx.execute("SELECT	1 + 1; /* trailing comment */").fetchall()
+        cnx.execute(text("SELECT	1 + 1; /* trailing comment */")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 5)
@@ -76,9 +76,9 @@ class TestSqlalchemyInstrumentation(TestBase):
         )
 
         cnx_1 = engine_1.connect()
-        cnx_1.execute("SELECT	1 + 1;").fetchall()
+        cnx_1.execute(text("SELECT	1 + 1;")).fetchall()
         cnx_2 = engine_2.connect()
-        cnx_2.execute("SELECT	1 + 1;").fetchall()
+        cnx_2.execute(text("SELECT	1 + 1;")).fetchall()
 
         spans = self.memory_exporter.get_finished_spans()
         # 2 queries + 2 engine connect
@@ -144,7 +144,7 @@ class TestSqlalchemyInstrumentation(TestBase):
                 tracer_provider=self.tracer_provider,
             )
             cnx = engine.connect()
-            cnx.execute("SELECT	1 + 1;").fetchall()
+            cnx.execute(text("SELECT	1 + 1;")).fetchall()
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)
@@ -156,7 +156,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -187,7 +187,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         # sqlcommenter
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
@@ -207,7 +207,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         # sqlcommenter
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
@@ -233,7 +233,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -346,7 +346,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -359,10 +359,10 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         self.memory_exporter.clear()
         SQLAlchemyInstrumentor().uninstrument()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         engine2 = create_engine("sqlite:///:memory:")
         cnx2 = engine2.connect()
-        cnx2.execute("SELECT	2 + 2;").fetchall()
+        cnx2.execute(text("SELECT	2 + 2;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -371,7 +371,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
 
@@ -384,13 +384,13 @@ class TestSqlalchemyInstrumentation(TestBase):
         engine = create_engine("sqlite:///:memory:")
 
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
 
         self.memory_exporter.clear()
         SQLAlchemyInstrumentor().uninstrument()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -401,7 +401,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=trace.NoOpTracerProvider(),
         )
         cnx = engine.connect()
-        cnx.execute("SELECT 1 + 1;").fetchall()
+        cnx.execute(text("SELECT 1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -420,7 +420,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             # collection
             weakref.finalize(engine, callback)
             with engine.connect() as conn:
-                conn.execute("SELECT 1 + 1;").fetchall()
+                conn.execute(text("SELECT 1 + 1;")).fetchall()
 
         for _ in range(0, 5):
             make_shortlived_engine()

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlcommenter.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlcommenter.py
@@ -14,7 +14,7 @@
 import logging
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from opentelemetry import context
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -37,7 +37,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             engine=engine, tracer_provider=self.tracer_provider
         )
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
 
         self.assertEqual(self.caplog.records[-2].getMessage(), "SELECT 1;")
 
@@ -50,7 +50,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             commenter_options={"db_framework": False},
         )
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)',traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -68,7 +68,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             },
         )
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)'\*/;",
@@ -90,7 +90,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
         )
         context.attach(sqlcommenter_context)
 
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)',flask=1,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -105,7 +105,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT 1 /\*db_driver='(.*)',traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -120,5 +120,5 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
         self.assertEqual(self.caplog.records[-2].getMessage(), "SELECT 1;")


### PR DESCRIPTION
# Description

Fedora 40 will ship with SQLAlchemy 2. A `python-sqlalchemy1.4` compat package will be available for now, but the idea is that this should be a temporary stopgap.

Currently, there are 17 test failures with SQLAlchemy 2.0.25, all similar to the one represented at the end of the PR text. This PR fixes them all by ensuring that plain-text query strings in the tests are always wrapped in `sqlalchemy.text()`. It also updates an example in a doc-string.

Note that no changes were required to the actual library implementation.

Fixes # (**I did not file an issue.**)

## Type of change

It’s hard to say whether to characterize this as a bug fix, a new feature, or neither, since it primarily just expands compatibility in the tests. There is certainly no breaking change, and I don’t think it requires a documentation update.

# How Has This Been Tested?

I applied this as a patch to the [`python-opentelemetry-contrib` package](https://src.fedoraproject.org/rpms/python-opentelemetry-contrib) and confirmed it fixed the test failures. You can test it by running the sqlalchemy instrumentation tests with SQLAlchemy 2.x in whatever way makes the most sense to you.

I could try adding testing with SQLAlchemy 2.x to `tox.ini`, but this is a little hard for me to test locally, especially the Docker part.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **No, should I?**
- [ ] Unit tests have been added **N/A, this fixes tests**
- [ ] Documentation has been updated **N/A**

Sample test failure (before this PR):

```
___________ TestSqlalchemyInstrumentation.test_create_engine_wrapper ___________

self = <sqlalchemy.engine.base.Connection object at 0x7f87397c7c80>
statement = 'SELECT\t1 + 1;', parameters = None

    def execute(
        self,
        statement: Executable,
        parameters: Optional[_CoreAnyExecuteParams] = None,
        *,
        execution_options: Optional[CoreExecuteOptionsParameter] = None,
    ) -> CursorResult[Any]:
        r"""Executes a SQL statement construct and returns a
        :class:`_engine.CursorResult`.
    
        :param statement: The statement to be executed.  This is always
         an object that is in both the :class:`_expression.ClauseElement` and
         :class:`_expression.Executable` hierarchies, including:
    
         * :class:`_expression.Select`
         * :class:`_expression.Insert`, :class:`_expression.Update`,
           :class:`_expression.Delete`
         * :class:`_expression.TextClause` and
           :class:`_expression.TextualSelect`
         * :class:`_schema.DDL` and objects which inherit from
           :class:`_schema.ExecutableDDLElement`
    
        :param parameters: parameters which will be bound into the statement.
         This may be either a dictionary of parameter names to values,
         or a mutable sequence (e.g. a list) of dictionaries.  When a
         list of dictionaries is passed, the underlying statement execution
         will make use of the DBAPI ``cursor.executemany()`` method.
         When a single dictionary is passed, the DBAPI ``cursor.execute()``
         method will be used.
    
        :param execution_options: optional dictionary of execution options,
         which will be associated with the statement execution.  This
         dictionary can provide a subset of the options that are accepted
         by :meth:`_engine.Connection.execution_options`.
    
        :return: a :class:`_engine.Result` object.
    
        """
        distilled_parameters = _distill_params_20(parameters)
        try:
>           meth = statement._execute_on_connection
E           AttributeError: 'str' object has no attribute '_execute_on_connection'

/usr/lib64/python3.12/site-packages/sqlalchemy/engine/base.py:1412: AttributeError

The above exception was the direct cause of the following exception:

self = <tests.test_sqlalchemy.TestSqlalchemyInstrumentation testMethod=test_create_engine_wrapper>

    def test_create_engine_wrapper(self):
        SQLAlchemyInstrumentor().instrument()
        from sqlalchemy import create_engine  # pylint: disable-all
    
        engine = create_engine("sqlite:///:memory:")
        cnx = engine.connect()
>       cnx.execute("SELECT	1 + 1;").fetchall()

instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py:159: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sqlalchemy.engine.base.Connection object at 0x7f87397c7c80>
statement = 'SELECT\t1 + 1;', parameters = None

    def execute(
        self,
        statement: Executable,
        parameters: Optional[_CoreAnyExecuteParams] = None,
        *,
        execution_options: Optional[CoreExecuteOptionsParameter] = None,
    ) -> CursorResult[Any]:
        r"""Executes a SQL statement construct and returns a
        :class:`_engine.CursorResult`.
    
        :param statement: The statement to be executed.  This is always
         an object that is in both the :class:`_expression.ClauseElement` and
         :class:`_expression.Executable` hierarchies, including:
    
         * :class:`_expression.Select`
         * :class:`_expression.Insert`, :class:`_expression.Update`,
           :class:`_expression.Delete`
         * :class:`_expression.TextClause` and
           :class:`_expression.TextualSelect`
         * :class:`_schema.DDL` and objects which inherit from
           :class:`_schema.ExecutableDDLElement`
    
        :param parameters: parameters which will be bound into the statement.
         This may be either a dictionary of parameter names to values,
         or a mutable sequence (e.g. a list) of dictionaries.  When a
         list of dictionaries is passed, the underlying statement execution
         will make use of the DBAPI ``cursor.executemany()`` method.
         When a single dictionary is passed, the DBAPI ``cursor.execute()``
         method will be used.
    
        :param execution_options: optional dictionary of execution options,
         which will be associated with the statement execution.  This
         dictionary can provide a subset of the options that are accepted
         by :meth:`_engine.Connection.execution_options`.
    
        :return: a :class:`_engine.Result` object.
    
        """
        distilled_parameters = _distill_params_20(parameters)
        try:
            meth = statement._execute_on_connection
        except AttributeError as err:
>           raise exc.ObjectNotExecutableError(statement) from err
E           sqlalchemy.exc.ObjectNotExecutableError: Not an executable object: 'SELECT\t1 + 1;'

/usr/lib64/python3.12/site-packages/sqlalchemy/engine/base.py:1414: ObjectNotExecutableError
```