### PR TITLE
Remove pkg_resource and replace for importlib.metadata in autoinstrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 - Deprecation of pkg_resource in favor of importlib.metadata
-  ([#2180](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2180))
+  ([#2181](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2181))
 
 ## Version 1.27.0/0.48b0 ()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking changes
+
+- Deprecation of pkg_resource in favor of importlib.metadata
+  ([#2180](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2180))
+
 ## Version 1.27.0/0.48b0 ()
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Deprecation of pkg_resource in favor of importlib.metadata
-  ([#2180](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2180))
 - `opentelemetry-instrumentation-kafka-python` Instrument temporary fork, kafka-python-ng inside kafka-python's instrumentation
   ([#2537](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2537))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `opentelemetry-instrumentation-kafka-python` Instrument temporary fork, kafka-python-ng
-  inside kafka-python's instrumentation
+- Deprecation of pkg_resource in favor of importlib.metadata
+  ([#2180](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2180))
+- `opentelemetry-instrumentation-kafka-python` Instrument temporary fork, kafka-python-ng inside kafka-python's instrumentation
   ([#2537](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2537))
 
 ### Breaking changes

--- a/opentelemetry-instrumentation/pyproject.toml
+++ b/opentelemetry-instrumentation/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.4",
-  "setuptools >= 16.0",
   "wrapt >= 1.0.0, < 2.0.0",
 ]
 

--- a/opentelemetry-instrumentation/pyproject.toml
+++ b/opentelemetry-instrumentation/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.4",
   "wrapt >= 1.0.0, < 2.0.0",
-  "importlib-metadata >= 6.0, < 7.0",
+  "importlib-metadata >= 6.0, < 8.0",
   "packaging >= 18.0",
 ]
 

--- a/opentelemetry-instrumentation/pyproject.toml
+++ b/opentelemetry-instrumentation/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.4",
   "wrapt >= 1.0.0, < 2.0.0",
+  "importlib-metadata >= 6.0, < 7.0",
+  "packaging >= 18.0",
 ]
 
 [project.scripts]

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -48,9 +48,7 @@ def run() -> None:
 
     argument_otel_environment_variable = {}
 
-    for entry_point in entry_points().get(
-        "opentelemetry_environment_variables", []
-    ):
+    for entry_point in entry_points(group="opentelemetry_environment_variables"):
         environment_variable_module = entry_point.load()
 
         for attribute in dir(environment_variable_module):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 from argparse import REMAINDER, ArgumentParser
+from importlib.metadata import entry_points
 from logging import getLogger
 from os import environ, execl, getcwd
 from os.path import abspath, dirname, pathsep
 from re import sub
 from shutil import which
-
-from importlib.metadata import entry_points
 
 from opentelemetry.instrumentation.version import __version__
 
@@ -48,7 +47,9 @@ def run() -> None:
 
     argument_otel_environment_variable = {}
 
-    for entry_point in entry_points(group="opentelemetry_environment_variables"):
+    for entry_point in entry_points(
+        group="opentelemetry_environment_variables"
+    ):
         environment_variable_module = entry_point.load()
 
         for attribute in dir(environment_variable_module):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -19,7 +19,7 @@ from os.path import abspath, dirname, pathsep
 from re import sub
 from shutil import which
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 from opentelemetry.instrumentation.version import __version__
 
@@ -48,8 +48,8 @@ def run() -> None:
 
     argument_otel_environment_variable = {}
 
-    for entry_point in iter_entry_points(
-        "opentelemetry_environment_variables"
+    for entry_point in entry_points().get(
+        "opentelemetry_environment_variables", []
     ):
         environment_variable_module = entry_point.load()
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -56,7 +56,7 @@ class _EntryPointDistFinder:
 
 def _load_distro() -> BaseDistro:
     distro_name = environ.get(OTEL_PYTHON_DISTRO, None)
-    for entry_point in entry_points().get("opentelemetry_distro", []):
+    for entry_point in entry_points(group="opentelemetry_distro"):
         try:
             # If no distro is specified, use first to come up.
             if distro_name is None or distro_name == entry_point.name:
@@ -87,10 +87,10 @@ def _load_instrumentors(distro):
         # to handle users entering "requests , flask" or "requests, flask" with spaces
         package_to_exclude = [x.strip() for x in package_to_exclude]
 
-    for entry_point in entry_points().get("opentelemetry_pre_instrument", []):
+    for entry_point in entry_points(group="opentelemetry_pre_instrument"):
         entry_point.load()()
 
-    for entry_point in entry_points().get("opentelemetry_instrumentor", []):
+    for entry_point in entry_points(group="opentelemetry_instrumentor"):
         if entry_point.name in package_to_exclude:
             _logger.debug(
                 "Instrumentation skipped for library %s", entry_point.name
@@ -115,14 +115,14 @@ def _load_instrumentors(distro):
             _logger.exception("Instrumenting of %s failed", entry_point.name)
             raise exc
 
-    for entry_point in entry_points().get("opentelemetry_post_instrument", []):
+    for entry_point in entry_points(group="opentelemetry_post_instrument"):
         entry_point.load()()
 
 
 def _load_configurators():
     configurator_name = environ.get(OTEL_PYTHON_CONFIGURATOR, None)
     configured = None
-    for entry_point in entry_points().get("opentelemetry_configurator", []):
+    for entry_point in entry_points(group="opentelemetry_configurator"):
         if configured is not None:
             _logger.warning(
                 "Configuration of %s not loaded, %s already loaded",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -15,7 +15,7 @@
 from logging import getLogger
 from os import environ
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 from opentelemetry.instrumentation.dependencies import (
     get_dist_dependency_conflicts,
@@ -33,7 +33,7 @@ _logger = getLogger(__name__)
 
 def _load_distro() -> BaseDistro:
     distro_name = environ.get(OTEL_PYTHON_DISTRO, None)
-    for entry_point in iter_entry_points("opentelemetry_distro"):
+    for entry_point in entry_points().get("opentelemetry_distro", []):
         try:
             # If no distro is specified, use first to come up.
             if distro_name is None or distro_name == entry_point.name:
@@ -63,10 +63,10 @@ def _load_instrumentors(distro):
         # to handle users entering "requests , flask" or "requests, flask" with spaces
         package_to_exclude = [x.strip() for x in package_to_exclude]
 
-    for entry_point in iter_entry_points("opentelemetry_pre_instrument"):
+    for entry_point in entry_points().get("opentelemetry_pre_instrument", []):
         entry_point.load()()
 
-    for entry_point in iter_entry_points("opentelemetry_instrumentor"):
+    for entry_point in entry_points().get("opentelemetry_instrumentor", []):
         if entry_point.name in package_to_exclude:
             _logger.debug(
                 "Instrumentation skipped for library %s", entry_point.name
@@ -90,14 +90,14 @@ def _load_instrumentors(distro):
             _logger.exception("Instrumenting of %s failed", entry_point.name)
             raise exc
 
-    for entry_point in iter_entry_points("opentelemetry_post_instrument"):
+    for entry_point in entry_points().get("opentelemetry_post_instrument", []):
         entry_point.load()()
 
 
 def _load_configurators():
     configurator_name = environ.get(OTEL_PYTHON_CONFIGURATOR, None)
     configured = None
-    for entry_point in iter_entry_points("opentelemetry_configurator"):
+    for entry_point in entry_points().get("opentelemetry_configurator", []):
         if configured is not None:
             _logger.warning(
                 "Configuration of %s not loaded, %s already loaded",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib.metadata import EntryPoint, distributions, entry_points
 from logging import getLogger
 from os import environ
-
-from importlib.metadata import entry_points, EntryPoint, distributions
 
 from opentelemetry.instrumentation.dependencies import (
     get_dist_dependency_conflicts,

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -15,6 +15,7 @@
 import argparse
 import logging
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from subprocess import (
     PIPE,
     CalledProcessError,
@@ -24,7 +25,6 @@ from subprocess import (
 )
 
 from packaging.requirements import Requirement
-from importlib.metadata import PackageNotFoundError, version
 
 from opentelemetry.instrumentation.bootstrap_gen import (
     default_instrumentations,
@@ -93,18 +93,18 @@ def _pip_check():
 
 def _is_installed(req):
     req = Requirement(req)
-    
+
     try:
         dist_version = version(req.name)
     except PackageNotFoundError:
         return False
-    
+
     if not req.specifier.filter(dist_version):
         logger.warning(
             "instrumentation for package %s is available"
             " but version %s is installed. Skipping.",
             req,
-            dist_version
+            dist_version,
         )
         return False
     return True

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -23,7 +23,7 @@ from subprocess import (
     check_call,
 )
 
-import pkg_resources
+from importlib.metadata import distribution, PackageNotFoundError
 
 from opentelemetry.instrumentation.bootstrap_gen import (
     default_instrumentations,
@@ -93,17 +93,10 @@ def _pip_check():
 def _is_installed(req):
     if req in sys.modules:
         return True
-
+    
     try:
-        pkg_resources.get_distribution(req)
-    except pkg_resources.DistributionNotFound:
-        return False
-    except pkg_resources.VersionConflict as exc:
-        logger.warning(
-            "instrumentation for package %s is available but version %s is installed. Skipping.",
-            exc.req,
-            exc.dist.as_requirement(),  # pylint: disable=no-member
-        )
+        distribution(req)
+    except PackageNotFoundError:
         return False
     return True
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -52,7 +52,7 @@ def get_dependency_conflicts(
                     dep,
                     exc,
                 )
-                return DependencyConflict(dep)            
+                return DependencyConflict(dep)
 
         try:
             dist_version = version(req.name)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -1,13 +1,7 @@
 from logging import getLogger
 from typing import Collection, Optional
 
-from pkg_resources import (
-    Distribution,
-    DistributionNotFound,
-    RequirementParseError,
-    VersionConflict,
-    get_distribution,
-)
+from importlib.metadata import distribution, PackageNotFoundError, Distribution
 
 logger = getLogger(__name__)
 
@@ -47,16 +41,7 @@ def get_dependency_conflicts(
 ) -> Optional[DependencyConflict]:
     for dep in deps:
         try:
-            get_distribution(dep)
-        except VersionConflict as exc:
-            return DependencyConflict(dep, exc.dist)
-        except DistributionNotFound:
-            return DependencyConflict(dep)
-        except RequirementParseError as exc:
-            logger.warning(
-                'error parsing dependency, reporting as a conflict: "%s" - %s',
-                dep,
-                exc,
-            )
+            distribution(dep)
+        except PackageNotFoundError:
             return DependencyConflict(dep)
     return None

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -1,8 +1,8 @@
+from importlib.metadata import Distribution, PackageNotFoundError, version
 from logging import getLogger
-from typing import Collection, Optional
+from typing import Collection, Optional, Union
 
-from packaging.requirements import Requirement, InvalidRequirement
-from importlib.metadata import PackageNotFoundError, Distribution, version
+from packaging.requirements import InvalidRequirement, Requirement
 
 logger = getLogger(__name__)
 
@@ -38,7 +38,7 @@ def get_dist_dependency_conflicts(
 
 
 def get_dependency_conflicts(
-    deps: Collection[str, Requirement],
+    deps: Collection[Union[str, Requirement]],
 ) -> Optional[DependencyConflict]:
     for dep in deps:
         if isinstance(dep, Requirement):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
@@ -18,9 +18,8 @@ OpenTelemetry Base Distribution (Distro)
 """
 
 from abc import ABC, abstractmethod
-from logging import getLogger
-
 from importlib.metadata import EntryPoint
+from logging import getLogger
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
@@ -20,7 +20,7 @@ OpenTelemetry Base Distribution (Distro)
 from abc import ABC, abstractmethod
 from logging import getLogger
 
-from pkg_resources import EntryPoint
+from importlib.metadata import EntryPoint
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -30,7 +30,13 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_configurators(
         self, iter_mock
@@ -61,7 +67,13 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_configurators_no_ep(
         self, iter_mock
@@ -74,7 +86,13 @@ class TestLoad(TestCase):
         "os.environ", {OTEL_PYTHON_CONFIGURATOR: "custom_configurator2"}
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_configurators_error(self, iter_mock):
         # Add multiple entry points but only specify the 2nd in the environment variable.
@@ -101,7 +119,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.isinstance"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_distro(self, iter_mock, isinstance_mock):
         # Add multiple entry points but only specify the 2nd in the environment variable.
@@ -134,7 +158,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.DefaultDistro"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_distro_not_distro(
         self, iter_mock, default_distro_mock, isinstance_mock
@@ -166,7 +196,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.DefaultDistro"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_distro_no_ep(self, iter_mock, default_distro_mock):
         iter_mock.return_value = ()
@@ -181,7 +217,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.isinstance"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_distro_error(self, iter_mock, isinstance_mock):
         ep_mock1 = Mock()
@@ -211,7 +253,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_instrumentors(self, iter_mock, dep_mock):
         # Mock opentelemetry_pre_instrument entry points
@@ -285,7 +333,13 @@ class TestLoad(TestCase):
         "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
     )
     @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.iter_entry_points"
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.distributions"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.EntryPoint"
     )
     def test_load_instrumentors_dep_conflict(
         self, iter_mock, dep_mock

--- a/opentelemetry-instrumentation/tests/test_dependencies.py
+++ b/opentelemetry-instrumentation/tests/test_dependencies.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=protected-access
 
-import pkg_resources
+from importlib.metadata import Distribution, requires
 import pytest
 
 from opentelemetry.instrumentation.dependencies import (
@@ -53,14 +53,12 @@ class TestDependencyConflicts(TestBase):
     def test_get_dist_dependency_conflicts(self):
         def mock_requires(extras=()):
             if "instruments" in extras:
-                return [
-                    pkg_resources.Requirement(
+                return requires(
                         'test-pkg ~= 1.0; extra == "instruments"'
                     )
-                ]
             return []
 
-        dist = pkg_resources.Distribution(
+        dist = Distribution(
             project_name="test-instrumentation", version="1.0"
         )
         dist.requires = mock_requires

--- a/opentelemetry-instrumentation/tests/test_distro.py
+++ b/opentelemetry-instrumentation/tests/test_distro.py
@@ -51,7 +51,7 @@ class TestDistro(TestCase):
         distro = MockDistro()
 
         instrumentor = MockInstrumetor()
-        entry_point = MockEntryPoint(MockInstrumetor)
+        entry_point = MockEntryPoint(MockInstrumetor, value="opentelemetry", group="opentelemetry_distro")
 
         self.assertFalse(instrumentor._is_instrumented_by_opentelemetry)
         distro.load_instrumentor(entry_point)

--- a/opentelemetry-instrumentation/tests/test_distro.py
+++ b/opentelemetry-instrumentation/tests/test_distro.py
@@ -15,7 +15,7 @@
 
 from unittest import TestCase
 
-from pkg_resources import EntryPoint
+from importlib.metadata import EntryPoint
 
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor


### PR DESCRIPTION
# Description

Pkgresource dependency is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources), on this pr i replaced pkg_resource for importlib.metadata.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2180

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run with tox the unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
