### PR TITLE
fix(async-io): instrumented `asyncio.wait_for` properly raises `asyncio.TimeoutError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-instrumentation-asyncio` instrumented `asyncio.wait_for` properly raises `asyncio.TimeoutError` as expected
+  ([#2637](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2637))
 - `opentelemetry-instrumentation-aws-lambda` Bugfix: AWS Lambda event source key incorrect for SNS in instrumentation library. 
   ([#2612](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2612))
 - `opentelemetry-instrumentation-system-metrics` Permit to use psutil 6.0+.

--- a/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
@@ -280,8 +280,11 @@ class AsyncioInstrumentor(BaseInstrumentor):
         # CancelledError is raised when a coroutine is cancelled
         # before it has a chance to run. We don't want to record
         # this as an error.
+        # Still it needs to be raised in order for `asyncio.wait_for`
+        # to properly work with timeout and raise accordingly `asyncio.TimeoutError`
         except asyncio.CancelledError:
             attr["state"] = "cancelled"
+            raise
         except Exception as exc:
             exception = exc
             state = determine_state(exception)

--- a/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_wait.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_wait.py
@@ -68,6 +68,19 @@ class TestAsyncioWait(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
 
+    def test_asyncio_wait_for_with_timeout(self):
+        expected_timeout_error = None
+
+        async def main():
+            nonlocal expected_timeout_error
+            try:
+                await asyncio.wait_for(async_func(), 0.01)
+            except asyncio.TimeoutError as timeout_error:
+                expected_timeout_error = timeout_error
+
+        asyncio.run(main())
+        self.assertNotEqual(expected_timeout_error, None)
+
     def test_asyncio_as_completed(self):
         async def main():
             if sys.version_info >= (3, 11):


### PR DESCRIPTION
# Description

As per the example from https://docs.python.org/3.13/library/asyncio-task.html#asyncio.wait_for when `asyncio.wait_for` hits the defined `timeout` it should raise an `asyncio.TimeoutError`,
however this is not the case when `opentelemetry-instrumentation-asyncio` is enabled

If everything is good running the below code in both cases should print `timeout!`

```
# asyncio-wait-for-example.py
import asyncio
import os

from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.instrumentation.asyncio import AsyncioInstrumentor

OTEL_PYTHON_DISABLED_INSTRUMENTATIONS = os.getenv("OTEL_PYTHON_DISABLED_INSTRUMENTATIONS", "")
if 'asyncio' not in OTEL_PYTHON_DISABLED_INSTRUMENTATIONS:
    AsyncioInstrumentor().instrument()

trace.set_tracer_provider(TracerProvider())
tracer = trace.get_tracer(__name__)

# code below taken from https://docs.python.org/3.13/library/asyncio-task.html#asyncio.wait_for
async def eternity():
    # Sleep for one hour
    await asyncio.sleep(3600)
    print('yay!')

async def main():
    # Wait for at most 1 second
    try:
        await asyncio.wait_for(eternity(), timeout=1.0)
    except TimeoutError:
        print('timeout!')

asyncio.run(main())

# Expected output:
#
#     timeout!
```

The PR fixes that by not swallowing `asyncio.CancelledError` that is used internally from `asyncio` timeouts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] disabled asyncio instrumentation `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="asyncio" python asyncio-wait-for-example.py` prints `timeout!`
- [x] enabled asyncio instrumentation `python asyncio-wait-for-example.py` as well prints `timeout!`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
