### PR TITLE
add OTEL_ENABLE_SERVER_ATTRIBUTES_FOR_REQUEST_DURATION flag 

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -311,6 +311,13 @@ def get_default_span_name():
     return span_name
 
 
+def add_route(attributes):
+    if flask.request.url_rule:
+        # For 404 that result from no route found, etc, we
+        # don't have a url_rule.
+        attributes[SpanAttributes.HTTP_ROUTE] = flask.request.url_rule.rule
+
+
 def _rewrapped_app(
     wsgi_app,
     active_requests_counter,
@@ -344,6 +351,7 @@ def _rewrapped_app(
                 excluded_urls is None
                 or not excluded_urls.url_disabled(flask.request.url)
             ):
+                add_route(attributes)
                 span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
 
                 propagator = get_global_response_propagator()
@@ -420,10 +428,7 @@ def _wrapped_before_request(
             flask_request_environ,
             sem_conv_opt_in_mode=sem_conv_opt_in_mode,
         )
-        if flask.request.url_rule:
-            # For 404 that result from no route found, etc, we
-            # don't have a url_rule.
-            attributes[SpanAttributes.HTTP_ROUTE] = flask.request.url_rule.rule
+        add_route(attributes)
         span, token = _start_internal_or_server_span(
             tracer=tracer,
             span_name=span_name,

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -24,6 +24,7 @@ from opentelemetry.instrumentation._semconv import (
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
     _server_active_requests_count_attrs_new,
+    _server_duration_attrs_new_with_server_attributes,
     _server_active_requests_count_attrs_old,
     _server_duration_attrs_new,
     _server_duration_attrs_old,
@@ -99,7 +100,7 @@ _recommended_metrics_attrs_old = {
 }
 _recommended_metrics_attrs_new = {
     "http.server.active_requests": _server_active_requests_count_attrs_new,
-    "http.server.request.duration": _server_duration_attrs_new,
+    "http.server.request.duration": _server_duration_attrs_new_with_server_attributes,
 }
 _server_active_requests_count_attrs_both = (
     _server_active_requests_count_attrs_old
@@ -132,6 +133,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
             "os.environ",
             {
                 "OTEL_PYTHON_FLASK_EXCLUDED_URLS": "http://localhost/env_excluded_arg/123,env_excluded_noarg",
+                "OTEL_ENABLE_SERVER_ATTRIBUTES_FOR_REQUEST_DURATION": "true",
                 OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode,
             },
         )
@@ -519,6 +521,9 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                             histogram_data_point_seen = True
                         if isinstance(point, NumberDataPoint):
                             number_data_point_seen = True
+                        for attr in _recommended_metrics_attrs_new[metric.name]:
+                            if attr != _SPAN_ATTRIBUTES_ERROR_TYPE:
+                                self.assertIn(attr, point.attributes)
                         for attr in point.attributes:
                             self.assertIn(
                                 attr,
@@ -596,9 +601,12 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.client.get("/hello/756")
         expected_duration_attributes = {
             "http.request.method": "GET",
+            "http.route": "/hello/<int:helloid>",
             "url.scheme": "http",
             "network.protocol.version": "1.1",
             "http.response.status_code": 200,
+            "server.address": "localhost",
+            "server.port": 80,
         }
         expected_requests_count_attributes = {
             "http.request.method": "GET",
@@ -642,6 +650,8 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
             "url.scheme": "http",
             "network.protocol.version": "1.1",
             "http.response.status_code": 405,
+            "server.address": "localhost",
+            "server.port": 80,
         }
         expected_requests_count_attributes = {
             "http.request.method": "_OTHER",
@@ -667,6 +677,8 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
             "url.scheme": "http",
             "network.protocol.version": "1.1",
             "http.response.status_code": 405,
+            "server.address": "localhost",
+            "server.port": 80,
         }
         expected_requests_count_attributes = {
             "http.request.method": "NONSTANDARD",

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -208,6 +208,7 @@ API
 """
 
 import functools
+import os
 import typing
 import wsgiref.util as wsgiref_util
 from timeit import default_timer
@@ -225,6 +226,7 @@ from opentelemetry.instrumentation._semconv import (
     _report_new,
     _report_old,
     _server_active_requests_count_attrs_new,
+    _server_duration_attrs_new_with_server_attributes,
     _server_active_requests_count_attrs_old,
     _server_duration_attrs_new,
     _server_duration_attrs_old,
@@ -463,7 +465,9 @@ def _parse_duration_attrs(
     return _filter_semconv_duration_attrs(
         req_attrs,
         _server_duration_attrs_old,
-        _server_duration_attrs_new,
+        _server_duration_attrs_new_with_server_attributes
+        if os.environ.get("OTEL_ENABLE_SERVER_ATTRIBUTES_FOR_REQUEST_DURATION")
+        else _server_duration_attrs_new,
         sem_conv_opt_in_mode,
     )
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -68,6 +68,17 @@ _server_duration_attrs_new = [
     SpanAttributes.URL_SCHEME,
 ]
 
+_server_duration_attrs_new_with_server_attributes = [
+    _SPAN_ATTRIBUTES_ERROR_TYPE,
+    SpanAttributes.HTTP_REQUEST_METHOD,
+    SpanAttributes.HTTP_RESPONSE_STATUS_CODE,
+    SpanAttributes.HTTP_ROUTE,
+    SpanAttributes.NETWORK_PROTOCOL_VERSION,
+    SpanAttributes.URL_SCHEME,
+    SpanAttributes.SERVER_ADDRESS,
+    SpanAttributes.SERVER_PORT,
+]
+
 _server_active_requests_count_attrs_old = [
     SpanAttributes.HTTP_METHOD,
     SpanAttributes.HTTP_HOST,


### PR DESCRIPTION
# Description

add `OTEL_ENABLE_SERVER_ATTRIBUTES_FOR_REQUEST_DURATION` flag to add `server.address` and `server.port` for `http.server.request.duration` - which are [opt-in](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration) 

This env var does not exist for any other language so far.

Also fixes the problem that `http.route` was not added to `http.server.request.duration` for flask - can be extracted to separate PR if required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

tests included in this PR

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project 
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
