### PR TITLE
Loosen fastapi-slim version bound to be like the one for fastapi

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -19,7 +19,7 @@
 | [opentelemetry-instrumentation-django](./opentelemetry-instrumentation-django) | django >= 1.10 | Yes | experimental
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 6.0 | No | experimental
 | [opentelemetry-instrumentation-falcon](./opentelemetry-instrumentation-falcon) | falcon >= 1.4.1, < 4.0.0 | Yes | experimental
-| [opentelemetry-instrumentation-fastapi](./opentelemetry-instrumentation-fastapi) | fastapi ~= 0.58,fastapi-slim ~= 0.111.0 | Yes | migration
+| [opentelemetry-instrumentation-fastapi](./opentelemetry-instrumentation-fastapi) | fastapi ~= 0.58,fastapi-slim ~= 0.111 | Yes | migration
 | [opentelemetry-instrumentation-flask](./opentelemetry-instrumentation-flask) | flask >= 1.0 | Yes | migration
 | [opentelemetry-instrumentation-grpc](./opentelemetry-instrumentation-grpc) | grpcio ~= 1.27 | No | experimental
 | [opentelemetry-instrumentation-httpx](./opentelemetry-instrumentation-httpx) | httpx >= 0.18.0 | No | migration

--- a/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 instruments = [
     "fastapi ~= 0.58",
-    "fastapi-slim ~= 0.111.0",
+    "fastapi-slim ~= 0.111",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/package.py
@@ -14,7 +14,7 @@
 
 
 _fastapi = "fastapi ~= 0.58"
-_fastapi_slim = "fastapi-slim ~= 0.111.0"
+_fastapi_slim = "fastapi-slim ~= 0.111"
 
 _instruments = (_fastapi, _fastapi_slim)
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -85,7 +85,7 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-fastapi==0.48b0.dev",
     },
     {
-        "library": "fastapi-slim ~= 0.111.0",
+        "library": "fastapi-slim ~= 0.111",
         "instrumentation": "opentelemetry-instrumentation-fastapi==0.48b0.dev",
     },
     {


### PR DESCRIPTION
# Description

See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2774, which this would fix, for a discussion of the issue.

> If the original `fastapi` behavior is intended, then `.0` should be dropped from the `fastapi-slim` version specification.
> 
> If the new `fastapi-slim` behavior is intended, then `.0` should be added to the `fastapi` version specifications, and I’ll drop the FastAPI instrumentations from the Fedora package as I have needed to do for other instrumentations that require old versions of the instrumented libraries.

This PR implements the first option above.

Fixes #2774

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I did not run any tests.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated **N/A, I think?**
- [ ] Unit tests have been added **N/A**
- [x] Documentation has been updated
