### PR TITLE
Add auth parameter on PrometheusRemoteWriteMetricsExporter to enable Custom HTTP authentication like AWS Sigv4

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -66,6 +66,7 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         timeout: timeout for remote write requests in seconds, defaults to 30 (Optional)
         proxies: dict mapping request proxy protocols to proxy urls (Optional)
         tls_config: configuration for remote write TLS settings (Optional)
+        auth: auth tuple or callable to enable Basic/Digest/Custom HTTP Auth (Optional)
     """
 
     def __init__(
@@ -79,6 +80,7 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         resources_as_labels: bool = True,
         preferred_temporality: Dict[type, AggregationTemporality] = None,
         preferred_aggregation: Dict = None,
+        auth = None,
     ):
         self.endpoint = endpoint
         self.basic_auth = basic_auth
@@ -87,6 +89,7 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         self.tls_config = tls_config
         self.proxies = proxies
         self.resources_as_labels = resources_as_labels
+        self.auth = auth
 
         if not preferred_temporality:
             preferred_temporality = {
@@ -180,6 +183,14 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
     @headers.setter
     def headers(self, headers: Dict):
         self._headers = headers
+
+    @property
+    def auth(self):
+        return self._auth
+    
+    @auth.setter
+    def auth(self, auth):
+        self._auth = auth
 
     def export(
         self,
@@ -370,6 +381,8 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         auth = None
         if self.basic_auth:
             auth = (self.basic_auth["username"], self.basic_auth["password"])
+        elif self.auth:
+            auth = self.auth
 
         cert = None
         verify = True


### PR DESCRIPTION
# Description

https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2177

Fixes # 2177

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used custom AWS Sigv4 authentication object to export metrics to Amazon Managed Prometheus service directly, as the following code:

```
    from opentelemetry.sdk.metrics import MeterProvider
    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
    from opentelemetry.exporter.prometheus_remote_write import (
    PrometheusRemoteWriteMetricsExporter,
)
    from requests_auth_aws_sigv4 import AWSSigV4

    aws_auth = AWSSigV4('aps',
        aws_access_key_id=AWS_ACCESS_KEY_ID,
        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
        region='eu-west-1',
    )
    exporter = PrometheusRemoteWriteMetricsExporter(
        endpoint='REMOTE_WRITE_ENDPOINT',
        headers={},
        auth=aws_auth, 
    )

    reader = PeriodicExportingMetricReader(exporter, 1000)
    provider = MeterProvider(metric_readers=[reader])

    FlaskInstrumentor().instrument_app(app, meter_provider=provider)
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
