### PR TITLE
Add key predicate to baggage span processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2397](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2397)))
 - `opentelemetry-processor-baggage` Initial release
   ([#2436](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2436))
+- `opentelemetry-processor-baggage` Add baggage key predicate
+  ([#2535](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2535))
 
 ### Fixed
 

--- a/processor/opentelemetry-processor-baggage/README.rst
+++ b/processor/opentelemetry-processor-baggage/README.rst
@@ -20,3 +20,32 @@ Do not put sensitive information in Baggage.
 
 To repeat: a consequence of adding data to Baggage is that the keys and
 values will appear in all outgoing HTTP headers from the application.
+
+## Usage
+
+Add the span processor when configuring the tracer provider.
+
+To configure the span processor to copy all baggage entries during configuration:
+
+```python
+from opentelemetry.processor.baggage import BaggageSpanProcessor, ALLOW_ALL_BAGGAGE_KEYS
+
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+```
+
+Alternatively, you can provide a custom baggage key predicate to select which baggage keys you want to copy.
+
+For example, to only copy baggage entries that start with `my-key`:
+
+```python
+starts_with_predicate = lambda baggage_key: baggage_key.startswith("my-key")
+tracer_provider.add_span_processor(BaggageSpanProcessor(starts_with_predicate))
+```
+
+For example, to only copy baggage entries that match the regex `^key.+`:
+
+```python
+regex_predicate = lambda baggage_key: baggage_key.startswith("^key.+")
+tracer_provider.add_span_processor(BaggageSpanProcessor(regex_predicate))
+```

--- a/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/__init__.py
+++ b/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/__init__.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=import-error
 
-from .processor import BaggageSpanProcessor
+from .processor import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from .version import __version__
 
-__all__ = ["BaggageSpanProcessor", "__version__"]
+__all__ = ["ALLOW_ALL_BAGGAGE_KEYS", "BaggageSpanProcessor", "__version__"]

--- a/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
+++ b/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
@@ -19,15 +19,11 @@ from opentelemetry.context import Context
 from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.trace import Span
 
-"""
-A BaggageKeyPredicate is a function that takes a baggage key and returns a boolean
-"""
-type BaggageKeyPredicate = Callable[[str], bool]
+# A BaggageKeyPredicate is a function that takes a baggage key and returns a boolean
+BaggageKeyPredicateT = Callable[[str], bool]
 
-"""
-A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans
-"""
-ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicate = lambda baggageKey: True
+# A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans
+ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicateT = lambda _: True
 
 
 class BaggageSpanProcessor(SpanProcessor):
@@ -54,9 +50,8 @@ class BaggageSpanProcessor(SpanProcessor):
 
     """
 
-    def __init__(self, baggage_key_predicate: BaggageKeyPredicate) -> None:
+    def __init__(self, baggage_key_predicate: BaggageKeyPredicateT) -> None:
         self._baggage_key_predicate = baggage_key_predicate
-        pass
 
     def on_start(
         self, span: "Span", parent_context: Optional[Context] = None

--- a/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
+++ b/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Callable, Optional
 
 from opentelemetry.baggage import get_all as get_all_baggage
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.trace import Span
 
+"""
+A BaggageKeyPredicate is a function that takes a baggage key and returns a boolean 
+"""
+type BaggageKeyPredicate = Callable[[str], bool]
+
+""" 
+A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans
+"""
+ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicate = lambda baggageKey: True
 
 class BaggageSpanProcessor(SpanProcessor):
     """
@@ -44,7 +53,8 @@ class BaggageSpanProcessor(SpanProcessor):
 
     """
 
-    def __init__(self) -> None:
+    def __init__(self, baggage_key_predicate: BaggageKeyPredicate) -> None:
+        self._baggage_key_predicate = baggage_key_predicate
         pass
 
     def on_start(
@@ -52,4 +62,5 @@ class BaggageSpanProcessor(SpanProcessor):
     ) -> None:
         baggage = get_all_baggage(parent_context)
         for key, value in baggage.items():
-            span.set_attribute(key, value)
+            if self._baggage_key_predicate(key):
+                span.set_attribute(key, value)

--- a/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
+++ b/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
@@ -20,14 +20,15 @@ from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.trace import Span
 
 """
-A BaggageKeyPredicate is a function that takes a baggage key and returns a boolean 
+A BaggageKeyPredicate is a function that takes a baggage key and returns a boolean
 """
 type BaggageKeyPredicate = Callable[[str], bool]
 
-""" 
+"""
 A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans
 """
 ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicate = lambda baggageKey: True
+
 
 class BaggageSpanProcessor(SpanProcessor):
     """

--- a/processor/opentelemetry-processor-baggage/tests/test_baggage_processor.py
+++ b/processor/opentelemetry-processor-baggage/tests/test_baggage_processor.py
@@ -29,7 +29,9 @@ from opentelemetry.trace import Span, Tracer
 
 class BaggageSpanProcessorTest(unittest.TestCase):
     def test_check_the_baggage(self):
-        self.assertIsInstance(BaggageSpanProcessor(), SpanProcessor)
+        self.assertIsInstance(
+            BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS), SpanProcessor
+        )
 
     def test_set_baggage_attaches_to_child_spans_and_detaches_properly_with_context(
         self,
@@ -156,8 +158,10 @@ class BaggageSpanProcessorTest(unittest.TestCase):
         detach(honey_token)
         self.assertEqual(get_all_baggage(), {})
 
+    @staticmethod
     def has_prefix(baggage_key: str) -> bool:
         return baggage_key.startswith("que")
 
+    @staticmethod
     def matches_regex(baggage_key: str) -> bool:
         return re.match(r"que.*", baggage_key) is not None


### PR DESCRIPTION
# Description

Updates the Baggage span processor to require a baggage key predicate function that selects what keys are copied to new spans.

Fixes #2472 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
  (The original span processor PR #2428 has been published yet so this is not breaking)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
