### PR TITLE
Fix lint-instrumentation-mysqlclient in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -953,7 +953,7 @@ commands =
   lint-instrumentation-mysqlclient: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient
   lint-instrumentation-mysqlclient: isort --diff --check-only --settings-path {toxinidir}/.isort.cfg {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient
   lint-instrumentation-mysqlclient: flake8 --config {toxinidir}/.flake8 {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient
-  lint-instrumentation-mysqliclient: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-mysqliclient"
+  lint-instrumentation-mysqlclient: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-mysqliclient"
 
   test-instrumentation-sio-pika: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-pika/tests {posargs}
   lint-instrumentation-sio-pika: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/instrumentation/opentelemetry-instrumentation-pika


### PR DESCRIPTION
# Description

Small typo on mysqlclient instrumentation lint

Found while working on uv PR through `tox list`, which was printing:
```
additional environments:
lint                                        -> [no description]
coverage                                    -> [no description]
lint-instrumentation-mysqliclient           -> [no description]
```
