### PR TITLE
Adding support to export spans to sqs

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
@@ -74,6 +74,33 @@ populate `resource` attributes by creating a `TraceProvider` using the `AwsEc2Re
 Refer to each detectors' docstring to determine any possible requirements for that
 detector.
 
+Usage ( SQS Span Exporter )
+------------------------------
+
+Use the provided `SQS Exporter` to export all spans to preferred `AWS SQS Queue <https://aws.amazon.com/sqs/>`_.
+Use the `SQS Exporter` with preferred `SpanProcessor`
+
+For example, if tracing with OpenTelemetry, you can automatically export spans generated to 
+`AWS SQS Queue <https://aws.amazon.com/sqs/>`_
+
+.. code-block:: python
+
+    import opentelemetry.trace as trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.extension.aws.exporter.sqs import (
+        AwsSqsSpanExporter
+    )
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    import boto3
+
+    sqs_exporter = SqsSpanExporter(session=boto3.Session(), 
+                                   sqs_queue_url="https://sqs.<accountRegion>.amazonaws.com/<accountId>/<queueName>")
+
+    span_processor = BatchSpanProcessor(sqs_exporter)
+
+    trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor))
+
+
 References
 ----------
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/exporter/sqs/__init__.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/exporter/sqs/__init__.py
@@ -1,0 +1,103 @@
+import json
+import sys
+from typing import List
+import boto3
+import logging
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+# SQS Limit for each message is 256Kb - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
+# 100 KB less than the limit to transport the last span
+MAX_SQS_TO_SQS = 262144-100
+
+# https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter
+class AwsSqsSpanExporter(SpanExporter):
+    def __init__(self, session: boto3.Session, sqs_queue_url: str) -> None:
+        super().__init__()
+        self.session = session
+        self.logger = logging.getLogger(__name__)
+        self.sqs_client = session.client("sqs")
+        self.sqs_queue_url = sqs_queue_url
+        
+
+    def _get_size(self, span: dict) -> int:
+        """This function recursively finds the size of a nested dictionary
+        Args:
+            span (dict): dictionary of spans to export
+                         Eg: { 1: ReadableSpan }
+        Returns:
+            int: Size of dictionary
+        """
+        size = sys.getsizeof(span)
+        for v in span.values():
+            if isinstance(v, dict):
+                size += self._get_size(v)
+            else:
+                size += sys.getsizeof(v)
+        return size
+
+
+    def _publish_message_to_sqs(self, message: str, attributes: dict):
+        """Function used to submit jobs to SQS queue.
+
+        Args:
+            message (str): dictionary of messages
+            attributes (dict): sqs message attributes
+        """
+        sqs_attributes = {}
+        # Converting all attribute dictionary into SQS Message Attributes
+        for i, v in attributes.items():
+            sqs_attributes[i] = {"StringValue": v, "DataType": "String"}
+        try:
+            resp = self.sqs_client.send_message(
+                QueueUrl=self.sqs_queue_url,
+                MessageAttributes=sqs_attributes,
+                MessageBody=json.dumps(message),
+            )
+            self.logger.info(f"Message deployed with id {resp['MessageId']}")
+            return resp["MessageId"]
+
+        except Exception as e:
+            self.logger.error(f"Error publishing message to SQS: {e}")
+            raise e
+
+    def _compress_and_export_spans(self, spans: List[ReadableSpan]) -> None:
+        """Function used to compress the spans into a single sqs message and export to SQS.
+           This function also handles the 256Kb Message limit for SQS.
+           It will break the messages into halfs if the limit if hit
+
+        Args:
+            spans (List[ReadableSpan]): List of Spans
+        """
+        compressed_spans = {}
+        sqs_attributes = {}
+        total_number_of_spans_per_sqs_message = 0
+        self.logger.debug(f"Size of spans {len(spans)}")
+        for span in spans:
+            total_number_of_spans_per_sqs_message += 1
+            compressed_spans[total_number_of_spans_per_sqs_message] = json.loads(span.to_json())
+            size_of_spans = self._get_size(compressed_spans)
+            # checking if the span size is not greater than SQS message limit
+            if size_of_spans >= MAX_SQS_TO_SQS:
+                sqs_attributes["number_of_spans"] = str(total_number_of_spans_per_sqs_message)
+                self._publish_message_to_sqs(compressed_spans, attributes)
+                self.logger.info(f"Spans exported to sqs {total_number_of_spans_per_sqs_message}")
+                # reseting it back to 0 for next batch
+                total_number_of_spans_per_sqs_message = 0
+                compressed_spans = {}
+                attributes = {}
+
+        # if we dont hit the limit we trigger with whenever we have collected
+        attributes["number_of_spans"] = str(total_number_of_spans_per_sqs_message)
+        self.logger.info(f"Limit not hit, transporting {total_number_of_spans_per_sqs_message} messages to sqs")
+        self._publish_message_to_sqs(compressed_spans, sqs_attributes)
+        self.logger.info(f"Spans exported to sqs {total_number_of_spans_per_sqs_message}")
+
+
+    def export(self, batch_of_spans: List[ReadableSpan]):
+        try:
+            self._compress_and_export_spans(batch_of_spans)
+            return SpanExportResult.SUCCESS
+        except Exception as e:
+            self.logger.error(f"Error exporting spans: {e}")
+            return SpanExportResult.FAILURE


### PR DESCRIPTION
# Description

This PR adds support for exporting Otel Spans to SQS Queues. The messages to SQS Queue is transported based on size limit for sqs messages. Hence each SQS message is a batch of spans. Upon testing, it is calculated that each sqs message can have upto ~70 Otel Spans.

Fixes # (issue)
#2383 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [X] Documentation has been updated
