### PR TITLE
Update test_jinja2.py

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -143,7 +143,7 @@ class TestJinja2Instrumentor(TestBase):
     def test_file_template_with_root(self):
         with self.tracer.start_as_current_span("root"):
             loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
-            env = jinja2.Environment(loader=loader)
+            env = jinja2.Environment(loader=loader, autoescape=True)
             template = env.get_template("template.html")
             self.assertEqual(
                 template.render(name="Jinja"), "Message: Hello Jinja!"
@@ -164,7 +164,7 @@ class TestJinja2Instrumentor(TestBase):
 
     def test_file_template(self):
         loader = jinja2.loaders.FileSystemLoader(TMPL_DIR)
-        env = jinja2.Environment(loader=loader)
+        env = jinja2.Environment(loader=loader, autoescape=True)
         template = env.get_template("template.html")
         self.assertEqual(
             template.render(name="Jinja"), "Message: Hello Jinja!"


### PR DESCRIPTION
Cross-site scripting (XSS) attacks can occur if untrusted input is not escaped. This applies to templates as well as code. The jinja2 templates may be vulnerable to XSS if the environment has autoescape set to False. Unfortunately, jinja2 sets autoescape to False by default. Explicitly setting autoescape to True when creating an Environment object will prevent this.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
