### PR TITLE
Audit and test opentelemetry-instrumentation-fastapi NoOpTracerProvider

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -1069,6 +1069,18 @@ class TestAutoInstrumentation(TestBaseAutoFastAPI):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 3)
 
+    def test_no_op_tracer_provider(self):
+        self._instrumentor.uninstrument()
+        self._instrumentor.instrument(
+            tracer_provider=trace.NoOpTracerProvider()
+        )
+
+        app = self._create_fastapi_app()
+        client = TestClient(app)
+        client.get("/foobar")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
     def tearDown(self):
         self._instrumentor.uninstrument()
         super().tearDown()


### PR DESCRIPTION
# Description

Add test for Fastapi using NoOpTracerProvider
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/982


## Type of change

Please delete options that are not relevant.


# How Has This Been Tested?

Instrument the library using a NoOpTracerProvider. The test validates that no spans are being produced.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
