### PR TITLE
instrumentation/django: fix test_trace_parent

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -390,7 +390,7 @@ class TestMiddleware(WsgiTestBase):
         self.assertIsInstance(response_hook_args[2], HttpResponse)
         self.assertEqual(response_hook_args[2], response)
 
-    async def test_trace_parent(self):
+    def test_trace_parent(self):
         id_generator = RandomIdGenerator()
         trace_id = format_trace_id(id_generator.generate_trace_id())
         span_id = format_span_id(id_generator.generate_span_id())
@@ -398,7 +398,7 @@ class TestMiddleware(WsgiTestBase):
 
         Client().get(
             "/span_name/1234/",
-            traceparent=traceparent_value,
+            HTTP_TRACEPARENT=traceparent_value,
         )
         span = self.memory_exporter.get_finished_spans()[0]
 


### PR DESCRIPTION

# Description

Remove async keyword that did not make the test run and then fix tests to send the traceparent as header instead of query string.

Fixes #2336

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
