### PR TITLE
opentelemetry-instrumentation: make it easier to use bootstrap with custom values

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -75,7 +75,7 @@ def _sys_pip_install(package):
         print(error)
 
 
-def _pip_check():
+def _pip_check(libraries):
     """Ensures none of the instrumentations have dependency conflicts.
     Clean check reported as:
     'No broken requirements found.'
@@ -113,7 +113,7 @@ def _is_installed(req):
     return True
 
 
-def _find_installed_libraries():
+def _find_installed_libraries(default_instrumentations, libraries):
     for lib in default_instrumentations:
         yield lib
 
@@ -122,18 +122,24 @@ def _find_installed_libraries():
             yield lib["instrumentation"]
 
 
-def _run_requirements():
+def _run_requirements(default_instrumentations, libraries):
     logger.setLevel(logging.ERROR)
-    print("\n".join(_find_installed_libraries()))
+    print(
+        "\n".join(
+            _find_installed_libraries(default_instrumentations, libraries)
+        )
+    )
 
 
-def _run_install():
-    for lib in _find_installed_libraries():
+def _run_install(default_instrumentations, libraries):
+    for lib in _find_installed_libraries(default_instrumentations, libraries):
         _sys_pip_install(lib)
     _pip_check()
 
 
-def run() -> None:
+def run(
+    default_instrumentations=default_instrumentations, libraries=libraries
+) -> None:
     action_install = "install"
     action_requirements = "requirements"
 
@@ -167,4 +173,4 @@ def run() -> None:
         action_install: _run_install,
         action_requirements: _run_requirements,
     }[args.action]
-    cmd()
+    cmd(default_instrumentations, libraries)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -137,7 +137,7 @@ def _run_requirements(default_instrumentations, libraries):
 def _run_install(default_instrumentations, libraries):
     for lib in _find_installed_libraries(default_instrumentations, libraries):
         _sys_pip_install(lib)
-    _pip_check()
+    _pip_check(libraries)
 
 
 def run(

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -22,6 +22,7 @@ from subprocess import (
     SubprocessError,
     check_call,
 )
+from typing import Optional
 
 from packaging.requirements import Requirement
 
@@ -140,8 +141,8 @@ def _run_install(default_instrumentations, libraries):
 
 
 def run(
-    default_instrumentations=gen_default_instrumentations,
-    libraries=gen_libraries,
+    default_instrumentations: Optional[list] = None,
+    libraries: Optional[list] = None,
 ) -> None:
     action_install = "install"
     action_requirements = "requirements"
@@ -171,6 +172,12 @@ def run(
         """,
     )
     args = parser.parse_args()
+
+    if libraries is None:
+        libraries = gen_libraries
+
+    if default_instrumentations is None:
+        default_instrumentations = gen_default_instrumentations
 
     cmd = {
         action_install: _run_install,

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap.py
@@ -26,8 +26,10 @@ from subprocess import (
 from packaging.requirements import Requirement
 
 from opentelemetry.instrumentation.bootstrap_gen import (
-    default_instrumentations,
-    libraries,
+    default_instrumentations as gen_default_instrumentations,
+)
+from opentelemetry.instrumentation.bootstrap_gen import (
+    libraries as gen_libraries,
 )
 from opentelemetry.instrumentation.version import __version__
 from opentelemetry.util._importlib_metadata import (
@@ -138,7 +140,8 @@ def _run_install(default_instrumentations, libraries):
 
 
 def run(
-    default_instrumentations=default_instrumentations, libraries=libraries
+    default_instrumentations=gen_default_instrumentations,
+    libraries=gen_libraries,
 ) -> None:
     action_install = "install"
     action_requirements = "requirements"


### PR DESCRIPTION
# Description

Pass the available instrumentation libraries and the default libraries from _bootstrap_gen_ to _run()_ (and down to all the functions) instead of relying on the globals. This way it's easier to reuse _run()_ with custom values.

While at it fix mock handling in tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
