### PR TITLE
Fixing w3c baggage support in opentelemetry-instrumentation-aws-lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+## Breaking changes
+
 ## Fixed
 
 - `opentelemetry-instrumentation-aws-lambda` Avoid exception when a handler is not present.
@@ -17,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2483](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2484))
 - `opentelemetry-instrumentation-fastapi` Fix fastapi-slim support
   ([#2756](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2756))
+- `opentelemetry-instrumentation-aws-lambda` Fixing w3c baggage support
+  ([#2589](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2589))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 
@@ -113,7 +119,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2610))
 - `opentelemetry-instrumentation-asgi` Bugfix: Middleware did not set status code attribute on duration metrics for non-recording spans.
   ([#2627](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2627))
+<<<<<<< HEAD
 - `opentelemetry-instrumentation-mysql` Add support for `mysql-connector-python` v9 ([#2751](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2751))
+=======
+>>>>>>> 5a623233 (Changelog update)
 
 ## Version 1.25.0/0.46b0 (2024-05-31)
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -308,7 +308,6 @@ def _instrument(
         try:
             with tracer.start_as_current_span(
                 name=orig_handler_name,
-                context=parent_context,
                 kind=span_kind,
             ) as span:
                 if span.is_recording():

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/lambda_function.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/lambda_function.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
+from opentelemetry import baggage as baggage_api
+
 
 def handler(event, context):
-    return "200 ok"
+    baggage_content = dict(baggage_api.get_all().items())
+    return json.dumps({"baggage_content": baggage_content})
 
 
 def rest_api_handler(event, context):

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -289,6 +289,7 @@ class TestAwsLambdaInstrumentor(TestBase):
                 expected_state_value=MOCK_W3C_TRACE_STATE_VALUE,
                 xray_traceid=MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED,
                 expected_baggage=MOCK_W3C_BAGGAGE_VALUE,
+                propagators="tracecontext,baggage",
             ),
         ]
         for test in tests:

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -274,7 +274,7 @@ class TestAwsLambdaInstrumentor(TestBase):
                 xray_traceid=MOCK_XRAY_TRACE_CONTEXT_SAMPLED,
             ),
             TestCase(
-                name="baggae_propagation",
+                name="baggage_propagation",
                 custom_extractor=None,
                 context={
                     "headers": {

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import os
 from dataclasses import dataclass
 from importlib import import_module, reload
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict
 from unittest import mock
 
 from opentelemetry import propagate
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.environment_variables import OTEL_PROPAGATORS
 from opentelemetry.instrumentation.aws_lambda import (
     _HANDLER,
@@ -79,6 +80,9 @@ MOCK_W3C_TRACE_CONTEXT_SAMPLED = (
 MOCK_W3C_TRACE_STATE_KEY = "vendor_specific_key"
 MOCK_W3C_TRACE_STATE_VALUE = "test_value"
 
+MOCK_W3C_BAGGAGE_KEY = "baggage_key"
+MOCK_W3C_BAGGAGE_VALUE = "baggage_value"
+
 
 def mock_execute_lambda(event=None):
     """Mocks the AWS Lambda execution.
@@ -97,7 +101,7 @@ def mock_execute_lambda(event=None):
 
     module_name, handler_name = os.environ[_HANDLER].rsplit(".", 1)
     handler_module = import_module(module_name.replace("/", "."))
-    getattr(handler_module, handler_name)(event, MOCK_LAMBDA_CONTEXT)
+    return getattr(handler_module, handler_name)(event, MOCK_LAMBDA_CONTEXT)
 
 
 class TestAwsLambdaInstrumentor(TestBase):
@@ -181,6 +185,9 @@ class TestAwsLambdaInstrumentor(TestBase):
             expected_state_value: str = None
             expected_trace_state_len: int = 0
             propagators: str = "tracecontext"
+            expected_baggage: str = None
+            disable_aws_context_propagation: bool = False
+            disable_aws_context_propagation_envvar: str = ""
 
         def custom_event_context_extractor(lambda_event):
             return get_global_textmap().extract(lambda_event["foo"]["headers"])
@@ -266,6 +273,23 @@ class TestAwsLambdaInstrumentor(TestBase):
                 expected_state_value=MOCK_W3C_TRACE_STATE_VALUE,
                 xray_traceid=MOCK_XRAY_TRACE_CONTEXT_SAMPLED,
             ),
+            TestCase(
+                name="baggae_propagation",
+                custom_extractor=None,
+                context={
+                    "headers": {
+                        TraceContextTextMapPropagator._TRACEPARENT_HEADER_NAME: MOCK_W3C_TRACE_CONTEXT_SAMPLED,
+                        TraceContextTextMapPropagator._TRACESTATE_HEADER_NAME: f"{MOCK_W3C_TRACE_STATE_KEY}={MOCK_W3C_TRACE_STATE_VALUE},foo=1,bar=2",
+                        W3CBaggagePropagator._BAGGAGE_HEADER_NAME: f"{MOCK_W3C_BAGGAGE_KEY}={MOCK_W3C_BAGGAGE_VALUE}",
+                    }
+                },
+                expected_traceid=MOCK_W3C_TRACE_ID,
+                expected_parentid=MOCK_W3C_PARENT_SPAN_ID,
+                expected_trace_state_len=3,
+                expected_state_value=MOCK_W3C_TRACE_STATE_VALUE,
+                xray_traceid=MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED,
+                expected_baggage=MOCK_W3C_BAGGAGE_VALUE,
+            ),
         ]
         for test in tests:
 
@@ -284,7 +308,9 @@ class TestAwsLambdaInstrumentor(TestBase):
             AwsLambdaInstrumentor().instrument(
                 event_context_extractor=test.custom_extractor,
             )
-            mock_execute_lambda(test.context)
+            result = mock_execute_lambda(test.context)
+            result = json.loads(result)
+
             spans = self.memory_exporter.get_finished_spans()
             assert spans
             self.assertEqual(len(spans), 1)
@@ -304,6 +330,10 @@ class TestAwsLambdaInstrumentor(TestBase):
             self.assertEqual(
                 parent_context.trace_state.get(MOCK_W3C_TRACE_STATE_KEY),
                 test.expected_state_value,
+            )
+            self.assertEqual(
+                result["baggage_content"].get(MOCK_W3C_BAGGAGE_KEY),
+                test.expected_baggage,
             )
             self.assertTrue(parent_context.is_remote)
             self.memory_exporter.clear()


### PR DESCRIPTION
# Description

Fixing baggage support in `opentelemetry-instrumentation-aws-lambda` package.

After determining the parent context (`_determine_parent_context()`), it was only used to create the wrapper span, but wasn't attached to the global context. Although the `start_as_current_span()` call attaches the span's context, but because the `SpanContext` only contains span-related info, the baggage content was lost, and the propagators couldn't pick it up.
This change attaches/detaches the baggage to the context in a `try/finally` clause. Other instrumentations do the same either directly, or through `_start_internal_or_server_span()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Implemented a unit test, and ran all the relevant tests:
```
tox -e lint-instrumentation-aws-lambda
tox -e py38-test-instrumentation-aws-lambda
tox -e py39-test-instrumentation-aws-lambda
tox -e py310-test-instrumentation-aws-lambda
tox -e py311-test-instrumentation-aws-lambda
```

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
