### PR TITLE
feat: add importlib metadata default on flask module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `opentelemetry-instrumentation-celery` Allow Celery instrumentation to be installed multiple times
   ([#2342](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2342))
-- Align gRPC span status codes to OTEL specification ([#1756](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1756))
+- Align gRPC span status codes to OTEL specification
+  ([#1756](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1756))
+- `opentelemetry-instrumentation-flask` Add importlib metadata default for deprecation warning flask version
+  ([#2297](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2297))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
-- Drop support for 3.7
+- Drop uspport for 3.7
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2151))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector
   ([#2119](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2119))

--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-semantic-conventions == 0.45b0.dev",
   "opentelemetry-util-http == 0.45b0.dev",
   "packaging >= 21.0",
-  "importlib-metadata >= 6.0, < 7.0",
+  "importlib-metadata >= 6.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-semantic-conventions == 0.45b0.dev",
   "opentelemetry-util-http == 0.45b0.dev",
   "packaging >= 21.0",
-  "importlib-metadata >= 6.0",
+  "importlib-metadata >= 4.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "opentelemetry-semantic-conventions == 0.45b0.dev",
   "opentelemetry-util-http == 0.45b0.dev",
   "packaging >= 21.0",
+  "importlib-metadata >= 6.0, < 7.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -243,17 +243,15 @@ from logging import getLogger
 from time import time_ns
 from timeit import default_timer
 from typing import Collection
-import importlib_metadata as metadata
 
 import flask
+import importlib_metadata as metadata
 from packaging import version as package_version
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.flask.package import _instruments
 from opentelemetry.instrumentation.flask.version import __version__
-
-
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.propagators import (
     get_global_response_propagator,

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -243,6 +243,7 @@ from logging import getLogger
 from time import time_ns
 from timeit import default_timer
 from typing import Collection
+import importlib_metadata as metadata
 
 import flask
 from packaging import version as package_version
@@ -252,14 +253,6 @@ from opentelemetry import context, trace
 from opentelemetry.instrumentation.flask.package import _instruments
 from opentelemetry.instrumentation.flask.version import __version__
 
-try:
-    flask_version = flask.__version__
-except AttributeError:
-    try:
-        from importlib import metadata
-    except ImportError:
-        import importlib_metadata as metadata
-    flask_version = metadata.version("flask")
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.propagators import (
@@ -280,6 +273,8 @@ _ENVIRON_REQCTX_REF_KEY = "opentelemetry-flask.reqctx_ref_key"
 _ENVIRON_TOKEN = "opentelemetry-flask.token"
 
 _excluded_urls_from_env = get_excluded_urls("FLASK")
+
+flask_version = metadata.version("flask")
 
 if package_version.parse(flask_version) >= package_version.parse("2.2.0"):
 


### PR DESCRIPTION
# Description

With the just-release opentelemetry-instrumentation-flask 0.44b0 I get this from the flask instrumentation:

DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Flask 3.1. Use feature detection or 'importlib.metadata.version("flask")' instead.

I add the lower bound of importlib_metadata as 4.0 because of pep 566 
https://github.com/python/importlib_metadata/blob/v6.0.0/CHANGES.rst#v400

Fixes #2297

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 I dont think this would have an extra test

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
