### PR TITLE
Use set -e to catch errors in all scripts

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/proto/generate-proto-py.sh
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/proto/generate-proto-py.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 PROM_VERSION=v2.39.0
 PROTO_VERSION=v1.3.2

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#
+set -e
+
 # This script:
 #   1. parses the version number from the branch name
 #   2. updates version.py files to match that version


### PR DESCRIPTION
# Description

A couple of build scripts were not setting -e to detect errors in commands (the other scripts already were).

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

