### PR TITLE
Adds NoOpTracerProvider test case for botocore instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-fastapi`, `opentelemetry-instrumentation-starlette` Use `tracer` and `meter` of originating components instead of one from `asgi` middleware
   ([#2580](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2580))
 
+### Added
+
+- `opentelemtry-instrumentation-botocore` Adds test case for NoOpTracerProvider ([#2586](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2586))
+
 ### Fixed
 
 - `opentelemetry-instrumentation-httpx` Ensure httpx.get or httpx.request like methods are instrumented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2573](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2573))
 - `opentelemetry-instrumentation-confluent-kafka` Add support for version 2.4.0 of confluent_kafka
   ([#2616](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2616))
+- `opentelemtry-instrumentation-botocore` Adds test case for NoOpTracerProvider 
+  ([#2586](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2586))
 
 ### Breaking changes
 
 - `opentelemetry-instrumentation-asgi`, `opentelemetry-instrumentation-fastapi`, `opentelemetry-instrumentation-starlette` Use `tracer` and `meter` of originating components instead of one from `asgi` middleware
   ([#2580](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2580))
-
-### Added
-
-- `opentelemtry-instrumentation-botocore` Adds test case for NoOpTracerProvider ([#2586](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2586))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -104,6 +104,19 @@ class TestBotocoreInstrumentor(TestBase):
         self.assert_span("EC2", "DescribeInstances", request_id=request_id)
 
     @mock_aws
+    def test_no_op_tracer_provider_ec2(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
+
+        ec2 = self._make_client("ec2")
+        ec2.describe_instances()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+    @mock_aws
     def test_not_recording(self):
         mock_tracer = Mock()
         mock_span = Mock()
@@ -147,13 +160,19 @@ class TestBotocoreInstrumentor(TestBase):
 
         s3.list_buckets()
         self.assert_span("S3", "ListBuckets")
-   
-    @mock_s3
+
+    @mock_aws
     def test_no_op_tracer_provider_s3(self):
         BotocoreInstrumentor().uninstrument()
         BotocoreInstrumentor().instrument(
-            tracer_provider = trace_api.NoOpTracerProvider()
+            tracer_provider=trace_api.NoOpTracerProvider()
         )
+
+        s3 = self._make_client("s3")
+        s3.list_buckets()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
 
     @mock_aws
     def test_s3_put(self):
@@ -184,6 +203,19 @@ class TestBotocoreInstrumentor(TestBase):
         )
 
     @mock_aws
+    def test_no_op_tracer_provider_sqs(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
+
+        sqs = self._make_client("sqs")
+        sqs.list_queues()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+    @mock_aws
     def test_sqs_send_message(self):
         sqs = self._make_client("sqs")
         test_queue_name = "test_queue_name"
@@ -210,12 +242,12 @@ class TestBotocoreInstrumentor(TestBase):
 
         kinesis.list_streams()
         self.assert_span("Kinesis", "ListStreams")
-    
-    @mock_kinesis
+
+    @mock_aws
     def test_no_op_tracer_provider_kinesis(self):
         BotocoreInstrumentor().uninstrument()
         BotocoreInstrumentor().instrument(
-            tracer_provider = trace_api.NoOpTracerProvider()
+            tracer_provider=trace_api.NoOpTracerProvider()
         )
 
         kinesis = self._make_client("kinesis")
@@ -277,6 +309,19 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(expected, dict(span.attributes))
 
     @mock_aws
+    def test_no_op_tracer_provider_kms(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
+
+        kms = self._make_client("kms")
+        kms.list_keys(Limit=21)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+    @mock_aws
     def test_sts_client(self):
         sts = self._make_client("sts")
 
@@ -287,6 +332,19 @@ class TestBotocoreInstrumentor(TestBase):
         expected["aws.request_id"] = ANY
         # check for exact attribute set to make sure not to leak any sts secrets
         self.assertEqual(expected, dict(span.attributes))
+
+    @mock_aws
+    def test_no_op_tracer_provider_sts(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
+
+        sts = self._make_client("sts")
+        sts.get_caller_identity()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
 
     @mock_aws
     def test_propagator_injects_into_request(self):
@@ -354,6 +412,19 @@ class TestBotocoreInstrumentor(TestBase):
             xray_client.put_trace_segments(TraceSegmentDocuments=["str1"])
             xray_client.put_trace_segments(TraceSegmentDocuments=["str2"])
         self.assertEqual(0, len(self.get_finished_spans()))
+
+    @mock_aws
+    def test_no_op_tracer_provider_xray(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+        )
+
+        xray_client = self._make_client("xray")
+        xray_client.put_trace_segments(TraceSegmentDocuments=["str1"])
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
 
     @mock_aws
     def test_suppress_http_instrumentation_xray_client(self):

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -147,6 +147,13 @@ class TestBotocoreInstrumentor(TestBase):
 
         s3.list_buckets()
         self.assert_span("S3", "ListBuckets")
+   
+    @mock_s3
+    def test_no_op_tracer_provider_s3(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider = trace_api.NoOpTracerProvider()
+        )
 
     @mock_aws
     def test_s3_put(self):
@@ -203,6 +210,19 @@ class TestBotocoreInstrumentor(TestBase):
 
         kinesis.list_streams()
         self.assert_span("Kinesis", "ListStreams")
+    
+    @mock_kinesis
+    def test_no_op_tracer_provider_kinesis(self):
+        BotocoreInstrumentor().uninstrument()
+        BotocoreInstrumentor().instrument(
+            tracer_provider = trace_api.NoOpTracerProvider()
+        )
+
+        kinesis = self._make_client("kinesis")
+        kinesis.list_streams()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
 
     @mock_aws
     def test_unpatch(self):


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for botocore instrumentation.

Fixes [#988](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/988)

# How Has This Been Tested?
tox -e test-instrumentation-botocore

# Does This PR Require a Core Repo Change?
No.