### PR TITLE
instrumentation/fastapi: fix fastapi-slim support

### DIFF
--- a/.github/workflows/instrumentations_1.yml
+++ b/.github/workflows/instrumentations_1.yml
@@ -38,7 +38,7 @@ jobs:
           - "resource-detector-azure"
           - "resource-detector-container"
           - "util-http"
-          - "fastapi-slim"
+          - "fastapislim"
           - "processor-baggage"
         os: [ubuntu-20.04]
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2746](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2746))
 - `opentelemetry-instrumentation-grpc` Fixes the issue with the gRPC instrumentation not working with the 1.63.0 and higher version of gRPC
   ([#2483](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2484))
+- `opentelemetry-instrumentation-fastapi` Fix fastapi-slim support
+  ([#2756](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2756))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -176,6 +176,7 @@ from importlib.util import find_spec
 from typing import Collection
 
 import fastapi
+from pkg_resources import get_distribution
 from starlette.routing import Match
 
 from opentelemetry.instrumentation._semconv import (
@@ -285,10 +286,16 @@ class FastAPIInstrumentor(BaseInstrumentor):
         app._is_instrumented_by_opentelemetry = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
+        # need to use get_distribution because find_spec("fastapi") will return
+        # something even with just fastapi-slim installed
+        try:
+            get_distribution("fastapi-slim")
+            return (_fastapi_slim,)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         if find_spec("fastapi") is not None:
             return (_fastapi,)
-        if find_spec("fastapi_slim") is not None:
-            return (_fastapi_slim,)
         # If neither is installed, return both as potential dependencies
         return _instruments
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -172,10 +172,10 @@ API
 ---
 """
 import logging
+from importlib.metadata import PackageNotFoundError, distribution
 from typing import Collection
 
 import fastapi
-from pkg_resources import get_distribution
 from starlette.routing import Match
 
 from opentelemetry.instrumentation._semconv import (
@@ -285,18 +285,18 @@ class FastAPIInstrumentor(BaseInstrumentor):
         app._is_instrumented_by_opentelemetry = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
-        # need to use get_distribution because find_spec("fastapi") will return
+        # need to use distribution because find_spec("fastapi") will return
         # something even with just fastapi-slim installed
         try:
-            get_distribution("fastapi-slim")
+            distribution("fastapi-slim")
             return (_fastapi_slim,)
-        except Exception:  # pylint: disable=broad-exception-caught
+        except PackageNotFoundError:
             pass
 
         try:
-            get_distribution("fastapi")
+            distribution("fastapi")
             return (_fastapi,)
-        except Exception:  # pylint: disable=broad-exception-caught
+        except PackageNotFoundError:
             pass
 
         # If neither is installed, return both as potential dependencies

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -172,7 +172,6 @@ API
 ---
 """
 import logging
-from importlib.util import find_spec
 from typing import Collection
 
 import fastapi
@@ -294,8 +293,12 @@ class FastAPIInstrumentor(BaseInstrumentor):
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
-        if find_spec("fastapi") is not None:
+        try:
+            get_distribution("fastapi")
             return (_fastapi,)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         # If neither is installed, return both as potential dependencies
         return _instruments
 

--- a/tox.ini
+++ b/tox.ini
@@ -116,9 +116,9 @@ envlist =
 
     ; opentelemetry-instrumentation-fastapi
     py3{8,9,10,11,12}-test-instrumentation-fastapi
-    py3{8,9,10,11,12}-test-instrumentation-fastapi-slim
+    py3{8,9,10,11,12}-test-instrumentation-fastapislim
     pypy3-test-instrumentation-fastapi
-    pypy3-test-instrumentation-fastapi-slim
+    pypy3-test-instrumentation-fastapislim
     lint-instrumentation-fastapi
 
     ; opentelemetry-instrumentation-flask
@@ -556,11 +556,11 @@ commands_pre =
   fastapi: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
   fastapi: pip install opentelemetry-test-utils@{env:CORE_REPO}\#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils
   fastapi: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements.txt
-  fastapi-slim: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
-  fastapi-slim: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions
-  fastapi-slim: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
-  fastapi-slim: pip install opentelemetry-test-utils@{env:CORE_REPO}\#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils
-  fastapi-slim: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements-slim.txt
+  fastapislim: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
+  fastapislim: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions
+  fastapislim: pip install opentelemetry-sdk@{env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
+  fastapislim: pip install opentelemetry-test-utils@{env:CORE_REPO}\#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils
+  fastapislim: pip install -r {toxinidir}/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements-slim.txt
 
   mysql: pip install opentelemetry-api@{env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api
   mysql: pip install opentelemetry-semantic-conventions@{env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions


### PR DESCRIPTION
# Description

In instrumentation_dependencies we need to use importlib.metadata.distribution because find_spec("fastapi") will return something even with just fastapi-slim installed.

Then need to fix the tox environment name otherwise all the fastapi dependencies will also be installed for fastapi-slim and tests would pass because they find fastapi installed.

Fixes #2683

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
