### PR TITLE
Re-raise `redis.WatchError`s when they occur

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -359,7 +359,7 @@ class TestRedis(TestBase):
 
     def test_watch_error_sync(self):
         def redis_operations():
-            try:
+            with pytest.raises(WatchError):
                 redis_client = fakeredis.FakeStrictRedis()
                 pipe = redis_client.pipeline(transaction=True)
                 pipe.watch("a")
@@ -367,8 +367,6 @@ class TestRedis(TestBase):
                 pipe.multi()
                 pipe.set("a", "1")
                 pipe.execute()
-            except WatchError:
-                pass
 
         redis_operations()
 
@@ -400,7 +398,7 @@ class TestRedisAsync(TestBase, IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     async def test_watch_error_async(self):
         async def redis_operations():
-            try:
+            with pytest.raises(WatchError):
                 redis_client = FakeRedis()
                 async with redis_client.pipeline(transaction=False) as pipe:
                     await pipe.watch("a")
@@ -408,8 +406,6 @@ class TestRedisAsync(TestBase, IsolatedAsyncioTestCase):
                     pipe.multi()
                     await pipe.set("a", "1")
                     await pipe.execute()
-            except WatchError:
-                pass
 
         await redis_operations()
 


### PR DESCRIPTION
# Description

In #2668, we started to avoid having the `redis.WatchError` mark the span as
having failed, but we were inadvertently suppressing that exception from the
calling code.  `redis.WatchError` is used for flow-of-control concurrency in
many applications, and applications depend on catching the error to handle
concurrent changes to keys during redis pipelines.

This re-raises the `WatchError` to keep the instrumentation transparent to the
application.

Fixes #2639

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated unit test

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
