### PR TITLE
opentelemetry-instrumentation: add unwrapping from dotted paths strings

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/utils.py
@@ -14,6 +14,7 @@
 
 import urllib.parse
 from contextlib import contextmanager
+from importlib import import_module
 from re import escape, sub
 from typing import Dict, Iterable, Sequence
 
@@ -83,10 +84,27 @@ def http_status_to_status_code(
 def unwrap(obj, attr: str):
     """Given a function that was wrapped by wrapt.wrap_function_wrapper, unwrap it
 
+    The object containing the function to unwrap may be passed as dotted module path string.
+
     Args:
-        obj: Object that holds a reference to the wrapped function
+        obj: Object that holds a reference to the wrapped function or dotted import path as string
         attr (str): Name of the wrapped function
     """
+    if isinstance(obj, str):
+        try:
+            module_path, class_name = obj.rsplit(".", 1)
+        except ValueError as exc:
+            raise ImportError(
+                f"Cannot parse '{obj}' as dotted import path"
+            ) from exc
+        module = import_module(module_path)
+        try:
+            obj = getattr(module, class_name)
+        except AttributeError as exc:
+            raise ImportError(
+                f"Cannot import '{class_name}' from '{module}'"
+            ) from exc
+
     func = getattr(obj, attr, None)
     if func and isinstance(func, ObjectProxy) and hasattr(func, "__wrapped__"):
         setattr(obj, attr, func.__wrapped__)

--- a/opentelemetry-instrumentation/tests/test_utils.py
+++ b/opentelemetry-instrumentation/tests/test_utils.py
@@ -15,6 +15,8 @@
 import unittest
 from http import HTTPStatus
 
+from wrapt import ObjectProxy, wrap_function_wrapper
+
 from opentelemetry.context import (
     _SUPPRESS_HTTP_INSTRUMENTATION_KEY,
     _SUPPRESS_INSTRUMENTATION_KEY,
@@ -29,8 +31,17 @@ from opentelemetry.instrumentation.utils import (
     is_instrumentation_enabled,
     suppress_http_instrumentation,
     suppress_instrumentation,
+    unwrap,
 )
 from opentelemetry.trace import StatusCode
+
+
+class WrappedClass:
+    def method(self):
+        pass
+
+    def wrapper_method(self):
+        pass
 
 
 class TestUtils(unittest.TestCase):
@@ -240,3 +251,72 @@ class TestUtils(unittest.TestCase):
             self.assertTrue(get_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY))
 
         self.assertIsNone(get_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY))
+
+    @staticmethod
+    def _wrap_method():
+        return wrap_function_wrapper(
+            WrappedClass, "method", WrappedClass.wrapper_method
+        )
+
+    def test_unwrap_can_unwrap_object_attribute(self):
+        self._wrap_method()
+        instance = WrappedClass()
+        self.assertTrue(isinstance(instance.method, ObjectProxy))
+
+        unwrap(WrappedClass, "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+
+    def test_unwrap_can_unwrap_object_attribute_as_string(self):
+        self._wrap_method()
+        instance = WrappedClass()
+        self.assertTrue(isinstance(instance.method, ObjectProxy))
+
+        unwrap("tests.test_utils.WrappedClass", "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+
+    def test_unwrap_raises_import_error_if_path_not_well_formed(self):
+        self._wrap_method()
+        instance = WrappedClass()
+        self.assertTrue(isinstance(instance.method, ObjectProxy))
+
+        with self.assertRaisesRegex(
+            ImportError, "Cannot parse '' as dotted import path"
+        ):
+            unwrap("", "method")
+
+        unwrap(WrappedClass, "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+
+    def test_unwrap_raises_import_error_if_cannot_find_module(self):
+        self._wrap_method()
+        instance = WrappedClass()
+        self.assertTrue(isinstance(instance.method, ObjectProxy))
+
+        with self.assertRaisesRegex(ImportError, "No module named 'does'"):
+            unwrap("does.not.exist.WrappedClass", "method")
+
+        unwrap(WrappedClass, "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+
+    def test_unwrap_raises_import_error_if_cannot_find_object(self):
+        self._wrap_method()
+        instance = WrappedClass()
+        self.assertTrue(isinstance(instance.method, ObjectProxy))
+
+        with self.assertRaisesRegex(
+            ImportError, "Cannot import 'NotWrappedClass' from"
+        ):
+            unwrap("tests.test_utils.NotWrappedClass", "method")
+
+        unwrap(WrappedClass, "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+
+    def test_does_nothing_if_cannot_find_attribute(self):
+        instance = WrappedClass()
+        unwrap(instance, "method_not_found")
+
+    def test_unwrap_does_nothing_if_attribute_is_not_from_wrapt(self):
+        instance = WrappedClass()
+        self.assertFalse(isinstance(instance.method, ObjectProxy))
+        unwrap(WrappedClass, "method")
+        self.assertFalse(isinstance(instance.method, ObjectProxy))


### PR DESCRIPTION
# Description

Make it possible to express object to unwrap as dotted module paths strings. This helps in avoiding side effects or race conditions with other instrumentations if we do importing too early.

While at it add tests also for current functionality.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
