### PR TITLE
httpx: rewrite patching to use wrapt instead of subclassing client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2871](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2871))
 - `opentelemetry-instrumentation` Don't fail distro loading if instrumentor raises ImportError, instead skip them
   ([#2923](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2923))
+- `opentelemetry-instrumentation-httpx` Rewrote instrumentation to use wrapt instead of subclassing
+  ([#2909](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2909))
 
 ## Version 1.27.0/0.48b0 (2024-08-28)
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-instrumentation == 0.49b0.dev",
   "opentelemetry-semantic-conventions == 0.49b0.dev",
   "opentelemetry-util-http == 0.49b0.dev",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -934,7 +934,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
-                raise exception
+                raise exception.with_traceback(exception.__traceback__)
 
         return response
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=too-many-lines
 """
 Usage
 -----
@@ -785,13 +786,11 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         )
 
     def _uninstrument(self, **kwargs):
-        import httpx
-
         unwrap(httpx.HTTPTransport, "handle_request")
         unwrap(httpx.AsyncHTTPTransport, "handle_async_request")
 
-    def _handle_request_wrapper(
-        self,
+    @staticmethod
+    def _handle_request_wrapper(  # pylint: disable=too-many-locals
         wrapped,
         instance,
         args,
@@ -864,8 +863,8 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
 
         return response
 
-    async def _handle_async_request_wrapper(
-        self,
+    @staticmethod
+    async def _handle_async_request_wrapper(  # pylint: disable=too-many-locals
         wrapped,
         instance,
         args,
@@ -982,14 +981,14 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
             async_request_hook = request_hook
             request_hook = None
         else:
-            request_hook = request_hook
+            # request_hook already set
             async_request_hook = None
 
         if iscoroutinefunction(response_hook):
             async_response_hook = response_hook
             response_hook = None
         else:
-            response_hook = response_hook
+            # response_hook already set
             async_response_hook = None
 
         if hasattr(client._transport, "handle_request"):

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -738,10 +738,6 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
         self._async_request_hook = kwargs.get("async_request_hook")
         self._async_response_hook = kwargs.get("async_response_hook")
 
-        if getattr(self, "__instrumented", False):
-            print("already instrumented")
-            return
-
         _OpenTelemetrySemanticConventionStability._initialize()
         self._sem_conv_opt_in_mode = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
             _OpenTelemetryStabilitySignalType.HTTP,
@@ -763,8 +759,6 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
             "AsyncHTTPTransport.handle_async_request",
             self._handle_async_request_wrapper,
         )
-
-        self.__instrumented = True
 
     def _uninstrument(self, **kwargs):
         import httpx

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -734,8 +734,12 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 ``async_response_hook``: Async``response_hook`` for ``httpx.AsyncClient``
         """
         tracer_provider = kwargs.get("tracer_provider")
-        self._request_hook = kwargs.get("request_hook")
-        self._response_hook = kwargs.get("response_hook")
+        _request_hook = kwargs.get("request_hook")
+        self._request_hook = _request_hook if callable(_request_hook) else None
+        _response_hook = kwargs.get("response_hook")
+        self._response_hook = (
+            _response_hook if callable(_response_hook) else None
+        )
         _async_request_hook = kwargs.get("async_request_hook")
         self._async_request_hook = (
             _async_request_hook

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -1004,7 +1004,6 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 ),
             )
             for transport in client._mounts.values():
-                # FIXME: check it's not wrapped already?
                 wrap_function_wrapper(
                     transport,
                     "handle_request",
@@ -1030,7 +1029,6 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 ),
             )
             for transport in client._mounts.values():
-                # FIXME: check it's not wrapped already?
                 wrap_function_wrapper(
                     transport,
                     "handle_async_request",

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -193,6 +193,7 @@ API
 
 import logging
 import typing
+from asyncio import iscoroutinefunction
 from types import TracebackType
 
 import httpx
@@ -928,6 +929,20 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 "Attempting to instrument Httpx client while already instrumented"
             )
             return
+
+        if iscoroutinefunction(request_hook):
+            self._async_request_hook = request_hook
+            self._request_hook = None
+        else:
+            self._request_hook = request_hook
+            self._async_request_hook = None
+
+        if iscoroutinefunction(response_hook):
+            self._async_response_hook = response_hook
+            self._response_hook = None
+        else:
+            self._response_hook = response_hook
+            self._async_response_hook = None
 
         if hasattr(client._transport, "handle_request"):
             wrap_function_wrapper(

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -859,7 +859,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
-                raise exception
+                raise exception.with_traceback(exception.__traceback__)
 
         return response
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -1018,7 +1018,6 @@ class BaseTestCases:
             result = self.perform_request(self.URL, client=client)
 
             self.assertEqual(result.text, "Hello!")
-            # FIXME: this does fail if uninstrument() has been called before and is a change of behaviour from before
             self.assert_span(num_spans=0)
             self.assert_proxy_mounts(
                 client._mounts.values(),

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -167,10 +167,6 @@ class BaseTestCases:
                 )
             )
 
-        def print_spans(self, spans):
-            for span in spans:
-                print(span.name, span.attributes)
-
         # pylint: disable=invalid-name
         def tearDown(self):
             super().tearDown()
@@ -184,9 +180,7 @@ class BaseTestCases:
             if exporter is None:
                 exporter = self.memory_exporter
             span_list = exporter.get_finished_spans()
-            self.assertEqual(
-                num_spans, len(span_list), self.print_spans(span_list)
-            )
+            self.assertEqual(num_spans, len(span_list))
             if num_spans == 0:
                 return None
             if num_spans == 1:
@@ -993,23 +987,6 @@ class BaseTestCases:
                 client._mounts.values(),
                 2,
             )
-
-        def print_handler(self, client):
-            transport = client._transport
-            handler = getattr(
-                transport,
-                "handle_request",
-                getattr(transport, "handle_async_request", None),
-            )
-            print(
-                handler,
-                (
-                    getattr(handler, "__wrapped__", "no wrapped")
-                    if handler
-                    else "no handler"
-                ),
-            )
-            return handler
 
         def test_instrument_client_with_proxy(self):
             proxy_mounts = self.create_proxy_mounts()

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -744,7 +744,6 @@ class BaseTestCases:
         def setUp(self):
             super().setUp()
             self.client = self.create_client()
-            # FIXME: calling instrument() instead fixes 13*2 tests :(
             HTTPXClientInstrumentor().instrument_client(self.client)
 
         def tearDown(self):

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -1182,6 +1182,21 @@ class TestSyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):
     def create_proxy_transport(self, url):
         return httpx.HTTPTransport(proxy=httpx.Proxy(url))
 
