### PR TITLE
elasticsearch: don't set body as db statement for bulk requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2151](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2298))
 - Avoid losing repeated HTTP headers
   ([#2266](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2266))
+- `opentelemetry-instrumentation-elasticsearch` Don't send bulk request body as db statement
+  ([#2355](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2355))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -245,9 +245,11 @@ def _wrap_perform_request(
                 if method:
                     attributes["elasticsearch.method"] = method
                 if body:
-                    attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
-                        body
-                    )
+                    # Don't set db.statement for bulk requests, as it can be very large
+                    if isinstance(body, dict):
+                        attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
+                            body
+                        )
                 if params:
                     attributes["elasticsearch.params"] = str(params)
                 if doc_id:

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -247,9 +247,9 @@ def _wrap_perform_request(
                 if body:
                     # Don't set db.statement for bulk requests, as it can be very large
                     if isinstance(body, dict):
-                        attributes[SpanAttributes.DB_STATEMENT] = sanitize_body(
-                            body
-                        )
+                        attributes[
+                            SpanAttributes.DB_STATEMENT
+                        ] = sanitize_body(body)
                 if params:
                     attributes["elasticsearch.params"] = str(params)
                 if doc_id:

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -51,6 +51,8 @@ else:
 
 Article = helpers.Article
 
+# pylint: disable=too-many-public-methods
+
 
 @mock.patch(
     "elasticsearch.connection.http_urllib3.Urllib3HttpConnection.perform_request"
@@ -491,7 +493,24 @@ class TestElasticsearchIntegration(TestBase):
         request_mock.return_value = (1, {}, "")
 
         es = Elasticsearch()
-        es.bulk([dict(_op_type="index", _index="sw", _doc_type="_doc", _id=1, doc={"name": "adam"})] * 2)
+        es.bulk(
+            [
+                {
+                    "_op_type": "index",
+                    "_index": "sw",
+                    "_doc_type": "_doc",
+                    "_id": 1,
+                    "doc": {"name": "adam"},
+                },
+                {
+                    "_op_type": "index",
+                    "_index": "sw",
+                    "_doc_type": "_doc",
+                    "_id": 1,
+                    "doc": {"name": "adam"},
+                },
+            ]
+        )
 
         spans_list = self.get_finished_spans()
         self.assertEqual(len(spans_list), 1)


### PR DESCRIPTION
# Description

bulk requests can be too big and diverse to make sense as db statement. Other than that the sanitizer currently only handles dicts so it's crashing.

Closes former PR #2150

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
