### PR TITLE
Fix psycopg2 instrument issue

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -235,7 +235,7 @@ class TestPostgresqlIntegration(TestBase):
     # pylint: disable=unused-argument
     def test_uninstrument_connection_with_instrument_connection(self):
         cnx = psycopg2.connect(database="test")
-        Psycopg2Instrumentor().instrument_connection(cnx)
+        cnx = Psycopg2Instrumentor().instrument_connection(cnx)
         query = "SELECT * FROM test"
         cursor = cnx.cursor()
         cursor.execute(query)


### PR DESCRIPTION
# Description

Currently there is issue with psycopg2, the instrumentation can not work as expected. Update the codes based on mysql and sqlite3 to resolve the issue. Will check the two properties _otel_orig_cursor_factory and _is_instrumented_by_opentelemetry in subsequent issue later.
Fix one issue in unit test, assign instrumented connection to cnx.

Fixes #2522

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with below command to run unit test
tox -e py310-test-opentelemetry-instrumentation-psycopg2

Tested traces with local environment and the traces are displayed without error.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
