### PR TITLE
instrumentation/grpc: bump zipp to 3.19.2 in test requirements

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/test-requirements-1.txt
+++ b/instrumentation/opentelemetry-instrumentation-grpc/test-requirements-1.txt
@@ -15,6 +15,6 @@ pytest-benchmark==4.0.0
 tomli==2.0.1
 typing_extensions==4.9.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-instrumentation
 -e instrumentation/opentelemetry-instrumentation-grpc


### PR DESCRIPTION
# Description

Bump zipp to 3.19.2 to solve dependabot alert