### PR TITLE
Fix OpenTelemetry Aio-pika instrumentation link

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aio-pika/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aio-pika/README.rst
@@ -18,6 +18,6 @@ Installation
 References
 ----------
 
-* `OpenTelemetry Aio-pika instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/aio-pika/aio-pika.html>`_
+* `OpenTelemetry Aio-pika instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/aio_pika/aio_pika.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_


### PR DESCRIPTION
# Description

Just fixes the broken URL to the aio-pika page. 