### PR TITLE
Improved Test Coverage for HTTP Utility's IP Setting Functionality

### DIFF
--- a/util/opentelemetry-util-http/tests/test_try_set_ip.py
+++ b/util/opentelemetry-util-http/tests/test_try_set_ip.py
@@ -1,0 +1,56 @@
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+import logging
+import socket
+from http.client import HTTPConnection
+from opentelemetry.util.http.httplib import trysetip
+
+class TestTrySetIP(unittest.TestCase):
+    def setUp(self):
+        # Setup a mock HTTPConnection
+        self.conn = MagicMock(spec=HTTPConnection)
+        self.conn.sock = MagicMock(spec=socket.socket)
+
+        # Mock state function and Span class
+        self.mock_state = {'need_ip': [MagicMock()]}
+        self.mock_getstate = patch('opentelemetry.util.http.httplib._getstate', return_value=self.mock_state)
+        self.mock_getstate.start()
+
+        # Setup the logger to capture output
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.logger = logging.getLogger('opentelemetry.util.http.httplib')
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_ip_set_successfully(self):
+        self.conn.sock.getpeername.return_value = ('192.168.1.1', 8080)
+
+        success = trysetip(self.conn, loglevel=logging.DEBUG)
+
+        # Verify that the IP was set correctly
+        for span in self.mock_state['need_ip']:
+            span.set_attribute.assert_called_once_with('net.peer.ip', '192.168.1.1')
+        self.assertTrue(success)
+
+    def test_no_socket_connection(self):
+        # Setup the connection with no socket
+        self.conn.sock = None
+
+        success = trysetip(self.conn, loglevel=logging.DEBUG)
+
+        self.assertFalse(success)
+
+    def test_exception_during_ip_retrieval(self):
+        self.conn.sock.getpeername.side_effect = Exception("Test Exception")
+
+        success = trysetip(self.conn, loglevel=logging.DEBUG)
+
+        self.assertIn('Failed to get peer address', self.stream.getvalue())
+        self.assertTrue(success)
+
+    def tearDown(self):
+        self.mock_getstate.stop()
+        self.logger.removeHandler(self.handler)
+        self.handler.close()

--- a/util/opentelemetry-util-http/tests/test_try_set_ip.py
+++ b/util/opentelemetry-util-http/tests/test_try_set_ip.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import logging
 import socket
 import unittest
@@ -35,13 +34,6 @@ class TestTrySetIP(unittest.TestCase):
             return_value=self.mock_state,
         )
         self.mock_getstate.start()
-
-        # Setup the logger to capture output
-        self.stream = io.StringIO()
-        self.handler = logging.StreamHandler(self.stream)
-        self.logger = logging.getLogger("opentelemetry.util.http.httplib")
-        self.logger.addHandler(self.handler)
-        self.logger.setLevel(logging.DEBUG)
 
     def test_ip_set_successfully(self):
         self.conn.sock.getpeername.return_value = ("192.168.1.1", 8080)
@@ -73,8 +65,3 @@ class TestTrySetIP(unittest.TestCase):
                 "Failed to get peer address", warning.records[0].message
             )
             self.assertTrue(success)
-
-    def tearDown(self):
-        self.mock_getstate.stop()
-        self.logger.removeHandler(self.handler)
-        self.handler.close()

--- a/util/opentelemetry-util-http/tests/test_try_set_ip.py
+++ b/util/opentelemetry-util-http/tests/test_try_set_ip.py
@@ -59,10 +59,11 @@ class TestTrySetIP(unittest.TestCase):
     def test_exception_during_ip_retrieval(self):
         self.conn.sock.getpeername.side_effect = Exception("Test Exception")
 
-        success = trysetip(self.conn, loglevel=logging.DEBUG)
-
-        self.assertIn('Failed to get peer address', self.stream.getvalue())
-        self.assertTrue(success)
+        with self.assertLogs(level=logging.WARNING) as warning:
+            success = trysetip(self.conn, loglevel=logging.WARNING)
+            self.assertEqual(len(warning.records), 1)
+            self.assertIn('Failed to get peer address', warning.records[0].message)
+            self.assertTrue(success)
 
     def tearDown(self):
         self.mock_getstate.stop()

--- a/util/opentelemetry-util-http/tests/test_try_set_ip.py
+++ b/util/opentelemetry-util-http/tests/test_try_set_ip.py
@@ -1,3 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import io
 import unittest
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
# Description

This pull request includes enhancements to the test suite for the trysetip function within the HTTP utility module. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Correctly handling cases where the connection's socket is not set.
- [x] Ensuring that the IP address is properly set on spans when the connection is active.
- [x] Validating that the function logs errors appropriately when exceptions occur during IP retrieval.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
