### PR TITLE
Comment out aiohttp-server from bootstrap_gen libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix bootstrap when aiohttp installed ([#2299](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2299))
+
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
 - Drop support for 3.7

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -24,11 +24,6 @@ libraries = [
         "library": "aiohttp ~= 3.0",
         "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.45b0.dev",
     },
-    # FIXME: Add this logic once these packages are available in Pypi
-    # {
-    #     "library": "aiohttp ~= 3.0",
-    #     "instrumentation": "opentelemetry-instrumentation-aiohttp-server==0.45b0.dev",
-    # },
     {
         "library": "aiopg >= 0.13.0, < 2.0.0",
         "instrumentation": "opentelemetry-instrumentation-aiopg==0.45b0.dev",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -24,10 +24,11 @@ libraries = [
         "library": "aiohttp ~= 3.0",
         "instrumentation": "opentelemetry-instrumentation-aiohttp-client==0.45b0.dev",
     },
-    {
-        "library": "aiohttp ~= 3.0",
-        "instrumentation": "opentelemetry-instrumentation-aiohttp-server==0.45b0.dev",
-    },
+    # FIXME: Add this logic once these packages are available in Pypi
+    # {
+    #     "library": "aiohttp ~= 3.0",
+    #     "instrumentation": "opentelemetry-instrumentation-aiohttp-server==0.45b0.dev",
+    # },
     {
         "library": "aiopg >= 0.13.0, < 2.0.0",
         "instrumentation": "opentelemetry-instrumentation-aiopg==0.45b0.dev",

--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -59,6 +59,10 @@ def main():
     default_instrumentations = ast.List(elts=[])
     libraries = ast.List(elts=[])
     for pkg in get_instrumentation_packages():
+        # FIXME: Remove this logic once these packages are available in Pypi
+        if pkg["name"] == "opentelemetry-instrumentation-aiohttp-server":
+            continue
+
         if not pkg["instruments"]:
             default_instrumentations.elts.append(ast.Str(pkg["requirement"]))
         for target_pkg in pkg["instruments"]:


### PR DESCRIPTION
# Description

Removes `opentelemetry-instrumentation-aiohttp-server` from libraries list used to [find](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/8daa8ad48108775d8e799a3abc3ed06f84b4c00e/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py#L102-L108) and install instrumentors that match installed Python frameworks at bootstrap.

For example: with Opentelemetry 1.23.0/0.44b0, Python 3.9 and aiohttp 3.9.3 in a test environment, I get `RuntimeError` at `opentelemetry-bootstrap`:

```
ERROR: Could not find a version that satisfies the requirement opentelemetry-instrumentation-aiohttp-server==0.44b0 (from versions: none)
ERROR: No matching distribution found for opentelemetry-instrumentation-aiohttp-server==0.44b0
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/bootstrap.py", line 35, in wrapper
    return func(package)
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/bootstrap.py", line 51, in _sys_pip_install
    subprocess.check_call(
  File "/usr/local/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/local/bin/python', '-m', 'pip', 'install', '-U', '--upgrade-strategy', 'only-if-needed', 'opentelemetry-instrumentation-aiohttp-server==0.44b0']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/opentelemetry-bootstrap", line 8, in <module>
    sys.exit(run())
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/bootstrap.py", line 156, in run
    cmd()
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/bootstrap.py", line 118, in _run_install
    _sys_pip_install(lib)
  File "/usr/local/lib/python3.9/site-packages/opentelemetry/instrumentation/bootstrap.py", line 43, in wrapper
    raise RuntimeError(msg)
RuntimeError: Error calling system command "/usr/local/bin/python -m pip install -U --upgrade-strategy only-if-needed opentelemetry-instrumentation-aiohttp-server==0.44b0" for package "opentelemetry-instrumentation-aiohttp-server==0.44b0"
```

This PR temporarily patches https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2053 until PyPI package is made available.

Related to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2258.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In a python:3.9 docker container, I have a FastAPI app that uses aiohttp 3.9.3. I locally installed a working copy of `opentelemetry-instrumentation` and its dependencies (`pip install -Ie <dir>`). The updated `libraries` list stops the `RuntimeError` from happening and bootstrap finishes.

# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
