### PR TITLE
Auto Instrumentation sitecustomize: allowing unset PYTHONPATH

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -29,7 +29,7 @@ logger = getLogger(__name__)
 def initialize():
     # prevents auto-instrumentation of subprocesses if code execs another python process
     environ["PYTHONPATH"] = _python_path_without_directory(
-        environ["PYTHONPATH"], dirname(abspath(__file__)), pathsep
+        environ.get("PYTHONPATH", ""), dirname(abspath(__file__)), pathsep
     )
 
     try:


### PR DESCRIPTION
For edge cases where PYTHONPATH is not set at all

# Description

Allowing edge cases where PYTHONPATH is not set outside the `sitecustomize.py` file by providing a default empty string

Fixes # (issue)
None, I can create one

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Used locally in my own project by running this at start of file:
```
import opentelemetry.instrumentation.auto_instrumentation.sitecustomize
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
