### PR TITLE
bump aiohttp verison to 3.10.2 in test-requirements

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.4
+aiohttp==3.10.2
 aiosignal==1.3.1
 asgiref==3.7.2
 async-timeout==4.0.3

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -468,7 +468,7 @@ class TestAioHttpIntegration(TestBase):
             [
                 (
                     "GET",
-                    (StatusCode.ERROR, "ServerTimeoutError"),
+                    (StatusCode.ERROR, "SocketTimeoutError"),
                     {
                         SpanAttributes.HTTP_METHOD: "GET",
                         SpanAttributes.HTTP_URL: f"http://{host}:{port}/test_timeout",

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/test-requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.4
+aiohttp==3.10.2
 aiosignal==1.3.1
 asgiref==3.7.2
 async-timeout==4.0.3


### PR DESCRIPTION
# Description
Bump aiohttp version to 3.10.2 in test requirements to fix dependabot alerts, also fix tests for this version which nows separates timeout error in two types:  `ConnectionTimeoutError` and `SocketTimeoutError`
> There shouldn't be any change, since ConnectionTimeoutError and SocketTimeoutError both inherit from ServerTimeoutError, users can either catch in general ServerTimeoutError, or if they need to, they can now catch the specific timeouts. 