### PR TITLE
Add consistent import statement for URLLibInstrumentor

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-urllib/README.rst
@@ -29,6 +29,8 @@ The hooks can be configured as follows:
 
 .. code:: python
 
+    from opentelemetry.instrumentation.urllib import URLLibInstrumentor
+
     # `request_obj` is an instance of urllib.request.Request
     def request_hook(span, request_obj):
         pass

--- a/instrumentation/opentelemetry-instrumentation-urllib/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-urllib/README.rst
@@ -40,7 +40,7 @@ The hooks can be configured as follows:
     def response_hook(span, request_obj, response)
         pass
 
-    URLLibInstrumentor.instrument(
+    URLLibInstrumentor().instrument(
         request_hook=request_hook, response_hook=response_hook
     )
 

--- a/instrumentation/opentelemetry-instrumentation-urllib/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-urllib/README.rst
@@ -41,7 +41,7 @@ The hooks can be configured as follows:
         pass
 
     URLLibInstrumentor.instrument(
-        request_hook=request_hook, response_hook=response_hook)
+        request_hook=request_hook, response_hook=response_hook
     )
 
 Exclude lists


### PR DESCRIPTION
# Description

1. Adds the import statement to the top of the python script for consistent as show in other examples like: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-httpx#instrumenting-all-clients
2. Updates the example script to fix an extra `)` that was included

## Type of change

Please delete options that are not relevant.

- [ ] Documentation update

# How Has This Been Tested?

This change was found and tested as a part of a repo I am maintaining: https://github.com/Sage-Bionetworks/synapsePythonClient


# Does This PR Require a Core Repo Change?

- [X ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Changelogs have been updated (Not required per Contributing docs as behavior did not change)

