### PR TITLE
exporter/prometheus-remote-write: fix test requirements for pypy

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
@@ -1,7 +1,9 @@
 asgiref==3.7.2
 certifi==2024.2.2
 charset-normalizer==3.3.2
-cramjam==2.8.1
+# We can drop this after bumping baseline to pypy-39
+cramjam==2.1.0; platform_python_implementation == "PyPy"
+cramjam==2.8.1; platform_python_implementation != "PyPy"
 Deprecated==1.2.14
 idna==3.7
 importlib-metadata==6.11.0


### PR DESCRIPTION
# Description

pypy 3.8 is missing something to being able to work with recent versions of cramjam so stick to an old version that works fine.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e pypy3-test-exporter-prometheus-remote-write

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
