### PR TITLE
Adds NoOpTracerProvider test case for pymysql instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymysql/tests/test_pymysql_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/tests/test_pymysql_integration.py
@@ -17,10 +17,10 @@ from unittest import mock
 import pymysql
 
 import opentelemetry.instrumentation.pymysql
+from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.pymysql import PyMySQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.test.test_base import TestBase
-from opentelemetry import trace as trace_api
 
 
 class TestPyMysqlIntegration(TestBase):


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for pymysql instrumentation.

Fixes [#970](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/970)

# How Has This Been Tested?

tox -e test-instrumentation-pymysql


# Does This PR Require a Core Repo Change?
- [x] No.
