### PR TITLE
Fix HTTP header normalization

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -132,7 +132,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -166,7 +166,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_custom_headers.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_custom_headers.py
@@ -105,17 +105,17 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         for span in span_list:
             if span.kind == SpanKind.SERVER:
@@ -132,12 +132,12 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
         }
         not_expected = {
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
         }
@@ -158,19 +158,19 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         for span in span_list:
             if span.kind == SpanKind.SERVER:
@@ -187,7 +187,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -221,17 +221,17 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         for span in span_list:
             if span.kind == SpanKind.SERVER:
@@ -259,7 +259,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         not_expected = {
-            "http.request.header.custom_test_header_3": (
+            "http.request.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -291,19 +291,19 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         for span in span_list:
             if span.kind == SpanKind.SERVER:
@@ -332,7 +332,7 @@ class TestCustomHeaders(AsgiTestBase, TestBase):
         self.get_all_output()
         span_list = self.exporter.get_finished_spans()
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -177,7 +177,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -211,7 +211,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -594,17 +594,17 @@ class TestMiddlewareWsgiWithCustomHeaders(WsgiTestBase):
 
     def test_http_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         Client(
             HTTP_CUSTOM_TEST_HEADER_1="test-header-value-1",
@@ -623,7 +623,7 @@ class TestMiddlewareWsgiWithCustomHeaders(WsgiTestBase):
 
     def test_http_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
         }
@@ -639,19 +639,19 @@ class TestMiddlewareWsgiWithCustomHeaders(WsgiTestBase):
 
     def test_http_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         Client().get("/traced_custom_header/")
         spans = self.exporter.get_finished_spans()
@@ -664,7 +664,7 @@ class TestMiddlewareWsgiWithCustomHeaders(WsgiTestBase):
 
     def test_http_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware_asgi.py
@@ -470,17 +470,17 @@ class TestMiddlewareAsgiWithCustomHeaders(SimpleTestCase, TestBase):
 
     async def test_http_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         await self.async_client.get(
             "/traced/",
@@ -502,7 +502,7 @@ class TestMiddlewareAsgiWithCustomHeaders(SimpleTestCase, TestBase):
 
     async def test_http_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
         }
@@ -523,19 +523,19 @@ class TestMiddlewareAsgiWithCustomHeaders(SimpleTestCase, TestBase):
 
     async def test_http_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         await self.async_client.get("/traced_custom_header/")
         spans = self.exporter.get_finished_spans()
@@ -548,7 +548,7 @@ class TestMiddlewareAsgiWithCustomHeaders(SimpleTestCase, TestBase):
 
     async def test_http_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -125,7 +125,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -159,7 +159,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -471,18 +471,18 @@ class TestCustomRequestResponseHeaders(TestFalconBase):
         assert span.status.is_ok
 
         expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         not_expected = {
-            "http.request.header.custom_test_header_3": ("TestValue4",),
+            "http.request.header.custom-test-header-3": ("TestValue4",),
         }
 
         self.assertEqual(span.kind, trace.SpanKind.SERVER)
@@ -506,17 +506,17 @@ class TestCustomRequestResponseHeaders(TestFalconBase):
             span = self.memory_exporter.get_finished_spans()[0]
             assert span.status.is_ok
             not_expected = {
-                "http.request.header.custom_test_header_1": ("Test Value 1",),
-                "http.request.header.custom_test_header_2": (
+                "http.request.header.custom-test-header-1": ("Test Value 1",),
+                "http.request.header.custom-test-header-2": (
                     "TestValue2,TestValue3",
                 ),
-                "http.request.header.regex_test_header_1": (
+                "http.request.header.regex-test-header-1": (
                     "Regex Test Value 1",
                 ),
-                "http.request.header.regex_test_header_2": (
+                "http.request.header.regex-test-header-2": (
                     "RegexTestValue2,RegexTestValue3",
                 ),
-                "http.request.header.my_secret_header": ("[REDACTED]",),
+                "http.request.header.my-secret-header": ("[REDACTED]",),
             }
             self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
             for key, _ in not_expected.items():
@@ -534,23 +534,23 @@ class TestCustomRequestResponseHeaders(TestFalconBase):
         span = self.memory_exporter.get_finished_spans()[0]
         assert span.status.is_ok
         expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("0",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("0",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         not_expected = {
-            "http.response.header.dont_capture_me": ("test-value",)
+            "http.response.header.dont-capture-me": ("test-value",)
         }
         self.assertEqual(span.kind, trace.SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
@@ -571,20 +571,20 @@ class TestCustomRequestResponseHeaders(TestFalconBase):
             span = self.memory_exporter.get_finished_spans()[0]
             assert span.status.is_ok
             not_expected = {
-                "http.response.header.content_type": (
+                "http.response.header.content-type": (
                     "text/plain; charset=utf-8",
                 ),
-                "http.response.header.content_length": ("0",),
-                "http.response.header.my_custom_header": (
+                "http.response.header.content-length": ("0",),
+                "http.response.header.my-custom-header": (
                     "my-custom-value-1,my-custom-header-2",
                 ),
-                "http.response.header.my_custom_regex_header_1": (
+                "http.response.header.my-custom-regex-header-1": (
                     "my-custom-regex-value-1,my-custom-regex-value-2",
                 ),
-                "http.response.header.my_custom_regex_header_2": (
+                "http.response.header.my-custom-regex-header-2": (
                     "my-custom-regex-value-3,my-custom-regex-value-4",
                 ),
-                "http.response.header.my_secret_header": ("[REDACTED]",),
+                "http.response.header.my-secret-header": ("[REDACTED]",),
             }
             self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
             for key, _ in not_expected.items():

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -115,7 +115,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -149,7 +149,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -589,17 +589,17 @@ class TestHTTPAppWithCustomHeaders(TestBase):
 
     def test_http_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         resp = self.client.get(
             "/foobar",
@@ -623,7 +623,7 @@ class TestHTTPAppWithCustomHeaders(TestBase):
 
     def test_http_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_3": (
+            "http.request.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -650,19 +650,19 @@ class TestHTTPAppWithCustomHeaders(TestBase):
 
     def test_http_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         resp = self.client.get("/foobar")
         self.assertEqual(200, resp.status_code)
@@ -676,7 +676,7 @@ class TestHTTPAppWithCustomHeaders(TestBase):
 
     def test_http_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -745,10 +745,10 @@ class TestWebSocketAppWithCustomHeaders(TestBase):
 
     def test_web_socket_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
         }
@@ -781,7 +781,7 @@ class TestWebSocketAppWithCustomHeaders(TestBase):
     )
     def test_web_socket_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_3": (
+            "http.request.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -808,10 +808,10 @@ class TestWebSocketAppWithCustomHeaders(TestBase):
 
     def test_web_socket_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
         }
@@ -831,7 +831,7 @@ class TestWebSocketAppWithCustomHeaders(TestBase):
 
     def test_web_socket_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -182,7 +182,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -216,7 +216,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -658,15 +658,15 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
         self.assertEqual(200, resp.status_code)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         self.assertEqual(span.kind, trace.SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
@@ -685,17 +685,17 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
             self.assertEqual(200, resp.status_code)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.request.header.custom_test_header_1": ("Test Value 1",),
-                "http.request.header.custom_test_header_2": (
+                "http.request.header.custom-test-header-1": ("Test Value 1",),
+                "http.request.header.custom-test-header-2": (
                     "TestValue2,TestValue3",
                 ),
-                "http.request.header.regex_test_header_1": (
+                "http.request.header.regex-test-header-1": (
                     "Regex Test Value 1",
                 ),
-                "http.request.header.regex_test_header_2": (
+                "http.request.header.regex-test-header-2": (
                     "RegexTestValue2,RegexTestValue3",
                 ),
-                "http.request.header.my_secret_header": ("[REDACTED]",),
+                "http.request.header.my-secret-header": ("[REDACTED]",),
             }
             self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
             for key, _ in not_expected.items():
@@ -706,20 +706,20 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
         self.assertEqual(resp.status_code, 200)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("13",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("13",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         self.assertEqual(span.kind, trace.SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
@@ -731,20 +731,20 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
             self.assertEqual(resp.status_code, 200)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.response.header.content_type": (
+                "http.response.header.content-type": (
                     "text/plain; charset=utf-8",
                 ),
-                "http.response.header.content_length": ("13",),
-                "http.response.header.my_custom_header": (
+                "http.response.header.content-length": ("13",),
+                "http.response.header.my-custom-header": (
                     "my-custom-value-1,my-custom-header-2",
                 ),
-                "http.response.header.my_custom_regex_header_1": (
+                "http.response.header.my-custom-regex-header-1": (
                     "my-custom-regex-value-1,my-custom-regex-value-2",
                 ),
-                "http.response.header.my_custom_regex_header_2": (
+                "http.response.header.my-custom-regex-header-2": (
                     "my-custom-regex-value-3,my-custom-regex-value-4",
                 ),
-                "http.response.header.my_secret_header": ("[REDACTED]",),
+                "http.response.header.my-secret-header": ("[REDACTED]",),
             }
             self.assertEqual(span.kind, trace.SpanKind.INTERNAL)
             for key, _ in not_expected.items():

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
@@ -128,7 +128,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -162,7 +162,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -319,18 +319,18 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
         self.assertEqual(200, resp.status_code)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         not_expected = {
-            "http.request.header.custom_test_header_3": ("TestValue4",),
+            "http.request.header.custom-test-header-3": ("TestValue4",),
         }
         self.assertEqual(span.kind, SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
@@ -348,8 +348,8 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
             self.assertEqual(200, resp.status_code)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.request.header.custom_test_header_1": ("Test Value 1",),
-                "http.request.header.custom_test_header_2": (
+                "http.request.header.custom-test-header-1": ("Test Value 1",),
+                "http.request.header.custom-test-header-2": (
                     "TestValue2,TestValue3",
                 ),
             }
@@ -362,23 +362,23 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
         self.assertEqual(200, resp.status_code)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("7",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("7",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         not_expected = {
-            "http.response.header.dont_capture_me": ("test-value",)
+            "http.response.header.dont-capture-me": ("test-value",)
         }
         self.assertEqual(span.kind, SpanKind.SERVER)
         self.assertSpanHasAttributes(span, expected)
@@ -392,11 +392,11 @@ class TestCustomRequestResponseHeaders(InstrumentationTest, WsgiTestBase):
             self.assertEqual(200, resp.status_code)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.response.header.content_type": (
+                "http.response.header.content-type": (
                     "text/plain; charset=utf-8",
                 ),
-                "http.response.header.content_length": ("7",),
-                "http.response.header.my_custom_header": (
+                "http.response.header.content-length": ("7",),
+                "http.response.header.my-custom-header": (
                     "my-custom-value-1,my-custom-header-2",
                 ),
             }

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -111,7 +111,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -145,7 +145,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -481,17 +481,17 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         resp = self._client.get(
             "/foobar",
@@ -522,7 +522,7 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
     )
     def test_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_3": (
+            "http.request.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -549,19 +549,19 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         resp = self._client.get("/foobar")
         self.assertEqual(200, resp.status_code)
@@ -576,7 +576,7 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -607,17 +607,17 @@ class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_request_headers_in_span_attributes(self):
         expected = {
-            "http.request.header.custom_test_header_1": (
+            "http.request.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         with self._client.websocket_connect(
             "/foobar_web",
@@ -642,7 +642,7 @@ class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_request_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.request.header.custom_test_header_3": (
+            "http.request.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }
@@ -671,19 +671,19 @@ class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_response_headers_in_span_attributes(self):
         expected = {
-            "http.response.header.custom_test_header_1": (
+            "http.response.header.custom-test-header-1": (
                 "test-header-value-1",
             ),
-            "http.response.header.custom_test_header_2": (
+            "http.response.header.custom-test-header-2": (
                 "test-header-value-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         with self._client.websocket_connect("/foobar_web") as websocket:
             data = websocket.receive_json()
@@ -700,7 +700,7 @@ class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
     def test_custom_response_headers_not_in_span_attributes(self):
         not_expected = {
-            "http.response.header.custom_test_header_3": (
+            "http.response.header.custom-test-header-3": (
                 "test-header-value-3",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -121,7 +121,7 @@ The name of the added span attribute will follow the format ``http.request.heade
 The value of the attribute will be single item list containing all the header values.
 
 Example of the added span attribute,
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -143,7 +143,7 @@ The name of the added span attribute will follow the format ``http.response.head
 The value of the attribute will be single item list containing all the header values.
 
 Example of the added span attribute,
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Note:
     Environment variable names to capture http headers are still experimental, and thus are subject to change.

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -672,8 +672,8 @@ class TestTornadoCustomRequestResponseHeadersAddedWithServerSpan(TornadoTest):
             self.memory_exporter.get_finished_spans()
         )
         expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
         }
@@ -693,11 +693,11 @@ class TestTornadoCustomRequestResponseHeadersAddedWithServerSpan(TornadoTest):
             self.memory_exporter.get_finished_spans()
         )
         expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("0",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("0",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
         }
@@ -738,8 +738,8 @@ class TestTornadoCustomRequestResponseHeadersNotAddedWithInternalSpan(
             self.memory_exporter.get_finished_spans()
         )
         not_expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
         }
@@ -760,11 +760,11 @@ class TestTornadoCustomRequestResponseHeadersNotAddedWithInternalSpan(
             self.memory_exporter.get_finished_spans()
         )
         not_expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("0",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("0",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
         }

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -144,7 +144,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.request.header.custom_request_header = ["<value1>,<value2>"]``
+``http.request.header.custom-request-header = ["<value1>,<value2>"]``
 
 Response headers
 ****************
@@ -178,7 +178,7 @@ is the normalized HTTP header name (lowercase, with ``-`` replaced by ``_``). Th
 single item list containing all the header values.
 
 For example:
-``http.response.header.custom_response_header = ["<value1>,<value2>"]``
+``http.response.header.custom-response-header = ["<value1>,<value2>"]``
 
 Sanitizing headers
 ******************

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -617,15 +617,15 @@ class TestAdditionOfCustomRequestResponseHeaders(WsgiTestBase):
         self.iterate_response(response)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.request.header.custom_test_header_1": ("Test Value 1",),
-            "http.request.header.custom_test_header_2": (
+            "http.request.header.custom-test-header-1": ("Test Value 1",),
+            "http.request.header.custom-test-header-2": (
                 "TestValue2,TestValue3",
             ),
-            "http.request.header.regex_test_header_1": ("Regex Test Value 1",),
-            "http.request.header.regex_test_header_2": (
+            "http.request.header.regex-test-header-1": ("Regex Test Value 1",),
+            "http.request.header.regex-test-header-2": (
                 "RegexTestValue2,RegexTestValue3",
             ),
-            "http.request.header.my_secret_header": ("[REDACTED]",),
+            "http.request.header.my-secret-header": ("[REDACTED]",),
         }
         self.assertSpanHasAttributes(span, expected)
 
@@ -650,7 +650,7 @@ class TestAdditionOfCustomRequestResponseHeaders(WsgiTestBase):
             self.iterate_response(response)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.request.header.custom_test_header_1": ("Test Value 1",),
+                "http.request.header.custom-test-header-1": ("Test Value 1",),
             }
             for key, _ in not_expected.items():
                 self.assertNotIn(key, span.attributes)
@@ -670,20 +670,20 @@ class TestAdditionOfCustomRequestResponseHeaders(WsgiTestBase):
         self.iterate_response(response)
         span = self.memory_exporter.get_finished_spans()[0]
         expected = {
-            "http.response.header.content_type": (
+            "http.response.header.content-type": (
                 "text/plain; charset=utf-8",
             ),
-            "http.response.header.content_length": ("100",),
-            "http.response.header.my_custom_header": (
+            "http.response.header.content-length": ("100",),
+            "http.response.header.my-custom-header": (
                 "my-custom-value-1,my-custom-header-2",
             ),
-            "http.response.header.my_custom_regex_header_1": (
+            "http.response.header.my-custom-regex-header-1": (
                 "my-custom-regex-value-1,my-custom-regex-value-2",
             ),
-            "http.response.header.my_custom_regex_header_2": (
+            "http.response.header.my-custom-regex-header-2": (
                 "my-custom-regex-value-3,my-custom-regex-value-4",
             ),
-            "http.response.header.my_secret_header": ("[REDACTED]",),
+            "http.response.header.my-secret-header": ("[REDACTED]",),
         }
         self.assertSpanHasAttributes(span, expected)
 
@@ -704,7 +704,7 @@ class TestAdditionOfCustomRequestResponseHeaders(WsgiTestBase):
             self.iterate_response(response)
             span = self.memory_exporter.get_finished_spans()[0]
             not_expected = {
-                "http.response.header.my_custom_header": (
+                "http.response.header.my-custom-header": (
                     "my-custom-value-1,my-custom-header-2",
                 ),
             }

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -187,12 +187,12 @@ def remove_url_credentials(url: str) -> str:
 
 
 def normalise_request_header_name(header: str) -> str:
-    key = header.lower().replace("-", "_")
+    key = header.lower()
     return f"http.request.header.{key}"
 
 
 def normalise_response_header_name(header: str) -> str:
-    key = header.lower().replace("-", "_")
+    key = header.lower()
     return f"http.response.header.{key}"
 
 

--- a/util/opentelemetry-util-http/tests/test_capture_custom_headers.py
+++ b/util/opentelemetry-util-http/tests/test_capture_custom_headers.py
@@ -104,8 +104,8 @@ class TestCaptureCustomHeaders(unittest.TestCase):
 
     def test_normalise_request_header_name(self):
         key = normalise_request_header_name("Test-Header")
-        self.assertEqual(key, "http.request.header.test_header")
+        self.assertEqual(key, "http.request.header.test-header")
 
     def test_normalise_response_header_name(self):
         key = normalise_response_header_name("Test-Header")
-        self.assertEqual(key, "http.response.header.test_header")
+        self.assertEqual(key, "http.response.header.test-header")


### PR DESCRIPTION
# Description

HTTP request and response headers (attributes `http.request.header.*` and `http.response.header.*`) should be normalized by just being converted to lowercase, not replacing underscore with dash.

This is made clear in the docs [here](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/):

<img width="862" alt="image" src="https://github.com/open-telemetry/opentelemetry-python-contrib/assets/4039449/c8900db8-47a9-4fe0-81b2-3684e1a5cc1f">
<img width="893" alt="image" src="https://github.com/open-telemetry/opentelemetry-python-contrib/assets/4039449/37324b1e-a4ea-4b88-b67d-06906ac8f251">

The current incorrect behavior of `replace('_', '-')` is extremely problematic since you can't know what the original header was - e.g. if you see a key `http.request.header.foo_bar` what was the original value? It could have been `foo-bar` or `foo_bar`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] replaced all the tests expecting the incorrect behavior

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
