### PR TITLE
Improved logging instrumentor

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
@@ -53,7 +53,7 @@ class TestAsyncioAnext(TestBase):
                     yield it
 
             async_gen_instance = async_gen()
-            agen = anext(async_gen_instance)
+            agen = anext(async_gen_instance)  # noqa: F821
             await asyncio.create_task(agen)
 
         asyncio.run(main())

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -15,8 +15,9 @@
 # pylint: disable=empty-docstring,no-value-for-parameter,no-member,no-name-in-module
 
 import logging  # pylint: disable=import-self
+from contextlib import suppress
 from os import environ
-from typing import Collection
+from typing import Callable, Collection, Optional
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.logging.constants import (
@@ -29,9 +30,11 @@ from opentelemetry.instrumentation.logging.environment_variables import (
     OTEL_PYTHON_LOG_LEVEL,
 )
 from opentelemetry.instrumentation.logging.package import _instruments
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.trace import (
     INVALID_SPAN,
     INVALID_SPAN_CONTEXT,
+    TracerProvider,
     get_current_span,
     get_tracer_provider,
 )
@@ -49,7 +52,8 @@ LEVELS = {
 class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
     __doc__ = f"""An instrumentor for stdlib logging module.
 
-    This instrumentor injects tracing context into logging records and optionally sets the global logging format to the following:
+    This instrumentor injects tracing context into logging records and optionally
+    sets the global logging format to the following:
 
     .. code-block::
 
@@ -61,8 +65,10 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
 
     Args:
         tracer_provider: Tracer provider instance that can be used to fetch a tracer.
-        set_logging_format: When set to True, it calls logging.basicConfig() and sets a logging format.
-        logging_format: Accepts a string and sets it as the logging format when set_logging_format
+        set_logging_format: When set to True, it calls logging.basicConfig() and sets
+        a logging format.
+        logging_format: Accepts a string and sets it as the logging format when
+        set_logging_format
             is set to True.
         log_level: Accepts one of the following values and sets the logging level to it.
             logging.INFO
@@ -75,78 +81,102 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
     See `BaseInstrumentor`
     """
 
-    _old_factory = None
-    _log_hook = None
+    SPAN_ID_FIELD = "otelSpanID"
+    TRACE_ID_FIELD = "otelTraceID"
+    TRACE_SAMPLED_FIELD = "otelTraceSampled"
+    SERVICE_NAME_FIELD = "otelServiceName"
+
+    _old_factory: Callable[..., logging.LogRecord] = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        provider = kwargs.get("tracer_provider", None) or get_tracer_provider()
-        old_factory = logging.getLogRecordFactory()
-        LoggingInstrumentor._old_factory = old_factory
-        LoggingInstrumentor._log_hook = kwargs.get("log_hook", None)
+    def _get_service_name(self, provider: TracerProvider) -> str:
+        """Get service name from provider."""
+        resource: Optional[Resource] = getattr(provider, "resource", None)
+        if resource is None:
+            return ""
 
-        service_name = None
+        return resource.attributes.get("service.name", "")
 
-        def record_factory(*args, **kwargs):
+    def _instrument(self, **_kwargs):
+        provider = _kwargs.get("tracer_provider", get_tracer_provider())
+        service_name = self._get_service_name(provider)
+        old_factory = self._get_old_factory()
+        log_hook: Optional[Callable] = _kwargs.get("log_hook", None)
+
+        service_name_field = self.SERVICE_NAME_FIELD
+        trace_id_field = self.TRACE_ID_FIELD
+        trace_sampled_field = self.TRACE_SAMPLED_FIELD
+        span_id_field = self.SPAN_ID_FIELD
+
+        def record_factory(*args, **kwargs) -> logging.LogRecord:
             record = old_factory(*args, **kwargs)
 
-            record.otelSpanID = "0"
-            record.otelTraceID = "0"
-            record.otelTraceSampled = False
-
-            nonlocal service_name
-            if service_name is None:
-                resource = getattr(provider, "resource", None)
-                if resource:
-                    service_name = (
-                        resource.attributes.get("service.name") or ""
-                    )
-                else:
-                    service_name = ""
-
-            record.otelServiceName = service_name
+            setattr(record, service_name_field, service_name)
+            setattr(record, trace_id_field, "0")
+            setattr(record, trace_sampled_field, "0")
+            setattr(record, span_id_field, False)
 
             span = get_current_span()
-            if span != INVALID_SPAN:
-                ctx = span.get_span_context()
-                if ctx != INVALID_SPAN_CONTEXT:
-                    record.otelSpanID = format(ctx.span_id, "016x")
-                    record.otelTraceID = format(ctx.trace_id, "032x")
-                    record.otelTraceSampled = ctx.trace_flags.sampled
-                    if callable(LoggingInstrumentor._log_hook):
-                        try:
-                            LoggingInstrumentor._log_hook(  # pylint: disable=E1102
-                                span, record
-                            )
-                        except Exception:  # pylint: disable=W0703
-                            pass
+            if span == INVALID_SPAN:
+                return record
+
+            ctx = span.get_span_context()
+            if ctx == INVALID_SPAN_CONTEXT:
+                return record
+
+            setattr(record, trace_id_field, format(ctx.trace_id, "032x"))
+            setattr(record, trace_sampled_field, ctx.trace_flags.sampled)
+            setattr(record, span_id_field, format(ctx.span_id, "016x"))
 
             return record
 
-        logging.setLogRecordFactory(record_factory)
+        def record_factory_with_hook(*args, **kwargs):
+            record = record_factory(*args, **kwargs)
+            span = get_current_span()
+            with suppress(Exception):
+                log_hook(span, record)
 
+        _factory = record_factory_with_hook if log_hook else record_factory
+        logging.setLogRecordFactory(_factory)
+        self._set_logging_format(**_kwargs)
+
+    def _uninstrument(self, **kwargs):
+        self._set_old_factory()
+
+    def _get_old_factory(self) -> Callable[..., logging.LogRecord]:
+        """Get and store original log factory."""
+        old_factory = logging.getLogRecordFactory()
+        self.__class__._old_factory = old_factory
+        return old_factory
+
+    def _set_old_factory(self) -> None:
+        """Set original log factory."""
+        old_factory = self.__class__._old_factory
+        if old_factory is None:
+            return
+
+        logging.setLogRecordFactory(old_factory)
+        self.__class__._old_factory = None
+
+    def _set_logging_format(self, **kwargs):
         set_logging_format = kwargs.get(
             "set_logging_format",
             environ.get(OTEL_PYTHON_LOG_CORRELATION, "false").lower()
             == "true",
         )
+        if not set_logging_format:
+            return
 
-        if set_logging_format:
-            log_format = kwargs.get(
-                "logging_format", environ.get(OTEL_PYTHON_LOG_FORMAT, None)
-            )
-            log_format = log_format or DEFAULT_LOGGING_FORMAT
+        log_format = kwargs.get(
+            "logging_format", environ.get(OTEL_PYTHON_LOG_FORMAT, None)
+        )
+        log_format = log_format or DEFAULT_LOGGING_FORMAT
 
-            log_level = kwargs.get(
-                "log_level", LEVELS.get(environ.get(OTEL_PYTHON_LOG_LEVEL))
-            )
-            log_level = log_level or logging.INFO
+        log_level = kwargs.get(
+            "log_level", LEVELS.get(environ.get(OTEL_PYTHON_LOG_LEVEL))
+        )
+        log_level = log_level or logging.INFO
 
-            logging.basicConfig(format=log_format, level=log_level)
-
-    def _uninstrument(self, **kwargs):
-        if LoggingInstrumentor._old_factory:
-            logging.setLogRecordFactory(LoggingInstrumentor._old_factory)
-            LoggingInstrumentor._old_factory = None
+        logging.basicConfig(format=log_format, level=log_level)


### PR DESCRIPTION
# Description

## Performance

- don't call `log_hook` in `LogRecordFactory` on every log record if log hook is not set
- don't calculate `service_name` on every log record

## Customization

- ability to set own log record field names

## Readability

- used early log record return for every case, when you can't get trace or span


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
