### PR TITLE
fix for Audit and test opentelemetry-instrumentation-jinja2 #978

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -225,7 +225,7 @@ class TestJinja2Instrumentor(TestBase):
         Jinja2Instrumentor().uninstrument()
         Jinja2Instrumentor().instrument(
             tracer_provider=trace_api.NoOpTracerProvider()
-            )
+        )
         template = jinja2.environment.Template("Hello {{name}}!")
         self.assertEqual(template.render(name="Jinja"), "Hello Jinja!")
         spans = self.memory_exporter.get_finished_spans()

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -219,3 +219,14 @@ class TestJinja2Instrumentor(TestBase):
         self.assertEqual(len(spans), 0)
 
         Jinja2Instrumentor().instrument()
+    
+    def test_no_op_tracer_provider(self):
+        self.memory_exporter.clear()
+        Jinja2Instrumentor().uninstrument()
+        Jinja2Instrumentor().instrument(
+            tracer_provider=trace_api.NoOpTracerProvider()
+            )
+        template = jinja2.environment.Template("Hello {{name}}!")
+        self.assertEqual(template.render(name="Jinja"), "Hello Jinja!")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -219,7 +219,7 @@ class TestJinja2Instrumentor(TestBase):
         self.assertEqual(len(spans), 0)
 
         Jinja2Instrumentor().instrument()
-    
+
     def test_no_op_tracer_provider(self):
         self.memory_exporter.clear()
         Jinja2Instrumentor().uninstrument()


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for jinja2 instrumentation.

Fixes #978 

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- tox -e py311-test-instrumentation-jinja2

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
