### PR TITLE
distro: decouple default configuration test from environment

### DIFF
--- a/opentelemetry-distro/tests/test_distro.py
+++ b/opentelemetry-distro/tests/test_distro.py
@@ -14,7 +14,7 @@
 # type: ignore
 
 import os
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from pkg_resources import DistributionNotFound, require
 
@@ -33,17 +33,10 @@ class TestDistribution(TestCase):
         except DistributionNotFound:
             self.fail("opentelemetry-distro not installed")
 
+    @mock.patch.dict("os.environ", {}, clear=True)
     def test_default_configuration(self):
         distro = OpenTelemetryDistro()
-        self.assertIsNone(os.environ.get(OTEL_TRACES_EXPORTER))
-        self.assertIsNone(os.environ.get(OTEL_METRICS_EXPORTER))
         distro.configure()
-        self.assertEqual(
-            "otlp", os.environ.get(OTEL_TRACES_EXPORTER)
-        )
-        self.assertEqual(
-            "otlp", os.environ.get(OTEL_METRICS_EXPORTER)
-        )
-        self.assertEqual(
-            "grpc", os.environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
-        )
+        self.assertEqual("otlp", os.environ.get(OTEL_TRACES_EXPORTER))
+        self.assertEqual("otlp", os.environ.get(OTEL_METRICS_EXPORTER))
+        self.assertEqual("grpc", os.environ.get(OTEL_EXPORTER_OTLP_PROTOCOL))


### PR DESCRIPTION
# Description

Decouple distro default configuration test from environment

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
