### PR TITLE
Fix missing attributes in RedisCluster spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -128,6 +128,8 @@ _REDIS_ASYNCIO_CLUSTER_VERSION = (4, 3, 2)
 
 
 def _set_connection_attributes(span, conn):
+    if hasattr(conn, "nodes_manager"):
+        conn = conn.nodes_manager.default_node.redis_connection
     if not span.is_recording() or not hasattr(conn, "connection_pool"):
         return
     for key, value in _extract_conn_attributes(


### PR DESCRIPTION
# Description

Modifies _set_connection_attributes to handle `conn` being an instance of `redis.cluster.RedisCluster`.

Fixes [#2505](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2505)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Followed steps to reproduce listed in linked issue.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
