### PR TITLE
add missing tests to urllib3 after semconv migration

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -36,13 +36,6 @@ from opentelemetry.instrumentation.utils import (
     suppress_instrumentation,
 )
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
-from opentelemetry.semconv.attributes.http_attributes import (
-    HTTP_REQUEST_METHOD,
-    HTTP_REQUEST_METHOD_ORIGINAL,
-    HTTP_RESPONSE_STATUS_CODE,
-)
-from opentelemetry.semconv.attributes.url_attributes import URL_FULL
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import Span
@@ -123,24 +116,29 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(
             span.status.status_code, trace.status.StatusCode.UNSET
         )
-        attr_old = {
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_URL: url,
-            SpanAttributes.HTTP_STATUS_CODE: 200,
+        expected_attr_old = {
+            "http.method": "GET",
+            "http.url": url,
+            "http.status_code": 200,
         }
 
-        attr_new = {
-            HTTP_REQUEST_METHOD: "GET",
-            URL_FULL: url,
-            HTTP_RESPONSE_STATUS_CODE: 200,
+        expected_attr_new = {
+            "http.request.method": "GET",
+            "url.full": url,
+            "http.response.status_code": 200,
         }
 
         attributes = {
-            _HTTPStabilityMode.DEFAULT: attr_old,
-            _HTTPStabilityMode.HTTP: attr_new,
-            _HTTPStabilityMode.HTTP_DUP: {**attr_new, **attr_old},
+            _HTTPStabilityMode.DEFAULT: expected_attr_old,
+            _HTTPStabilityMode.HTTP: expected_attr_new,
+            _HTTPStabilityMode.HTTP_DUP: {
+                **expected_attr_new,
+                **expected_attr_old,
+            },
         }
-        self.assertEqual(span.attributes, attributes.get(sem_conv_opt_in_mode))
+        self.assertDictEqual(
+            dict(span.attributes), attributes.get(sem_conv_opt_in_mode)
+        )
 
     def assert_exception_span(
         self,
@@ -149,24 +147,29 @@ class TestURLLib3Instrumentor(TestBase):
     ):
         span = self.assert_span()
 
-        attr_old = {
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_URL: url,
+        expected_attr_old = {
+            "http.method": "GET",
+            "http.url": url,
         }
 
-        attr_new = {
-            HTTP_REQUEST_METHOD: "GET",
-            URL_FULL: url,
+        expected_attr_new = {
+            "http.request.method": "GET",
+            "url.full": url,
             # TODO: Add `error.type` attribute when supported
         }
 
         attributes = {
-            _HTTPStabilityMode.DEFAULT: attr_old,
-            _HTTPStabilityMode.HTTP: attr_new,
-            _HTTPStabilityMode.HTTP_DUP: {**attr_new, **attr_old},
+            _HTTPStabilityMode.DEFAULT: expected_attr_old,
+            _HTTPStabilityMode.HTTP: expected_attr_new,
+            _HTTPStabilityMode.HTTP_DUP: {
+                **expected_attr_new,
+                **expected_attr_old,
+            },
         }
 
-        self.assertEqual(span.attributes, attributes.get(sem_conv_opt_in_mode))
+        self.assertDictEqual(
+            dict(span.attributes), attributes.get(sem_conv_opt_in_mode)
+        )
         self.assertEqual(
             trace.status.StatusCode.ERROR, span.status.status_code
         )
@@ -265,9 +268,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(404, response.status)
 
         span = self.assert_span()
-        self.assertEqual(
-            404, span.attributes.get(SpanAttributes.HTTP_STATUS_CODE)
-        )
+        self.assertEqual(404, span.attributes.get("http.status_code"))
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     def test_basic_not_found_new_semconv(self):
@@ -278,7 +279,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(404, response.status)
 
         span = self.assert_span()
-        self.assertEqual(404, span.attributes.get(HTTP_RESPONSE_STATUS_CODE))
+        self.assertEqual(404, span.attributes.get("http.response.status_code"))
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     def test_basic_not_found_both_semconv(self):
@@ -289,10 +290,8 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(404, response.status)
 
         span = self.assert_span()
-        self.assertEqual(404, span.attributes.get(HTTP_RESPONSE_STATUS_CODE))
-        self.assertEqual(
-            404, span.attributes.get(SpanAttributes.HTTP_STATUS_CODE)
-        )
+        self.assertEqual(404, span.attributes.get("http.response.status_code"))
+        self.assertEqual(404, span.attributes.get("http.status_code"))
         self.assertIs(trace.status.StatusCode.ERROR, span.status.status_code)
 
     @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
@@ -303,12 +302,8 @@ class TestURLLib3Instrumentor(TestBase):
         self.perform_request(self.HTTP_URL, method="NONSTANDARD")
         span = self.assert_span()
         self.assertEqual("HTTP", span.name)
-        self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_METHOD), "_OTHER"
-        )
-        self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 405
-        )
+        self.assertEqual(span.attributes.get("http.method"), "_OTHER")
+        self.assertEqual(span.attributes.get("http.status_code"), 405)
 
     @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
     def test_nonstandard_http_method_new_semconv(self):
@@ -318,11 +313,11 @@ class TestURLLib3Instrumentor(TestBase):
         self.perform_request(self.HTTP_URL, method="NONSTANDARD")
         span = self.assert_span()
         self.assertEqual("HTTP", span.name)
-        self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
+        self.assertEqual(span.attributes.get("http.request.method"), "_OTHER")
         self.assertEqual(
-            span.attributes.get(HTTP_REQUEST_METHOD_ORIGINAL), "NONSTANDARD"
+            span.attributes.get("http.request.method_original"), "NONSTANDARD"
         )
-        self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
+        self.assertEqual(span.attributes.get("http.response.status_code"), 405)
 
     @mock.patch("httpretty.http.HttpBaseClass.METHODS", ("NONSTANDARD",))
     def test_nonstandard_http_method_both_semconv(self):
@@ -332,17 +327,13 @@ class TestURLLib3Instrumentor(TestBase):
         self.perform_request(self.HTTP_URL, method="NONSTANDARD")
         span = self.assert_span()
         self.assertEqual("HTTP", span.name)
+        self.assertEqual(span.attributes.get("http.method"), "_OTHER")
+        self.assertEqual(span.attributes.get("http.status_code"), 405)
+        self.assertEqual(span.attributes.get("http.request.method"), "_OTHER")
         self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_METHOD), "_OTHER"
