### PR TITLE
Update README.rst

### DIFF
--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -40,7 +40,7 @@ to figure out which instrumentation packages the user might want to install. By 
 prints out a list of the default and detected instrumentation packages that can be added to a
 requirements.txt file. It also supports installing the packages when run with
 :code:`--action=install` or :code:`-a install` flag. All default and detectable
-instrumentation packages are defined `here <https://github.com/flands/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py>`.
+instrumentation packages are defined `here <https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py>`.
 
 
 opentelemetry-instrument


### PR DESCRIPTION
The URL link is incorrect; it should be a repository in the open-telemetry account.

# Description

The URL link `https://github.com/flands/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py` should be `https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py`.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

It’s only a documentation update, so there is no need to test.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
