### PR TITLE
Put the xray propagator’s test dep. on requests in the test extra, not just tox.ini

### DIFF
--- a/propagator/opentelemetry-propagator-aws-xray/pyproject.toml
+++ b/propagator/opentelemetry-propagator-aws-xray/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = []
+test = [
+    "requests",
+]
 
 [project.entry-points.opentelemetry_propagator]
 xray = "opentelemetry.propagators.aws:AwsXRayPropagator"

--- a/tox.ini
+++ b/tox.ini
@@ -472,7 +472,7 @@ commands_pre =
 ; In order to get a health coverage report,
   propagator-ot-trace: pip install {toxinidir}/propagator/opentelemetry-propagator-ot-trace[test]
 
-  propagator-aws-xray: pip install requests {toxinidir}/propagator/opentelemetry-propagator-aws-xray[test]
+  propagator-aws-xray: pip install {toxinidir}/propagator/opentelemetry-propagator-aws-xray[test]
 
 ; we have to install packages in editable mode.
   coverage: python {toxinidir}/scripts/eachdist.py install --editable


### PR DESCRIPTION
# Description

The `opentelemetry-propagator-aws-xray` package uses [`requests`](https://pypi.org/project/requests/) in its tests,

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/8fd2105ceae604cf39a67f1c4dd154753b43fcd1/propagator/opentelemetry-propagator-aws-xray/tests/test_aws_xray_propagator.py#L18

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/8fd2105ceae604cf39a67f1c4dd154753b43fcd1/propagator/opentelemetry-propagator-aws-xray/tests/performance/benchmarks/test_benchmark_aws_xray_propagator.py#L15

but lacks a direct dependency on it in the `tests` extra:

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/8fd2105ceae604cf39a67f1c4dd154753b43fcd1/propagator/opentelemetry-propagator-aws-xray/pyproject.toml#L30-L31

This has probably not been noticed because there are already test dependencies on `requests` elsewhere in the repository, e.g. in `opentelemetry-instrumentation-fastapi` and in `opentelemetry-exporter-prometheus-remote-write`, so it ends up installed when testing the repository as a whole.

This PR simply adds the missing dependency.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was considered too trivial to test.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **N/A**
- [ ] Unit tests have been added **N/A**
- [ ] Documentation has been updated **N/A**
