### PR TITLE
fix(requests): Fix wrong time unit for duration histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2420](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2420))
 - `opentelemetry-instrumentation-asyncio` Check for __name__ attribute in the coroutine
   ([#2521](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2521))
+- `opentelemetry-instrumentation-requests` Fix wrong time unit for duration histogram
+  ([#2553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2553))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -229,9 +229,7 @@ def _instrument(
                     exception = exc
                     result = getattr(exc, "response", None)
                 finally:
-                    elapsed_time = max(
-                        round((default_timer() - start_time) * 1000), 0
-                    )
+                    elapsed_time = max(default_timer() - start_time, 0)
 
             if isinstance(result, Response):
                 span_attributes = {}


### PR DESCRIPTION
# Description

#2002 introduced support for new semantic conventions for HTTP Metrics changing the unit from ms to s.

Unfortunately #2061 reverted the change back to ms breaking the units.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
