### PR TITLE
Handle empty statement in psycopg instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2612](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2612))
 - `opentelemetry-instrumentation-system-metrics` Permit to use psutil 6.0+.
   ([#2630](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2630))
-- `opentelemetry-instrumentation-psycopg` Bugfix: Handle empty statement. ([#2644](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2644))
 
 ### Added
 
@@ -39,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2590](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2590))
 - Reference symbols from generated semantic conventions
   ([#2611](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2611))
+- `opentelemetry-instrumentation-psycopg` Bugfix: Handle empty statement.
+  ([#2644](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2644))
 
 ## Version 1.25.0/0.46b0 (2024-05-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2612](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2612))
 - `opentelemetry-instrumentation-system-metrics` Permit to use psutil 6.0+.
   ([#2630](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2630))
+- `opentelemetry-instrumentation-psycopg` Bugfix: Handle empty statement. ([#2644](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2644))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
@@ -269,7 +269,8 @@ class CursorTracer(dbapi.CursorTracer):
         if isinstance(statement, Composed):
             statement = statement.as_string(cursor)
 
-        if isinstance(statement, str):
+        # `statement` can be empty string. See #2643
+        if isinstance(statement, str) and statement != "":
             # Strip leading comments so we get the operation name.
             return self._leading_comment_remover.sub("", statement).split()[0]
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
@@ -270,7 +270,7 @@ class CursorTracer(dbapi.CursorTracer):
             statement = statement.as_string(cursor)
 
         # `statement` can be empty string. See #2643
-        if isinstance(statement, str) and statement != "":
+        if statement and isinstance(statement, str):
             # Strip leading comments so we get the operation name.
             return self._leading_comment_remover.sub("", statement).split()[0]
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg/tests/test_psycopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/tests/test_psycopg_integration.py
@@ -245,14 +245,18 @@ class TestPostgresqlIntegration(PostgresqlIntegrationTestMixin, TestBase):
         cursor.execute("/* leading comment */ query")
         cursor.execute("/* leading comment */ query /* trailing comment */")
         cursor.execute("query /* trailing comment */")
+        cursor.execute("")
+        cursor.execute("--")
         spans_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(spans_list), 6)
+        self.assertEqual(len(spans_list), 8)
         self.assertEqual(spans_list[0].name, "Test")
         self.assertEqual(spans_list[1].name, "multi")
         self.assertEqual(spans_list[2].name, "tab")
         self.assertEqual(spans_list[3].name, "query")
         self.assertEqual(spans_list[4].name, "query")
         self.assertEqual(spans_list[5].name, "query")
+        self.assertEqual(spans_list[6].name, "postgresql")
+        self.assertEqual(spans_list[7].name, "--")
 
     # pylint: disable=unused-argument
     def test_not_recording(self):


### PR DESCRIPTION
Fixes #2643

# Description

Handle case where statement can be empty in psycopg

Fixes #2643

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit test cases for empty string query

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
