### PR TITLE
Extract a full context (e.g. baggage) in aiohttp-server instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2461](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2461))
 - Remove SDK dependency from opentelemetry-instrumentation-grpc
   ([#2474](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2474))
+- `opentelemetry-instrumentation-aiohttp-server` Correctly extract all context info including
+  baggage
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
@@ -24,7 +24,10 @@ from opentelemetry.context import _SUPPRESS_HTTP_INSTRUMENTATION_KEY
 from opentelemetry.instrumentation.aiohttp_server.package import _instruments
 from opentelemetry.instrumentation.aiohttp_server.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import http_status_to_status_code
+from opentelemetry.instrumentation.utils import (
+    http_status_to_status_code,
+    _start_internal_or_server_span,
+)
 from opentelemetry.propagate import extract
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.semconv.metrics import MetricInstruments
@@ -216,27 +219,38 @@ async def middleware(request, handler):
         description="measures the number of concurrent HTTP requests those are currently in flight",
     )
 
-    with tracer.start_as_current_span(
+    span, token = _start_internal_or_server_span(
+        tracer,
         span_name,
-        context=extract(request, getter=getter),
-        kind=trace.SpanKind.SERVER,
-    ) as span:
-        attributes = collect_request_attributes(request)
-        attributes.update(additional_attributes)
-        span.set_attributes(attributes)
-        start = default_timer()
-        active_requests_counter.add(1, active_requests_count_attrs)
-        try:
-            resp = await handler(request)
-            set_status_code(span, resp.status)
-        except web.HTTPException as ex:
-            set_status_code(span, ex.status_code)
-            raise
-        finally:
-            duration = max((default_timer() - start) * 1000, 0)
-            duration_histogram.record(duration, duration_attrs)
-            active_requests_counter.add(-1, active_requests_count_attrs)
-        return resp
+        start_time=None,
+        context_carrier=request,
+        context_getter=getter,
+        attributes=additional_attributes,
+    )
+
+    try:
+        with trace.use_span(span, end_on_exit=False) as current_span:
+            if current_span.is_recording():
+                attributes = collect_request_attributes(request)
+                current_span.set_attributes(attributes)
+            start = default_timer()
+            active_requests_counter.add(1, active_requests_count_attrs)
+            try:
+                resp = await handler(request)
+                set_status_code(current_span, resp.status)
+            except web.HTTPException as ex:
+                set_status_code(current_span, ex.status_code)
+                raise
+            finally:
+                duration = max((default_timer() - start) * 1000, 0)
+                duration_histogram.record(duration, duration_attrs)
+                active_requests_counter.add(-1, active_requests_count_attrs)
+            return resp
+    finally:
+        if token:
+            context.detach(token)
+        if span.is_recording():
+            span.end()
 
 
 class _InstrumentedApplication(web.Application):


### PR DESCRIPTION
# Description

Before, only a parent span was extracted, any other cross-cutting context extracted from the message would be dropped on the floor. Instead, attach the full context extracted for the duration of the call.

This uses the `_start_internal_or_server_span` helper function as used in e.g. flask.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ran tox -e py38-test-instrumentation-aiohttp-server
- [x] ran tox -e py39-test-instrumentation-aiohttp-server
- [x] ran tox -e py310-test-instrumentation-aiohttp-server
- [x] ran tox -e py311-test-instrumentation-aiohttp-server

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
