### PR TITLE
Divided proc_cpu_percent by 100 to get value between 0 and 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- `opentelemetry-instrumentation-system-metrics` fix `process.runtime.cpu.utilization` values to be shown in range of 0 to 1
+  ([2812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2812))
 - `opentelemetry-instrumentation-fastapi` fix `fastapi` auto-instrumentation by removing `fastapi-slim` support, `fastapi-slim` itself is discontinued from maintainers
   ([2783](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2783))
 - `opentelemetry-instrumentation-aws-lambda` Avoid exception when a handler is not present.

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -729,7 +729,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
         """Observer callback for runtime CPU utilization"""
         proc_cpu_percent = self._proc.cpu_percent()
         yield Observation(
-            proc_cpu_percent,
+            proc_cpu_percent / 100,
             self._runtime_cpu_utilization_labels.copy(),
         )
 

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -837,7 +837,7 @@ class TestSystemMetrics(TestBase):
 
     @mock.patch("psutil.Process.cpu_percent")
     def test_runtime_cpu_percent(self, mock_process_cpu_percent):
-        mock_process_cpu_percent.configure_mock(**{"return_value": 0.42})
+        mock_process_cpu_percent.configure_mock(**{"return_value": 42})
 
         expected = [_SystemMetricsResult({}, 0.42)]
         self._test_metrics(

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -837,9 +837,9 @@ class TestSystemMetrics(TestBase):
 
     @mock.patch("psutil.Process.cpu_percent")
     def test_runtime_cpu_percent(self, mock_process_cpu_percent):
-        mock_process_cpu_percent.configure_mock(**{"return_value": 42})
+        mock_process_cpu_percent.configure_mock(**{"return_value": 0.42})
 
-        expected = [_SystemMetricsResult({}, 42)]
+        expected = [_SystemMetricsResult({}, 0.42)]
         self._test_metrics(
             f"process.runtime.{self.implementation}.cpu.utilization", expected
         )


### PR DESCRIPTION
# Description

`process.runtime.cpu.utilization` should record value between 0 and 1 as per [OTEL spec](https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-naming).

`psutil` reports percentage value for cpu utilization. This MR converts CPU utilization from percentage to decimal between 0.0 and 1.0.

Fixes #2810 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py::TestSystemMetrics::test_runtime_cpu_percent PASSED      

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
