### PR TITLE
Ensure httpx non-client methods are instrumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `opentelemetry-instrumentation-dbapi` Fix compatibility with Psycopg3 to extract libpq build version (#2500)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2500]
+- `opentelemetry-instrumentation-dbapi` Fix compatibility with Psycopg3 to extract libpq build version
+  ([#2500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2500))
+- `opentelemetry-instrumentation-httpx` Ensure httpx.get or httpx.request like methods are instrumented
+  ([#1742](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2538))
 - `opentelemetry-instrumentation-grpc` AioClientInterceptor should propagate with a Metadata object
   ([#2363](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2363))
 - `opentelemetry-instrumentation-boto3sqs` Instrument Session and resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-dbapi` Fix compatibility with Psycopg3 to extract libpq build version
   ([#2500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2500))
 - `opentelemetry-instrumentation-httpx` Ensure httpx.get or httpx.request like methods are instrumented
-  ([#1742](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2538))
+  ([#2538](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2538))
 - `opentelemetry-instrumentation-grpc` AioClientInterceptor should propagate with a Metadata object
   ([#2363](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2363))
 - `opentelemetry-instrumentation-boto3sqs` Instrument Session and resource

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -564,11 +564,11 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedClient._tracer_provider = tracer_provider
         _InstrumentedAsyncClient._tracer_provider = tracer_provider
-        httpx.Client = _InstrumentedClient
+        httpx.Client = httpx._api.Client = _InstrumentedClient
         httpx.AsyncClient = _InstrumentedAsyncClient
 
     def _uninstrument(self, **kwargs):
-        httpx.Client = self._original_client
+        httpx.Client = httpx._api.Client = self._original_client
         httpx.AsyncClient = self._original_async_client
         _InstrumentedClient._tracer_provider = None
         _InstrumentedClient._request_hook = None

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -564,6 +564,8 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedClient._tracer_provider = tracer_provider
         _InstrumentedAsyncClient._tracer_provider = tracer_provider
+        # Intentionally using a private attribute here, see:
+        # https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2538#discussion_r1610603719
         httpx.Client = httpx._api.Client = _InstrumentedClient
         httpx.AsyncClient = _InstrumentedAsyncClient
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -545,10 +545,12 @@ class BaseTestCases:
 
             spans = self.assert_span(num_spans=len(results))
             for idx, res in enumerate(results):
-                self.assertEqual(res.text, "Hello!")
-                self.assertEqual(
-                    spans[idx].attributes[SpanAttributes.HTTP_URL], self.URL
-                )
+                with self.subTest(idx=idx, res=res):
+                    self.assertEqual(res.text, "Hello!")
+                    self.assertEqual(
+                        spans[idx].attributes[SpanAttributes.HTTP_URL],
+                        self.URL,
+                    )
 
             HTTPXClientInstrumentor().uninstrument()
 


### PR DESCRIPTION
# Description

This is an update of [previous MR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2011) for which the original author unfortunately didn't submit the updates required for merging into `main`. We actively use this instrumentation and this instrumentation gap is quite annoying to deal with.

Quote from MR

The `httpx.get`, `httpx.post`, etc. methods ultimately use `httpx._api.request`, which makes instantiates `httpx._api.Client`. But `httpx.Client` is modified during instrumentation without updating the value imported in the `httpx._api` module.

Fixing this was as easy as also patching the `Client` value in `httpx._api`.

All credit for the fix goes to @dmontagu.

Fixes #1742 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test which tests instrumentation of various ways to make a request in `httpx` without `httpx.Client`. Uninstrumentation is also tested.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
