### PR TITLE
HTTP semantic convention stability migration for urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2673](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2673))
 - `opentelemetry-instrumentation-django` Add `http.target` to Django duration metric attributes
   ([#2624](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2624))
+- `opentelemetry-instrumentation-urllib3` Implement new semantic convention opt-in migration
+  ([#2715](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2715))
 
 ### Breaking changes
 
@@ -44,8 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2580](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2580))
 - Populate `{method}` as `HTTP` on `_OTHER` methods from scope for `asgi` middleware
   ([#2610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2610))
-  - Populate `{method}` as `HTTP` on `_OTHER` methods from scope for `fastapi` middleware
+- Populate `{method}` as `HTTP` on `_OTHER` methods from scope for `fastapi` middleware
   ([#2682](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2682))
+- `opentelemetry-instrumentation-urllib3` Populate `{method}` as `HTTP` on `_OTHER` methods for span name
+  ([#2715](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2715))
 
 ### Fixed
 - Handle `redis.exceptions.WatchError` as a non-error event in redis instrumentation
@@ -73,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2153](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2153))
 - `opentelemetry-instrumentation-asgi` Removed `NET_HOST_NAME` AND `NET_HOST_PORT` from active requests count attribute
   ([#2610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2610))
-- `opentelemetry-instrumentation-asgi` Bugfix: Middleware did not set status code attribute on duration metrics for non-recording spans. 
+- `opentelemetry-instrumentation-asgi` Bugfix: Middleware did not set status code attribute on duration metrics for non-recording spans.
   ([#2627](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2627))
 
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -46,5 +46,5 @@
 | [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | Yes | experimental
 | [opentelemetry-instrumentation-tortoiseorm](./opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | No | experimental
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib | Yes | experimental
-| [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 3.0.0 | Yes | experimental
+| [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 3.0.0 | Yes | migration
 | [opentelemetry-instrumentation-wsgi](./opentelemetry-instrumentation-wsgi) | wsgi | Yes | migration

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -103,32 +103,28 @@ from opentelemetry.instrumentation._semconv import (
     _set_http_network_protocol_version,
     _set_http_peer_port_client,
     _set_http_scheme,
-    _set_http_status_code,
     _set_http_url,
+    _set_status,
 )
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.urllib3.package import _instruments
 from opentelemetry.instrumentation.urllib3.version import __version__
 from opentelemetry.instrumentation.utils import (
-    http_status_to_status_code,
     is_http_instrumentation_enabled,
     suppress_http_instrumentation,
     unwrap,
 )
 from opentelemetry.metrics import Histogram, get_meter
 from opentelemetry.propagate import inject
-from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
-from opentelemetry.semconv.attributes.network_attributes import (
-    NETWORK_PEER_ADDRESS,
-    NETWORK_PEER_PORT,
+from opentelemetry.semconv._incubating.metrics.http_metrics import (
+    create_http_client_request_body_size,
+    create_http_client_response_body_size,
 )
 from opentelemetry.semconv.metrics import MetricInstruments
 from opentelemetry.semconv.metrics.http_metrics import (
     HTTP_CLIENT_REQUEST_DURATION,
 )
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, Tracer, get_tracer
-from opentelemetry.trace.status import Status
 from opentelemetry.util.http import (
     ExcludeList,
     get_excluded_urls,
@@ -209,28 +205,55 @@ class URLLib3Instrumentor(BaseInstrumentor):
             meter_provider,
             schema_url=schema_url,
         )
+        duration_histogram_old = None
+        request_size_histogram_old = None
+        response_size_histogram_old = None
+        if _report_old(sem_conv_opt_in_mode):
+            # http.client.duration histogram
+            duration_histogram_old = meter.create_histogram(
+                name=MetricInstruments.HTTP_CLIENT_DURATION,
+                unit="ms",
+                description="Measures the duration of the outbound HTTP request",
+            )
+            # http.client.request.size histogram
+            request_size_histogram_old = meter.create_histogram(
+                name=MetricInstruments.HTTP_CLIENT_REQUEST_SIZE,
+                unit="By",
+                description="Measures the size of HTTP request messages.",
+            )
+            # http.client.response.size histogram
+            response_size_histogram_old = meter.create_histogram(
+                name=MetricInstruments.HTTP_CLIENT_RESPONSE_SIZE,
+                unit="By",
+                description="Measures the size of HTTP response messages.",
+            )
 
-        duration_histogram = meter.create_histogram(
-            name=MetricInstruments.HTTP_CLIENT_DURATION,
-            unit="ms",
-            description="Measures the duration of outbound HTTP requests.",
-        )
-        request_size_histogram = meter.create_histogram(
-            name=MetricInstruments.HTTP_CLIENT_REQUEST_SIZE,
-            unit="By",
-            description="Measures the size of HTTP request messages.",
-        )
-        response_size_histogram = meter.create_histogram(
-            name=MetricInstruments.HTTP_CLIENT_RESPONSE_SIZE,
-            unit="By",
-            description="Measures the size of HTTP response messages.",
-        )
-
+        duration_histogram_new = None
+        request_size_histogram_new = None
+        response_size_histogram_new = None
+        if _report_new(sem_conv_opt_in_mode):
+            # http.client.request.duration histogram
+            duration_histogram_new = meter.create_histogram(
+                name=HTTP_CLIENT_REQUEST_DURATION,
+                unit="s",
+                description="Duration of HTTP client requests.",
+            )
+            # http.client.request.body.size histogram
+            request_size_histogram_new = create_http_client_request_body_size(
+                meter
+            )
+            # http.client.response.body.size histogram
+            response_size_histogram_new = (
+                create_http_client_response_body_size(meter)
+            )
         _instrument(
             tracer,
-            duration_histogram,
-            request_size_histogram,
-            response_size_histogram,
+            duration_histogram_old,
+            duration_histogram_new,
+            request_size_histogram_old,
+            request_size_histogram_new,
+            response_size_histogram_old,
+            response_size_histogram_new,
             request_hook=kwargs.get("request_hook"),
             response_hook=kwargs.get("response_hook"),
             url_filter=kwargs.get("url_filter"),
@@ -246,11 +269,21 @@ class URLLib3Instrumentor(BaseInstrumentor):
         _uninstrument()
 
 
+def _get_span_name(method: str) -> str:
+    method = sanitize_method(method.strip())
+    if method == "_OTHER":
+        method = "HTTP"
+    return method
+
+
 def _instrument(
     tracer: Tracer,
-    duration_histogram: Histogram,
-    request_size_histogram: Histogram,
-    response_size_histogram: Histogram,
+    duration_histogram_old: Histogram,
+    duration_histogram_new: Histogram,
+    request_size_histogram_old: Histogram,
+    request_size_histogram_new: Histogram,
+    response_size_histogram_old: Histogram,
+    response_size_histogram_new: Histogram,
     request_hook: _RequestHookT = None,
     response_hook: _ResponseHookT = None,
     url_filter: _UrlFilterT = None,
@@ -269,11 +302,17 @@ def _instrument(
         headers = _prepare_headers(kwargs)
         body = _get_url_open_arg("body", args, kwargs)
 
-        span_name = sanitize_method(method.strip())
-        span_attributes = {
-            SpanAttributes.HTTP_METHOD: method,
-            SpanAttributes.HTTP_URL: url,
-        }
+        span_name = _get_span_name(method)
+        span_attributes = {}
+        # If the HTTP request method is not known to instrumentation,
+        # it MUST set the http.request.method attribute to _OTHER.
+        _set_http_method(
+            span_attributes,
+            method,
+            sanitize_method(method),
+            sem_conv_opt_in_mode,
+        )
+        _set_http_url(span_attributes, url, sem_conv_opt_in_mode)
 
         with tracer.start_as_current_span(
             span_name, kind=SpanKind.CLIENT, attributes=span_attributes
@@ -282,31 +321,43 @@ def _instrument(
                 request_hook(span, instance, headers, body)
             inject(headers)
 
+            # TODO: add error handling to set `error.type` in new semconv
             with suppress_http_instrumentation():
                 start_time = default_timer()
                 response = wrapped(*args, **kwargs)
-                elapsed_time = round((default_timer() - start_time) * 1000)
+                duration_s = default_timer() - start_time
 
-            _apply_response(span, response)
+            # set http status code based on semconv
+            metric_attributes = {}
+            _set_status_code_attribute(
+                span, response.status, metric_attributes, sem_conv_opt_in_mode
+            )
+
             if callable(response_hook):
                 response_hook(span, instance, response)
 
             request_size = _get_body_size(body)
             response_size = int(response.headers.get("Content-Length", 0))
 
-            metric_attributes = _create_metric_attributes(
-                instance, response, method
+            _set_metric_attributes(
+                metric_attributes,
+                instance,
+                response,
+                method,
+                sem_conv_opt_in_mode,
             )
 
-            duration_histogram.record(
-                elapsed_time, attributes=metric_attributes
-            )
-            if request_size is not None:
-                request_size_histogram.record(
-                    request_size, attributes=metric_attributes
-                )
-            response_size_histogram.record(
-                response_size, attributes=metric_attributes
+            _record_metrics(
+                metric_attributes,
+                duration_histogram_old,
+                duration_histogram_new,
+                request_size_histogram_old,
+                request_size_histogram_new,
+                response_size_histogram_old,
+                response_size_histogram_new,
+                duration_s,
+                request_size,
+                response_size,
             )
 
             return response
@@ -380,35 +431,133 @@ def _prepare_headers(urlopen_kwargs: typing.Dict) -> typing.Dict:
     return headers
 
 
-def _apply_response(span: Span, response: urllib3.response.HTTPResponse):
-    if not span.is_recording():
-        return
+# response: urllib3.response.HTTPResponse
+def _set_status_code_attribute(
+    span: Span,
+    status_code: int,
+    metric_attributes: typing.Optional[typing.Dict] = None,
+    sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
+) -> None:
 
-    span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, response.status)
-    span.set_status(Status(http_status_to_status_code(response.status)))
+    status_code_str = str(status_code)
+    try:
+        status_code = int(status_code)
+    except ValueError:
+        status_code = -1
+
+    if metric_attributes is None:
+        metric_attributes = {}
+
+    _set_status(
+        span,
+        metric_attributes,
+        status_code,
+        status_code_str,
+        server_span=False,
+        sem_conv_opt_in_mode=sem_conv_opt_in_mode,
+    )
 
 
-def _create_metric_attributes(
+def _set_metric_attributes(
+    metric_attributes: dict,
     instance: urllib3.connectionpool.HTTPConnectionPool,
     response: urllib3.response.HTTPResponse,
     method: str,
-) -> dict:
-    metric_attributes = {
-        SpanAttributes.HTTP_METHOD: method,
-        SpanAttributes.HTTP_HOST: instance.host,
-        SpanAttributes.HTTP_SCHEME: instance.scheme,
-        SpanAttributes.HTTP_STATUS_CODE: response.status,
-        SpanAttributes.NET_PEER_NAME: instance.host,
-        SpanAttributes.NET_PEER_PORT: instance.port,
-    }
+    sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
+) -> None:
+
+    _set_http_host(metric_attributes, instance.host, sem_conv_opt_in_mode)
+    _set_http_scheme(metric_attributes, instance.scheme, sem_conv_opt_in_mode)
+    _set_http_method(
+        metric_attributes,
+        method,
+        sanitize_method(method),
+        sem_conv_opt_in_mode,
+    )
+    _set_http_net_peer_name_client(
+        metric_attributes, instance.host, sem_conv_opt_in_mode
+    )
+    _set_http_peer_port_client(
+        metric_attributes, instance.port, sem_conv_opt_in_mode
+    )
 
     version = getattr(response, "version")
     if version:
-        metric_attributes[SpanAttributes.HTTP_FLAVOR] = (
-            "1.1" if version == 11 else "1.0"
+        http_version = "1.1" if version == 11 else "1.0"
+        _set_http_network_protocol_version(
+            metric_attributes, http_version, sem_conv_opt_in_mode
         )
 
-    return metric_attributes
+    # return metric_attributes
+
+
+def _parse_duration_attrs(
+    attributes,
+    sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
+):
+    return _filter_semconv_duration_attrs(
+        attributes,
+        _client_duration_attrs_old,
+        _client_duration_attrs_new,
+        sem_conv_opt_in_mode,
+    )
+
+
+def _record_metrics(
+    attributes: dict,
+    duration_histogram_old: Histogram,
+    duration_histogram_new: Histogram,
+    request_size_histogram_old: Histogram,
+    request_size_histogram_new: Histogram,
+    response_size_histogram_old: Histogram,
+    response_size_histogram_new: Histogram,
+    duration_s: float,
+    request_size: typing.Optional[int],
+    response_size: int,
+):
+    duration_attrs_old = None
+    duration_attrs_new = None
+
+    if duration_histogram_old:
+        duration_attrs_old = _parse_duration_attrs(
+            attributes, _HTTPStabilityMode.DEFAULT
+        )
+        # Default behavior is to record the duration in milliseconds
+        duration_histogram_old.record(
+            max(round(duration_s * 1000), 0),
+            attributes=duration_attrs_old,
+        )
+
+    if duration_histogram_new:
+        duration_attrs_new = _parse_duration_attrs(
+            attributes, _HTTPStabilityMode.HTTP
+        )
+        # New semconv record the duration in seconds
+        duration_histogram_new.record(
+            duration_s,
+            attributes=duration_attrs_new,
+        )
+
+    if request_size is not None:
+        if request_size_histogram_old:
+            request_size_histogram_old.record(
+                request_size, attributes=duration_attrs_old
+            ),
+
+        if request_size_histogram_new:
+            request_size_histogram_new.record(
+                request_size, attributes=duration_attrs_new
+            )
+
+    if response_size_histogram_old:
+        response_size_histogram_old.record(
+            response_size, attributes=duration_attrs_old
+        )
+
+    if response_size_histogram_new:
+        response_size_histogram_new.record(
+            response_size, attributes=duration_attrs_new
+        )
 
 
 def _uninstrument():

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -319,7 +319,7 @@ def _instrument(
             if callable(request_hook):
                 request_hook(span, instance, headers, body)
             inject(headers)
-            # TODO: add error handling to set `error.type` in new semconv
+            # TODO: add error handling to also set exception `error.type` in new semconv
             with suppress_http_instrumentation():
                 start_time = default_timer()
                 response = wrapped(*args, **kwargs)

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -367,9 +367,7 @@ def _instrument(
     )
 
 
-def _get_url_open_arg(
-    name: str, args: typing.List, kwargs: typing.Mapping
-) -> str:
+def _get_url_open_arg(name: str, args: typing.List, kwargs: typing.Mapping):
     arg_idx = _URL_OPEN_ARG_TO_INDEX_MAPPING.get(name)
     if arg_idx is not None:
         try:

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py
@@ -16,3 +16,5 @@
 _instruments = ("urllib3 >= 1.0.0, < 3.0.0",)
 
 _supports_metrics = True
+
+_semconv_status = "migration"

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -16,16 +16,28 @@ import typing
 from unittest import mock
 
 import httpretty
+import httpretty.core
+import httpretty.http
 import urllib3
 import urllib3.exceptions
 
 from opentelemetry import trace
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _HTTPStabilityMode,
+    _OpenTelemetrySemanticConventionStability,
+)
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
 from opentelemetry.instrumentation.utils import (
     suppress_http_instrumentation,
     suppress_instrumentation,
 )
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
+from opentelemetry.semconv.attributes.http_attributes import (
+    HTTP_REQUEST_METHOD,
+    HTTP_RESPONSE_STATUS_CODE,
+)
+from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
@@ -41,12 +53,23 @@ class TestURLLib3Instrumentor(TestBase):
     def setUp(self):
         super().setUp()
 
+        test_name = ""
+        if hasattr(self, "_testMethodName"):
+            test_name = self._testMethodName
+        sem_conv_mode = "default"
+        if "new_semconv" in test_name:
+            sem_conv_mode = "http"
+        elif "both_semconv" in test_name:
+            sem_conv_mode = "http/dup"
+
         self.env_patch = mock.patch.dict(
             "os.environ",
             {
-                "OTEL_PYTHON_URLLIB3_EXCLUDED_URLS": "http://localhost/env_excluded_arg/123,env_excluded_noarg"
+                "OTEL_PYTHON_URLLIB3_EXCLUDED_URLS": "http://localhost/env_excluded_arg/123,env_excluded_noarg",
+                OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode,
             },
         )
+        _OpenTelemetrySemanticConventionStability._initialized = False
         self.env_patch.start()
 
         self.exclude_patch = mock.patch(
@@ -64,6 +87,7 @@ class TestURLLib3Instrumentor(TestBase):
 
     def tearDown(self):
         super().tearDown()
+        self.env_patch.stop()
         URLLib3Instrumentor().uninstrument()
 
         httpretty.disable()
@@ -81,46 +105,103 @@ class TestURLLib3Instrumentor(TestBase):
         return span_list
 
     def assert_success_span(
-        self, response: urllib3.response.HTTPResponse, url: str
+        self,
+        response: urllib3.response.HTTPResponse,
+        url: str,
+        sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
     ):
         self.assertEqual(b"Hello!", response.data)
 
         span = self.assert_span()
         self.assertIs(trace.SpanKind.CLIENT, span.kind)
         self.assertEqual("GET", span.name)
-
-        attributes = {
+        self.assertEqual(
+            span.status.status_code, trace.status.StatusCode.UNSET
+        )
+        attr_old = {
             SpanAttributes.HTTP_METHOD: "GET",
             SpanAttributes.HTTP_URL: url,
             SpanAttributes.HTTP_STATUS_CODE: 200,
         }
-        self.assertEqual(attributes, span.attributes)
 
-    def assert_exception_span(self, url: str):
-        span = self.assert_span()
+        attr_new = {
+            HTTP_REQUEST_METHOD: "GET",
+            URL_FULL: url,
+            HTTP_RESPONSE_STATUS_CODE: 200,
+        }
 
         attributes = {
+            _HTTPStabilityMode.DEFAULT: attr_old,
+            _HTTPStabilityMode.HTTP: attr_new,
+            _HTTPStabilityMode.HTTP_DUP: {**attr_new, **attr_old},
+        }
+        self.assertEqual(span.attributes, attributes.get(sem_conv_opt_in_mode))
+
+    def assert_exception_span(
+        self,
+        url: str,
+        sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
+    ):
+        span = self.assert_span()
+
+        attr_old = {
             SpanAttributes.HTTP_METHOD: "GET",
             SpanAttributes.HTTP_URL: url,
         }
-        self.assertEqual(attributes, span.attributes)
+
+        attr_new = {
+            HTTP_REQUEST_METHOD: "GET",
+            URL_FULL: url,
+            # TODO: Add `error.type` attribute when supported
+        }
+
+        attributes = {
+            _HTTPStabilityMode.DEFAULT: attr_old,
+            _HTTPStabilityMode.HTTP: attr_new,
+            _HTTPStabilityMode.HTTP_DUP: {**attr_new, **attr_old},
+        }
+
+        self.assertEqual(span.attributes, attributes.get(sem_conv_opt_in_mode))
         self.assertEqual(
             trace.status.StatusCode.ERROR, span.status.status_code
         )
 
     @staticmethod
     def perform_request(
-        url: str, headers: typing.Mapping = None, retries: urllib3.Retry = None
+        url: str,
+        headers: typing.Mapping = None,
+        retries: urllib3.Retry = None,
+        method: str = "GET",
     ) -> urllib3.response.HTTPResponse:
         if retries is None:
             retries = urllib3.Retry.from_int(0)
 
         pool = urllib3.PoolManager()
-        return pool.request("GET", url, headers=headers, retries=retries)
+        return pool.request(method, url, headers=headers, retries=retries)
 
     def test_basic_http_success(self):
         response = self.perform_request(self.HTTP_URL)
-        self.assert_success_span(response, self.HTTP_URL)
+        self.assert_success_span(
+            response,
+            self.HTTP_URL,
+            sem_conv_opt_in_mode=_HTTPStabilityMode.DEFAULT,
+        )
+
+    def test_basic_http_success_new_semconv(self):
+        response = self.perform_request(self.HTTP_URL)
+        self.assert_success_span(
+            response,
+            self.HTTP_URL,
+            sem_conv_opt_in_mode=_HTTPStabilityMode.HTTP,
+        )
+
+    def test_basic_http_success_both_semconv(self):
+        response = self.perform_request(self.HTTP_URL)
+        self.assert_success_span(
+            response,
+            self.HTTP_URL,
+            sem_conv_opt_in_mode=_HTTPStabilityMode.HTTP_DUP,
+        )
 
     def test_basic_http_success_using_connection_pool(self):
         pool = urllib3.HTTPConnectionPool("mock")
@@ -145,7 +226,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(b"Hello!", response.data)
         span = self.assert_span()
         self.assertEqual(
-            span.instrumentation_info.schema_url,
+            span.instrumentation_scope.schema_url,
             "https://opentelemetry.io/schemas/1.11.0",
         )
 
@@ -156,8 +237,8 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(b"Hello!", response.data)
         span = self.assert_span()
         self.assertEqual(
-            span.instrumentation_info.schema_url,
-            "https://opentelemetry.io/schemas/1.21.0",
+            span.instrumentation_scope.schema_url,
+            "https://opentelemetry.io/schemas/v1.21.0",
         )
 
     def test_schema_url_both_semconv(self):
@@ -167,8 +248,8 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(b"Hello!", response.data)
         span = self.assert_span()
         self.assertEqual(
-            span.instrumentation_info.schema_url,
-            "https://opentelemetry.io/schemas/1.21.0",
+            span.instrumentation_scope.schema_url,
+            "https://opentelemetry.io/schemas/v1.21.0",
         )
 
     def test_basic_not_found(self):
@@ -183,6 +264,74 @@ class TestURLLib3Instrumentor(TestBase):
             404, span.attributes.get(SpanAttributes.HTTP_STATUS_CODE)
         )
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
+
+    def test_basic_not_found_new_semconv(self):
+        url_404 = "http://mock/status/404"
+        httpretty.register_uri(httpretty.GET, url_404, status=404)
+
+        response = self.perform_request(url_404)
+        self.assertEqual(404, response.status)
+
+        span = self.assert_span()
+        self.assertEqual(404, span.attributes.get(HTTP_RESPONSE_STATUS_CODE))
+        self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
+
+    def test_basic_not_found_both_semconv(self):
+        url_404 = "http://mock/status/404"
+        httpretty.register_uri(httpretty.GET, url_404, status=404)
+
+        response = self.perform_request(url_404)
+        self.assertEqual(404, response.status)
+
+        span = self.assert_span()
+        self.assertEqual(404, span.attributes.get(HTTP_RESPONSE_STATUS_CODE))
+        self.assertEqual(
+            404, span.attributes.get(SpanAttributes.HTTP_STATUS_CODE)
+        )
+        self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
+
+    @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
+    def test_nonstandard_http_method(self):
+        httpretty.register_uri(
+            "NONSTANDARD", self.HTTP_URL, body="Hello!", status=405
+        )
+        self.perform_request(self.HTTP_URL, method="NONSTANDARD")
+        span = self.assert_span()
+        self.assertEqual("HTTP", span.name)
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.HTTP_METHOD), "_OTHER"
+        )
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 405
+        )
+
+    @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
+    def test_nonstandard_http_method_new_semconv(self):
+        httpretty.register_uri(
+            "NONSTANDARD", self.HTTP_URL, body="Hello!", status=405
+        )
+        self.perform_request(self.HTTP_URL, method="NONSTANDARD")
+        span = self.assert_span()
+        self.assertEqual("HTTP", span.name)
+        self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
+        self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
+
+    @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
+    def test_nonstandard_http_method_both_semconv(self):
+        httpretty.register_uri(
+            "NONSTANDARD", self.HTTP_URL, body="Hello!", status=405
+        )
+        self.perform_request(self.HTTP_URL, method="NONSTANDARD")
+        span = self.assert_span()
+        self.assertEqual("HTTP", span.name)
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.HTTP_METHOD), "_OTHER"
+        )
+        self.assertEqual(
+            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 405
+        )
+        self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
+        self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
 
     def test_basic_http_non_default_port(self):
         url = "http://mock:666/status/200"
@@ -308,6 +457,34 @@ class TestURLLib3Instrumentor(TestBase):
             )
 
         self.assert_exception_span(self.HTTP_URL)
+
+    @mock.patch(
+        "urllib3.connectionpool.HTTPConnectionPool._make_request",
+        side_effect=urllib3.exceptions.ConnectTimeoutError,
+    )
+    def test_request_exception_new_semconv(self, _):
+        with self.assertRaises(urllib3.exceptions.ConnectTimeoutError):
+            self.perform_request(
+                self.HTTP_URL, retries=urllib3.Retry(connect=False)
+            )
+
+        self.assert_exception_span(
+            self.HTTP_URL, sem_conv_opt_in_mode=_HTTPStabilityMode.HTTP
+        )
+
+    @mock.patch(
+        "urllib3.connectionpool.HTTPConnectionPool._make_request",
+        side_effect=urllib3.exceptions.ConnectTimeoutError,
+    )
+    def test_request_exception_both_semconv(self, _):
+        with self.assertRaises(urllib3.exceptions.ConnectTimeoutError):
+            self.perform_request(
+                self.HTTP_URL, retries=urllib3.Retry(connect=False)
+            )
+
+        self.assert_exception_span(
+            self.HTTP_URL, sem_conv_opt_in_mode=_HTTPStabilityMode.HTTP_DUP
+        )
 
     @mock.patch(
         "urllib3.connectionpool.HTTPConnectionPool._make_request",

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -35,6 +35,7 @@ from opentelemetry.instrumentation.utils import (
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.semconv.attributes.http_attributes import (
     HTTP_REQUEST_METHOD,
+    HTTP_REQUEST_METHOD_ORIGINAL,
     HTTP_RESPONSE_STATUS_CODE,
 )
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
@@ -314,6 +315,9 @@ class TestURLLib3Instrumentor(TestBase):
         span = self.assert_span()
         self.assertEqual("HTTP", span.name)
         self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
+        self.assertEqual(
+            span.attributes.get(HTTP_REQUEST_METHOD_ORIGINAL), "NONSTANDARD"
+        )
         self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
 
     @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
@@ -331,6 +335,9 @@ class TestURLLib3Instrumentor(TestBase):
             span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 405
         )
         self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
+        self.assertEqual(
+            span.attributes.get(HTTP_REQUEST_METHOD_ORIGINAL), "NONSTANDARD"
+        )
         self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
 
     def test_basic_http_non_default_port(self):

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -149,6 +149,28 @@ class TestURLLib3Instrumentor(TestBase):
             "https://opentelemetry.io/schemas/1.11.0",
         )
 
+    def test_schema_url_new_semconv(self):
+        pool = urllib3.HTTPSConnectionPool("mock")
+        response = pool.request("GET", "/status/200")
+
+        self.assertEqual(b"Hello!", response.data)
+        span = self.assert_span()
+        self.assertEqual(
+            span.instrumentation_info.schema_url,
+            "https://opentelemetry.io/schemas/1.21.0",
+        )
+
+    def test_schema_url_both_semconv(self):
+        pool = urllib3.HTTPSConnectionPool("mock")
+        response = pool.request("GET", "/status/200")
+
+        self.assertEqual(b"Hello!", response.data)
+        span = self.assert_span()
+        self.assertEqual(
+            span.instrumentation_info.schema_url,
+            "https://opentelemetry.io/schemas/1.21.0",
+        )
+
     def test_basic_not_found(self):
         url_404 = "http://mock/status/404"
         httpretty.register_uri(httpretty.GET, url_404, status=404)


### PR DESCRIPTION
# Description
Part of #2453 
Fixes #2681

# Checklist
- [X] Add semconv status as `migration` for urllib3 in instrumentations README
- [X] Populate `{method}` as `HTTP` when nonstandard method (sanitize_method)
- [X]  set request HTTP method attribute as `_OTHER` when nonstandard http method and for new semconv also set `http.request.method_original`  with the original nonstandard method.
- [X] Set schema_url based on the opt-in mode
- [X] Create histograms based on the opt-in mode (different metric names so no dup attributes)
- [X] Set metrics attributes based on the opt-in mode
- [X] Set span attributes based on the opt-in mode

At the current implementation, some of the required/recommended semconv span attributes aren't being set:
* `server.address` , `server.port`
* `network.protocol.verison`
