### PR TITLE
add metric attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `opentelemetry-instrumentation-flask` Add http route to metric attributes
+  ([#2506](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2506))
 - `opentelemetry-sdk-extension-aws` Register AWS resource detectors under the
   `opentelemetry_resource_detector` entry point
   ([#2382](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2382))

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -20,7 +20,6 @@ from flask import Flask, request
 
 from opentelemetry import trace
 from opentelemetry.instrumentation._semconv import (
-    _SPAN_ATTRIBUTES_ERROR_TYPE,
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
     _server_active_requests_count_attrs_new,
@@ -40,6 +39,7 @@ from opentelemetry.sdk.metrics.export import (
     NumberDataPoint,
 )
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 from opentelemetry.util.http import (
@@ -379,7 +379,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                 SpanAttributes.URL_PATH: "/hello/500",
                 SpanAttributes.HTTP_ROUTE: "/hello/<int:helloid>",
                 SpanAttributes.HTTP_RESPONSE_STATUS_CODE: 500,
-                _SPAN_ATTRIBUTES_ERROR_TYPE: "500",
+                ERROR_TYPE: "500",
                 SpanAttributes.URL_SCHEME: "http",
             }
         )
@@ -405,7 +405,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                 {
                     SpanAttributes.URL_PATH: "/hello/500",
                     SpanAttributes.HTTP_RESPONSE_STATUS_CODE: 500,
-                    _SPAN_ATTRIBUTES_ERROR_TYPE: "500",
+                    ERROR_TYPE: "500",
                     SpanAttributes.URL_SCHEME: "http",
                 }
             )
@@ -459,6 +459,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual(len(span_list), 1)
 
     def test_flask_metrics(self):
+        _server_duration_attrs_old.append("http.route")
         start = default_timer()
         self.client.get("/hello/123")
         self.client.get("/hello/321")
@@ -570,6 +571,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.client.get("/hello/756")
         expected_duration_attributes = {
             "http.method": "GET",
+            "http.route": "/hello/<int:helloid>",
             "http.host": "localhost",
             "http.scheme": "http",
             "http.flavor": "1.1",
@@ -597,6 +599,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         expected_duration_attributes = {
             "http.request.method": "GET",
             "url.scheme": "http",
+            "http.route": "/hello/<int:helloid>",
             "network.protocol.version": "1.1",
             "http.response.status_code": 200,
         }


### PR DESCRIPTION

# Description

Taking up [this closed PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2106), when sending metrics in the Flask instrumentation, the http.route attribute is added to them.
This attribute is super important in the use of metrics and will greatly improve the experience of using Flask. This change was tested locally.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 running: tox -e  test-instrumentation-flask


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated