### PR TITLE
upgrade pymongo to avoid CWE-125 vulnerability issue

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymongo/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/test-requirements.txt
@@ -8,7 +8,7 @@ packaging==23.2
 pluggy==1.4.0
 py==1.11.0
 py-cpuinfo==9.0.0
-pymongo==4.6.2
+pymongo==4.6.3
 pytest==7.1.3
 pytest-benchmark==4.0.0
 tomli==2.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1250,7 +1250,7 @@ deps =
   psycopg2==2.9.9
   psycopg2-binary==2.9.9
   pycparser==2.21
-  pymongo==4.6.2
+  pymongo==4.6.3
   PyMySQL==0.10.1
   PyNaCl==1.5.0
   # prerequisite: install unixodbc


### PR DESCRIPTION
# Description
Versions of the package pymongo before 4.6.3 are vulnerable to Out-of-bounds Read in the bson module. Using the crafted payload the attacker could force the parser to deserialize unmanaged memory. The parser tries to interpret bytes next to buffer and throws an exception with string. If the following bytes are not printable UTF-8 the parser throws an exception with a single byte.
Upgrade pymonge from version 4.6.2 to 4.6.3 in instrumentation/opentelemetry-instrumentation-pymongo/test-requirements.txt to fix this issue.
Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2435
## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# How Has This Been Tested?
Go to Contrib repo directory. ```cd ~/git/opentelemetry-python-contrib```
Create a virtual env in your contribute repo directory. ```python3 -m venv my_test_venv```.
Activate your virtual env. ```source m.test_yeny/bin/activate```
Make sure you have tox installed. ```pip install tox```.
Run tests for a package : ```tox -e test-instrumentation-pymong```

- [X] tox -e test-instrumentetion.pymongo
# Does This PR Require a Core Repo Change?
- [ ] Yes. - Link to PR:
- [X] No.
# Checklist:
- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated