### PR TITLE
Fix opentelemetry-util-http tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -761,6 +761,11 @@ commands_pre =
   processor-baggage: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
   processor-baggage: pip install -r {toxinidir}/processor/opentelemetry-processor-baggage/test-requirements.txt
 
+  http: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
+  http: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions
+  http: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
+  http: pip install opentelemetry-test-utils@{env:CORE_REPO}\#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils
+  http: pip install -r {toxinidir}/util/opentelemetry-util-http/test-requirements.txt
   http: pip install {toxinidir}/util/opentelemetry-util-http
 
 ; In order to get a health coverage report,

--- a/util/opentelemetry-util-http/test-requirements.txt
+++ b/util/opentelemetry-util-http/test-requirements.txt
@@ -1,0 +1,12 @@
+asgiref==3.7.2
+Deprecated==1.2.14
+importlib-metadata==6.11.0
+iniconfig==2.0.0
+packaging==24.0
+pluggy==1.5.0
+py-cpuinfo==9.0.0
+pytest==7.4.4
+pytest-benchmark==4.0.0
+tomli==2.0.1
+typing_extensions==4.10.0
+-e opentelemetry-instrumentation

--- a/util/opentelemetry-util-http/tests/test_sanitize_method.py
+++ b/util/opentelemetry-util-http/tests/test_sanitize_method.py
@@ -32,7 +32,7 @@ class TestSanitizeMethod(unittest.TestCase):
 
     def test_nonstandard_method(self):
         method = sanitize_method("UNKNOWN")
-        self.assertEqual(method, "NONSTANDARD")
+        self.assertEqual(method, "_OTHER")
 
     @patch.dict(
         "os.environ",
@@ -42,4 +42,4 @@ class TestSanitizeMethod(unittest.TestCase):
     )
     def test_nonstandard_method_allowed(self):
         method = sanitize_method("UNKNOWN")
-        self.assertEqual(method, "NONSTANDARD")
+        self.assertEqual(method, "UNKNOWN")


### PR DESCRIPTION
# Description
It seems opentelemetry-util-http tox commands aren't working properly and it's has been used for several instrumentations. Fix that

Fixes #2633

```shell
$ tox -e py312-test-util-http

========================================================================= warnings summary ==========================================================================
opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py:4
  /Users/emidio.neto/workspace/emd/github/opentelemetry/opentelemetry-python-contrib/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 24 passed, 1 warning in 3.64s ===================================================================
  py312-test-util-http: OK (28.81=setup[0.05]+cmd[5.56,5.44,5.67,5.32,1.70,1.12,3.94] seconds)
  congratulations :) (28.94 seconds)
```