### PR TITLE
bootstrap: don't strip \n for last item on listing

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -119,7 +119,7 @@ def _find_installed_libraries():
 
 def _run_requirements():
     logger.setLevel(logging.ERROR)
-    print("\n".join(_find_installed_libraries()), end="")
+    print("\n".join(_find_installed_libraries()))
 
 
 def _run_install():

--- a/opentelemetry-instrumentation/tests/test_bootstrap.py
+++ b/opentelemetry-instrumentation/tests/test_bootstrap.py
@@ -77,7 +77,7 @@ class TestBootstrap(TestCase):
             bootstrap.run()
             self.assertEqual(
                 fake_out.getvalue(),
-                "\n".join(self.installed_libraries),
+                "\n".join(self.installed_libraries) + "\n",
             )
 
     @patch("sys.argv", ["bootstrap", "-a", "install"])


### PR DESCRIPTION
# Description

When printing available instrumentation libraries don't strip the new line from the last item.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py311-test-opentelemetry-instrumentation

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