+            span.attributes.get("http.request.method_original"), "NONSTANDARD"
         )
-        self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 405
-        )
-        self.assertEqual(span.attributes.get(HTTP_REQUEST_METHOD), "_OTHER")
-        self.assertEqual(
-            span.attributes.get(HTTP_REQUEST_METHOD_ORIGINAL), "NONSTANDARD"
-        )
-        self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 405)
+        self.assertEqual(span.attributes.get("http.response.status_code"), 405)
 
     def test_basic_http_non_default_port(self):
         url = "http://mock:666/status/200"

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
@@ -26,26 +26,6 @@ from opentelemetry.instrumentation._semconv import (
     _OpenTelemetrySemanticConventionStability,
 )
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
-from opentelemetry.semconv._incubating.metrics.http_metrics import (
-    HTTP_CLIENT_REQUEST_BODY_SIZE,
-    HTTP_CLIENT_RESPONSE_BODY_SIZE,
-)
-from opentelemetry.semconv.attributes.http_attributes import (
-    HTTP_REQUEST_METHOD,
-    HTTP_RESPONSE_STATUS_CODE,
-)
-from opentelemetry.semconv.attributes.network_attributes import (
-    NETWORK_PROTOCOL_VERSION,
-)
-from opentelemetry.semconv.attributes.server_attributes import (
-    SERVER_ADDRESS,
-    SERVER_PORT,
-)
-from opentelemetry.semconv.metrics import MetricInstruments
-from opentelemetry.semconv.metrics.http_metrics import (
-    HTTP_CLIENT_REQUEST_DURATION,
-)
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.httptest import HttpTestBase
 from opentelemetry.test.test_base import TestBase
 
@@ -102,18 +82,16 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         ) = metrics
 
         attrs_old = {
-            SpanAttributes.HTTP_STATUS_CODE: 200,
-            SpanAttributes.HTTP_HOST: "mock",
-            SpanAttributes.NET_PEER_PORT: 80,
-            SpanAttributes.NET_PEER_NAME: "mock",
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            "http.status_code": 200,
+            "http.host": "mock",
+            "net.peer.port": 80,
+            "net.peer.name": "mock",
+            "http.method": "GET",
+            "http.flavor": "1.1",
+            "http.scheme": "http",
         }
 
