### PR TITLE
Reinstate tox -e lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,8 @@ You can run `tox` with the following arguments:
 `black` and `isort` are executed when `tox -e lint` is run. The reported errors can be tedious to fix manually.
 An easier way to do so is:
 
-1. Run `.tox/lint-some-package/bin/black .`
-2. Run `.tox/lint-some-package/bin/isort .`
+1. Run `.tox/lint/bin/black .`
+2. Run `.tox/lint/bin/isort .`
 
 Or you can call formatting and linting in one command by [pre-commit](https://pre-commit.com/):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1189,6 +1189,17 @@ changedir = docs
 commands =
   sphinx-build -E -a -W -b html -T . _build/html
 
+[testenv:lint]
+basepython: python3
+recreate = True
+deps =
+  -r dev-requirements.txt
+
+commands =
+  black --config {toxinidir}/pyproject.toml {{toxinidir}} --diff --check
+  isort --settings-path {toxinidir}/.isort.cfg {{toxinidir}} --diff --check-only
+  flake8 --config {toxinidir}/.flake8 {toxinidir}
+
 [testenv:spellcheck]
 basepython: python3
 recreate = True


### PR DESCRIPTION
# Description

Reintroduce the lint environment after 5116305f77bcd4c8ab18ef302a4351bb5b724c1e to just run the cheap linting tools so that developers can rely on it

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e lint

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
