### PR TITLE
Fix net peer attribute for unix socket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-requests` Fix wrong time unit for duration histogram
   ([#2553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2553))
 - `opentelemetry-util-http` Preserve brackets around literal IPv6 hosts ([#2552](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2552))
+- `opentelemetry-util-redis` Fix net peer attribute for unix socket connection ([#2493](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2493))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
@@ -29,7 +29,12 @@ def _extract_conn_attributes(conn_kwargs):
     }
     db = conn_kwargs.get("db", 0)
     attributes[SpanAttributes.DB_REDIS_DATABASE_INDEX] = db
-    try:
+    if "path" in conn_kwargs:
+        attributes[SpanAttributes.NET_PEER_NAME] = conn_kwargs.get("path", "")
+        attributes[SpanAttributes.NET_TRANSPORT] = (
+            NetTransportValues.OTHER.value
+        )
+    else:
         attributes[SpanAttributes.NET_PEER_NAME] = conn_kwargs.get(
             "host", "localhost"
         )
@@ -38,11 +43,6 @@ def _extract_conn_attributes(conn_kwargs):
         )
         attributes[SpanAttributes.NET_TRANSPORT] = (
             NetTransportValues.IP_TCP.value
-        )
-    except KeyError:
-        attributes[SpanAttributes.NET_PEER_NAME] = conn_kwargs.get("path", "")
-        attributes[SpanAttributes.NET_TRANSPORT] = (
-            NetTransportValues.OTHER.value
         )
 
     return attributes


### PR DESCRIPTION
# Description

After switch on `.get(...)`, `KeyError` exception is never raised

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import redis
from opentelemetry.instrumentation.redis import RedisInstrumentor

RedisInstrumentor().instrument()

client = redis.Redis(unix_socket_path="/foobar")  # or redis.Redis.from_url("unix:///foobar")
# Span attribute `net.peer.name` must be equal to `/foobar`
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
