### PR TITLE
Include dummy version upload as part of contributing process to mitig…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,7 @@ Below is a checklist of things to be mindful of when implementing a new instrume
 
 - Follow semantic conventions
   - The instrumentation should follow the semantic conventions defined [here](https://github.com/open-telemetry/semantic-conventions/tree/main/docs)
-- Contains a name that is not already claimed in [Pypi](https://pypi.org/)
+- Contains a name that is not already claimed in [Pypi](https://pypi.org/). Contact a maintainer, bring the issue up in the weekly Python SIG or create a ticket in Pypi if a desired name has already been taken.
 - Extends from [BaseInstrumentor](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/2518a4ac07cb62ad6587dd8f6cbb5f8663a7e179/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py#L35)
 - Supports auto-instrumentation
   - Add an entry point (ex. <https://github.com/open-telemetry/opentelemetry-python-contrib/blob/2518a4ac07cb62ad6587dd8f6cbb5f8663a7e179/instrumentation/opentelemetry-instrumentation-requests/pyproject.toml#L44>)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,8 @@ The continuous integration overrides that environment variable with as per the c
 Below is a checklist of things to be mindful of when implementing a new instrumentation or working on a specific instrumentation. It is one of our goals as a community to keep the implementation specific details of instrumentations as similar across the board as possible for ease of testing and feature parity. It is also good to abstract as much common functionality as possible.
 
 - Follow semantic conventions
-  - The instrumentation should follow the semantic conventions defined [here](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/semantic-conventions.md)
+  - The instrumentation should follow the semantic conventions defined [here](https://github.com/open-telemetry/semantic-conventions/tree/main/docs)
+- Contains a name that is not already claimed in [Pypi](https://pypi.org/)
 - Extends from [BaseInstrumentor](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/2518a4ac07cb62ad6587dd8f6cbb5f8663a7e179/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py#L35)
 - Supports auto-instrumentation
   - Add an entry point (ex. <https://github.com/open-telemetry/opentelemetry-python-contrib/blob/2518a4ac07cb62ad6587dd8f6cbb5f8663a7e179/instrumentation/opentelemetry-instrumentation-requests/pyproject.toml#L44>)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,10 @@
     <https://readthedocs.org/projects/opentelemetry-python/builds/>.
     If the build has not run automatically, it can be manually trigger via the readthedocs interface.
 
+## Releasing dev version of new packages to claim namespace
+
+When a contribution introduces a new package, in order to mitigate name-squatting incidents, release the current development version of the new package under the `opentelemetry` user to simply claim the namespace. This should be done shortly after the PR that introduced this package has been merged into `main`.
+
 ## Troubleshooting
 
 ### Publish failed


### PR DESCRIPTION
…ate namespace issues

As discussed in the 07/25 SIG, we will begin releasing dummy versions of new packages immediately after the corresponding PR has been merged to mitigate name-squatting incidents.

Also included an excerpt in CONTRIBUTING.md to confirm whether namespaces have already been taken before the addition of new packages.

