### PR TITLE
Remove package install from aiopg instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/test-requirements.txt
@@ -4,7 +4,6 @@ async-timeout==4.0.3
 Deprecated==1.2.14
 importlib-metadata==6.11.0
 iniconfig==2.0.0
-install==1.3.5
 packaging==24.0
 pluggy==1.5.0
 psycopg2-binary==2.9.9


### PR DESCRIPTION
# Description

There's no reference for this package in pypi anymore and  is causing aiopg tests fail in CI. See https://github.com/open-telemetry/opentelemetry-python/actions/runs/9960047001/job/27519027634#step:7:194. tests works fine without this


