### PR TITLE
Opentelemetry instrumentation sqlite3 964

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py
@@ -111,4 +111,4 @@ class TestSQLite3(TestBase):
         with self._tracer.start_as_current_span("rootSpan"):
             self._cursor.executemany(stmt, data)
         spans = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(spans), 0)
+        self.assertEqual(len(spans), 2)


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for sqllite3 instrumentation.

Fixes # (issue)

https://github.com/open-telemetry/opentelemetry-python-contrib/issues/964


# How Has This Been Tested?
tox -e test-instrumentation-sqlite3


instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py::TestSQLite3::test_callproc PASSED                                                                                              [ 25%]
instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py::TestSQLite3::test_execute PASSED                                                                                               [ 50%]
instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py::TestSQLite3::test_executemany PASSED                                                                                           [ 75%]
instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py::TestSQLite3::test_no_op_tracer_provider PASSED                                                                                 [100%]


# Does This PR Require a Core Repo Change?

 No.

