### PR TITLE
Fix `http.host` and `net.peer.ip` new http semconv mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Handle http client exception and record exception info into span
   ([#2563](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2563))
 - `opentelemetry-instrumentation` fix `http.host` new http semantic convention mapping to depend on `kind` of span
-  ([2814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2814))
+  ([#2814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2814))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2792](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2792))
 - `opentelemetry-instrumentation-tornado` Handle http client exception and record exception info into span
   ([#2563](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2563))
+- `opentelemetry-instrumentation` fix `http.host` new http semantic convention mapping to depend on `kind` of span
+  ([2783](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2783))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-tornado` Handle http client exception and record exception info into span
   ([#2563](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2563))
 - `opentelemetry-instrumentation` fix `http.host` new http semantic convention mapping to depend on `kind` of span
-  ([2783](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2783))
+  ([2814](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2814))
 
 ## Version 1.26.0/0.47b0 (2024-07-23)
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -218,7 +218,7 @@ from opentelemetry.instrumentation._semconv import (
     _set_http_host_server,
     _set_http_method,
     _set_http_net_host_port,
-    _set_http_peer_ip,
+    _set_http_peer_ip_server,
     _set_http_peer_port_server,
     _set_http_scheme,
     _set_http_target,
@@ -380,7 +380,7 @@ def collect_request_attributes(
         _set_http_user_agent(result, http_user_agent[0], sem_conv_opt_in_mode)
 
     if "client" in scope and scope["client"] is not None:
-        _set_http_peer_ip(result, scope.get("client")[0], sem_conv_opt_in_mode)
+        _set_http_peer_ip_server(result, scope.get("client")[0], sem_conv_opt_in_mode)
         _set_http_peer_port_server(
             result, scope.get("client")[1], sem_conv_opt_in_mode
         )

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -215,7 +215,7 @@ from opentelemetry.instrumentation._semconv import (
     _server_duration_attrs_new,
     _server_duration_attrs_old,
     _set_http_flavor_version,
-    _set_http_host,
+    _set_http_host_server,
     _set_http_method,
     _set_http_net_host_port,
     _set_http_peer_ip,
@@ -342,7 +342,7 @@ def collect_request_attributes(
     if scheme:
         _set_http_scheme(result, scheme, sem_conv_opt_in_mode)
     if server_host:
-        _set_http_host(result, server_host, sem_conv_opt_in_mode)
+        _set_http_host_server(result, server_host, sem_conv_opt_in_mode)
     if port:
         _set_http_net_host_port(result, port, sem_conv_opt_in_mode)
     flavor = scope.get("http_version")

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -380,7 +380,9 @@ def collect_request_attributes(
         _set_http_user_agent(result, http_user_agent[0], sem_conv_opt_in_mode)
 
     if "client" in scope and scope["client"] is not None:
-        _set_http_peer_ip_server(result, scope.get("client")[0], sem_conv_opt_in_mode)
+        _set_http_peer_ip_server(
+            result, scope.get("client")[0], sem_conv_opt_in_mode
+        )
         _set_http_peer_port_server(
             result, scope.get("client")[1], sem_conv_opt_in_mode
         )

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -53,9 +53,7 @@ from opentelemetry.semconv.attributes.http_attributes import (
 from opentelemetry.semconv.attributes.network_attributes import (
     NETWORK_PROTOCOL_VERSION,
 )
-from opentelemetry.semconv.attributes.server_attributes import (
-    SERVER_PORT,
-)
+from opentelemetry.semconv.attributes.server_attributes import SERVER_PORT
 from opentelemetry.semconv.attributes.url_attributes import (
     URL_PATH,
     URL_QUERY,

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -1086,7 +1086,6 @@ class TestAsgiApplication(AsgiTestBase):
                     SpanAttributes.HTTP_METHOD: self.scope["method"],
                     URL_SCHEME: self.scope["scheme"],
                     SERVER_PORT: self.scope["server"][1],
-                    SERVER_ADDRESS: self.scope["server"][0],
                     NETWORK_PROTOCOL_VERSION: self.scope["http_version"],
                     URL_PATH: self.scope["path"],
                     CLIENT_ADDRESS: self.scope["client"][0],
@@ -1629,7 +1628,6 @@ class TestAsgiAttributes(unittest.TestCase):
             attrs,
             {
                 HTTP_REQUEST_METHOD: "GET",
-                SERVER_ADDRESS: "127.0.0.1",
                 URL_PATH: "/",
                 URL_QUERY: "foo=bar",
                 SERVER_PORT: 80,
@@ -1665,7 +1663,6 @@ class TestAsgiAttributes(unittest.TestCase):
                 SpanAttributes.NET_PEER_IP: "127.0.0.1",
                 SpanAttributes.NET_PEER_PORT: 32767,
                 HTTP_REQUEST_METHOD: "GET",
-                SERVER_ADDRESS: "127.0.0.1",
                 URL_PATH: "/",
                 URL_QUERY: "foo=bar",
                 SERVER_PORT: 80,
@@ -1690,7 +1687,7 @@ class TestAsgiAttributes(unittest.TestCase):
             _HTTPStabilityMode.HTTP,
         )
         self.assertEqual(attrs[URL_SCHEME], "http")
-        self.assertEqual(attrs[SERVER_ADDRESS], "127.0.0.1")
+        self.assertEqual(attrs[CLIENT_ADDRESS], "127.0.0.1")
         self.assertEqual(attrs[URL_PATH], "/")
         self.assertEqual(attrs[URL_QUERY], "foo=bar")
 
@@ -1704,7 +1701,7 @@ class TestAsgiAttributes(unittest.TestCase):
             attrs[SpanAttributes.HTTP_URL], "http://127.0.0.1/?foo=bar"
         )
         self.assertEqual(attrs[URL_SCHEME], "http")
-        self.assertEqual(attrs[SERVER_ADDRESS], "127.0.0.1")
+        self.assertEqual(attrs[CLIENT_ADDRESS], "127.0.0.1")
         self.assertEqual(attrs[URL_PATH], "/")
         self.assertEqual(attrs[URL_QUERY], "foo=bar")
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -406,7 +406,6 @@ class TestAsgiApplication(AsgiTestBase):
                     HTTP_REQUEST_METHOD: "GET",
                     URL_SCHEME: "http",
                     SERVER_PORT: 80,
-                    SERVER_ADDRESS: "127.0.0.1",
                     NETWORK_PROTOCOL_VERSION: "1.0",
                     URL_PATH: "/",
                     CLIENT_ADDRESS: "127.0.0.1",

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -54,7 +54,6 @@ from opentelemetry.semconv.attributes.network_attributes import (
     NETWORK_PROTOCOL_VERSION,
 )
 from opentelemetry.semconv.attributes.server_attributes import (
-    SERVER_ADDRESS,
     SERVER_PORT,
 )
 from opentelemetry.semconv.attributes.url_attributes import (

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -685,6 +685,7 @@ class TestAsgiApplication(AsgiTestBase):
         def update_expected_server(expected):
             expected[3]["attributes"].update(
                 {
+                    CLIENT_ADDRESS: "0.0.0.0",
                     SERVER_PORT: 80,
                 }
             )
@@ -711,6 +712,7 @@ class TestAsgiApplication(AsgiTestBase):
                     SpanAttributes.HTTP_HOST: "0.0.0.0",
                     SpanAttributes.NET_HOST_PORT: 80,
                     SpanAttributes.HTTP_URL: "http://0.0.0.0/",
+                    CLIENT_ADDRESS: "0.0.0.0",
                     SERVER_PORT: 80,
                 }
             )

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -686,7 +686,6 @@ class TestAsgiApplication(AsgiTestBase):
         def update_expected_server(expected):
             expected[3]["attributes"].update(
                 {
-                    SERVER_ADDRESS: "0.0.0.0",
                     SERVER_PORT: 80,
                 }
             )
@@ -713,7 +712,6 @@ class TestAsgiApplication(AsgiTestBase):
                     SpanAttributes.HTTP_HOST: "0.0.0.0",
                     SpanAttributes.NET_HOST_PORT: 80,
                     SpanAttributes.HTTP_URL: "http://0.0.0.0/",
-                    SERVER_ADDRESS: "0.0.0.0",
                     SERVER_PORT: 80,
                 }
             )

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -442,7 +442,6 @@ class TestAsgiApplication(AsgiTestBase):
                     HTTP_REQUEST_METHOD: "GET",
                     URL_SCHEME: "http",
                     SERVER_PORT: 80,
-                    SERVER_ADDRESS: "127.0.0.1",
                     NETWORK_PROTOCOL_VERSION: "1.0",
                     URL_PATH: "/",
                     CLIENT_ADDRESS: "127.0.0.1",
@@ -1001,7 +1000,6 @@ class TestAsgiApplication(AsgiTestBase):
                 "attributes": {
                     URL_SCHEME: self.scope["scheme"],
                     SERVER_PORT: self.scope["server"][1],
-                    SERVER_ADDRESS: self.scope["server"][0],
                     NETWORK_PROTOCOL_VERSION: self.scope["http_version"],
                     URL_PATH: self.scope["path"],
                     CLIENT_ADDRESS: self.scope["client"][0],

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -202,7 +202,7 @@ from opentelemetry.instrumentation._semconv import (
     _OpenTelemetrySemanticConventionStability,
     _OpenTelemetryStabilitySignalType,
     _report_new,
-    _set_http_host,
+    _set_http_host_client,
     _set_http_method,
     _set_http_network_protocol_version,
     _set_http_peer_port_client,
@@ -342,7 +342,7 @@ def _apply_request_client_attributes_to_span(
     if _report_new(semconv):
         if url.host:
             # http semconv transition: http.host -> server.address
-            _set_http_host(span_attributes, url.host, semconv)
+            _set_http_host_client(span_attributes, url.host, semconv)
             # http semconv transition: net.sock.peer.addr -> network.peer.address
             span_attributes[NETWORK_PEER_ADDRESS] = url.host
         if url.port:

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -92,7 +92,7 @@ from opentelemetry.instrumentation._semconv import (
     _OpenTelemetryStabilitySignalType,
     _report_new,
     _report_old,
-    _set_http_host,
+    _set_http_host_client,
     _set_http_method,
     _set_http_net_peer_name_client,
     _set_http_network_protocol_version,
@@ -212,14 +212,14 @@ def _instrument(
                         metric_labels, parsed_url.scheme, sem_conv_opt_in_mode
                     )
             if parsed_url.hostname:
-                _set_http_host(
+                _set_http_host_client(
                     metric_labels, parsed_url.hostname, sem_conv_opt_in_mode
                 )
                 _set_http_net_peer_name_client(
                     metric_labels, parsed_url.hostname, sem_conv_opt_in_mode
                 )
                 if _report_new(sem_conv_opt_in_mode):
-                    _set_http_host(
+                    _set_http_host_client(
                         span_attributes,
                         parsed_url.hostname,
                         sem_conv_opt_in_mode,

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -491,7 +491,9 @@ def _set_metric_attributes(
     sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
 ) -> None:
 
-    _set_http_host_client(metric_attributes, instance.host, sem_conv_opt_in_mode)
+    _set_http_host_client(
+        metric_attributes, instance.host, sem_conv_opt_in_mode
+    )
     _set_http_scheme(metric_attributes, instance.scheme, sem_conv_opt_in_mode)
     _set_http_method(
         metric_attributes,

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -103,7 +103,7 @@ from opentelemetry.instrumentation._semconv import (
     _OpenTelemetryStabilitySignalType,
     _report_new,
     _report_old,
-    _set_http_host,
+    _set_http_host_client,
     _set_http_method,
     _set_http_net_peer_name_client,
     _set_http_network_protocol_version,
@@ -491,7 +491,7 @@ def _set_metric_attributes(
     sem_conv_opt_in_mode: _HTTPStabilityMode = _HTTPStabilityMode.DEFAULT,
 ) -> None:
 
-    _set_http_host(metric_attributes, instance.host, sem_conv_opt_in_mode)
+    _set_http_host_client(metric_attributes, instance.host, sem_conv_opt_in_mode)
     _set_http_scheme(metric_attributes, instance.scheme, sem_conv_opt_in_mode)
     _set_http_method(
         metric_attributes,

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -231,7 +231,7 @@ from opentelemetry.instrumentation._semconv import (
     _set_http_net_host,
     _set_http_net_host_port,
     _set_http_net_peer_name_server,
-    _set_http_peer_ip,
+    _set_http_peer_ip_server,
     _set_http_peer_port_server,
     _set_http_scheme,
     _set_http_target,
@@ -360,7 +360,7 @@ def collect_request_attributes(
 
     remote_addr = environ.get("REMOTE_ADDR")
     if remote_addr:
-        _set_http_peer_ip(result, remote_addr, sem_conv_opt_in_mode)
+        _set_http_peer_ip_server(result, remote_addr, sem_conv_opt_in_mode)
 
     peer_port = environ.get("REMOTE_PORT")
     if peer_port:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -252,6 +252,22 @@ def _set_http_scheme(result, scheme, sem_conv_opt_in_mode):
         set_string_attribute(result, URL_SCHEME, scheme)
 
 
+def _set_http_flavor_version(result, version, sem_conv_opt_in_mode):
+    if _report_old(sem_conv_opt_in_mode):
+        set_string_attribute(result, SpanAttributes.HTTP_FLAVOR, version)
+    if _report_new(sem_conv_opt_in_mode):
+        set_string_attribute(result, NETWORK_PROTOCOL_VERSION, version)
+
+
+def _set_http_user_agent(result, user_agent, sem_conv_opt_in_mode):
+    if _report_old(sem_conv_opt_in_mode):
+        set_string_attribute(
+            result, SpanAttributes.HTTP_USER_AGENT, user_agent
+        )
+    if _report_new(sem_conv_opt_in_mode):
+        set_string_attribute(result, USER_AGENT_ORIGINAL, user_agent)
+
+
 # Client
 
 
@@ -319,13 +335,14 @@ def _set_http_host_server(result, host, sem_conv_opt_in_mode):
 
 # net.peer.ip -> net.sock.peer.addr
 # https://github.com/open-telemetry/semantic-conventions/blob/40db676ca0e735aa84f242b5a0fb14e49438b69b/schemas/1.15.0#L18
-# net.sock.peer.addr -> client.socket.address for server spans (TODO) AND client.address
+# net.sock.peer.addr -> client.socket.address for server spans (TODO) AND client.address if missing
 # https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/CHANGELOG.md#v1210-2023-07-13
 # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#common-attributes-across-http-client-and-server-spans
 def _set_http_peer_ip_server(result, ip, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_IP, ip)
     if _report_new(sem_conv_opt_in_mode):
+        # if result.get(CLIENT_ADDRESS) is not None:
         set_string_attribute(result, CLIENT_ADDRESS, ip)
 
 
@@ -336,27 +353,11 @@ def _set_http_peer_port_server(result, port, sem_conv_opt_in_mode):
         set_int_attribute(result, CLIENT_PORT, port)
 
 
-def _set_http_user_agent(result, user_agent, sem_conv_opt_in_mode):
-    if _report_old(sem_conv_opt_in_mode):
-        set_string_attribute(
-            result, SpanAttributes.HTTP_USER_AGENT, user_agent
-        )
-    if _report_new(sem_conv_opt_in_mode):
-        set_string_attribute(result, USER_AGENT_ORIGINAL, user_agent)
-
-
 def _set_http_net_peer_name_server(result, name, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_NAME, name)
     if _report_new(sem_conv_opt_in_mode):
         set_string_attribute(result, CLIENT_ADDRESS, name)
-
-
-def _set_http_flavor_version(result, version, sem_conv_opt_in_mode):
-    if _report_old(sem_conv_opt_in_mode):
-        set_string_attribute(result, SpanAttributes.HTTP_FLAVOR, version)
-    if _report_new(sem_conv_opt_in_mode):
-        set_string_attribute(result, NETWORK_PROTOCOL_VERSION, version)
 
 
 def _set_status(

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -252,14 +252,13 @@ def _set_http_scheme(result, scheme, sem_conv_opt_in_mode):
         set_string_attribute(result, URL_SCHEME, scheme)
 
 
-def _set_http_host(result, host, sem_conv_opt_in_mode):
+# Client
+
+def _set_http_host_client(result, host, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.HTTP_HOST, host)
     if _report_new(sem_conv_opt_in_mode):
         set_string_attribute(result, SERVER_ADDRESS, host)
-
-
-# Client
 
 
 def _set_http_net_peer_name_client(result, peer_name, sem_conv_opt_in_mode):
@@ -285,7 +284,6 @@ def _set_http_network_protocol_version(result, version, sem_conv_opt_in_mode):
 
 # Server
 
-
 def _set_http_net_host(result, host, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_HOST_NAME, host)
@@ -310,6 +308,18 @@ def _set_http_target(result, target, path, query, sem_conv_opt_in_mode):
             set_string_attribute(result, URL_QUERY, query)
 
 
+def _set_http_host_server(result, host, sem_conv_opt_in_mode):
+    if _report_old(sem_conv_opt_in_mode):
+        set_string_attribute(result, SpanAttributes.HTTP_HOST, host)
+    if _report_new(sem_conv_opt_in_mode):
+        set_string_attribute(result, CLIENT_ADDRESS, host)
+
+
+# net.peer.ip -> net.sock.peer.addr
+# https://github.com/open-telemetry/semantic-conventions/blob/40db676ca0e735aa84f242b5a0fb14e49438b69b/schemas/1.15.0#L18
+# net.sock.peer.addr -> client.socket.address for server spans (TODO) AND client.address
+# https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/CHANGELOG.md#v1210-2023-07-13
+# https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#common-attributes-across-http-client-and-server-spans
 def _set_http_peer_ip(result, ip, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_IP, ip)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -254,6 +254,7 @@ def _set_http_scheme(result, scheme, sem_conv_opt_in_mode):
 
 # Client
 
+
 def _set_http_host_client(result, host, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.HTTP_HOST, host)
@@ -283,6 +284,7 @@ def _set_http_network_protocol_version(result, version, sem_conv_opt_in_mode):
 
 
 # Server
+
 
 def _set_http_net_host(result, host, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
@@ -320,7 +322,7 @@ def _set_http_host_server(result, host, sem_conv_opt_in_mode):
 # net.sock.peer.addr -> client.socket.address for server spans (TODO) AND client.address
 # https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/CHANGELOG.md#v1210-2023-07-13
 # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#common-attributes-across-http-client-and-server-spans
-def _set_http_peer_ip(result, ip, sem_conv_opt_in_mode):
+def _set_http_peer_ip_server(result, ip, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_IP, ip)
     if _report_new(sem_conv_opt_in_mode):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -342,7 +342,8 @@ def _set_http_peer_ip_server(result, ip, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_IP, ip)
     if _report_new(sem_conv_opt_in_mode):
-        if result.get(CLIENT_ADDRESS) is not None:
+        # Only populate if not already populated
+        if not result.get(CLIENT_ADDRESS):
             set_string_attribute(result, CLIENT_ADDRESS, ip)
 
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -342,8 +342,8 @@ def _set_http_peer_ip_server(result, ip, sem_conv_opt_in_mode):
     if _report_old(sem_conv_opt_in_mode):
         set_string_attribute(result, SpanAttributes.NET_PEER_IP, ip)
     if _report_new(sem_conv_opt_in_mode):
-        # if result.get(CLIENT_ADDRESS) is not None:
-        set_string_attribute(result, CLIENT_ADDRESS, ip)
+        if result.get(CLIENT_ADDRESS) is not None:
+            set_string_attribute(result, CLIENT_ADDRESS, ip)
 
 
 def _set_http_peer_port_server(result, port, sem_conv_opt_in_mode):


### PR DESCRIPTION
`http.host` old semantic convention should map to different new semantic convention depending on if they are `client` or `server` type telemetry. See [spec](https://github.com/open-telemetry/semantic-conventions/blob/v1.27.0/docs/attributes-registry/http.md#deprecated-http-attributes) for details.

Also updates `net.peer.ip` -> `client.address` logic to be conditional only if it doesn't exist already. This is outlined in the [migration doc](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#common-attributes-across-http-client-and-server-spans) net.peer.ip -> net.sock.peer.addr → network.peer.address.
