### PR TITLE
Fix instrument types in system metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2860](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2860))
 - `opentelemetry-instrumentation-aiokafka` Add instrumentor and auto instrumentation support for aiokafka
   ([#2082](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2082))
+- `opentelemetry-instrumentation-system-metrics` Fix instrument types in system metrics
+  ([#2865](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2865))
 
 ## Version 1.27.0/0.48b0 ()
 

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -331,11 +331,10 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
             )
 
         if "system.network.connections" in self._config:
-            self._meter.create_observable_up_down_counter(
+            self._meter.create_observable_gauge(
                 name="system.network.connections",
                 callbacks=[self._get_system_network_connections],
                 description="System network connections",
-                unit="connections",
             )
 
         if "system.thread_count" in self._config:
@@ -346,7 +345,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
             )
 
         if "process.runtime.memory" in self._config:
-            self._meter.create_observable_up_down_counter(
+            self._meter.create_observable_gauge(
                 name=f"process.runtime.{self._python_implementation}.memory",
                 callbacks=[self._get_runtime_memory],
                 description=f"Runtime {self._python_implementation} memory",
@@ -367,15 +366,14 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
                     "The process.runtime.gc_count metric won't be collected because the interpreter is PyPy"
                 )
             else:
-                self._meter.create_observable_counter(
+                self._meter.create_observable_gauge(
                     name=f"process.runtime.{self._python_implementation}.gc_count",
                     callbacks=[self._get_runtime_gc_count],
                     description=f"Runtime {self._python_implementation} GC count",
-                    unit="bytes",
                 )
 
         if "process.runtime.thread_count" in self._config:
-            self._meter.create_observable_up_down_counter(
+            self._meter.create_observable_gauge(
                 name=f"process.runtime.{self._python_implementation}.thread_count",
                 callbacks=[self._get_runtime_thread_count],
                 description="Runtime active threads count",
@@ -398,7 +396,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
             )
 
         if "process.open_file_descriptor.count" in self._config:
-            self._meter.create_observable_up_down_counter(
+            self._meter.create_observable_gauge(
                 name="process.open_file_descriptor.count",
                 callbacks=[self._get_open_file_descriptors],
                 description="Number of file descriptors in use by the process.",


### PR DESCRIPTION
# Description

This PR fixes the instrument types when creating the system metrics.

Metrics that are impacted:
* system.network.connections:
  Collected from [psutil.net_connections](https://psutil.readthedocs.io/en/latest/#psutil.net_connections) is a snapshot of the current state of network connections, thus should be delta and is not monotonic.
* process.runtime.cpython.gc_count
  Collected from [python gc](https://docs.python.org/3/library/gc.html) is the current collection counts,  thus should be delta and is not monotonic.
* process.runtime.cpython.memory
  Collected from [psutil.Process.memory_info](https://psutil.readthedocs.io/en/latest/#psutil.Process.memory_info) is a snapshot of the process’s memory usage at the time of the call, thus should be delta and is not monotonic.
* process.runtime.cpython.thread_count
  Collected from [psutil.Process.num_threads](https://psutil.readthedocs.io/en/latest/#psutil.Process.num_threads) is the number of threads currently used by this process (non cumulative).
* process.open_file_descriptor.count
  Collected from [psutil.Process.num_fds](https://psutil.readthedocs.io/en/latest/#psutil.Process.num_fds) is the number of file descriptors currently opened by this process (non cumulative).

Change the instrument types for the metrics above to `observable_gauge` for correction.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2861

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* Tested locally using console exporter configured with `delta` temporality for all the metric types.

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
