### PR TITLE
tests: bump cryptography to 43.0.1 in test-requirements

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-boto/test-requirements.txt
@@ -5,7 +5,7 @@ botocore==1.34.44
 certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
-cryptography==42.0.5
+cryptography==43.0.1
 Deprecated==1.2.14
 docker==7.0.0
 idna==3.7

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements.txt
@@ -5,7 +5,7 @@ botocore==1.31.80
 certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
-cryptography==42.0.5
+cryptography==43.0.1
 Deprecated==1.2.14
 docker==7.0.0
 idna==3.7


### PR DESCRIPTION
# Description

To close 2 dependabot alerts