### PR TITLE
remove unecessary packages from sqlalchemy test requirements

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/test-requirements-0.txt
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/test-requirements-0.txt
@@ -1,15 +1,12 @@
 asgiref==3.7.2
 cffi==1.15.1
 Deprecated==1.2.14
-greenlet==0.4.13
-hpy==0.0.4.dev179+g9b5d200
 importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
 py-cpuinfo==9.0.0
 pytest==7.4.4
-readline==6.2.4.1
 SQLAlchemy==1.1.18
 tomli==2.0.1
 typing_extensions==4.10.0


### PR DESCRIPTION
# Description
No need to install those packages for testing. 
hpy==0.0.4.dev179+g9b5d200 isn't even available at pypi