### PR TITLE
Pin codespell version to fix builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1206,7 +1206,7 @@ commands =
 basepython: python3
 recreate = True
 deps =
-  codespell
+  codespell==2.2.6
 
 commands =
   codespell


### PR DESCRIPTION
Builds are [failing](https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/9216220040/job/25356069155?pr=2529) due to new version of [codespell](https://pypi.org/project/codespell/2.3.0/)
