### PR TITLE
allow a user-defined function for providing span attributes on engine/connect span begin

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -165,25 +165,26 @@ class SQLAlchemyInstrumentor(BaseInstrumentor):
 
         enable_commenter = kwargs.get("enable_commenter", False)
         commenter_options = kwargs.get("commenter_options", {})
+        attrs_provider = kwargs.get("attrs_provider")
 
         _w(
             "sqlalchemy",
             "create_engine",
             _wrap_create_engine(
-                tracer, connections_usage, enable_commenter, commenter_options
+                tracer, connections_usage, enable_commenter, commenter_options, attrs_provider
             ),
         )
         _w(
             "sqlalchemy.engine",
             "create_engine",
             _wrap_create_engine(
-                tracer, connections_usage, enable_commenter, commenter_options
+                tracer, connections_usage, enable_commenter, commenter_options, attrs_provider
             ),
         )
         _w(
             "sqlalchemy.engine.base",
             "Engine.connect",
-            _wrap_connect(tracer),
+            _wrap_connect(tracer, attrs_provider),
         )
         if parse_version(sqlalchemy.__version__).release >= (1, 4):
             _w(


### PR DESCRIPTION


# Description

Add `attr_provider` as an optional kwarg for `SQLAlchemyInstrumentor().instrument`. If attr_provider (a 0 argument callable) is provided, it will be evaluated before any calls to start_current_span within the engine or connection instrumentation. This allows users who have an attribute aware sampler to inject attributes into the sampler to control sample behavior.

Specifically, for my usecase, I have a subclass of the ParentBasedTraceIdRatio called OverrideableParentBasedTraceIdRatio which allows passing of an 'x-ignore-sample' attribute which forces the sample to emit a DROP decision when the parent is not already sampled. I would like to force all SqlAlchemy spans to be dropped unless the parent is sampled, which necessitates this change.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] New test in instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
