### PR TITLE
Remove SDK dependency from opentelemetry-instrumentation-grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2418](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2418))
 - Use sqlalchemy version in sqlalchemy commenter instead of opentelemetry library version
   ([#2404](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2404))
+- Remove SDK dependency from opentelemetry-instrumentation-grpc
+  ([#2474](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2474))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.12",
   "opentelemetry-instrumentation == 0.46b0.dev",
-  "opentelemetry-sdk ~= 1.12",
   "opentelemetry-semantic-conventions == 0.46b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
 ]


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2473

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Grepped through the code and we do not actually use the SDK anywhere outside of tests https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib%20path%3A%2F%5Einstrumentation%5C%2Fopentelemetry-instrumentation-grpc%5C%2F%2F%20sdk&type=code
- [ ] Existing tests pass fine

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
