### PR TITLE
Fix compatibility issue aio-pika instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aio-pika/src/opentelemetry/instrumentation/aio_pika/span_builder.py
+++ b/instrumentation/opentelemetry-instrumentation-aio-pika/src/opentelemetry/instrumentation/aio_pika/span_builder.py
@@ -47,8 +47,13 @@ class SpanBuilder:
         self._attributes[SpanAttributes.MESSAGING_DESTINATION] = destination
 
     def set_channel(self, channel: AbstractChannel):
-        connection = channel.connection
-        if getattr(connection, "connection", None):
+        if hasattr(channel, "_connection"):
+            # aio_rmq 9.1 and above removed the connection attribute from the abstract listings
+            connection = channel._connection
+        else:
+            # aio_rmq 9.0.5 and below
+            connection = channel.connection
+        if hasattr(connection, "connection"):
             # aio_rmq 7
             url = connection.connection.url
         else:
@@ -57,7 +62,7 @@ class SpanBuilder:
         self._attributes.update(
             {
                 SpanAttributes.NET_PEER_NAME: url.host,
-                SpanAttributes.NET_PEER_PORT: url.port,
+                SpanAttributes.NET_PEER_PORT: url.port or 5672,
             }
         )
 

--- a/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-3.txt
+++ b/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-3.txt
@@ -1,5 +1,5 @@
-aio-pika==9.0.5
-aiormq==6.7.1
+aio-pika==9.4.1
+aiormq==6.8.0
 asgiref==3.7.2
 attrs==23.2.0
 Deprecated==1.2.14
@@ -8,7 +8,7 @@ importlib-metadata==6.11.0
 iniconfig==2.0.0
 multidict==6.0.5
 packaging==23.2
-pamqp==3.2.1
+pamqp==3.3.0
 pluggy==1.4.0
 py==1.11.0
 py-cpuinfo==9.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -265,9 +265,10 @@ envlist =
     ; opentelemetry-instrumentation-aio-pika
     ; The numbers at the end of the environment names
     ; below mean these dependencies are being used:
-    ; 0: aio_pika~=7.2.0
-    ; 1: aio_pika>=8.0.0,<9.0.0
-    ; 2: aio_pika>=9.0.0,<10.0.0
+    ; 0: aio_pika==7.2.0
+    ; 1: aio_pika==8.3.0
+    ; 2: aio_pika==9.0.5
+    ; 3: aio_pika==9.4.1
     py3{8,9,10,11}-test-instrumentation-aio-pika-{0,1,2,3}
     pypy3-test-instrumentation-aio-pika-{0,1,2,3}
 

--- a/tox.ini
+++ b/tox.ini
@@ -268,8 +268,8 @@ envlist =
     ; 0: aio_pika~=7.2.0
     ; 1: aio_pika>=8.0.0,<9.0.0
     ; 2: aio_pika>=9.0.0,<10.0.0
-    py3{8,9,10,11}-test-instrumentation-aio-pika-{0,1,2}
-    pypy3-test-instrumentation-aio-pika-{0,1,2}
+    py3{8,9,10,11}-test-instrumentation-aio-pika-{0,1,2,3}
+    pypy3-test-instrumentation-aio-pika-{0,1,2,3}
 
     ; opentelemetry-instrumentation-kafka-python
     py3{8,9,10,11}-test-instrumentation-kafka-python
@@ -338,6 +338,7 @@ commands_pre =
   aio-pika-0: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-0.txt
   aio-pika-1: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-1.txt
   aio-pika-2: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-2.txt
+  aio-pika-3: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-3.txt
 
   kafka-python: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python/test-requirements.txt
 
@@ -427,8 +428,6 @@ commands_pre =
   jinja2: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-jinja2/test-requirements.txt
 
   logging: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-logging/test-requirements.txt
-
-  aio-pika-{0,1,2}: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aio-pika/test-requirements-2.txt
 
   aiohttp-client: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
 


### PR DESCRIPTION
- changed test-requirements-2.txt to use aio-pika==9.0.5
- added test-requirements-3.txt to use aio-pika==9.4.1 (latest atm)
- tox.ini: fixed incorrect commands_pre which would always install test-requirements-2.txt and cause dep installation conflict
- tox.ini: added aio-pika-3 commands

# Description

As mentioned in the release notes for aio-pika 9.1.0, there was a public API change which broke the instrumentation implementation. The instrumentation package's dependencies did not account for this incompatibility causing run time errors as documented in #2005. #1835 elaborates on this and even proposes a patch to get things working. The author, @phillipuniverse also [asked the aio-pika maintainers for guidance](https://github.com/mosquito/aio-pika/pull/533) on solving the issue but they haven't received any response so far.

The proposed implementation does not use the new public API (because it is async) and utilizes the underlying `_connection` directly. The motivation is to keep changes in the instrumentation to a minimum while having compatibility from aio-pika>=7.0.0.

Special call out to @phillipuniverse for proposing the original implementation.

Fixes # (issue)

#1835 
#2005

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new requirements file for aio-pika 9.0.5 and 9.4.1 (latest atm). Made changes in tox.ini to include this in the tests. All test have been run in py311.

Also, the tox.ini would always install test-requirements-2.txt in every configuration causing a dependency conflict. This has been addressed in this PR.

- [x] test-instrumentation-aio-pika-0
- [x] test-instrumentation-aio-pika-1
- [x] test-instrumentation-aio-pika-2
- [x] test-instrumentation-aio-pika-3

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