+    def test_can_instrument_subclassed_client(self):
+        class CustomClient(httpx.Client):
+            pass
+
+        client = CustomClient()
+        self.assertFalse(
+            isinstance(client._transport.handle_request, ObjectProxy)
+        )
+
+        HTTPXClientInstrumentor().instrument()
+
+        self.assertTrue(
+            isinstance(client._transport.handle_request, ObjectProxy)
+        )
+
 
 class TestAsyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):
     response_hook = staticmethod(_async_response_hook)
@@ -1257,3 +1272,18 @@ class TestAsyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):
         self.assertEqual(result.text, "Hello!")
         span = self.assert_span()
         self.assertEqual(span.name, "GET")
+
+    def test_can_instrument_subclassed_async_client(self):
+        class CustomAsyncClient(httpx.AsyncClient):
+            pass
+
+        client = CustomAsyncClient()
+        self.assertFalse(
+            isinstance(client._transport.handle_async_request, ObjectProxy)
+        )
+
+        HTTPXClientInstrumentor().instrument()
+
+        self.assertTrue(
+            isinstance(client._transport.handle_async_request, ObjectProxy)
+        )

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -206,7 +206,7 @@ class BaseTestCases:
             self.assertEqual(span.name, "GET")
 
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     SpanAttributes.HTTP_URL: self.URL,
@@ -230,7 +230,7 @@ class BaseTestCases:
             self.assertIs(span.kind, trace.SpanKind.CLIENT)
             self.assertEqual(span.name, "HTTP")
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "_OTHER",
                     SpanAttributes.HTTP_URL: self.URL,
@@ -254,7 +254,7 @@ class BaseTestCases:
             self.assertIs(span.kind, trace.SpanKind.CLIENT)
             self.assertEqual(span.name, "HTTP")
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     HTTP_REQUEST_METHOD: "_OTHER",
                     URL_FULL: self.URL,
@@ -294,7 +294,7 @@ class BaseTestCases:
                 SpanAttributes.SCHEMA_URL,
             )
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     HTTP_REQUEST_METHOD: "GET",
                     URL_FULL: url,
@@ -329,7 +329,7 @@ class BaseTestCases:
             )
 
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     HTTP_REQUEST_METHOD: "GET",
@@ -456,7 +456,7 @@ class BaseTestCases:
 
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     SpanAttributes.HTTP_URL: self.URL,
@@ -512,7 +512,7 @@ class BaseTestCases:
 
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     HTTP_REQUEST_METHOD: "GET",
                     URL_FULL: url,
@@ -533,7 +533,7 @@ class BaseTestCases:
 
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     HTTP_REQUEST_METHOD: "GET",
@@ -634,7 +634,7 @@ class BaseTestCases:
             self.assertEqual(result.text, "Hello!")
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     SpanAttributes.HTTP_URL: self.URL,
@@ -811,7 +811,7 @@ class BaseTestCases:
             self.assertEqual(result.text, "Hello!")
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     SpanAttributes.HTTP_URL: self.URL,
@@ -832,7 +832,7 @@ class BaseTestCases:
             self.assertEqual(result.text, "Hello!")
             span = self.assert_span()
             self.assertEqual(
-                span.attributes,
+                dict(span.attributes),
                 {
                     SpanAttributes.HTTP_METHOD: "GET",
                     SpanAttributes.HTTP_URL: self.URL,


### PR DESCRIPTION
# Description

Porting of httpx instrumentation to patch async transport methods instead of substituting the client. That is because the current approach will instrument httpx by instantianting another client with a custom transport class and this will race with code already subclassing. This one uses wrapt to patch the default httpx transport classes.

A few changes of behavior to discuss:
- we are patching the two default httpx transport classes, if you subclass something else it still won't be instrumented, still instrument_client should work
- global uninstrument() will remove instrumentation from client instrumented with instrument_client but I think that's legit
- would be nice to deprecate the client subclassing thing and remove a ton of code

There is still a couple of FIXME that would like to get a second opinion.

Fixes #2364 
Fixes #2609

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
