### PR TITLE
Fix wrong unit in Flask new semconv test

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -514,7 +514,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                         if isinstance(point, HistogramDataPoint):
                             self.assertEqual(point.count, 3)
                             self.assertAlmostEqual(
-                                duration_s, point.sum, delta=10
+                                duration_s, point.sum, delta=2
                             )
                             histogram_data_point_seen = True
                         if isinstance(point, NumberDataPoint):

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -514,7 +514,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                         if isinstance(point, HistogramDataPoint):
                             self.assertEqual(point.count, 3)
                             self.assertAlmostEqual(
-                                duration_s, point.sum, delta=2
+                                duration_s, point.sum, places=2
                             )
                             histogram_data_point_seen = True
                         if isinstance(point, NumberDataPoint):

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -497,8 +497,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.client.get("/hello/123")
         self.client.get("/hello/321")
         self.client.get("/hello/756")
-        # new semconv Unit: ms -> s
-        duration = max(default_timer() - start, 0)
+        duration_s = max(default_timer() - start, 0)
         metrics_list = self.memory_metrics_reader.get_metrics_data()
         number_data_point_seen = False
         histogram_data_point_seen = False
@@ -515,7 +514,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
                         if isinstance(point, HistogramDataPoint):
                             self.assertEqual(point.count, 3)
                             self.assertAlmostEqual(
-                                duration, point.sum, delta=10
+                                duration_s, point.sum, delta=10
                             )
                             histogram_data_point_seen = True
                         if isinstance(point, NumberDataPoint):

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -497,7 +497,8 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.client.get("/hello/123")
         self.client.get("/hello/321")
         self.client.get("/hello/756")
-        duration = max(round((default_timer() - start) * 1000), 0)
+        # new semconv Unit: ms -> s
+        duration = max(default_timer() - start, 0)
         metrics_list = self.memory_metrics_reader.get_metrics_data()
         number_data_point_seen = False
         histogram_data_point_seen = False


### PR DESCRIPTION
# Description
Changes duration to be measured in seconds during the test since in [stable semconv](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/migration-guide.md#http-client-duration-metric), the unit changed from ms to s and we are recording in [seconds](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py#L398)

Probably Fixes #2596

