### PR TITLE
Fix exception handling for events with requestContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2363](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2363))
 - `opentelemetry-instrumentation-boto3sqs` Instrument Session and resource
   ([#2161](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2161))
+- `opentelemetry-instrumentation-aws-lambda` Fix exception handling for events with requestContext
+  ([#2418](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2418))
 - Use sqlalchemy version in sqlalchemy commenter instead of opentelemetry library version
   ([#2404](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2404))
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -365,6 +365,7 @@ def _instrument(
                 )
 
             exception = None
+            result = None
             try:
                 result = call_wrapped(*args, **kwargs)
             except Exception as exc:  # pylint: disable=W0703

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -436,6 +436,27 @@ class TestAwsLambdaInstrumentor(TestBase):
 
         exc_env_patch.stop()
 
+    def test_lambda_handles_handler_exception_with_api_gateway_proxy_event(self):
+        exc_env_patch = mock.patch.dict(
+            "os.environ",
+            {_HANDLER: "tests.mocks.lambda_function.handler_exc"},
+        )
+        exc_env_patch.start()
+        AwsLambdaInstrumentor().instrument()
+        # instrumentor re-raises the exception
+        with self.assertRaises(Exception):
+            mock_execute_lambda({"requestContext": {"http": {"method": "GET"}}})
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        self.assertEqual(len(span.events), 1)
+        event = span.events[0]
+        self.assertEqual(event.name, "exception")
+
+        exc_env_patch.stop()
+
     def test_uninstrument(self):
         AwsLambdaInstrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -436,7 +436,9 @@ class TestAwsLambdaInstrumentor(TestBase):
 
         exc_env_patch.stop()
 
-    def test_lambda_handles_handler_exception_with_api_gateway_proxy_event(self):
+    def test_lambda_handles_handler_exception_with_api_gateway_proxy_event(
+        self,
+    ):
         exc_env_patch = mock.patch.dict(
             "os.environ",
             {_HANDLER: "tests.mocks.lambda_function.handler_exc"},
@@ -445,7 +447,9 @@ class TestAwsLambdaInstrumentor(TestBase):
         AwsLambdaInstrumentor().instrument()
         # instrumentor re-raises the exception
         with self.assertRaises(Exception):
-            mock_execute_lambda({"requestContext": {"http": {"method": "GET"}}})
+            mock_execute_lambda(
+                {"requestContext": {"http": {"method": "GET"}}}
+            )
 
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)


### PR DESCRIPTION
# Description

For Lambda invocations with an event that contains a `requestContext` property, the current code throws an `UnboundLocalError` if an exception (of other type) is thrown in the function execution, due to the `result` variable being accessed before being initialized. This PR simply makes sure that is initialized before being used.


Fixes #2399 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ran `tox -e py38-test-instrumentation-aws-lambda`
- [x] ran `tox -e py39-test-instrumentation-aws-lambda`
- [x] ran `tox -e py310-test-instrumentation-aws-lambda`
- [x] ran `tox -e py311-test-instrumentation-aws-lambda`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
