### PR TITLE
DO NOT MERGE: Auto instrumentation paramaters proposal

### DIFF
--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -41,14 +41,5 @@ class OpenTelemetryDistro(BaseDistro):
         # Since the distro sets these env vars, these params are not necesary.
         # However they could replace these env var defaults.
         # Otherwise, they just serve as an example.
-        configuration_kwargs = {
-            # Could be trace_exporters or span_exporters
-            "span_exporter_names": ("otlp"),
-            "metric_exporter_names": ("otlp"),
-            "log_exporter_names": ("otlp"),
-            "sampler_name": None,
-            # Could be attribute dict or Resource object
-            "resource_attributes": {},
-            # Could be string or bool
-            "logging_enabled": False,
-        }
+        configuration_kwargs = {}
+        return configuration_kwargs

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -38,3 +38,17 @@ class OpenTelemetryDistro(BaseDistro):
         os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")
         os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp")
         os.environ.setdefault(OTEL_EXPORTER_OTLP_PROTOCOL, "grpc")
+        # Since the distro sets these env vars, these params are not necesary.
+        # However they could replace these env var defaults.
+        # Otherwise, they just serve as an example.
+        configuration_kwargs = {
+            # Could be trace_exporters or span_exporters
+            "span_exporter_names": ("otlp"),
+            "metric_exporter_names": ("otlp"),
+            "log_exporter_names": ("otlp"),
+            "sampler_name": None,
+            # Could be attribute dict or Resource object
+            "resource_attributes": {},
+            # Could be string or bool
+            "logging_enabled": False,
+        }

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -94,7 +94,8 @@ def _load_instrumentors(distro):
         entry_point.load()()
 
 
-def _load_configurators():
+def _load_configurators(**configuration_kwargs):
+    configuration_kwargs["auto_instrumentation_version"] =__version__
     configurator_name = environ.get(OTEL_PYTHON_CONFIGURATOR, None)
     configured = None
     for entry_point in iter_entry_points("opentelemetry_configurator"):
@@ -110,7 +111,7 @@ def _load_configurators():
                 configurator_name is None
                 or configurator_name == entry_point.name
             ):
-                entry_point.load()().configure(auto_instrumentation_version=__version__)  # type: ignore
+                entry_point.load()().configure(**configuration_kwargs)  # type: ignore
                 configured = entry_point.name
             else:
                 _logger.warning(

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -34,8 +34,8 @@ def initialize():
 
     try:
         distro = _load_distro()
-        distro.configure()
-        _load_configurators()
+        configuration_kwargs = distro.configure()
+        _load_configurators(**configuration_kwargs)
         _load_instrumentors(distro)
     except Exception:  # pylint: disable=broad-except
         logger.exception("Failed to auto initialize opentelemetry")


### PR DESCRIPTION
# Description

Currently, the only way for custom distros to configure is through setting or defaulting environment variables. While it makes sense for customers to configure distros with env vars. There is no reason distros should need be able to directly configure start up (exporters, samplers...etc). Exposing distro configuration of otel via env var defaults is invasive, confusing, and easy for users to mess up. For instrance, even a blank env var or a left over setting from previous run could interfere with a distro starting up.

This is a draft proposal for what changing this approach could look like. In this approach, distros can output kwargs that our sitecustomize setup can then pass to configurators, and by extension the _initialize_components method which currently _only_ considers env vars.

main repo pr: https://github.com/open-telemetry/opentelemetry-python/pull/3864
contrib pr: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2439