### PR TITLE
Fix azure vm resource detector tests/Suppress instrumentation for urllib call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-resource-detector-azure` Changed timeout to 4 seconds due to [timeout bug](https://github.com/open-telemetry/opentelemetry-python/issues/3644)
   ([#2136](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2136))
 - `opentelemetry-resource-detector-azure` Suppress instrumentation for `urllib` call
-  ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
+  ([#2178](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2178))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Drop uspport for 3.7
+- Drop support for 3.7
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2151))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2132](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2132))
 - `opentelemetry-resource-detector-azure` Changed timeout to 4 seconds due to [timeout bug](https://github.com/open-telemetry/opentelemetry-python/issues/3644)
   ([#2136](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2136))
+- `opentelemetry-resource-detector-azure` Suppress instrumentation for `urllib` call
+  ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
@@ -49,15 +49,11 @@ class AzureVMResourceDetector(ResourceDetector):
     # pylint: disable=no-self-use
     def detect(self) -> "Resource":
         attributes = {}
-        metadata_json = (
-            _get_azure_vm_metadata()
-        )
+        metadata_json = _get_azure_vm_metadata()
         if not metadata_json:
             return Resource(attributes)
         for attribute_key in EXPECTED_AZURE_AMS_ATTRIBUTES:
-            attributes[
-                attribute_key
-            ] = _get_attribute_from_metadata(
+            attributes[attribute_key] = _get_attribute_from_metadata(
                 metadata_json, attribute_key
             )
         return Resource(attributes)
@@ -79,9 +75,7 @@ def _get_azure_vm_metadata():
         _logger.exception("Failed to receive Azure VM metadata: %s", e)
         return None
 
-def _get_attribute_from_metadata(
-    metadata_json, attribute_key
-):
+def _get_attribute_from_metadata(metadata_json, attribute_key):
     ams_value = ""
     if attribute_key == _AZURE_VM_SCALE_SET_NAME_ATTRIBUTE:
         ams_value = metadata_json["vmScaleSetName"]

--- a/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
+++ b/resource/opentelemetry-resource-detector-azure/src/opentelemetry/resource/detector/azure/vm.py
@@ -50,63 +50,62 @@ class AzureVMResourceDetector(ResourceDetector):
     def detect(self) -> "Resource":
         attributes = {}
         metadata_json = (
-            _AzureVMMetadataServiceRequestor().get_azure_vm_metadata()
+            _get_azure_vm_metadata()
         )
         if not metadata_json:
             return Resource(attributes)
         for attribute_key in EXPECTED_AZURE_AMS_ATTRIBUTES:
             attributes[
                 attribute_key
-            ] = _AzureVMMetadataServiceRequestor().get_attribute_from_metadata(
+            ] = _get_attribute_from_metadata(
                 metadata_json, attribute_key
             )
         return Resource(attributes)
 
 
-class _AzureVMMetadataServiceRequestor:
-    def get_azure_vm_metadata(self):  # pylint: disable=no-self-use
-        request = Request(_AZURE_VM_METADATA_ENDPOINT)
-        request.add_header("Metadata", "True")
-        try:
-            # TODO: Changed to 4s to fit into OTel SDK's 5 second timeout.
-            # Lengthen or allow user input if issue is resolved.
-            # See https://github.com/open-telemetry/opentelemetry-python/issues/3644
-            with urlopen(request, timeout=4) as response:
-                return loads(response.read())
-        except URLError:
-            # Not on Azure VM
-            return None
-        except Exception as e:  # pylint: disable=broad-except,invalid-name
-            _logger.exception("Failed to receive Azure VM metadata: %s", e)
-            return None
+def _get_azure_vm_metadata():
+    request = Request(_AZURE_VM_METADATA_ENDPOINT)
+    request.add_header("Metadata", "True")
+    try:
+        # TODO: Changed to 4s to fit into OTel SDK's 5 second timeout.
+        # Lengthen or allow user input if issue is resolved.
+        # See https://github.com/open-telemetry/opentelemetry-python/issues/3644
+        with urlopen(request, timeout=4) as response:
+            return loads(response.read())
+    except URLError:
+        # Not on Azure VM
+        return None
+    except Exception as e:  # pylint: disable=broad-except,invalid-name
+        _logger.exception("Failed to receive Azure VM metadata: %s", e)
+        return None
 
-    def get_attribute_from_metadata(
-        self, metadata_json, attribute_key
-    ):  # pylint: disable=no-self-use
-        ams_value = ""
-        if attribute_key == _AZURE_VM_SCALE_SET_NAME_ATTRIBUTE:
-            ams_value = metadata_json["vmScaleSetName"]
-        elif attribute_key == _AZURE_VM_SKU_ATTRIBUTE:
-            ams_value = metadata_json["sku"]
-        elif attribute_key == ResourceAttributes.CLOUD_PLATFORM:
-            ams_value = CloudPlatformValues.AZURE_VM.value
-        elif attribute_key == ResourceAttributes.CLOUD_PROVIDER:
-            ams_value = CloudProviderValues.AZURE.value
-        elif attribute_key == ResourceAttributes.CLOUD_REGION:
-            ams_value = metadata_json["location"]
-        elif attribute_key == ResourceAttributes.CLOUD_RESOURCE_ID:
-            ams_value = metadata_json["resourceId"]
-        elif attribute_key in (
-            ResourceAttributes.HOST_ID,
-            ResourceAttributes.SERVICE_INSTANCE_ID,
-        ):
-            ams_value = metadata_json["vmId"]
-        elif attribute_key == ResourceAttributes.HOST_NAME:
-            ams_value = metadata_json["name"]
-        elif attribute_key == ResourceAttributes.HOST_TYPE:
-            ams_value = metadata_json["vmSize"]
-        elif attribute_key == ResourceAttributes.OS_TYPE:
-            ams_value = metadata_json["osType"]
-        elif attribute_key == ResourceAttributes.OS_VERSION:
-            ams_value = metadata_json["version"]
-        return ams_value
+def _get_attribute_from_metadata(
+    metadata_json, attribute_key
+):
+    ams_value = ""
+    if attribute_key == _AZURE_VM_SCALE_SET_NAME_ATTRIBUTE:
+        ams_value = metadata_json["vmScaleSetName"]
+    elif attribute_key == _AZURE_VM_SKU_ATTRIBUTE:
+        ams_value = metadata_json["sku"]
+    elif attribute_key == ResourceAttributes.CLOUD_PLATFORM:
+        ams_value = CloudPlatformValues.AZURE_VM.value
+    elif attribute_key == ResourceAttributes.CLOUD_PROVIDER:
+        ams_value = CloudProviderValues.AZURE.value
+    elif attribute_key == ResourceAttributes.CLOUD_REGION:
+        ams_value = metadata_json["location"]
+    elif attribute_key == ResourceAttributes.CLOUD_RESOURCE_ID:
+        ams_value = metadata_json["resourceId"]
+    elif attribute_key in (
+        ResourceAttributes.HOST_ID,
+        ResourceAttributes.SERVICE_INSTANCE_ID,
+    ):
+        ams_value = metadata_json["vmId"]
+    elif attribute_key == ResourceAttributes.HOST_NAME:
+        ams_value = metadata_json["name"]
+    elif attribute_key == ResourceAttributes.HOST_TYPE:
+        ams_value = metadata_json["vmSize"]
+    elif attribute_key == ResourceAttributes.OS_TYPE:
+        ams_value = metadata_json["osType"]
+    elif attribute_key == ResourceAttributes.OS_VERSION:
+        ams_value = metadata_json["version"]
+    return ams_value

--- a/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
+++ b/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
@@ -363,14 +363,18 @@ WINDOWS_ATTRIBUTES = {
 class TestAzureVMResourceDetector(unittest.TestCase):
     @patch("opentelemetry.resource.detector.azure.vm.urlopen")
     def test_linux(self, mock_urlopen):
-        mock_urlopen.return_value.__enter__.return_value.read.return_value = LINUX_JSON
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = (
+            LINUX_JSON
+        )
         attributes = AzureVMResourceDetector().detect().attributes
         for attribute_key, attribute_value in LINUX_ATTRIBUTES.items():
             self.assertEqual(attributes[attribute_key], attribute_value)
 
     @patch("opentelemetry.resource.detector.azure.vm.urlopen")
     def test_windows(self, mock_urlopen):
-        mock_urlopen.return_value.__enter__.return_value.read.return_value = WINDOWS_JSON
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = (
+            WINDOWS_JSON
+        )
         attributes = AzureVMResourceDetector().detect().attributes
         for attribute_key, attribute_value in WINDOWS_ATTRIBUTES.items():
             self.assertEqual(attributes[attribute_key], attribute_value)

--- a/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
+++ b/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 # pylint: disable=no-name-in-module
 from opentelemetry.resource.detector.azure.vm import AzureVMResourceDetector

--- a/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
+++ b/resource/opentelemetry-resource-detector-azure/tests/test_vm.py
@@ -363,18 +363,14 @@ WINDOWS_ATTRIBUTES = {
 class TestAzureVMResourceDetector(unittest.TestCase):
     @patch("opentelemetry.resource.detector.azure.vm.urlopen")
     def test_linux(self, mock_urlopen):
-        mock_response = Mock()
-        mock_urlopen.return_value = mock_response
-        mock_response.read.return_value = LINUX_JSON
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = LINUX_JSON
         attributes = AzureVMResourceDetector().detect().attributes
         for attribute_key, attribute_value in LINUX_ATTRIBUTES.items():
             self.assertEqual(attributes[attribute_key], attribute_value)
 
     @patch("opentelemetry.resource.detector.azure.vm.urlopen")
     def test_windows(self, mock_urlopen):
-        mock_response = Mock()
-        mock_urlopen.return_value = mock_response
-        mock_response.read.return_value = WINDOWS_JSON
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = WINDOWS_JSON
         attributes = AzureVMResourceDetector().detect().attributes
-        for attribute_key, attribute_value in LINUX_ATTRIBUTES.items():
+        for attribute_key, attribute_value in WINDOWS_ATTRIBUTES.items():
             self.assertEqual(attributes[attribute_key], attribute_value)


### PR DESCRIPTION
I get an error when mocking out the context manager in the current tests.

![image](https://github.com/open-telemetry/opentelemetry-python-contrib/assets/11580155/a91a1029-fc76-4cef-839a-d833421a97d3)

1. Fixes tests to properly mock out `urlopen`
2. Fixes tests to use `WINDOWS_ATTRIBUTES` for the windows tests.
3. Extract helper methods `_get_azure_vm_metadata` out of class `_AzureVMMetadataServiceRequestor`
4. Suppress instrumentation for urllib call

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2179
