### PR TITLE
Increase test coverage of instrumentation-aws-lambda

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/alb_conventional_headers_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/alb_conventional_headers_event.py
@@ -1,0 +1,24 @@
+MOCK_LAMBDA_ALB_EVENT = {
+    "requestContext": {
+        "elb": {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+        }
+    },
+    "httpMethod": "GET",
+    "path": "/",
+    "queryStringParameters": {"foo": "bar"},
+    "headers": {
+        "accept": "text/html,application/xhtml+xml",
+        "accept-language": "en-US,en;q=0.8",
+        "content-type": "text/plain",
+        "cookie": "cookies",
+        "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+        "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+        "x-forwarded-for": "72.21.198.66",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https",
+    },
+    "isBase64Encoded": False,
+    "body": "request_body",
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/alb_multi_value_headers_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/alb_multi_value_headers_event.py
@@ -1,0 +1,30 @@
+"""
+https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
+
+When an ALB is configured to send multi-value headers, the headers are sent as a list of values under the key in the multiValueHeaders object.
+"""
+
+MOCK_LAMBDA_ALB_MULTI_VALUE_HEADER_EVENT = {
+    "requestContext": {
+        "elb": {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+        }
+    },
+    "httpMethod": "GET",
+    "path": "/",
+    "queryStringParameters": {"foo": "bar"},
+    "multiValueHeaders": {
+        "accept": ["text/html,application/xhtml+xml"],
+        "accept-language": ["en-US,en;q=0.8"],
+        "content-type": ["text/plain"],
+        "cookie": ["cookies"],
+        "host": ["lambda-846800462-us-east-2.elb.amazonaws.com"],
+        "user-agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)"],
+        "x-amzn-trace-id": ["Root=1-5bdb40ca-556d8b0c50dc66f0511bf520"],
+        "x-forwarded-for": ["72.21.198.66"],
+        "x-forwarded-port": ["443"],
+        "x-forwarded-proto": ["https"],
+    },
+    "isBase64Encoded": False,
+    "body": "request_body",
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/dynamo_db_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/dynamo_db_event.py
@@ -1,0 +1,48 @@
+"""
+https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
+"""
+
+MOCK_LAMBDA_DYNAMO_DB_EVENT = {
+    "Records": [
+        {
+            "eventID": "1",
+            "eventVersion": "1.0",
+            "dynamodb": {
+                "Keys": {"Id": {"N": "101"}},
+                "NewImage": {
+                    "Message": {"S": "New item!"},
+                    "Id": {"N": "101"},
+                },
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+                "SequenceNumber": "111",
+                "SizeBytes": 26,
+            },
+            "awsRegion": "us-west-2",
+            "eventName": "INSERT",
+            "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+            "eventSource": "aws:dynamodb",
+        },
+        {
+            "eventID": "2",
+            "eventVersion": "1.0",
+            "dynamodb": {
+                "OldImage": {
+                    "Message": {"S": "New item!"},
+                    "Id": {"N": "101"},
+                },
+                "SequenceNumber": "222",
+                "Keys": {"Id": {"N": "101"}},
+                "SizeBytes": 59,
+                "NewImage": {
+                    "Message": {"S": "This item has changed"},
+                    "Id": {"N": "101"},
+                },
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            },
+            "awsRegion": "us-west-2",
+            "eventName": "MODIFY",
+            "eventSourceARN": "arn:aws:dynamodb:us-east-2:123456789012:table/my-table/stream/2023-06-10T19:26:16.525",
+            "eventSource": "aws:dynamodb",
+        },
+    ]
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/s3_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/s3_event.py
@@ -1,0 +1,36 @@
+"""
+https://docs.aws.amazon.com/lambda/latest/dg/with-s3.html
+"""
+
+MOCK_LAMBDA_S3_EVENT = {
+    "Records": [
+        {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "us-east-2",
+            "eventTime": "2019-09-03T19:37:27.192Z",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {"principalId": "AWS:AIDAINPONIXQXHT3IKHL2"},
+            "requestParameters": {"sourceIPAddress": "205.255.255.255"},
+            "responseElements": {
+                "x-amz-request-id": "D82B88E5F771F645",
+                "x-amz-id-2": "vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo=",
+            },
+            "s3": {
+                "s3SchemaVersion": "1.0",
+                "configurationId": "828aa6fc-f7b5-4305-8584-487c791949c1",
+                "bucket": {
+                    "name": "DOC-EXAMPLE-BUCKET",
+                    "ownerIdentity": {"principalId": "A3I5XTEXAMAI3E"},
+                    "arn": "arn:aws:s3:::lambda-artifacts-deafc19498e3f2df",
+                },
+                "object": {
+                    "key": "b21b84d653bb07b05b1e6b33684dc11b",
+                    "size": 1305107,
+                    "eTag": "b21b84d653bb07b05b1e6b33684dc11b",
+                    "sequencer": "0C0F6F405D6ED209E1",
+                },
+            },
+        }
+    ]
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/sns_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/sns_event.py
@@ -1,0 +1,29 @@
+"""
+https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
+"""
+
+MOCK_LAMBDA_SNS_EVENT = {
+    "Records": [
+        {
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+            "EventSource": "aws:sns",
+            "Sns": {
+                "SignatureVersion": "1",
+                "Timestamp": "2019-01-02T12:45:07.000Z",
+                "Signature": "mock-signature",
+                "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+                "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+                "Message": "Hello from SNS!",
+                "MessageAttributes": {
+                    "Test": {"Type": "String", "Value": "TestString"},
+                    "TestBinary": {"Type": "Binary", "Value": "TestBinary"},
+                },
+                "Type": "Notification",
+                "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-1:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:sns-lambda",
+                "Subject": "TestInvoke",
+            },
+        }
+    ]
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/sqs_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/sqs_event.py
@@ -1,0 +1,24 @@
+"""
+https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+"""
+
+MOCK_LAMBDA_SQS_EVENT = {
+    "Records": [
+        {
+            "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+            "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+            "body": "Test message.",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1545082649183",
+                "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                "ApproximateFirstReceiveTimestamp": "1545082649185",
+            },
+            "messageAttributes": {},
+            "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "awsRegion": "us-east-2",
+        }
+    ]
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import os
 from dataclasses import dataclass
 from importlib import import_module, reload
@@ -41,10 +40,18 @@ from opentelemetry.trace.propagation.tracecontext import (
 )
 from opentelemetry.util._importlib_metadata import entry_points
 
+from .mocks.alb_conventional_headers_event import MOCK_LAMBDA_ALB_EVENT
+from .mocks.alb_multi_value_headers_event import (
+    MOCK_LAMBDA_ALB_MULTI_VALUE_HEADER_EVENT,
+)
 from .mocks.api_gateway_http_api_event import (
     MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT,
 )
 from .mocks.api_gateway_proxy_event import MOCK_LAMBDA_API_GATEWAY_PROXY_EVENT
+from .mocks.dynamo_db_event import MOCK_LAMBDA_DYNAMO_DB_EVENT
+from .mocks.s3_event import MOCK_LAMBDA_S3_EVENT
+from .mocks.sns_event import MOCK_LAMBDA_SNS_EVENT
+from .mocks.sqs_event import MOCK_LAMBDA_SQS_EVENT
 
 
 class MockLambdaContext:
@@ -58,8 +65,17 @@ MOCK_LAMBDA_CONTEXT = MockLambdaContext(
     invoked_function_arn="arn:aws:lambda:us-east-1:123456:function:myfunction:myalias",
 )
 
-MOCK_XRAY_TRACE_ID = 0x5FB7331105E8BB83207FA31D4D9CDB4C
+MOCK_LAMBDA_CONTEXT_ATTRIBUTES = {
+    SpanAttributes.CLOUD_RESOURCE_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn,
+    SpanAttributes.FAAS_INVOCATION_ID: MOCK_LAMBDA_CONTEXT.aws_request_id,
+    ResourceAttributes.CLOUD_ACCOUNT_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn.split(
+        ":"
+    )[
+        4
+    ],
+}
 
+MOCK_XRAY_TRACE_ID = 0x5FB7331105E8BB83207FA31D4D9CDB4C
 MOCK_XRAY_TRACE_ID_STR = f"{MOCK_XRAY_TRACE_ID:x}"
 MOCK_XRAY_PARENT_SPAN_ID = 0x3328B8445A6DBAD2
 MOCK_XRAY_TRACE_CONTEXT_COMMON = f"Root={TRACE_ID_VERSION}-{MOCK_XRAY_TRACE_ID_STR[:TRACE_ID_FIRST_PART_LENGTH]}-{MOCK_XRAY_TRACE_ID_STR[TRACE_ID_FIRST_PART_LENGTH:]};Parent={MOCK_XRAY_PARENT_SPAN_ID:x}"
@@ -88,7 +104,6 @@ def mock_execute_lambda(event=None):
     """Mocks the AWS Lambda execution.
 
     NOTE: We don't use `moto`'s `mock_lambda` because we are not instrumenting
-
     calls to AWS Lambda using the AWS SDK. Instead, we are instrumenting AWS
     Lambda itself.
 
@@ -104,7 +119,7 @@ def mock_execute_lambda(event=None):
     return getattr(handler_module, handler_name)(event, MOCK_LAMBDA_CONTEXT)
 
 
-class TestAwsLambdaInstrumentor(TestBase):
+class TestAwsLambdaInstrumentorBase(TestBase):
     """AWS Lambda Instrumentation Testsuite"""
 
     def setUp(self):
@@ -124,6 +139,8 @@ class TestAwsLambdaInstrumentor(TestBase):
         self.common_env_patch.stop()
         AwsLambdaInstrumentor().uninstrument()
 
+
+class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
     def test_active_tracing(self):
         test_env_patch = mock.patch.dict(
             "os.environ",
@@ -153,15 +170,7 @@ class TestAwsLambdaInstrumentor(TestBase):
         self.assertEqual(span.kind, SpanKind.SERVER)
         self.assertSpanHasAttributes(
             span,
-            {
-                SpanAttributes.CLOUD_RESOURCE_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn,
-                SpanAttributes.FAAS_INVOCATION_ID: MOCK_LAMBDA_CONTEXT.aws_request_id,
-                ResourceAttributes.CLOUD_ACCOUNT_ID: MOCK_LAMBDA_CONTEXT.invoked_function_arn.split(
-                    ":"
-                )[
-                    4
-                ],
-            },
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
         )
 
         parent_context = span.parent
@@ -293,53 +302,52 @@ class TestAwsLambdaInstrumentor(TestBase):
             ),
         ]
         for test in tests:
+            with self.subTest(test_name=test.name):
+                test_env_patch = mock.patch.dict(
+                    "os.environ",
+                    {
+                        **os.environ,
+                        # NOT Active Tracing
+                        _X_AMZN_TRACE_ID: test.xray_traceid,
+                        OTEL_PROPAGATORS: test.propagators,
+                    },
+                )
+                test_env_patch.start()
+                reload(propagate)
 
-            test_env_patch = mock.patch.dict(
-                "os.environ",
-                {
-                    **os.environ,
-                    # NOT Active Tracing
-                    _X_AMZN_TRACE_ID: test.xray_traceid,
-                    OTEL_PROPAGATORS: test.propagators,
-                },
-            )
-            test_env_patch.start()
-            reload(propagate)
+                AwsLambdaInstrumentor().instrument(
+                    event_context_extractor=test.custom_extractor,
+                )
 
-            AwsLambdaInstrumentor().instrument(
-                event_context_extractor=test.custom_extractor,
-            )
-            result = mock_execute_lambda(test.context)
-            result = json.loads(result)
+                mock_execute_lambda(test.context)
 
-            spans = self.memory_exporter.get_finished_spans()
-            assert spans
-            self.assertEqual(len(spans), 1)
-            span = spans[0]
-            self.assertEqual(
-                span.get_span_context().trace_id, test.expected_traceid
-            )
+                spans = self.memory_exporter.get_finished_spans()
+                assert spans
+                self.assertEqual(len(spans), 1)
+                span = spans[0]
+                self.assertEqual(
+                    span.get_span_context().trace_id, test.expected_traceid
+                )
 
-            parent_context = span.parent
-            self.assertEqual(
-                parent_context.trace_id, span.get_span_context().trace_id
-            )
-            self.assertEqual(parent_context.span_id, test.expected_parentid)
-            self.assertEqual(
-                len(parent_context.trace_state), test.expected_trace_state_len
-            )
-            self.assertEqual(
-                parent_context.trace_state.get(MOCK_W3C_TRACE_STATE_KEY),
-                test.expected_state_value,
-            )
-            self.assertEqual(
-                result["baggage_content"].get(MOCK_W3C_BAGGAGE_KEY),
-                test.expected_baggage,
-            )
-            self.assertTrue(parent_context.is_remote)
-            self.memory_exporter.clear()
-            AwsLambdaInstrumentor().uninstrument()
-            test_env_patch.stop()
+                parent_context = span.parent
+                self.assertEqual(
+                    parent_context.trace_id, span.get_span_context().trace_id
+                )
+                self.assertEqual(
+                    parent_context.span_id, test.expected_parentid
+                )
+                self.assertEqual(
+                    len(parent_context.trace_state),
+                    test.expected_trace_state_len,
+                )
+                self.assertEqual(
+                    parent_context.trace_state.get(MOCK_W3C_TRACE_STATE_KEY),
+                    test.expected_state_value,
+                )
+                self.assertTrue(parent_context.is_remote)
+                self.memory_exporter.clear()
+                AwsLambdaInstrumentor().uninstrument()
+                test_env_patch.stop()
 
     def test_lambda_no_error_with_invalid_flush_timeout(self):
         test_env_patch = mock.patch.dict(
@@ -419,57 +427,16 @@ class TestAwsLambdaInstrumentor(TestBase):
 
         assert spans
         assert len(spans) == 1
-        assert (
-            spans[0].kind == SpanKind.SERVER
-        )  # Default to SERVER for unknown sources
+        # Default to SERVER for unknown sources
+        assert spans[0].kind == SpanKind.SERVER
+
+        for span in spans:
+            self.assertSpanHasAttributes(
+                span,
+                MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+            )
 
         test_env_patch.stop()
-
-    def test_api_gateway_proxy_event_sets_attributes(self):
-        handler_patch = mock.patch.dict(
-            "os.environ",
-            {_HANDLER: "tests.mocks.lambda_function.rest_api_handler"},
-        )
-        handler_patch.start()
-
-        AwsLambdaInstrumentor().instrument()
-
-        mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_PROXY_EVENT)
-
-        span = self.memory_exporter.get_finished_spans()[0]
-
-        self.assertSpanHasAttributes(
-            span,
-            {
-                SpanAttributes.FAAS_TRIGGER: "http",
-                SpanAttributes.HTTP_METHOD: "POST",
-                SpanAttributes.HTTP_ROUTE: "/{proxy+}",
-                SpanAttributes.HTTP_TARGET: "/{proxy+}?foo=bar",
-                SpanAttributes.NET_HOST_NAME: "1234567890.execute-api.us-east-1.amazonaws.com",
-                SpanAttributes.HTTP_USER_AGENT: "Custom User Agent String",
-                SpanAttributes.HTTP_SCHEME: "https",
-                SpanAttributes.HTTP_STATUS_CODE: 200,
-            },
-        )
-
-    def test_api_gateway_http_api_proxy_event_sets_attributes(self):
-        AwsLambdaInstrumentor().instrument()
-
-        mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT)
-
-        span = self.memory_exporter.get_finished_spans()[0]
-
-        self.assertSpanHasAttributes(
-            span,
-            {
-                SpanAttributes.FAAS_TRIGGER: "http",
-                SpanAttributes.HTTP_METHOD: "POST",
-                SpanAttributes.HTTP_ROUTE: "/path/to/resource",
-                SpanAttributes.HTTP_TARGET: "/path/to/resource?parameter1=value1&parameter1=value2&parameter2=value",
-                SpanAttributes.NET_HOST_NAME: "id.execute-api.us-east-1.amazonaws.com",
-                SpanAttributes.HTTP_USER_AGENT: "agent",
-            },
-        )
 
     def test_lambda_handles_list_event(self):
         AwsLambdaInstrumentor().instrument()
@@ -490,31 +457,6 @@ class TestAwsLambdaInstrumentor(TestBase):
         # instrumentor re-raises the exception
         with self.assertRaises(Exception):
             mock_execute_lambda()
-
-        spans = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(spans), 1)
-        span = spans[0]
-        self.assertEqual(span.status.status_code, StatusCode.ERROR)
-        self.assertEqual(len(span.events), 1)
-        event = span.events[0]
-        self.assertEqual(event.name, "exception")
-
-        exc_env_patch.stop()
-
-    def test_lambda_handles_handler_exception_with_api_gateway_proxy_event(
-        self,
-    ):
-        exc_env_patch = mock.patch.dict(
-            "os.environ",
-            {_HANDLER: "tests.mocks.lambda_function.handler_exc"},
-        )
-        exc_env_patch.start()
-        AwsLambdaInstrumentor().instrument()
-        # instrumentor re-raises the exception
-        with self.assertRaises(Exception):
-            mock_execute_lambda(
-                {"requestContext": {"http": {"method": "GET"}}}
-            )
 
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
@@ -575,3 +517,197 @@ class TestAwsLambdaInstrumentor(TestBase):
             ).load(),
             AwsLambdaInstrumentor,
         )
+
+
+class TestAwsLambdaInstrumentorMocks(TestAwsLambdaInstrumentorBase):
+    def test_api_gateway_proxy_event_sets_attributes(self):
+        handler_patch = mock.patch.dict(
+            "os.environ",
+            {_HANDLER: "tests.mocks.lambda_function.rest_api_handler"},
+        )
+        handler_patch.start()
+
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_PROXY_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+        self.assertSpanHasAttributes(
+            span,
+            {
+                SpanAttributes.FAAS_TRIGGER: "http",
+                SpanAttributes.HTTP_METHOD: "POST",
+                SpanAttributes.HTTP_ROUTE: "/{proxy+}",
+                SpanAttributes.HTTP_TARGET: "/{proxy+}?foo=bar",
+                SpanAttributes.NET_HOST_NAME: "1234567890.execute-api.us-east-1.amazonaws.com",
+                SpanAttributes.HTTP_USER_AGENT: "Custom User Agent String",
+                SpanAttributes.HTTP_SCHEME: "https",
+                SpanAttributes.HTTP_STATUS_CODE: 200,
+            },
+        )
+
+    def test_api_gateway_http_api_proxy_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_API_GATEWAY_HTTP_API_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+        self.assertSpanHasAttributes(
+            span,
+            {
+                SpanAttributes.FAAS_TRIGGER: "http",
+                SpanAttributes.HTTP_METHOD: "POST",
+                SpanAttributes.HTTP_ROUTE: "/path/to/resource",
+                SpanAttributes.HTTP_TARGET: "/path/to/resource?parameter1=value1&parameter1=value2&parameter2=value",
+                SpanAttributes.NET_HOST_NAME: "id.execute-api.us-east-1.amazonaws.com",
+                SpanAttributes.HTTP_USER_AGENT: "agent",
+            },
+        )
+
+    def test_alb_conventional_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_ALB_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+        self.assertSpanHasAttributes(
+            span,
+            {
+                SpanAttributes.FAAS_TRIGGER: "http",
+                SpanAttributes.HTTP_METHOD: "GET",
+            },
+        )
+
+    def test_alb_multi_value_header_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_ALB_MULTI_VALUE_HEADER_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+        self.assertSpanHasAttributes(
+            span,
+            {
+                SpanAttributes.FAAS_TRIGGER: "http",
+                SpanAttributes.HTTP_METHOD: "GET",
+            },
+        )
+
+    def test_dynamo_db_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_DYNAMO_DB_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.CONSUMER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+    def test_s3_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_S3_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.CONSUMER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+    def test_sns_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_SNS_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.CONSUMER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+    def test_sqs_event_sets_attributes(self):
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_SQS_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.kind, SpanKind.CONSUMER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+    def test_lambda_handles_handler_exception_with_api_gateway_proxy_event(
+        self,
+    ):
+        exc_env_patch = mock.patch.dict(
+            "os.environ",
+            {_HANDLER: "tests.mocks.lambda_function.handler_exc"},
+        )
+        exc_env_patch.start()
+        AwsLambdaInstrumentor().instrument()
+
+        # instrumentor re-raises the exception
+        with self.assertRaises(Exception):
+            mock_execute_lambda(
+                {"requestContext": {"http": {"method": "GET"}}}
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span, *_ = spans
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        self.assertEqual(len(span.events), 1)
+
+        event, *_ = span.events
+        self.assertEqual(event.name, "exception")
+
+        exc_env_patch.stop()


### PR DESCRIPTION
# Description

Split from: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2585

Increases the test coverage of instrumentation-aws-lambda in preparation for adding support for ALB events (and eventual refactoring)

## Type of change
- [x] Increase test coverage

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Sample events have been added for all types of events that the instrumentation supports.
- Unit test coverage has been increased.

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] ~~Changelogs have been updated~~
  - No changes to the instrumentation have been made. Tests only.
- [x] Unit tests have been added
- [x] ~~Documentation has been updated~~
  - No changes to the instrumentation have been made. Tests only. 
