### PR TITLE
fix(instrumentation-asgi): remove high cardinal path from span name

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -403,13 +403,9 @@ def get_default_span_details(scope: dict) -> Tuple[str, dict]:
     Returns:
         a tuple of the span name, and any attributes to attach to the span.
     """
-    path = scope.get("path", "").strip()
-    method = scope.get("method", "").strip()
-    if method and path:  # http
-        return f"{method} {path}", {}
-    if path:  # websocket
-        return path, {}
-    return method, {}  # http with no path
+    if scope.get("type") == "http":
+        return scope.get("method", ""), {}
+    return scope.get("type", ""), {}
 
 
 def _collect_target_attribute(


### PR DESCRIPTION
# Description

The `path` value of the ASGI `scope` is a non-generalized path. This is not an issue in other frameworks such as fastapi or falsk where the templatized path is accessible. This PR updates the span name to not contain the high cardinal value for ASGI instrumentation span names. The highly cardinal span names will become a problem when used with the span metrics connection from the collector.

The spec guidelines say https://opentelemetry.io/docs/specs/otel/trace/api/#span

>The span name concisely identifies the work represented by the Span, for example, an RPC method name, a function name, or the name of a subtask or stage within a larger computation. The span name SHOULD be the most general string that identifies a (statistically) interesting class of Spans, rather than individual Span instances while still being human-readable. That is, “get_user” is a reasonable name, while “get_user/314159”, where “314159” is a user ID, is not a good name due to its high cardinality. Generality SHOULD be prioritized over human-readability.

