### PR TITLE
Celery duplicated instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
+- `opentelemetry-instrumentation-celery` Allow Celery instrumentation to be installed multiple times
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/XXXX))
 - Drop support for 3.7
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2151))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- `opentelemetry-instrumentation-celery` Allow Celery instrumentation to be installed multiple times
+  ([#2342](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2342))
 - Align gRPC span status codes to OTEL specification ([#1756](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1756))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
-- `opentelemetry-instrumentation-celery` Allow Celery instrumentation to be installed multiple times
-  ([#2342](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2342))
 - Drop support for 3.7
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2151))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
 - `opentelemetry-instrumentation-celery` Allow Celery instrumentation to be installed multiple times
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/XXXX))
+  ([#2342](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2342))
 - Drop support for 3.7
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2151))
 - `opentelemetry-resource-detector-azure` Added 10s timeout to VM Resource Detector

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -116,9 +116,6 @@ class CeleryInstrumentor(BaseInstrumentor):
     metrics = None
     task_id_to_start_time = {}
 
-    def __init__(self):
-        super().__init__()
-
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -113,10 +113,11 @@ celery_getter = CeleryGetter()
 
 
 class CeleryInstrumentor(BaseInstrumentor):
+    metrics = None
+    task_id_to_start_time = {}
+
     def __init__(self):
         super().__init__()
-        self.metrics = None
-        self.task_id_to_start_time = {}
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_duplicate.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_duplicate.py
@@ -16,8 +16,8 @@ import unittest
 
 from opentelemetry.instrumentation.celery import CeleryInstrumentor
 
-class TestUtils(unittest.TestCase):
 
+class TestUtils(unittest.TestCase):
     def test_duplicate_instrumentaion(self):
         first = CeleryInstrumentor()
         first.instrument()
@@ -26,5 +26,5 @@ class TestUtils(unittest.TestCase):
         CeleryInstrumentor().uninstrument()
         self.assertIsNotNone(first.metrics)
         self.assertIsNotNone(second.metrics)
-        self.assertEqual(first.task_id_to_start_time,{})
+        self.assertEqual(first.task_id_to_start_time, {})
         self.assertEqual(second.task_id_to_start_time, {})

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_duplicate.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_duplicate.py
@@ -1,0 +1,30 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
+class TestUtils(unittest.TestCase):
+
+    def test_duplicate_instrumentaion(self):
+        first = CeleryInstrumentor()
+        first.instrument()
+        second = CeleryInstrumentor()
+        second.instrument()
+        CeleryInstrumentor().uninstrument()
+        self.assertIsNotNone(first.metrics)
+        self.assertIsNotNone(second.metrics)
+        self.assertEqual(first.task_id_to_start_time,{})
+        self.assertEqual(second.task_id_to_start_time, {})


### PR DESCRIPTION
# Description

Setting `metrics`  in `__init__` corrupts the singleton state of BaseInstrumentor. Aslo moves `task_id_to_start_time` instance variable to class-level in order to prevent resetting of the dictionary when/if multiple calls to constructor happens.

Fixes #2029 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Added a unit test `test_duplicate_instrumentaion` wich reproduces the errors (fails without the patch)

Problem can be reproduced by running the provided testcase without the `__init__.py` changes for celery instrumentation.  It is worth noting that this problem is very similar to #1791  as @marcuslimdw  points out in issue #2029 . 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
