### PR TITLE
fix(async-io): check for __name__ attribute when tracing coroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2474](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2474))
 - `opentelemetry-instrumentation-elasticsearch` Improved support for version 8
   ([#2420](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2420))
+- `opentelemetry-instrumentation-asyncio` Check for __name__ attribute in the coroutine
+  ([#2521](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2521))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
@@ -261,6 +261,8 @@ class AsyncioInstrumentor(BaseInstrumentor):
         return coro_or_future
 
     async def trace_coroutine(self, coro):
+        if not hasattr(coro, "__name__"):
+            return
         start = default_timer()
         attr = {
             "type": "coroutine",

--- a/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+from unittest.mock import patch
+
+# pylint: disable=no-name-in-module
+from opentelemetry.instrumentation.asyncio import AsyncioInstrumentor
+from opentelemetry.instrumentation.asyncio.environment_variables import (
+    OTEL_PYTHON_ASYNCIO_COROUTINE_NAMES_TO_TRACE,
+)
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import get_tracer
+
+
+class TestAsyncioAnext(TestBase):
+    @patch.dict(
+        "os.environ",
+        {OTEL_PYTHON_ASYNCIO_COROUTINE_NAMES_TO_TRACE: "async_func"},
+    )
+    def setUp(self):
+        super().setUp()
+        AsyncioInstrumentor().instrument()
+        self._tracer = get_tracer(
+            __name__,
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        AsyncioInstrumentor().uninstrument()
+
+    # Asyncio anext() does not have __name__ attribute, which is used to determine if the coroutine should be traced.
+    # This test is to ensure that the instrumentation does not break when the coroutine does not have __name__ attribute.
+    def test_asyncio_anext(self):
+        async def main():
+            async def async_gen():
+                for it in range(2):
+                    yield it
+
+            async_gen_instance = async_gen()
+            agen = anext(async_gen_instance)
+            await asyncio.create_task(agen)
+
+        asyncio.run(main())
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)


### PR DESCRIPTION
# Description

This PR takes over stale PR https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2353.

Basically we need to check if coroutine has __name__ attribute before trying to trace, as not all coroutines have this attribute. More details are in the issue.

I've applied suggestions from @xrmx comment in here https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2353#pullrequestreview-1945704015

Fixes [#2340](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2340)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit test. Ran the test without the fix and it fails with the following error:

```
self = <opentelemetry.instrumentation.asyncio.AsyncioInstrumentor object at 0x79c618a75d60>
coro = <async_generator_asend object at 0x79c618a6d0c0>

    async def trace_coroutine(self, coro):
        start = default_timer()

        attr = {
            "type": "coroutine",
>           "name": coro.__name__,
        }
E       AttributeError: 'async_generator_asend' object has no attribute '__name__'. Did you mean: '__ne__'?

instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py:268: AttributeError
```

With the fix the unit test passes.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
