### PR TITLE
fix(async-io):  return coro when __name__ is not present

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
@@ -262,7 +262,7 @@ class AsyncioInstrumentor(BaseInstrumentor):
 
     async def trace_coroutine(self, coro):
         if not hasattr(coro, "__name__"):
-            return
+            return coro
         start = default_timer()
         attr = {
             "type": "coroutine",


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2340

Seems to be we need to return coro when __name__ is not present as per https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2521#discussion_r1609925219

Though demo app and unit test works in both cases :thinking: 

I guess it's still better for consistency

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Running:

Installing dev dependency and running:
python3 anext.py

from the issue - https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2340



- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
