### PR TITLE
Fix while calling asyncio `exception()`

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
@@ -307,7 +307,14 @@ class AsyncioInstrumentor(BaseInstrumentor):
         )
 
         def callback(f):
-            exception = f.exception()
+            try:
+                exception = f.exception()
+            except asyncio.CancelledError as ex:
+                # If the future has been cancelled, raises CancelledError
+                exception = ex
+            except asyncio.InvalidStateError as ex:
+                # If the future isn't done yet, raises InvalidStateError
+                exception = ex
             attr = {
                 "type": "future",
             }


### PR DESCRIPTION
# Description

While updating our setup from operator 0.94.0 we started to have errors in python applications that were fine before.

It looks like asyncio was added on version 0.95.0 https://github.com/open-telemetry/opentelemetry-operator/pull/2677/files#diff-e8feb6bbad63df255d68837a72bc1c440ad0cac92b0406281d64879682e41c52R19

```
[2024-04-04 10:06:41,746] [7] [ERROR] Exception in callback AsyncioInstrumentor.trace_future.<locals>.callback(<Future cancelled>) at /otel-auto-instrumentation-python/opentelemetry/instrumentation/asyncio/__init__.py:309
handle: <Handle AsyncioInstrumentor.trace_future.<locals>.callback(<Future cancelled>) at /otel-auto-instrumentation-python/opentelemetry/instrumentation/asyncio/__init__.py:309>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/asyncio/events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "/otel-auto-instrumentation-python/opentelemetry/instrumentation/asyncio/__init__.py", line 310, in callback
    exception = f.exception()
                ^^^^^^^^^^^^^
asyncio.exceptions.CancelledError 
```


Our scenario is an application using faust to consume kafka messages. https://faust.readthedocs.io/en/latest/
Quite a big legacy application with many consumers, so it was a bit hard to extract the exact scenario.


The problem is when a callback invokes the `exception()` function, which is expected to throw exception in some conditions.

In this PR we catch them instead of letting them be propagated.


## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've re-build it and the errors logs were gone


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
