### PR TITLE
Use sqlalchemy version in sqlalchemy commenter instead of opentelemetry library version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Use sqlalchemy version in sqlalchemy commenter instead of opentelemetry library version
+  ([#2404](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2404))
+
 ### Added
 
 - `opentelemetry-instrumentation-pika` Instrumentation for `channel.consume()` (supported

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import re
+import sqlalchemy
 import weakref
 
 from sqlalchemy.event import (  # pylint: disable=no-name-in-module
@@ -227,7 +228,7 @@ class EngineTracer:
                 commenter_data = {
                     "db_driver": conn.engine.driver,
                     # Driver/framework centric information.
-                    "db_framework": f"sqlalchemy:{__version__}",
+                    "db_framework": f"sqlalchemy:{sqlalchemy.__version__}",
                 }
 
                 if self.commenter_options.get("opentelemetry_values", True):

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import os
 import re
-import sqlalchemy
 import weakref
 
+import sqlalchemy
 from sqlalchemy.event import (  # pylint: disable=no-name-in-module
     listen,
     remove,

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -22,7 +22,6 @@ from sqlalchemy.event import (  # pylint: disable=no-name-in-module
 )
 
 from opentelemetry import trace
-from opentelemetry.instrumentation.sqlalchemy.version import __version__
 from opentelemetry.instrumentation.sqlcommenter_utils import _add_sql_comment
 from opentelemetry.instrumentation.utils import _get_opentelemetry_values
 from opentelemetry.semconv.trace import NetTransportValues, SpanAttributes


### PR DESCRIPTION
# Description

The SqlAlchemy commenter is currently using the library version in the comment it emits, e.g.:

```
{
  'db_driver': 'psycopg2', 
  'db_framework': 'sqlalchemy:0.45b0'
}
```

We should instead be using the sqlalchemy version here, as [SqlCommenter did before](https://github.com/google/sqlcommenter/blob/c447d218a1b8ff628571b22cf4e74f2a6fe2e38a/python/sqlcommenter-python/google/cloud/sqlcommenter/sqlalchemy/executor.py#L57)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Currently no tests, not sure how to test this in your testing setup. Please let me know how you want me to test!

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [N/A] Documentation has been updated
