### PR TITLE
Sort labelset to ensure compatibility with thanos-receive

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -258,7 +258,7 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         timeseries = []
         for labels, samples in sample_sets.items():
             ts = TimeSeries()
-            for label_name, label_value in chain(resource_labels, labels):
+            for label_name, label_value in sorted(chain(resource_labels, labels)):
                 # Previous implementation did not str() the names...
                 ts.labels.append(self._label(label_name, str(label_value)))
             for value, timestamp in samples:


### PR DESCRIPTION
We're using thanos-receive which requires labels to be sorted lexicographically. Trying to submit a metric without first sorting the label list results in the write request being rejected, yielding the message `Out of order labels in the label set`.

This PR fixes this behaviour. 

Please note I only tested this on thanos-remote, could use testing on other implementations.