### PR TITLE
httpx: fix handling of async hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Added
+### Added
 
 - `opentelemetry-instrumentation-kafka-python` Instrument temporary fork, kafka-python-ng
   inside kafka-python's instrumentation
   ([#2537](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2537))
 
-## Breaking changes
+### Breaking changes
 
 - `opentelemetry-bootstrap` Remove `opentelemetry-instrumentation-aws-lambda` from the defaults instrumentations
   ([#2786](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2786))
 
-## Fixed
+### Fixed
 
 - `opentelemetry-instrumentation-httpx` fix handling of async hooks
   ([#2823](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2823))
 - `opentelemetry-instrumentation-system-metrics` fix `process.runtime.cpu.utilization` values to be shown in range of 0 to 1
-  ([2812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2812))
+  ([#2812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2812))
 - `opentelemetry-instrumentation-fastapi` fix `fastapi` auto-instrumentation by removing `fastapi-slim` support, `fastapi-slim` itself is discontinued from maintainers
-  ([2783](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2783))
+  ([#2783](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2783))
 - `opentelemetry-instrumentation-aws-lambda` Avoid exception when a handler is not present.
   ([#2750](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2750))
 - `opentelemetry-instrumentation-django` Fix regression - `http.target` re-added back to old semconv duration metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - `opentelemetry-instrumentation-httpx` fix handling of async hooks
-  ([2823](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2823))
+  ([#2823](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2823))
 - `opentelemetry-instrumentation-system-metrics` fix `process.runtime.cpu.utilization` values to be shown in range of 0 to 1
   ([2812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2812))
 - `opentelemetry-instrumentation-fastapi` fix `fastapi` auto-instrumentation by removing `fastapi-slim` support, `fastapi-slim` itself is discontinued from maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- `opentelemetry-instrumentation-httpx` fix handling of async hooks
+  ([2823](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2823))
 - `opentelemetry-instrumentation-system-metrics` fix `process.runtime.cpu.utilization` values to be shown in range of 0 to 1
   ([2812](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2812))
 - `opentelemetry-instrumentation-fastapi` fix `fastapi` auto-instrumentation by removing `fastapi-slim` support, `fastapi-slim` itself is discontinued from maintainers

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -192,6 +192,7 @@ API
 """
 import logging
 import typing
+from asyncio import iscoroutinefunction
 from types import TracebackType
 
 import httpx
@@ -731,15 +732,15 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         self._original_async_client = httpx.AsyncClient
         request_hook = kwargs.get("request_hook")
         response_hook = kwargs.get("response_hook")
-        async_request_hook = kwargs.get("async_request_hook", request_hook)
-        async_response_hook = kwargs.get("async_response_hook", response_hook)
+        async_request_hook = kwargs.get("async_request_hook")
+        async_response_hook = kwargs.get("async_response_hook")
         if callable(request_hook):
             _InstrumentedClient._request_hook = request_hook
-        if callable(async_request_hook):
+        if callable(async_request_hook) and iscoroutinefunction(async_request_hook):
             _InstrumentedAsyncClient._request_hook = async_request_hook
         if callable(response_hook):
             _InstrumentedClient._response_hook = response_hook
-        if callable(async_response_hook):
+        if callable(async_response_hook) and iscoroutinefunction(async_response_hook):
             _InstrumentedAsyncClient._response_hook = async_response_hook
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedClient._tracer_provider = tracer_provider

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -736,11 +736,15 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         async_response_hook = kwargs.get("async_response_hook")
         if callable(request_hook):
             _InstrumentedClient._request_hook = request_hook
-        if callable(async_request_hook) and iscoroutinefunction(async_request_hook):
+        if callable(async_request_hook) and iscoroutinefunction(
+            async_request_hook
+        ):
             _InstrumentedAsyncClient._request_hook = async_request_hook
         if callable(response_hook):
             _InstrumentedClient._response_hook = response_hook
-        if callable(async_response_hook) and iscoroutinefunction(async_response_hook):
+        if callable(async_response_hook) and iscoroutinefunction(
+            async_response_hook
+        ):
             _InstrumentedAsyncClient._response_hook = async_response_hook
         tracer_provider = kwargs.get("tracer_provider")
         _InstrumentedClient._tracer_provider = tracer_provider

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -780,13 +780,15 @@ class BaseTestCases:
             HTTPXClientInstrumentor().uninstrument()
 
         def test_response_hook(self):
-            response_hook_key = "async_response_hook" if asyncio.iscoroutinefunction(self.response_hook) else "response_hook"
-            response_hook_kwargs = {
-               response_hook_key: self.response_hook
-            }
+            response_hook_key = (
+                "async_response_hook"
+                if asyncio.iscoroutinefunction(self.response_hook)
+                else "response_hook"
+            )
+            response_hook_kwargs = {response_hook_key: self.response_hook}
             HTTPXClientInstrumentor().instrument(
                 tracer_provider=self.tracer_provider,
-                **response_hook_kwargs
+                **response_hook_kwargs,
             )
             client = self.create_client()
             result = self.perform_request(self.URL, client=client)
@@ -827,10 +829,12 @@ class BaseTestCases:
             HTTPXClientInstrumentor().uninstrument()
 
         def test_request_hook(self):
-            request_hook_key = "async_request_hook" if asyncio.iscoroutinefunction(self.request_hook) else "request_hook"
-            request_hook_kwargs = {
-               request_hook_key: self.request_hook
-            }
+            request_hook_key = (
+                "async_request_hook"
+                if asyncio.iscoroutinefunction(self.request_hook)
+                else "request_hook"
+            )
+            request_hook_kwargs = {request_hook_key: self.request_hook}
             HTTPXClientInstrumentor().instrument(
                 tracer_provider=self.tracer_provider,
                 **request_hook_kwargs,


### PR DESCRIPTION
# Description

Don't default to sync hooks for async hooks, then check that they are actually async. Needed to fix current tests that were testing only the sync path because tests are inherited from a base class :broken_heart: .

Fixes #2734
Supersedes #2794

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
