### PR TITLE
973 opentelemetry instrumentation psycopg2

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -271,14 +271,13 @@ class TestPostgresqlIntegration(TestBase):
         kwargs = event_mocked.call_args[1]
         self.assertEqual(kwargs["enable_commenter"], False)
 
-    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
-    def test_sqlcommenter_enabled_no_op_tracer(self, event_mocked):
-        cnx = psycopg2.connect(database="test")
+    def test_no_op_tracer_provider(self):
         Psycopg2Instrumentor().instrument(
-            tracer_provider=trace.NoOpTracerProvider(), enable_commenter=True
+            tracer_provider=trace.NoOpTracerProvider()
         )
-        query = "SELECT * FROM test"
+        cnx = psycopg2.connect(database="test")
         cursor = cnx.cursor()
+        query = "SELECT * FROM test"
         cursor.execute(query)
-        kwargs = event_mocked.call_args[1]
-        self.assertEqual(kwargs["enable_commenter"], True)
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -262,18 +262,6 @@ class TestPostgresqlIntegration(TestBase):
         self.assertEqual(kwargs["enable_commenter"], True)
 
     @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
-    def test_sqlcommenter_enabled_no_op_tracer(self, event_mocked):
-        tracer_provider = trace.NoOpTracerProvider()
-        trace.set_tracer_provider(tracer_provider)
-        cnx = psycopg2.connect(database="test")
-        Psycopg2Instrumentor().instrument(tracer_provider=tracer_provider, enable_commenter=True)
-        query = "SELECT * FROM test"
-        cursor = cnx.cursor()
-        cursor.execute(query)
-        kwargs = event_mocked.call_args[1]
-        self.assertEqual(kwargs["enable_commenter"], True)
-
-    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
     def test_sqlcommenter_disabled(self, event_mocked):
         cnx = psycopg2.connect(database="test")
         Psycopg2Instrumentor().instrument()
@@ -282,3 +270,15 @@ class TestPostgresqlIntegration(TestBase):
         cursor.execute(query)
         kwargs = event_mocked.call_args[1]
         self.assertEqual(kwargs["enable_commenter"], False)
+
+    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
+    def test_sqlcommenter_enabled_no_op_tracer(self, event_mocked):
+        cnx = psycopg2.connect(database="test")
+        Psycopg2Instrumentor().instrument(
+            tracer_provider=trace.NoOpTracerProvider(), enable_commenter=True
+        )
+        query = "SELECT * FROM test"
+        cursor = cnx.cursor()
+        cursor.execute(query)
+        kwargs = event_mocked.call_args[1]
+        self.assertEqual(kwargs["enable_commenter"], True)


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for psycogp2 instrumentation.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/973

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

tox -e py311-test-instrumentation-psycogp2

# How Has This Been Tested?

tox -e py311-test-instrumentation-psycogp2

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
