### PR TITLE
fix(opentelemetry-instrumentation-celery): attach incoming context on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2756](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2756))
 - `opentelemetry-instrumentation-aws-lambda` Fixing w3c baggage support
   ([#2589](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2589))
+- `opentelemetry-instrumentation-celery` propagates baggage
+  ([#2385](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2385))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 
@@ -119,10 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2610))
 - `opentelemetry-instrumentation-asgi` Bugfix: Middleware did not set status code attribute on duration metrics for non-recording spans.
   ([#2627](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2627))
-<<<<<<< HEAD
-- `opentelemetry-instrumentation-mysql` Add support for `mysql-connector-python` v9 ([#2751](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2751))
-=======
->>>>>>> 5a623233 (Changelog update)
+- `opentelemetry-instrumentation-mysql` Add support for `mysql-connector-python` v9
+  ([#2751](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2751))
 
 ## Version 1.25.0/0.46b0 (2024-05-31)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -67,7 +67,7 @@ from billiard import VERSION
 from billiard.einfo import ExceptionInfo
 from celery import signals  # pylint: disable=no-name-in-module
 
-from opentelemetry import trace
+from opentelemetry import context, trace
 from opentelemetry.instrumentation.celery import utils
 from opentelemetry.instrumentation.celery.package import _instruments
 from opentelemetry.instrumentation.celery.version import __version__
@@ -169,6 +169,9 @@ class CeleryInstrumentor(BaseInstrumentor):
         self.update_task_duration_time(task_id)
         request = task.request
         tracectx = extract(request, getter=celery_getter) or None
+
+        if tracectx is not None:
+            context.attach(tracectx)
 
         logger.debug("prerun signal start task_id=%s", task_id)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -143,8 +143,12 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         signals.task_prerun.connect(self._trace_prerun, weak=False)
         signals.task_postrun.connect(self._trace_postrun, weak=False)
-        signals.before_task_publish.connect(self._trace_before_publish, weak=False)
-        signals.after_task_publish.connect(self._trace_after_publish, weak=False)
+        signals.before_task_publish.connect(
+            self._trace_before_publish, weak=False
+        )
+        signals.after_task_publish.connect(
+            self._trace_after_publish, weak=False
+        )
         signals.task_failure.connect(self._trace_failure, weak=False)
         signals.task_retry.connect(self._trace_retry, weak=False)
 
@@ -226,7 +230,9 @@ class CeleryInstrumentor(BaseInstrumentor):
         else:
             task_name = task.name
         operation_name = f"{_TASK_APPLY_ASYNC}/{task_name}"
-        span = self._tracer.start_span(operation_name, kind=trace.SpanKind.PRODUCER)
+        span = self._tracer.start_span(
+            operation_name, kind=trace.SpanKind.PRODUCER
+        )
 
         # apply some attributes here because most of the data is not available
         if span.is_recording():
@@ -238,7 +244,9 @@ class CeleryInstrumentor(BaseInstrumentor):
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101
 
-        utils.attach_context(task, task_id, span, activation, None, is_publish=True)
+        utils.attach_context(
+            task, task_id, span, activation, None, is_publish=True
+        )
 
         headers = kwargs.get("headers")
         if headers:

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -67,7 +67,8 @@ from billiard import VERSION
 from billiard.einfo import ExceptionInfo
 from celery import signals  # pylint: disable=no-name-in-module
 
-from opentelemetry import context, trace
+from opentelemetry import context as context_api
+from opentelemetry import trace
 from opentelemetry.instrumentation.celery import utils
 from opentelemetry.instrumentation.celery.package import _instruments
 from opentelemetry.instrumentation.celery.version import __version__
@@ -142,12 +143,9 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         signals.task_prerun.connect(self._trace_prerun, weak=False)
         signals.task_postrun.connect(self._trace_postrun, weak=False)
-        signals.before_task_publish.connect(
-            self._trace_before_publish, weak=False
-        )
-        signals.after_task_publish.connect(
-            self._trace_after_publish, weak=False
-        )
+        signals.before_task_publish.connect(self._trace_before_publish, weak=False)
+        signals.before_task_publish.connect(self._trace_before_publish, weak=False)
+        signals.after_task_publish.connect(self._trace_after_publish, weak=False)
         signals.task_failure.connect(self._trace_failure, weak=False)
         signals.task_retry.connect(self._trace_retry, weak=False)
 
@@ -169,9 +167,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         self.update_task_duration_time(task_id)
         request = task.request
         tracectx = extract(request, getter=celery_getter) or None
-
-        if tracectx is not None:
-            context.attach(tracectx)
+        token = context_api.attach(tracectx)
 
         logger.debug("prerun signal start task_id=%s", task_id)
 
@@ -182,7 +178,7 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101
-        utils.attach_span(task, task_id, (span, activation))
+        utils.attach_context(task, task_id, span, activation, token)
 
     def _trace_postrun(self, *args, **kwargs):
         task = utils.retrieve_task(kwargs)
@@ -194,10 +190,13 @@ class CeleryInstrumentor(BaseInstrumentor):
         logger.debug("postrun signal task_id=%s", task_id)
 
         # retrieve and finish the Span
-        span, activation = utils.retrieve_span(task, task_id)
-        if span is None:
+        ctx = utils.retrieve_context(task, task_id)
+
+        if ctx is None:
             logger.warning("no existing span found for task_id=%s", task_id)
             return
+
+        span, activation, token = ctx
 
         # request context tags
         if span.is_recording():
@@ -207,10 +206,11 @@ class CeleryInstrumentor(BaseInstrumentor):
             span.set_attribute(_TASK_NAME_KEY, task.name)
 
         activation.__exit__(None, None, None)
-        utils.detach_span(task, task_id)
+        utils.detach_context(task, task_id)
         self.update_task_duration_time(task_id)
         labels = {"task": task.name, "worker": task.request.hostname}
         self._record_histograms(task_id, labels)
+        context_api.detach(token)
 
     def _trace_before_publish(self, *args, **kwargs):
         task = utils.retrieve_task_from_sender(kwargs)
@@ -227,9 +227,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         else:
             task_name = task.name
         operation_name = f"{_TASK_APPLY_ASYNC}/{task_name}"
-        span = self._tracer.start_span(
-            operation_name, kind=trace.SpanKind.PRODUCER
-        )
+        span = self._tracer.start_span(operation_name, kind=trace.SpanKind.PRODUCER)
 
         # apply some attributes here because most of the data is not available
         if span.is_recording():
@@ -241,7 +239,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         activation = trace.use_span(span, end_on_exit=True)
         activation.__enter__()  # pylint: disable=E1101
 
-        utils.attach_span(task, task_id, (span, activation), is_publish=True)
+        utils.attach_context(task, task_id, span, activation, None, is_publish=True)
 
         headers = kwargs.get("headers")
         if headers:
@@ -256,13 +254,16 @@ class CeleryInstrumentor(BaseInstrumentor):
             return
 
         # retrieve and finish the Span
-        _, activation = utils.retrieve_span(task, task_id, is_publish=True)
-        if activation is None:
+        ctx = utils.retrieve_context(task, task_id, is_publish=True)
+
+        if ctx is None:
             logger.warning("no existing span found for task_id=%s", task_id)
             return
 
+        _, activation, _ = ctx
+
         activation.__exit__(None, None, None)  # pylint: disable=E1101
-        utils.detach_span(task, task_id, is_publish=True)
+        utils.detach_context(task, task_id, is_publish=True)
 
     @staticmethod
     def _trace_failure(*args, **kwargs):
@@ -272,9 +273,14 @@ class CeleryInstrumentor(BaseInstrumentor):
         if task is None or task_id is None:
             return
 
-        # retrieve and pass exception info to activation
-        span, _ = utils.retrieve_span(task, task_id)
-        if span is None or not span.is_recording():
+        ctx = utils.retrieve_context(task, task_id)
+
+        if ctx is None:
+            return
+
+        span, _, _ = ctx
+
+        if not span.is_recording():
             return
 
         status_kwargs = {"status_code": StatusCode.ERROR}
@@ -314,8 +320,14 @@ class CeleryInstrumentor(BaseInstrumentor):
         if task is None or task_id is None or reason is None:
             return
 
-        span, _ = utils.retrieve_span(task, task_id)
-        if span is None or not span.is_recording():
+        ctx = utils.retrieve_context(task, task_id)
+
+        if ctx is None:
+            return
+
+        span, _, _ = ctx
+
+        if not span.is_recording():
             return
 
         # Add retry reason metadata to span

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -170,7 +170,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         self.update_task_duration_time(task_id)
         request = task.request
         tracectx = extract(request, getter=celery_getter) or None
-        token = context_api.attach(tracectx)
+        token = context_api.attach(tracectx) if tracectx is not None else None
 
         logger.debug("prerun signal start task_id=%s", task_id)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -144,7 +144,6 @@ class CeleryInstrumentor(BaseInstrumentor):
         signals.task_prerun.connect(self._trace_prerun, weak=False)
         signals.task_postrun.connect(self._trace_postrun, weak=False)
         signals.before_task_publish.connect(self._trace_before_publish, weak=False)
-        signals.before_task_publish.connect(self._trace_before_publish, weak=False)
         signals.after_task_publish.connect(self._trace_after_publish, weak=False)
         signals.task_failure.connect(self._trace_failure, weak=False)
         signals.task_retry.connect(self._trace_retry, weak=False)

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Optional, ContextManager, Tuple
+from typing import ContextManager, Optional, Tuple
 
 from celery import registry  # pylint: disable=no-name-in-module
 from celery.app.task import Task

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -84,8 +84,12 @@ def set_attributes_from_context(span, context):
         elif key == "delivery_info":
             # Get also destination from this
             routing_key = value.get("routing_key")
+
             if routing_key is not None:
-                span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, routing_key)
+                span.set_attribute(
+                    SpanAttributes.MESSAGING_DESTINATION, routing_key
+                )
+
             value = str(value)
 
         elif key == "id":

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Optional, ContextManager
+from typing import Optional, ContextManager, Tuple
 
 from celery import registry  # pylint: disable=no-name-in-module
 from celery.app.task import Task
@@ -171,7 +171,7 @@ def detach_context(task, task_id, is_publish=False) -> None:
 
 def retrieve_context(
     task, task_id, is_publish=False
-) -> Optional[tuple[Span, ContextManager[Span], Optional[object]]]:
+) -> Optional[Tuple[Span, ContextManager[Span], Optional[object]]]:
     """Helper to retrieve an active `Span`, `ContextManager` and context token
     stored in a `Task` instance
     """

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from celery import Celery
+from opentelemetry import baggage
 
 
 class Config:
@@ -36,3 +37,8 @@ def task_add(num_a, num_b):
 @app.task
 def task_raises():
     raise CustomError("The task failed!")
+
+
+@app.task
+def task_returns_baggage():
+    return dict(baggage.get_all())

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from celery import Celery
+
 from opentelemetry import baggage
 
 

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -71,7 +71,9 @@ class TestCeleryInstrumentation(TestBase):
 
         self.assertEqual(0, len(consumer.events))
 
-        self.assertEqual(producer.name, "apply_async/tests.celery_test_tasks.task_add")
+        self.assertEqual(
+            producer.name, "apply_async/tests.celery_test_tasks.task_add"
+        )
         self.assertEqual(producer.kind, SpanKind.PRODUCER)
         self.assertSpanHasAttributes(
             producer,
@@ -103,7 +105,9 @@ class TestCeleryInstrumentation(TestBase):
 
         consumer, producer = spans
 
-        self.assertEqual(consumer.name, "run/tests.celery_test_tasks.task_raises")
+        self.assertEqual(
+            consumer.name, "run/tests.celery_test_tasks.task_raises"
+        )
         self.assertEqual(consumer.kind, SpanKind.CONSUMER)
         self.assertSpanHasAttributes(
             consumer,
@@ -123,7 +127,9 @@ class TestCeleryInstrumentation(TestBase):
         self.assertIn(SpanAttributes.EXCEPTION_STACKTRACE, event.attributes)
 
         # TODO: use plain assertEqual after 1.25 is released (https://github.com/open-telemetry/opentelemetry-python/pull/3837)
-        self.assertIn("CustomError", event.attributes[SpanAttributes.EXCEPTION_TYPE])
+        self.assertIn(
+            "CustomError", event.attributes[SpanAttributes.EXCEPTION_TYPE]
+        )
 
         self.assertEqual(
             event.attributes[SpanAttributes.EXCEPTION_MESSAGE],
@@ -219,7 +225,9 @@ class TestCelerySignatureTask(TestBase):
         self.assertEqual(consumer.name, "run/tests.test_tasks.hidden_task")
         self.assertEqual(consumer.kind, SpanKind.CONSUMER)
 
-        self.assertEqual(producer.name, "apply_async/tests.test_tasks.hidden_task")
+        self.assertEqual(
+            producer.name, "apply_async/tests.test_tasks.hidden_task"
+        )
         self.assertEqual(producer.kind, SpanKind.PRODUCER)
 
         self.assertNotEqual(consumer.parent, producer.context)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -71,9 +71,7 @@ class TestCeleryInstrumentation(TestBase):
 
         self.assertEqual(0, len(consumer.events))
 
-        self.assertEqual(
-            producer.name, "apply_async/tests.celery_test_tasks.task_add"
-        )
+        self.assertEqual(producer.name, "apply_async/tests.celery_test_tasks.task_add")
         self.assertEqual(producer.kind, SpanKind.PRODUCER)
         self.assertSpanHasAttributes(
             producer,
@@ -105,9 +103,7 @@ class TestCeleryInstrumentation(TestBase):
 
         consumer, producer = spans
 
-        self.assertEqual(
-            consumer.name, "run/tests.celery_test_tasks.task_raises"
-        )
+        self.assertEqual(consumer.name, "run/tests.celery_test_tasks.task_raises")
         self.assertEqual(consumer.kind, SpanKind.CONSUMER)
         self.assertSpanHasAttributes(
             consumer,
@@ -127,9 +123,7 @@ class TestCeleryInstrumentation(TestBase):
         self.assertIn(SpanAttributes.EXCEPTION_STACKTRACE, event.attributes)
 
         # TODO: use plain assertEqual after 1.25 is released (https://github.com/open-telemetry/opentelemetry-python/pull/3837)
-        self.assertIn(
-            "CustomError", event.attributes[SpanAttributes.EXCEPTION_TYPE]
-        )
+        self.assertIn("CustomError", event.attributes[SpanAttributes.EXCEPTION_TYPE])
 
         self.assertEqual(
             event.attributes[SpanAttributes.EXCEPTION_MESSAGE],
@@ -225,9 +219,7 @@ class TestCelerySignatureTask(TestBase):
         self.assertEqual(consumer.name, "run/tests.test_tasks.hidden_task")
         self.assertEqual(consumer.kind, SpanKind.CONSUMER)
 
-        self.assertEqual(
-            producer.name, "apply_async/tests.test_tasks.hidden_task"
-        )
+        self.assertEqual(producer.name, "apply_async/tests.test_tasks.hidden_task")
         self.assertEqual(producer.kind, SpanKind.PRODUCER)
 
         self.assertNotEqual(consumer.parent, producer.context)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -167,8 +167,10 @@ class TestUtils(unittest.TestCase):
         # propagate and retrieve a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
-        utils.attach_span(fn_task, task_id, span)
-        span_after = utils.retrieve_span(fn_task, task_id)
+        utils.attach_context(fn_task, task_id, span, mock.Mock(), "")
+        ctx = utils.retrieve_context(fn_task, task_id)
+        self.assertIsNotNone(ctx)
+        span_after, _, _ = ctx
         self.assertIs(span, span_after)
 
     def test_span_delete(self):
@@ -180,17 +182,17 @@ class TestUtils(unittest.TestCase):
         # propagate a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
-        utils.attach_span(fn_task, task_id, span)
+        utils.attach_context(fn_task, task_id, span, mock.Mock(), "")
         # delete the Span
-        utils.detach_span(fn_task, task_id)
-        self.assertEqual(utils.retrieve_span(fn_task, task_id), (None, None))
+        utils.detach_context(fn_task, task_id)
+        self.assertEqual(utils.retrieve_context(fn_task, task_id), None)
 
     def test_optional_task_span_attach(self):
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
 
         # assert this is is a no-aop
-        self.assertIsNone(utils.attach_span(None, task_id, span))
+        self.assertIsNone(utils.attach_context(None, task_id, span, mock.Mock(), ""))
 
     def test_span_delete_empty(self):
         # ensure detach_span doesn't raise an exception if span is not present
@@ -201,10 +203,8 @@ class TestUtils(unittest.TestCase):
         # delete the Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
         try:
-            utils.detach_span(fn_task, task_id)
-            self.assertEqual(
-                utils.retrieve_span(fn_task, task_id), (None, None)
-            )
+            utils.detach_context(fn_task, task_id)
+            self.assertEqual(utils.retrieve_context(fn_task, task_id), None)
         except Exception as ex:  # pylint: disable=broad-except
             self.fail(f"Exception was raised: {ex}")
 

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -58,18 +58,14 @@ class TestUtils(unittest.TestCase):
             span.attributes.get(SpanAttributes.MESSAGING_DESTINATION), "celery"
         )
 
-        self.assertEqual(
-            span.attributes["celery.delivery_info"], str({"eager": True})
-        )
+        self.assertEqual(span.attributes["celery.delivery_info"], str({"eager": True}))
         self.assertEqual(span.attributes.get("celery.eta"), "soon")
         self.assertEqual(span.attributes.get("celery.expires"), "later")
         self.assertEqual(span.attributes.get("celery.hostname"), "localhost")
 
         self.assertEqual(span.attributes.get("celery.reply_to"), "44b7f305")
         self.assertEqual(span.attributes.get("celery.retries"), 4)
-        self.assertEqual(
-            span.attributes.get("celery.timelimit"), ("now", "later")
-        )
+        self.assertEqual(span.attributes.get("celery.timelimit"), ("now", "later"))
         self.assertNotIn("custom_meta", span.attributes)
 
     def test_set_attributes_not_recording(self):
@@ -132,9 +128,7 @@ class TestUtils(unittest.TestCase):
         }
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
         utils.set_attributes_from_context(span, context)
-        self.assertEqual(
-            span.attributes.get("celery.timelimit"), ("", "later")
-        )
+        self.assertEqual(span.attributes.get("celery.timelimit"), ("", "later"))
 
     def test_set_attributes_from_context_empty_keys(self):
         # it should not extract empty keys
@@ -192,7 +186,9 @@ class TestUtils(unittest.TestCase):
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
 
         # assert this is is a no-aop
-        self.assertIsNone(utils.attach_context(None, task_id, span, mock.Mock(), ""))
+        self.assertIsNone(
+            utils.attach_context(None, task_id, span, mock.Mock(), "")
+        )
 
     def test_span_delete_empty(self):
         # ensure detach_span doesn't raise an exception if span is not present

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -58,14 +58,18 @@ class TestUtils(unittest.TestCase):
             span.attributes.get(SpanAttributes.MESSAGING_DESTINATION), "celery"
         )
 
-        self.assertEqual(span.attributes["celery.delivery_info"], str({"eager": True}))
+        self.assertEqual(
+            span.attributes["celery.delivery_info"], str({"eager": True})
+        )
         self.assertEqual(span.attributes.get("celery.eta"), "soon")
         self.assertEqual(span.attributes.get("celery.expires"), "later")
         self.assertEqual(span.attributes.get("celery.hostname"), "localhost")
 
         self.assertEqual(span.attributes.get("celery.reply_to"), "44b7f305")
         self.assertEqual(span.attributes.get("celery.retries"), 4)
-        self.assertEqual(span.attributes.get("celery.timelimit"), ("now", "later"))
+        self.assertEqual(
+            span.attributes.get("celery.timelimit"), ("now", "later")
+        )
         self.assertNotIn("custom_meta", span.attributes)
 
     def test_set_attributes_not_recording(self):
@@ -128,7 +132,9 @@ class TestUtils(unittest.TestCase):
         }
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
         utils.set_attributes_from_context(span, context)
-        self.assertEqual(span.attributes.get("celery.timelimit"), ("", "later"))
+        self.assertEqual(
+            span.attributes.get("celery.timelimit"), ("", "later")
+        )
 
     def test_set_attributes_from_context_empty_keys(self):
         # it should not extract empty keys


### PR DESCRIPTION
… _trace_prerun

# Description

Currently incoming baggage does not get picked up. So this PR applies the fix described in the original issue.

Fixes #784 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The original issue has steps to reproduce.

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
