### PR TITLE
AwsLambdaInstrumentor handles and re-raises handler function exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2136](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2136))
 - `opentelemetry-resource-detector-azure` Suppress instrumentation for `urllib` call
   ([#2178](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2178))
+- AwsLambdaInstrumentor handles and re-raises function exception ([#2245](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2245))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -279,6 +279,7 @@ def _set_api_gateway_v2_proxy_attributes(
     return span
 
 
+# pylint: disable=too-many-statements
 def _instrument(
     wrapped_module_name,
     wrapped_function_name,
@@ -288,6 +289,8 @@ def _instrument(
     disable_aws_context_propagation: bool = False,
     meter_provider: MeterProvider = None,
 ):
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-statements
     def _instrumented_lambda_handler_call(  # noqa pylint: disable=too-many-branches
         call_wrapped, instance, args, kwargs
     ):

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -357,6 +357,7 @@ def _instrument(
             except Exception as exc:  # pylint: disable=W0703
                 exception = exc
                 span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(exception)
 
             # If the request came from an API Gateway, extract http attributes from the event
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/lambda_function.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/lambda_function.py
@@ -19,3 +19,7 @@ def handler(event, context):
 
 def rest_api_handler(event, context):
     return {"statusCode": 200, "body": "200 ok"}
+
+
+def handler_exc(event, context):
+    raise Exception("500 internal server error")

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -411,11 +411,11 @@ class TestAwsLambdaInstrumentor(TestBase):
         assert spans
 
     def test_lambda_handles_handler_exception(self):
-        self.exc_env_patch = mock.patch.dict(
+        exc_env_patch = mock.patch.dict(
             "os.environ",
             {_HANDLER: "tests.mocks.lambda_function.handler_exc"},
         )
-        self.exc_env_patch.start()
+        exc_env_patch.start()
         AwsLambdaInstrumentor().instrument()
         # instrumentor re-raises the exception
         with self.assertRaises(Exception):
@@ -429,7 +429,7 @@ class TestAwsLambdaInstrumentor(TestBase):
         event = span.events[0]
         self.assertEqual(event.name, "exception")
 
-        self.exc_env_patch.stop()
+        exc_env_patch.stop()
 
     def test_uninstrument(self):
         AwsLambdaInstrumentor().instrument()


### PR DESCRIPTION
# Description

This adds a try-except to AwsLambdaInstrumentor in case the instrumented lambda handler function raises an exception. Instrumentor will record an exception event to the span and mark its status as Error. The exception is then re-raised after trace and metrics `force_flush` so telemetry is still exported, and the lambda exception is still raised instead of silenced.

This is similar to what some of the other instrumentors are already doing, for example: [requests](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b6492a7999ebf5bdbad3ff71ceab6288b63e3233/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py#L219-L230), asgi (via [try-except](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b6492a7999ebf5bdbad3ff71ceab6288b63e3233/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L376-L389) to set attributes and [finally](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b6492a7999ebf5bdbad3ff71ceab6288b63e3233/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L625-L626) to export telemetry).

Fixes [#2246](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2246)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests e.g. `tox -e py39-test-instrumentation-aws-lambda`
- [X] Manual tests: I built [Otel Python lambda layer](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/python) with this update and invoked a lambda function that immediately does `raise Exception`. Exception is parsed into the function response and an instance of [Otel Collector](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector) received the spans with error status and events.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
