### PR TITLE
fix: shellcheck and docker-tests in CI

### DIFF
--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -46,13 +46,11 @@ jobs:
       - name: Checkout pull request
         run: git checkout ${% raw %}{{ github.event.pull_request.head.sha }}{% endraw %}
       {%- endif %}
-      {%- if job_data != "shellcheck" %}
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      {%- endif %}
 
       - name: Install tox
         run: pip install tox

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -122,6 +122,11 @@ jobs:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: Install tox
         run: pip install tox
 

--- a/tests/opentelemetry-docker-tests/tests/check_availability.py
+++ b/tests/opentelemetry-docker-tests/tests/check_availability.py
@@ -112,8 +112,8 @@ def check_redis_connection():
 
 def new_mssql_connection() -> pyodbc.Connection:
     connection = pyodbc.connect(
-        f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={MSSQL_HOST},"
-        f"{MSSQL_PORT};DATABASE=master;UID={MSSQL_USER};"
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={MSSQL_HOST},"
+        f"{MSSQL_PORT};DATABASE=master;UID={MSSQL_USER};TrustServerCertificate=yes;"
         f"PWD={MSSQL_PASSWORD};",
         autocommit=True,
     )

--- a/tests/opentelemetry-docker-tests/tests/check_availability.py
+++ b/tests/opentelemetry-docker-tests/tests/check_availability.py
@@ -112,9 +112,9 @@ def check_redis_connection():
 
 def new_mssql_connection() -> pyodbc.Connection:
     connection = pyodbc.connect(
-        f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={MSSQL_HOST},"
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={MSSQL_HOST},"
         f"{MSSQL_PORT};DATABASE=master;UID={MSSQL_USER};"
-        f"PWD={MSSQL_PASSWORD}",
+        f"PWD={MSSQL_PASSWORD};TrustServerCertificate=yes;",
         autocommit=True,
     )
     return connection

--- a/tests/opentelemetry-docker-tests/tests/check_availability.py
+++ b/tests/opentelemetry-docker-tests/tests/check_availability.py
@@ -112,9 +112,9 @@ def check_redis_connection():
 
 def new_mssql_connection() -> pyodbc.Connection:
     connection = pyodbc.connect(
-        f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={MSSQL_HOST},"
+        f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={MSSQL_HOST},"
         f"{MSSQL_PORT};DATABASE=master;UID={MSSQL_USER};"
-        f"PWD={MSSQL_PASSWORD};TrustServerCertificate=yes;",
+        f"PWD={MSSQL_PASSWORD};",
         autocommit=True,
     )
     return connection

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
@@ -29,6 +29,7 @@ MSSQL_CONFIG = {
     "password": os.getenv("TEST_MSSQL_PASSWORD", "yourStrong(!)Password"),
     "database": os.getenv("TEST_MSSQL_DATABASE", "opentelemetry-tests"),
     "driver": os.getenv("TEST_MSSQL_DRIVER", "ODBC+Driver+17+for+SQL+Server"),
+    "trusted_connection": os.getenv("TEST_MSSQL_TRUSTED_CONNECTION", "yes"),
 }
 
 
@@ -40,7 +41,7 @@ class MssqlConnectorTestCase(SQLAlchemyTestMixin):
     VENDOR = "mssql"
     SQL_DB = "opentelemetry-tests"
     ENGINE_ARGS = {
-        "url": "mssql+pyodbc://%(user)s:%(password)s@%(host)s:%(port)s/%(database)s?driver=%(driver)s"
+        "url": "mssql+pyodbc://%(user)s:%(password)s@%(host)s:%(port)s/%(database)s?driver=%(driver)s&TrustServerCertificate=%(trusted_connection)s"
         % MSSQL_CONFIG
     }
 

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
@@ -28,7 +28,7 @@ MSSQL_CONFIG = {
     "user": os.getenv("TEST_MSSQL_USER", "sa"),
     "password": os.getenv("TEST_MSSQL_PASSWORD", "yourStrong(!)Password"),
     "database": os.getenv("TEST_MSSQL_DATABASE", "opentelemetry-tests"),
-    "driver": os.getenv("TEST_MSSQL_DRIVER", "ODBC+Driver+17+for+SQL+Server"),
+    "driver": os.getenv("TEST_MSSQL_DRIVER", "ODBC+Driver+18+for+SQL+Server"),
     "trusted_connection": os.getenv("TEST_MSSQL_TRUSTED_CONNECTION", "yes"),
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1341,7 +1341,6 @@ commands =
   python {toxinidir}/.github/workflows/generate_workflows.py
 
 [testenv:shellcheck]
-basepython: python3
 
 commands_pre =
   sh -c "sudo apt update -y && sudo apt install --assume-yes shellcheck"

--- a/tox.ini
+++ b/tox.ini
@@ -1286,7 +1286,7 @@ changedir =
   tests/opentelemetry-docker-tests/tests
 
 commands_pre =
-  sh -c "sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev unixodbc"
+  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev unixodbc"
   python -c "import pyodbc; print(pyodbc.drivers())"
   pip install {env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api \
               {env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions \

--- a/tox.ini
+++ b/tox.ini
@@ -1341,6 +1341,7 @@ commands =
   python {toxinidir}/.github/workflows/generate_workflows.py
 
 [testenv:shellcheck]
+basepython: python3
 
 commands_pre =
   sh -c "sudo apt update -y && sudo apt install --assume-yes shellcheck"

--- a/tox.ini
+++ b/tox.ini
@@ -1286,7 +1286,7 @@ changedir =
   tests/opentelemetry-docker-tests/tests
 
 commands_pre =
-  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev unixodbc"
+  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev unixodbc"
   python -c "import pyodbc; print(pyodbc.drivers())"
   pip install {env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api \
               {env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions \

--- a/tox.ini
+++ b/tox.ini
@@ -1286,6 +1286,8 @@ changedir =
   tests/opentelemetry-docker-tests/tests
 
 commands_pre =
+  sh -c "sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev unixodbc"
+  python -c "import pyodbc; print(pyodbc.drivers())"
   pip install {env:CORE_REPO}\#egg=opentelemetry-api&subdirectory=opentelemetry-api \
               {env:CORE_REPO}\#egg=opentelemetry-semantic-conventions&subdirectory=opentelemetry-semantic-conventions \
               {env:CORE_REPO}\#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk \


### PR DESCRIPTION
It seems Ubuntu changed the image, which is breaking spellcheck and docker-tests. Fixing that.

See: https://github.com/open-telemetry/opentelemetry-python/actions/runs/11346063440/job/31554334634 and the Ci for the first commit in this PR