### PR TITLE
add srprash as component owner of aws extension

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -35,6 +35,7 @@ components:
   sdk-extension/opentelemetry-sdk-extension-aws:
     - NathanielRN
     - Kausik-A
+    - srprash
 
   instrumentation/opentelemetry-instrumentation-tortoiseorm:
     - tonybaloney


### PR DESCRIPTION
Related: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1899