-        self.assertEqual(
-            client_duration.name, MetricInstruments.HTTP_CLIENT_DURATION
-        )
+        self.assertEqual(client_duration.name, "http.client.duration")
         self.assert_metric_expected(
             client_duration,
             [
@@ -128,10 +106,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
             est_value_delta=40,
         )
 
-        self.assertEqual(
-            client_request_size.name,
-            MetricInstruments.HTTP_CLIENT_REQUEST_SIZE,
-        )
+        self.assertEqual(client_request_size.name, "http.client.request.size")
         self.assert_metric_expected(
             client_request_size,
             [
@@ -147,8 +122,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
 
         expected_size = len(response.data)
         self.assertEqual(
-            client_response_size.name,
-            MetricInstruments.HTTP_CLIENT_RESPONSE_SIZE,
+            client_response_size.name, "http.client.response.size"
         )
         self.assert_metric_expected(
             client_response_size,
@@ -177,11 +151,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         ) = metrics
 
         attrs_new = {
-            NETWORK_PROTOCOL_VERSION: "1.1",
-            SERVER_ADDRESS: "mock",
-            SERVER_PORT: 80,
-            HTTP_REQUEST_METHOD: "GET",
-            HTTP_RESPONSE_STATUS_CODE: 200,
+            "network.protocol.version": "1.1",
+            "server.address": "mock",
+            "server.port": 80,
+            "http.request.method": "GET",
+            "http.response.status_code": 200,
             # TODO: add URL_SCHEME to tests when supported in the implementation
         }
 
@@ -253,27 +227,27 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         ) = metrics[:6]
 
         attrs_new = {
-            NETWORK_PROTOCOL_VERSION: "1.1",
-            SERVER_ADDRESS: "mock",
-            SERVER_PORT: 80,
-            HTTP_REQUEST_METHOD: "GET",
-            HTTP_RESPONSE_STATUS_CODE: 200,
+            "network.protocol.version": "1.1",
+            "server.address": "mock",
+            "server.port": 80,
+            "http.request.method": "GET",
+            "http.response.status_code": 200,
             # TODO: add URL_SCHEME to tests when supported in the implementation
         }
 
         attrs_old = {
-            SpanAttributes.HTTP_STATUS_CODE: 200,
-            SpanAttributes.HTTP_HOST: "mock",
-            SpanAttributes.NET_PEER_PORT: 80,
-            SpanAttributes.NET_PEER_NAME: "mock",
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            "http.status_code": 200,
+            "http.host": "mock",
+            "net.peer.port": 80,
+            "net.peer.name": "mock",
+            "http.method": "GET",
+            "http.flavor": "1.1",
+            "http.scheme": "http",
         }
 
         # assert new semconv metrics
         self.assertEqual(
-            client_request_duration.name, HTTP_CLIENT_REQUEST_DURATION
+            client_request_duration.name, "http.client.request.duration"
         )
         self.assert_metric_expected(
             client_request_duration,
@@ -290,7 +264,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         )
 
         self.assertEqual(
-            client_request_body_size.name, HTTP_CLIENT_REQUEST_BODY_SIZE
+            client_request_body_size.name, "http.client.request.body.size"
         )
         self.assert_metric_expected(
             client_request_body_size,
@@ -306,7 +280,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         )
 
         self.assertEqual(
-            client_response_body_size.name, HTTP_CLIENT_RESPONSE_BODY_SIZE
+            client_response_body_size.name, "http.client.response.body.size"
         )
         self.assert_metric_expected(
             client_response_body_size,
@@ -321,9 +295,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
             ],
         )
         # assert old semconv metrics
-        self.assertEqual(
-            client_duration.name, MetricInstruments.HTTP_CLIENT_DURATION
-        )
+        self.assertEqual(client_duration.name, "http.client.duration")
         self.assert_metric_expected(
             client_duration,
             [
@@ -338,10 +310,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
             est_value_delta=40,
         )
 
-        self.assertEqual(
-            client_request_size.name,
-            MetricInstruments.HTTP_CLIENT_REQUEST_SIZE,
-        )
+        self.assertEqual(client_request_size.name, "http.client.request.size")
         self.assert_metric_expected(
             client_request_size,
             [
@@ -356,8 +325,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         )
 
         self.assertEqual(
-            client_response_size.name,
-            MetricInstruments.HTTP_CLIENT_RESPONSE_SIZE,
+            client_response_size.name, "http.client.response.size"
         )
         self.assert_metric_expected(
             client_response_size,
@@ -391,13 +359,13 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         ) = metrics
 
         attrs_old = {
-            SpanAttributes.HTTP_STATUS_CODE: 405,
-            SpanAttributes.HTTP_HOST: "mock",
-            SpanAttributes.NET_PEER_PORT: 80,
-            SpanAttributes.NET_PEER_NAME: "mock",
-            SpanAttributes.HTTP_METHOD: "_OTHER",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            "http.status_code": 405,
+            "http.host": "mock",
+            "net.peer.port": 80,
+            "net.peer.name": "mock",
+            "http.method": "_OTHER",
+            "http.flavor": "1.1",
+            "http.scheme": "http",
         }
 
         self.assertEqual(client_duration.name, "http.client.duration")
@@ -464,11 +432,11 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
         ) = metrics
 
         attrs_new = {
-            NETWORK_PROTOCOL_VERSION: "1.1",
-            SERVER_ADDRESS: "mock",
-            SERVER_PORT: 80,
-            HTTP_REQUEST_METHOD: "_OTHER",
-            HTTP_RESPONSE_STATUS_CODE: 405,
+            "network.protocol.version": "1.1",
+            "server.address": "mock",
+            "server.port": 80,
+            "http.request.method": "_OTHER",
+            "http.response.status_code": 405,
             "error.type": "405",
             # TODO: add URL_SCHEME to tests when supported in the implementation
         }


### PR DESCRIPTION
# Description
Add missing tests to urllib3 instrumentation after semconv migration. I missed test both_semconv for metrics. 