### PR TITLE
feat: add opentelemetry-instrumentation-threading library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `type` attribute to `asgi.event.type` in `opentelemetry-instrumentation-asgi`
   ([#2300](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2300))
 
+### Added
+
+- `opentelemetry-instrumentation-threading` Initial release for threading
+  ([#2253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2253))
+
 ## Version 1.24.0/0.45b0 (2024-03-28)
 
 ### Added
@@ -57,8 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `opentelemetry-instrumentation-psycopg` Initial release for psycopg 3.x
-- `opentelemetry-instrumentation-threading` Initial release for threading
-  ([#2253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2253))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `opentelemetry-instrumentation-psycopg` Initial release for psycopg 3.x
+- `opentelemetry-instrumentation-threading` Initial release for threading
+  ([#2253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2253))
 
 ## Version 1.22.0/0.43b0 (2023-12-14)
 

--- a/docs/instrumentation/threading/threading.rst
+++ b/docs/instrumentation/threading/threading.rst
@@ -1,0 +1,7 @@
+OpenTelemetry Threading Instrumentation
+======================================
+
+.. automodule:: opentelemetry.instrumentation.threading
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/instrumentation/threading/threading.rst
+++ b/docs/instrumentation/threading/threading.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Threading Instrumentation
-======================================
+=======================================
 
 .. automodule:: opentelemetry.instrumentation.threading
     :members:

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -43,6 +43,7 @@
 | [opentelemetry-instrumentation-sqlite3](./opentelemetry-instrumentation-sqlite3) | sqlite3 | No
 | [opentelemetry-instrumentation-starlette](./opentelemetry-instrumentation-starlette) | starlette ~= 0.13.0 | Yes
 | [opentelemetry-instrumentation-system-metrics](./opentelemetry-instrumentation-system-metrics) | psutil >= 5 | No
+| [opentelemetry-instrumentation-threading](./opentelemetry-instrumentation-threading) | threading | No
 | [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | Yes
 | [opentelemetry-instrumentation-tortoiseorm](./opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | No
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib | Yes

--- a/instrumentation/opentelemetry-instrumentation-threading/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-threading/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-threading/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-threading/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry threading Instrumentation
+===========================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-threading.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-threading/
+
+This library provides instrumentation for the `threading` module to ensure that
+the OpenTelemetry context is propagated across threads.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-threading
+
+References
+----------
+
+* `OpenTelemetry Threading Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/threading/threading.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation/opentelemetry-instrumentation-threading/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-threading/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry threading Instrumentation
-===========================
+=======================================
 
 |pypi|
 

--- a/instrumentation/opentelemetry-instrumentation-threading/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-threading/README.rst
@@ -7,7 +7,9 @@ OpenTelemetry threading Instrumentation
    :target: https://pypi.org/project/opentelemetry-instrumentation-threading/
 
 This library provides instrumentation for the `threading` module to ensure that
-the OpenTelemetry context is propagated across threads.
+the OpenTelemetry context is propagated across threads. It is important to note
+that this instrumentation does not produce any telemetry data on its own. It
+merely ensures that the context is correctly propagated when threads are used.
 
 Installation
 ------------

--- a/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-threading"
+dynamic = ["version"]
+description = "Threading tracing for OpenTelemetry"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.8"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation == 0.45b0.dev",
+  "wrapt >= 1.0.0, < 2.0.0",
+]
+
+[project.optional-dependencies]
+instruments = []
+test = [
+  "opentelemetry-test-utils == 0.45b0.dev",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+threading = "opentelemetry.instrumentation.threading:ThreadingInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-threading"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/threading/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
@@ -25,15 +25,12 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.12",
-  "opentelemetry-instrumentation == 0.45b0.dev",
+  "opentelemetry-instrumentation == 0.46b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]
 instruments = []
-test = [
-  "opentelemetry-test-utils == 0.45b0.dev",
-]
 
 [project.entry-points.opentelemetry_instrumentor]
 threading = "opentelemetry.instrumentation.threading:ThreadingInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "opentelemetry-instrumentation-threading"
 dynamic = ["version"]
-description = "Threading tracing for OpenTelemetry"
+description = "Thread context propagation support for OpenTelemetry"
 readme = "README.rst"
 license = "Apache-2.0"
 requires-python = ">=3.8"

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -33,14 +33,14 @@ re-activated in the thread's run method.
 
 import threading
 from typing import Collection
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+
+from wrapt import wrap_function_wrapper
+
+from opentelemetry import context, trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.threading.package import _instruments
 from opentelemetry.instrumentation.threading.version import __version__
-from opentelemetry import context, trace
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from wrapt import wrap_function_wrapper
 
 
 class ThreadingInstrumentor(BaseInstrumentor):

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -57,17 +57,25 @@ class ThreadingInstrumentor(BaseInstrumentor):
 
     @staticmethod
     def _instrument_thread():
-        wrap_function_wrapper(threading.Thread, 'start',
-                              ThreadingInstrumentor.__wrap_threading_start)
-        wrap_function_wrapper(threading.Thread, 'run',
-                              ThreadingInstrumentor.__wrap_threading_run)
+        wrap_function_wrapper(
+            threading.Thread,
+            "start",
+            ThreadingInstrumentor.__wrap_threading_start,
+        )
+        wrap_function_wrapper(
+            threading.Thread, "run", ThreadingInstrumentor.__wrap_threading_run
+        )
 
     @staticmethod
     def _instrument_timer():
-        wrap_function_wrapper(threading.Timer, 'start',
-                              ThreadingInstrumentor.__wrap_threading_start)
-        wrap_function_wrapper(threading.Timer, 'run',
-                              ThreadingInstrumentor.__wrap_threading_run)
+        wrap_function_wrapper(
+            threading.Timer,
+            "start",
+            ThreadingInstrumentor.__wrap_threading_start,
+        )
+        wrap_function_wrapper(
+            threading.Timer, "run", ThreadingInstrumentor.__wrap_threading_run
+        )
 
     @staticmethod
     def _uninstrument_thread():

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -39,7 +39,6 @@ from wrapt import wrap_function_wrapper
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.threading.package import _instruments
-from opentelemetry.instrumentation.threading.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 
 

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -29,9 +29,9 @@ that this instrumentation does not produce any telemetry data on its own. It
 merely ensures that the context is correctly propagated when threads are used.
 
 
-When instrumented, new threads created using threading.Thread, threading.Timer, 
-or within futures.ThreadPoolExecutor will have the current OpenTelemetry 
-context attached, and this context will be re-activated in the thread's 
+When instrumented, new threads created using threading.Thread, threading.Timer,
+or within futures.ThreadPoolExecutor will have the current OpenTelemetry
+context attached, and this context will be re-activated in the thread's
 run method or the executor's worker thread."
 """
 

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -1,0 +1,95 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Instrument threading to propagate OpenTelemetry context.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+
+    ThreadingInstrumentor().instrument()
+
+This library provides instrumentation for the `threading` module to ensure that
+the OpenTelemetry context is propagated across threads.
+
+When instrumented, new threads created using `threading.Thread` or `threading.Timer`
+will have the current OpenTelemetry context attached, and this context will be
+re-activated in the thread's run method.
+"""
+
+import threading
+from typing import Collection
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.threading.package import _instruments
+from opentelemetry.instrumentation.threading.version import __version__
+from opentelemetry import context, trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from wrapt import wrap_function_wrapper
+
+
+class ThreadingInstrumentor(BaseInstrumentor):
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        self._instrument_thread()
+        self._instrument_timer()
+
+    def _uninstrument(self, **kwargs):
+        self._uninstrument_thread()
+        self._uninstrument_timer()
+
+    @staticmethod
+    def _instrument_thread():
+        wrap_function_wrapper(threading.Thread, 'start',
+                              ThreadingInstrumentor.__wrap_threading_start)
+        wrap_function_wrapper(threading.Thread, 'run',
+                              ThreadingInstrumentor.__wrap_threading_run)
+
+    @staticmethod
+    def _instrument_timer():
+        wrap_function_wrapper(threading.Timer, 'start',
+                              ThreadingInstrumentor.__wrap_threading_start)
+        wrap_function_wrapper(threading.Timer, 'run',
+                              ThreadingInstrumentor.__wrap_threading_run)
+
+    @staticmethod
+    def _uninstrument_thread():
+        unwrap(threading.Thread, "start")
+        unwrap(threading.Thread, "run")
+
+    @staticmethod
+    def _uninstrument_timer():
+        unwrap(threading.Timer, "start")
+        unwrap(threading.Timer, "run")
+
+    @staticmethod
+    def __wrap_threading_start(call_wrapped, instance, args, kwargs):
+        span = trace.get_current_span()
+        instance._otel_context = trace.set_span_in_context(span)
+        return call_wrapped(*args, **kwargs)
+
+    @staticmethod
+    def __wrap_threading_run(call_wrapped, instance, args, kwargs):
+        token = None
+        try:
+            token = context.attach(instance._otel_context)
+            return call_wrapped(*args, **kwargs)
+        finally:
+            context.detach(token)

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -24,72 +24,103 @@ Usage
     ThreadingInstrumentor().instrument()
 
 This library provides instrumentation for the `threading` module to ensure that
-the OpenTelemetry context is propagated across threads.
+the OpenTelemetry context is propagated across threads. It is important to note
+that this instrumentation does not produce any telemetry data on its own. It
+merely ensures that the context is correctly propagated when threads are used.
 
-When instrumented, new threads created using `threading.Thread` or `threading.Timer`
-will have the current OpenTelemetry context attached, and this context will be
-re-activated in the thread's run method.
+
+When instrumented, new threads created using threading.Thread, threading.Timer, 
+or within futures.ThreadPoolExecutor will have the current OpenTelemetry 
+context attached, and this context will be re-activated in the thread's 
+run method or the executor's worker thread."
 """
 
 import threading
+from concurrent import futures
 from typing import Collection
 
 from wrapt import wrap_function_wrapper
 
-from opentelemetry import context, trace
+from opentelemetry import context
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.threading.package import _instruments
 from opentelemetry.instrumentation.utils import unwrap
 
 
 class ThreadingInstrumentor(BaseInstrumentor):
+    __WRAPPER_START_METHOD = "start"
+    __WRAPPER_RUN_METHOD = "run"
+    __WRAPPER_SUBMIT_METHOD = "submit"
+    __WRAPPER_KWARGS = "kwargs"
+    __WRAPPER_CONTEXT = "_otel_context"
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs):
         self._instrument_thread()
         self._instrument_timer()
+        self._instrument_thread_pool()
 
     def _uninstrument(self, **kwargs):
         self._uninstrument_thread()
         self._uninstrument_timer()
+        self._uninstrument_thread_pool()
 
     @staticmethod
     def _instrument_thread():
         wrap_function_wrapper(
             threading.Thread,
-            "start",
+            ThreadingInstrumentor.__WRAPPER_START_METHOD,
             ThreadingInstrumentor.__wrap_threading_start,
         )
         wrap_function_wrapper(
-            threading.Thread, "run", ThreadingInstrumentor.__wrap_threading_run
+            threading.Thread,
+            ThreadingInstrumentor.__WRAPPER_RUN_METHOD,
+            ThreadingInstrumentor.__wrap_threading_run,
         )
 
     @staticmethod
     def _instrument_timer():
         wrap_function_wrapper(
             threading.Timer,
-            "start",
+            ThreadingInstrumentor.__WRAPPER_START_METHOD,
             ThreadingInstrumentor.__wrap_threading_start,
         )
         wrap_function_wrapper(
-            threading.Timer, "run", ThreadingInstrumentor.__wrap_threading_run
+            threading.Timer,
+            ThreadingInstrumentor.__WRAPPER_RUN_METHOD,
+            ThreadingInstrumentor.__wrap_threading_run,
+        )
+
+    @staticmethod
+    def _instrument_thread_pool():
+        wrap_function_wrapper(
+            futures.ThreadPoolExecutor,
+            ThreadingInstrumentor.__WRAPPER_SUBMIT_METHOD,
+            ThreadingInstrumentor.__wrap_thread_pool_submit,
         )
 
     @staticmethod
     def _uninstrument_thread():
-        unwrap(threading.Thread, "start")
-        unwrap(threading.Thread, "run")
+        unwrap(threading.Thread, ThreadingInstrumentor.__WRAPPER_START_METHOD)
+        unwrap(threading.Thread, ThreadingInstrumentor.__WRAPPER_RUN_METHOD)
 
     @staticmethod
     def _uninstrument_timer():
-        unwrap(threading.Timer, "start")
-        unwrap(threading.Timer, "run")
+        unwrap(threading.Timer, ThreadingInstrumentor.__WRAPPER_START_METHOD)
+        unwrap(threading.Timer, ThreadingInstrumentor.__WRAPPER_RUN_METHOD)
+
+    @staticmethod
+    def _uninstrument_thread_pool():
+        unwrap(
+            futures.ThreadPoolExecutor,
+            ThreadingInstrumentor.__WRAPPER_SUBMIT_METHOD,
+        )
 
     @staticmethod
     def __wrap_threading_start(call_wrapped, instance, args, kwargs):
-        span = trace.get_current_span()
-        instance._otel_context = trace.set_span_in_context(span)
+        instance._otel_context = context.get_current()
         return call_wrapped(*args, **kwargs)
 
     @staticmethod
@@ -100,3 +131,30 @@ class ThreadingInstrumentor(BaseInstrumentor):
             return call_wrapped(*args, **kwargs)
         finally:
             context.detach(token)
+
+    @staticmethod
+    def __wrap_thread_pool_submit(call_wrapped, instance, args, kwargs):
+        # obtain the original function and wrapped kwargs
+        original_func = args[0]
+        wrapped_kwargs = {
+            ThreadingInstrumentor.__WRAPPER_KWARGS: kwargs,
+            ThreadingInstrumentor.__WRAPPER_CONTEXT: context.get_current(),
+        }
+
+        def wrapped_func(*func_args, **func_kwargs):
+            original_kwargs = func_kwargs.pop(
+                ThreadingInstrumentor.__WRAPPER_KWARGS
+            )
+            otel_context = func_kwargs.pop(
+                ThreadingInstrumentor.__WRAPPER_CONTEXT
+            )
+            token = None
+            try:
+                token = context.attach(otel_context)
+                return original_func(*func_args, **original_kwargs)
+            finally:
+                context.detach(token)
+
+        # replace the original function with the wrapped function
+        new_args = (wrapped_func,) + args[1:]
+        return call_wrapped(*new_args, **wrapped_kwargs)

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -51,8 +51,6 @@ class ThreadingInstrumentor(BaseInstrumentor):
     __WRAPPER_START_METHOD = "start"
     __WRAPPER_RUN_METHOD = "run"
     __WRAPPER_SUBMIT_METHOD = "submit"
-    __WRAPPER_KWARGS = "kwargs"
-    __WRAPPER_CONTEXT = "_otel_context"
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/package.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/package.py
@@ -1,0 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_instruments = ()
+
+_supports_metrics = False

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/version.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.45b0.dev"
+__version__ = "0.46b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/version.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.45b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-threading/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-threading/test-requirements.txt
@@ -1,0 +1,18 @@
+asgiref==3.7.2
+attrs==23.2.0
+confluent-kafka==2.3.0
+Deprecated==1.2.14
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+packaging==23.2
+pluggy==1.4.0
+py==1.11.0
+py-cpuinfo==9.0.0
+pytest==7.1.3
+pytest-benchmark==4.0.0
+tomli==2.0.1
+typing_extensions==4.9.0
+wrapt==1.16.0
+zipp==3.17.0
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-threading

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -120,7 +120,7 @@ class TestThreading(TestBase):
                 # check result
                 self.assertEqual(future2.result(), expected_task2_context)
 
-    def fake_func(self) -> trace.SpanContext:
+    def fake_func(self):
         span_context = self.get_current_span_context_for_test()
         self._mock_span_contexts.append(span_context)
 

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -79,3 +79,107 @@ class TestThreading(TestBase):
         self.global_context = span_context
         self.global_trace_id = span_context.trace_id
         self.global_span_id = span_context.span_id
+
+    def print_square(self, num):
+        with self._tracer.start_as_current_span("square"):
+            return num * num
+
+    def print_cube(self, num):
+        with self._tracer.start_as_current_span("cube"):
+            return num * num * num
+
+    def print_square_with_thread(self, num):
+        with self._tracer.start_as_current_span("square"):
+            cube_thread = threading.Thread(target=self.print_cube, args=(10,))
+
+            cube_thread.start()
+            cube_thread.join()
+            return num * num
+
+    def calculate(self, num):
+        with self._tracer.start_as_current_span("calculate"):
+            square_thread = threading.Thread(
+                target=self.print_square, args=(num,)
+            )
+            cube_thread = threading.Thread(target=self.print_cube, args=(num,))
+            square_thread.start()
+            square_thread.join()
+
+            cube_thread.start()
+            cube_thread.join()
+
+    def test_without_thread_nesting(self):
+        square_thread = threading.Thread(target=self.print_square, args=(10,))
+
+        with self._tracer.start_as_current_span("root"):
+            square_thread.start()
+            square_thread.join()
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+
+        # pylint: disable=unbalanced-tuple-unpacking
+        target, root = spans[:2]
+
+        self.assertIs(target.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_with_thread_nesting(self):
+        #
+        #  Following scenario is tested.
+        #  threadA -> methodA -> threadB -> methodB
+        #
+
+        square_thread = threading.Thread(
+            target=self.print_square_with_thread, args=(10,)
+        )
+
+        with self._tracer.start_as_current_span("root"):
+            square_thread.start()
+            square_thread.join()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 3)
+        # pylint: disable=unbalanced-tuple-unpacking
+        cube, square, root = spans[:3]
+
+        self.assertIs(cube.parent, square.get_span_context())
+        self.assertIs(square.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_with_thread_multi_nesting(self):
+        #
+        # Following scenario is tested.
+        #                         / threadB -> methodB
+        #    threadA -> methodA ->
+        #                        \ threadC -> methodC
+        #
+        calculate_thread = threading.Thread(target=self.calculate, args=(10,))
+
+        with self._tracer.start_as_current_span("root"):
+            calculate_thread.start()
+            calculate_thread.join()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 4)
+
+        # pylint: disable=unbalanced-tuple-unpacking
+        cube, square, calculate, root = spans[:4]
+
+        self.assertIs(cube.parent, calculate.get_span_context())
+        self.assertIs(square.parent, calculate.get_span_context())
+        self.assertIs(calculate.parent, root.get_span_context())
+        self.assertIsNone(root.parent)
+
+    def test_uninstrumented(self):
+        ThreadingInstrumentor().uninstrument()
+
+        square_thread = threading.Thread(target=self.print_square, args=(10,))
+        square_thread.start()
+        square_thread.join()
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        ThreadingInstrumentor().instrument()

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -1,0 +1,79 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent import futures
+import threading
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+from opentelemetry import trace
+
+
+class TestThreading(TestBase):
+    def setUp(self):
+        super().setUp()
+        self._tracer = self.tracer_provider.get_tracer(__name__)
+        self.global_context = None
+        self.global_trace_id = None
+        self.global_span_id = None
+        ThreadingInstrumentor().instrument()
+
+    def tearDown(self):
+        ThreadingInstrumentor().uninstrument()
+        super().tearDown()
+
+    def get_root_span(self):
+        return self._tracer.start_as_current_span("rootSpan")
+
+    def test_trace_context_propagation_in_thread(self):
+        self.run_threading_test(threading.Thread(target=self.fake_func))
+
+    def test_trace_context_propagation_in_timer(self):
+        self.run_threading_test(threading.Timer(
+            interval=1, function=self.fake_func))
+
+    def run_threading_test(self, thread: threading.Thread):
+        with self.get_root_span() as span:
+            span_context = span.get_span_context()
+            expected_context = span_context
+            expected_trace_id = span_context.trace_id
+            expected_span_id = span_context.span_id
+            thread.start()
+            thread.join()
+
+            # check result
+            self.assertEqual(self.global_context, expected_context)
+            self.assertEqual(self.global_trace_id, expected_trace_id)
+            self.assertEqual(self.global_span_id, expected_span_id)
+
+    def test_trace_context_propagation_in_thread_pool(self):
+        with self.get_root_span() as span:
+            span_context = span.get_span_context()
+            expected_context = span_context
+            expected_trace_id = span_context.trace_id
+            expected_span_id = span_context.span_id
+
+            with futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(self.fake_func)
+                future.result()
+
+                # check result
+                self.assertEqual(self.global_context, expected_context)
+                self.assertEqual(self.global_trace_id, expected_trace_id)
+                self.assertEqual(self.global_span_id, expected_span_id)
+
+    def fake_func(self):
+        span_context = trace.get_current_span().get_span_context()
+        self.global_context = span_context
+        self.global_trace_id = span_context.trace_id
+        self.global_span_id = span_context.span_id

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -117,7 +117,8 @@ class TestThreading(TestBase):
         span_context = self.get_current_span_context_for_test()
         self._mock_span_contexts.append(span_context)
 
-    def get_current_span_context_for_test(self) -> trace.SpanContext:
+    @staticmethod
+    def get_current_span_context_for_test() -> trace.SpanContext:
         return trace.get_current_span().get_span_context()
 
     def print_square(self, num):

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -81,7 +81,7 @@ class TestThreading(TestBase):
         max_workers = 1
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # test propagation of the same trace context across multiple tasks
-            with self._tracer.start_as_current_span(f"task") as task_span:
+            with self._tracer.start_as_current_span("task") as task_span:
                 expected_task_context = task_span.get_span_context()
                 future1 = executor.submit(
                     self.get_current_span_context_for_test
@@ -95,7 +95,7 @@ class TestThreading(TestBase):
                 self.assertEqual(future2.result(), expected_task_context)
 
             # test propagation of different trace contexts across tasks in sequence
-            with self._tracer.start_as_current_span(f"task1") as task1_span:
+            with self._tracer.start_as_current_span("task1") as task1_span:
                 expected_task1_context = task1_span.get_span_context()
                 future1 = executor.submit(
                     self.get_current_span_context_for_test
@@ -104,7 +104,7 @@ class TestThreading(TestBase):
                 # check result
                 self.assertEqual(future1.result(), expected_task1_context)
 
-            with self._tracer.start_as_current_span(f"task2") as task2_span:
+            with self._tracer.start_as_current_span("task2") as task2_span:
                 expected_task2_context = task2_span.get_span_context()
                 future2 = executor.submit(
                     self.get_current_span_context_for_test

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -39,8 +39,9 @@ class TestThreading(TestBase):
         self.run_threading_test(threading.Thread(target=self.fake_func))
 
     def test_trace_context_propagation_in_timer(self):
-        self.run_threading_test(threading.Timer(
-            interval=1, function=self.fake_func))
+        self.run_threading_test(
+            threading.Timer(interval=1, function=self.fake_func)
+        )
 
     def run_threading_test(self, thread: threading.Thread):
         with self.get_root_span() as span:

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -75,14 +75,7 @@ class TestThreading(TestBase):
         result_span_contexts = [future.result() for future in futures_list]
 
         # check result
-        self.assertEqual(len(result_span_contexts), max_workers)
-        self.assertEqual(
-            len(result_span_contexts), len(expected_span_contexts)
-        )
-        for index, result_span_context in enumerate(result_span_contexts):
-            self.assertEqual(
-                result_span_context, expected_span_contexts[index]
-            )
+        self.assertEqual(result_span_contexts, expected_span_contexts)
 
     def test_trace_context_propagation_in_thread_pool_with_single_worker(self):
         max_workers = 1

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent import futures
 import threading
-from opentelemetry.test.test_base import TestBase
-from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+from concurrent import futures
+
 from opentelemetry import trace
+from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+from opentelemetry.test.test_base import TestBase
 
 
 class TestThreading(TestBase):

--- a/opentelemetry-contrib-instrumentations/pyproject.toml
+++ b/opentelemetry-contrib-instrumentations/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "opentelemetry-instrumentation-sqlite3==0.46b0.dev",
     "opentelemetry-instrumentation-starlette==0.46b0.dev",
     "opentelemetry-instrumentation-system-metrics==0.46b0.dev",
+    "opentelemetry-instrumentation-threading==0.46b0.dev",
     "opentelemetry-instrumentation-tornado==0.46b0.dev",
     "opentelemetry-instrumentation-tortoiseorm==0.46b0.dev",
     "opentelemetry-instrumentation-urllib==0.46b0.dev",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -191,6 +191,7 @@ default_instrumentations = [
     "opentelemetry-instrumentation-dbapi==0.46b0.dev",
     "opentelemetry-instrumentation-logging==0.46b0.dev",
     "opentelemetry-instrumentation-sqlite3==0.46b0.dev",
+    "opentelemetry-instrumentation-threading==0.46b0.dev",
     "opentelemetry-instrumentation-urllib==0.46b0.dev",
     "opentelemetry-instrumentation-wsgi==0.46b0.dev",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -523,6 +523,7 @@ commands =
   test-instrumentation-sqlite3: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-sqlite3/tests {posargs}
   test-instrumentation-starlette: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-starlette/tests {posargs}
   test-instrumentation-system-metrics: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics/tests {posargs}
+  test-instrumentation-threading: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-threading/tests {posargs}
   test-instrumentation-tornado: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-tornado/tests {posargs}
   test-instrumentation-tortoiseorm: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-tortoiseorm/tests {posargs}
   test-instrumentation-wsgi: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-wsgi/tests {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -233,6 +233,10 @@ envlist =
     py3{6,8,9,10,11}-test-instrumentation-system-metrics
     pypy3-test-instrumentation-system-metrics
 
+    ; opentelemetry-instrumentation-threading
+    py3{8,9,10,11}-test-instrumentation-threading
+    pypy3-test-instrumentation-threading
+
     ; opentelemetry-instrumentation-tornado
     py3{8,9,10,11}-test-instrumentation-tornado
     pypy3-test-instrumentation-tornado
@@ -421,6 +425,8 @@ commands_pre =
 
   system-metrics: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics/test-requirements.txt
 
+  threading: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-threading[test]
+
   tornado: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-tornado/test-requirements.txt
 
   tortoiseorm: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-tortoiseorm/test-requirements.txt
@@ -607,6 +613,7 @@ commands_pre =
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-confluent-kafka/test-requirements.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-pika/test-requirements-1.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-pymysql/test-requirements.txt
+  python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-pymysql[test]
   # prerequisite: follow the instructions here https://github.com/PyMySQL/mysqlclient#install
   # for your OS to install the required dependencies
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient/test-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -425,7 +425,7 @@ commands_pre =
 
   system-metrics: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics/test-requirements.txt
 
-  threading: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-threading[test]
+  threading: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-threading/test-requirements.txt
 
   tornado: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-tornado/test-requirements.txt
 
@@ -614,7 +614,6 @@ commands_pre =
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-confluent-kafka/test-requirements.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-pika/test-requirements-1.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-pymysql/test-requirements.txt
-  python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-pymysql[test]
   # prerequisite: follow the instructions here https://github.com/PyMySQL/mysqlclient#install
   # for your OS to install the required dependencies
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient/test-requirements.txt
@@ -628,6 +627,7 @@ commands_pre =
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-asyncio/test-requirements.txt
   pip install -r {toxinidir}/exporter/opentelemetry-exporter-richconsole/test-requirements.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics/test-requirements.txt
+  pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-threading/test-requirements.txt
   pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-tortoiseorm/test-requirements.txt
   # requires snappy headers to be available on the system
   pip install -r {toxinidir}/resource/opentelemetry-resource-detector-container/test-requirements.txt


### PR DESCRIPTION
# Description
At the current stage, Python OpenTelemetry does not support thread instrumentation. It is unable to pass the correct context in the execution thread context, leading to broken trace-IDs when users invoke threads. This results in the inability to properly trace operations.

Fixes #737

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have written the `test_threading.py` file for testing, which includes `threading.Thread` and `threading.Timer`, and have also used `futures.ThreadPoolExecutor` for testing.

- [x] tox -e test-instrumentation-threading

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
