### PR TITLE
opentelemetry-processor-baggage: silence ruff warning

### DIFF
--- a/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
+++ b/processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/processor.py
@@ -23,7 +23,7 @@ from opentelemetry.trace import Span
 BaggageKeyPredicateT = Callable[[str], bool]
 
 # A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans
-ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicateT = lambda _: True
+ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicateT = lambda _: True  # noqa: E731
 
 
 class BaggageSpanProcessor(SpanProcessor):


### PR DESCRIPTION
# Description

Ruff warns about the following which given the implementation seems safe to ignore:

```
E731 Do not assign a `lambda` expression, use a `def`
   |
25 | # A BaggageKeyPredicate that always returns True, allowing all baggage keys to be added to spans 26 | ALLOW_ALL_BAGGAGE_KEYS: BaggageKeyPredicateT = lambda _: True
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E731
   |
   = help: Rewrite `ALLOW_ALL_BAGGAGE_KEYS` as a `def`
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
