### PR TITLE
Add cloud.account.id attribute by AwsLambdaInstrumentor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2266](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2266))
 - `opentelemetry-instrumentation-elasticsearch` Don't send bulk request body as db statement
   ([#2355](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2355))
+- AwsLambdaInstrumentor sets `cloud.account.id` span attribute
+  ([#2367](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2367))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -354,6 +354,16 @@ def _instrument(
                     lambda_context.aws_request_id,
                 )
 
+                # NOTE: `cloud.account.id` can be parsed from the ARN as the fifth item when splitting on `:`
+                #
+                # See more:
+                # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/aws-lambda.md#all-triggers
+                account_id = lambda_context.invoked_function_arn.split(":")[4]
+                span.set_attribute(
+                    ResourceAttributes.CLOUD_ACCOUNT_ID,
+                    account_id,
+                )
+
             exception = None
             try:
                 result = call_wrapped(*args, **kwargs)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -147,6 +147,7 @@ class TestAwsLambdaInstrumentor(TestBase):
             {
                 ResourceAttributes.FAAS_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn,
                 SpanAttributes.FAAS_EXECUTION: MOCK_LAMBDA_CONTEXT.aws_request_id,
+                ResourceAttributes.CLOUD_ACCOUNT_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn.split(":")[4],
             },
         )
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -54,7 +54,7 @@ class MockLambdaContext:
 
 MOCK_LAMBDA_CONTEXT = MockLambdaContext(
     aws_request_id="mock_aws_request_id",
-    invoked_function_arn="arn://mock-lambda-function-arn",
+    invoked_function_arn="arn:aws:lambda:us-east-1:123456:function:myfunction:myalias",
 )
 
 MOCK_XRAY_TRACE_ID = 0x5FB7331105E8BB83207FA31D4D9CDB4C

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -147,7 +147,11 @@ class TestAwsLambdaInstrumentor(TestBase):
             {
                 ResourceAttributes.FAAS_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn,
                 SpanAttributes.FAAS_EXECUTION: MOCK_LAMBDA_CONTEXT.aws_request_id,
-                ResourceAttributes.CLOUD_ACCOUNT_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn.split(":")[4],
+                ResourceAttributes.CLOUD_ACCOUNT_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn.split(
+                    ":"
+                )[
+                    4
+                ],
             },
         )
 


### PR DESCRIPTION
# Description

Implements adding `cloud.account.id` span attribute by AwsLambdaInstrumentor to meet [current semconv](https://github.com/open-telemetry/semantic-conventions/blob/80a2d1a8f70c96c51e541827c7548ba42bb77876/docs/faas/aws-lambda.md?plain=1#L42). It is defined in Python semconvgen [here](https://github.com/open-telemetry/opentelemetry-python/blob/694445f6a39ab55826b955320c74650e1d2395ae/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py#L61-L64). This doesn't seem to replace a deprecated/migrated attribute key. In [AWS Lambda Context](https://docs.aws.amazon.com/lambda/latest/dg/python-context.html) there is no account accessor so this does the split described in the semconv instead.

Fixes [# 2368](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2368)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
