### PR TITLE
feat(urllib3)!: refactor request hook parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2726](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2726))
 - `opentelemetry-instrumentation-fastapi` Add dependency support for fastapi-slim
   ([#2702](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2702))
+- `opentelemetry-instrumentation-urllib3` improve request_hook, replacing `headers` and `body` parameters with a single `request_info: RequestInfo` parameter that now contains the `method` and `url` ([#2711](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2711))
 
 ### Fixed
 


### PR DESCRIPTION
# Description

Currently, in the `urllib3` instrumentation, there is no way for a request hook to inspect HTTP method and URL. This change implements forwarding the new parameters to request hooks.

Additionally, the documentation has been updated: both to represent the changes from this PR, and to fix the incorrect hook signatures.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The unit tests have been updated to verify moving the existing `body` parameter and the newly added parameters.

# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
