### PR TITLE
kafka-python Instrument temporary fork, kafka-python-ng inside kafka-python's instrumentation

### DIFF
--- a/.github/workflows/instrumentations_1.yml
+++ b/.github/workflows/instrumentations_1.yml
@@ -40,6 +40,7 @@ jobs:
           - "util-http"
           - "fastapislim"
           - "processor-baggage"
+          - "kafka-pythonng"
         os: [ubuntu-20.04]
         exclude:
           - python-version: pypy3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- `opentelemetry-instrumentation-kafka-python` Instrument temporary fork, kafka-python-ng
+  inside kafka-python's instrumentation
+  ([#2537](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2537)))
+
 ## Breaking changes
 
 ## Fixed

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -24,7 +24,7 @@
 | [opentelemetry-instrumentation-grpc](./opentelemetry-instrumentation-grpc) | grpcio ~= 1.27 | No | experimental
 | [opentelemetry-instrumentation-httpx](./opentelemetry-instrumentation-httpx) | httpx >= 0.18.0 | No | migration
 | [opentelemetry-instrumentation-jinja2](./opentelemetry-instrumentation-jinja2) | jinja2 >= 2.7, < 4.0 | No | experimental
-| [opentelemetry-instrumentation-kafka-python](./opentelemetry-instrumentation-kafka-python) | kafka-python >= 2.0 | No | experimental
+| [opentelemetry-instrumentation-kafka-python](./opentelemetry-instrumentation-kafka-python) | kafka-python >= 2.0, < 3.0,kafka-python-ng >= 2.0, < 3.0 | No | experimental
 | [opentelemetry-instrumentation-logging](./opentelemetry-instrumentation-logging) | logging | No | experimental
 | [opentelemetry-instrumentation-mysql](./opentelemetry-instrumentation-mysql) | mysql-connector-python >= 8.0, < 10.0 | No | experimental
 | [opentelemetry-instrumentation-mysqlclient](./opentelemetry-instrumentation-mysqlclient) | mysqlclient < 3 | No | experimental

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api ~= 1.5",
@@ -31,7 +32,8 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "kafka-python >= 2.0",
+  "kafka-python >= 2.0, < 3.0",
+  "kafka-python-ng >= 2.0, < 3.0"
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/package.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/package.py
@@ -13,4 +13,7 @@
 # limitations under the License.
 
 
-_instruments = ("kafka-python >= 2.0",)
+_instruments_kafka_python = "kafka-python >= 2.0, < 3.0"
+_instruments_kafka_python_ng = "kafka-python-ng >= 2.0, < 3.0"
+
+_instruments = (_instruments_kafka_python, _instruments_kafka_python_ng)

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/test-requirements-ng.txt
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/test-requirements-ng.txt
@@ -1,0 +1,15 @@
+asgiref==3.7.2
+Deprecated==1.2.14
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+kafka-python-ng==2.2.2
+packaging==24.0
+pluggy==1.5.0
+py-cpuinfo==9.0.0
+pytest==7.4.4
+tomli==2.0.1
+typing_extensions==4.9.0
+wrapt==1.16.0
+zipp==3.19.2
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-kafka-python

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -105,7 +105,11 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-jinja2==0.48b0.dev",
     },
     {
-        "library": "kafka-python >= 2.0",
+        "library": "kafka-python >= 2.0, < 3.0",
+        "instrumentation": "opentelemetry-instrumentation-kafka-python==0.48b0.dev",
+    },
+    {
+        "library": "kafka-python-ng >= 2.0, < 3.0",
         "instrumentation": "opentelemetry-instrumentation-kafka-python==0.48b0.dev",
     },
     {

--- a/tox.ini
+++ b/tox.ini
@@ -946,6 +946,9 @@ commands =
   lint-instrumentation-kafka-python: flake8 --config {toxinidir}/.flake8 {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python
   lint-instrumentation-kafka-python: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-kafka-python"
 
+  ; Test only for kafka-pythonng instrumentation as the only difference between kafka-python and kafka-pythonng is the version of kafka-python
+  test-instrumentation-kafka-pythonng: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python/tests {posargs}
+
   test-instrumentation-confluent-kafka: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests {posargs}
   lint-instrumentation-confluent-kafka: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/instrumentation/opentelemetry-instrumentation-confluent-kafka
   lint-instrumentation-confluent-kafka: isort --diff --check-only --settings-path {toxinidir}/.isort.cfg {toxinidir}/instrumentation/opentelemetry-instrumentation-confluent-kafka

--- a/tox.ini
+++ b/tox.ini
@@ -350,7 +350,9 @@ envlist =
 
     ; opentelemetry-instrumentation-kafka-python
     py3{8,9,10,11}-test-instrumentation-kafka-python
+    py3{8,9,10,11,12}-test-instrumentation-kafka-pythonng
     pypy3-test-instrumentation-kafka-python
+    pypy3-test-instrumentation-kafka-pythonng
     lint-instrumentation-kafka-python
 
     ; opentelemetry-instrumentation-confluent-kafka
@@ -443,6 +445,10 @@ commands_pre =
   kafka-python: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions
   kafka-python: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
   kafka-python: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python/test-requirements.txt
+  kafka-pythonng: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
+  kafka-pythonng: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions
+  kafka-pythonng: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
+  kafka-pythonng: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-kafka-python/test-requirements-ng.txt
 
   confluent-kafka: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
   confluent-kafka: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions


### PR DESCRIPTION
# Description

This PR adds kafka-python-ng, a temporary fork of kafka-python due to pypi access issues, to the kafka-python instrumentation.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Test 1:  Setup the code locally and then made sure that a sample pyramid app using kafka-python-ng instrumented without any errors.

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
