### PR TITLE
Ensure async generators are awaited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2589](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2589))
 - `opentelemetry-instrumentation-celery` propagates baggage
   ([#2385](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2385))
+- `opentelemetry-instrumentation-asyncio` Fixes async generator coroutines not being awaited
+  ([#2792](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2792))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 

--- a/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/__init__.py
@@ -262,7 +262,7 @@ class AsyncioInstrumentor(BaseInstrumentor):
 
     async def trace_coroutine(self, coro):
         if not hasattr(coro, "__name__"):
-            return coro
+            return await coro
         start = default_timer()
         attr = {
             "type": "coroutine",

--- a/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/tests/test_asyncio_anext.py
@@ -43,19 +43,23 @@ class TestAsyncioAnext(TestBase):
 
     # Asyncio anext() does not have __name__ attribute, which is used to determine if the coroutine should be traced.
     # This test is to ensure that the instrumentation does not break when the coroutine does not have __name__ attribute.
+    # Additionally, ensure the coroutine is actually awaited.
     @skipIf(
         sys.version_info < (3, 10), "anext is only available in Python 3.10+"
     )
     def test_asyncio_anext(self):
         async def main():
             async def async_gen():
-                for it in range(2):
+                # nothing special about this range other than to avoid returning a zero
+                # from a function named 'main' (which might cause confusion about intent)
+                for it in range(2, 4):
                     yield it
 
             async_gen_instance = async_gen()
             agen = anext(async_gen_instance)
-            await asyncio.create_task(agen)
+            return await asyncio.create_task(agen)
 
-        asyncio.run(main())
+        ret = asyncio.run(main())
+        self.assertEqual(ret, 2)  # first iteration from range()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)


### PR DESCRIPTION
# Description

This change simply `await`s coroutines that are not being processed; it basically corrects #2541.  There is no new functionality and no new dependencies.

Fixes #2791

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The reproduction in #2791 (self-explanatory) and my own (proprietary) application

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
