### PR TITLE
Update contributing guide and remove test instructions from readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,13 @@ $ pip install tox
 
 You can run `tox` with the following arguments:
 
-- `tox` to run all existing tox commands, including unit tests for all packages
+* `tox` to run all existing tox commands, including unit tests for all packages
   under multiple Python versions
-- `tox -e docs` to regenerate the API docs
-- `tox -e py312-test-instrumentation-aiopg` to e.g. run the aiopg instrumentation unit tests under a specific
+* `tox -e docs` to regenerate the API docs
+* `tox -e py312-test-instrumentation-aiopg` to e.g. run the aiopg instrumentation unit tests under a specific
   Python version
-- `tox -e spellcheck` to run a spellcheck on all the code
-- `tox -e lint-some-package` to run lint checks on `some-package`
+* `tox -e spellcheck` to run a spellcheck on all the code
+* `tox -e lint-some-package` to run lint checks on `some-package`
 
 `black` and `isort` are executed when `tox -e lint` is run. The reported errors can be tedious to fix manually.
 An easier way to do so is:
@@ -84,6 +84,7 @@ You can also configure it to run lint tools automatically before committing with
 
 ```console
 $ pre-commit install
+```
 
 See
 [`tox.ini`](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/tox.ini)
@@ -161,6 +162,7 @@ Open a pull request against the main `opentelemetry-python-contrib` repo.
 
 * If the PR is not ready for review, please put `[WIP]` in the title, tag it
   as `work-in-progress`, or mark it as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+* Make sure tests and lint are passing locally before requesting a review.
 * Make sure CLA is signed and CI is clear.
 
 ### How to Get PRs Reviewed
@@ -216,13 +218,26 @@ For a deeper discussion, see: https://github.com/open-telemetry/opentelemetry-sp
 2. Make sure you have `tox` installed. `pip install tox`.
 3. Run `tox` without any arguments to run tests for all the packages. Read more about [tox](https://tox.readthedocs.io/en/latest/).
 
+Some tests can be slow due to pre-steps that do dependencies installs. To help with that, you can run tox a first time, and after that run the tests using previous installed dependencies in toxdir as following:
+
+1. First time run (e.g., opentelemetry-instrumentation-aiopg)
+```console
+tox -e py312-test-instrumentation-aiopg
+```
+2. Run tests again withou pre-steps:
+```console
+.tox/py312-test-instrumentation-aiopg/bin/pytest instrumentation/opentelemetry-instrumentation-aiopg
+```
+
 ### Testing against a different Core repo branch/commit
 
 Some of the tox targets install packages from the [OpenTelemetry Python Core Repository](https://github.com/open-telemetry/opentelemetry-python) via pip. The version of the packages installed defaults to the main branch in that repository when tox is run locally. It is possible to install packages tagged with a specific git commit hash by setting an environment variable before running tox as per the following example:
 
+```sh
 CORE_REPO_SHA=c49ad57bfe35cfc69bfa863d74058ca9bec55fc3 tox
+```
 
-The continuation integration overrides that environment variable with as per the configuration [here](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/2518a4ac07cb62ad6587dd8f6cbb5f8663a7e179/.github/workflows/test.yml#L9).
+The continuous integration overrides that environment variable with as per the configuration [here](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/workflows/test.yml#L9).
 
 ## Style Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Some tests can be slow due to pre-steps that do dependencies installs. To help w
 ```console
 tox -e py312-test-instrumentation-aiopg
 ```
-2. Run tests again withou pre-steps:
+2. Run tests again without pre-steps:
 ```console
 .tox/py312-test-instrumentation-aiopg/bin/pytest instrumentation/opentelemetry-instrumentation-aiopg
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The Python auto-instrumentation libraries for [OpenTelemetry](https://openteleme
 * [Releasing](#releasing)
   * [Releasing a package as `1.0` stable](#releasing-a-package-as-10-stable)
 * [Contributing](#contributing)
-* [Running Tests Locally](#running-tests-locally)
 * [Thanks to all the people who already contributed](#thanks-to-all-the-people-who-already-contributed)
 
 ## Installation
@@ -142,14 +141,6 @@ Emeritus Maintainers:
 - [Yusuke Tsutsumi](https://github.com/toumorokoshi), Google
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
-
-## Running Tests Locally
-
-1. Go to your Contrib repo directory. `cd ~/git/opentelemetry-python-contrib`.
-2. Create a virtual env in your Contrib repo directory. `python3 -m venv my_test_venv`.
-3. Activate your virtual env. `source my_test_venv/bin/activate`.
-4. Make sure you have `tox` installed. `pip install tox`.
-5. Run tests for a package. (e.g. `tox -e test-instrumentation-flask`.)
 
 ### Thanks to all the people who already contributed
 


### PR DESCRIPTION
# Description

It seems that CONTRIBUTING.md has been missing a coding block backquotes for a while in the Development section. This is a simple fix for that and improved CONTRIBUTING.md as a whole. 

As a suggestion, also removed the section `Running tests locally` from README.md since we have a better version of this on CONTRIBUTING.md and also to keep it similar to the README from the main repo.
