### PR TITLE
opentelemetry-instrumentation-celery: don't detach a None token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2901])(https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2901)
 - `opentelemetry-instrumentation-system-metrics` Update metric units to conform to UCUM conventions.
   ([#2922](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2922))
+- `opentelemetry-instrumentation-celery` Don't detach context without a None token
+  ([#2927](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2927))
 
 ### Breaking changes
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -213,7 +213,10 @@ class CeleryInstrumentor(BaseInstrumentor):
         self.update_task_duration_time(task_id)
         labels = {"task": task.name, "worker": task.request.hostname}
         self._record_histograms(task_id, labels)
-        context_api.detach(token)
+        # if the process sending the task is not instrumented
+        # there's no incoming context and no token to detach
+        if token is not None:
+            context_api.detach(token)
 
     def _trace_before_publish(self, *args, **kwargs):
         task = utils.retrieve_task_from_sender(kwargs)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -188,20 +188,20 @@ class TestCeleryInstrumentation(TestBase):
 
         self.assertEqual(task.result, {"key": "value"})
 
-    def _retrieve_context_wrapper_none_token(
-        self, wrapped, instance, args, kwargs
-    ):
-        ctx = wrapped(*args, **kwargs)
-        if ctx is None:
-            return ctx
-        span, activation, _ = ctx
-        return span, activation, None
-
     def test_task_not_instrumented_does_not_raise(self):
+        def _retrieve_context_wrapper_none_token(
+            wrapped, instance, args, kwargs
+        ):
+            ctx = wrapped(*args, **kwargs)
+            if ctx is None:
+                return ctx
+            span, activation, _ = ctx
+            return span, activation, None
+
         wrap_function_wrapper(
             utils,
             "retrieve_context",
-            self._retrieve_context_wrapper_none_token,
+            _retrieve_context_wrapper_none_token,
         )
 
         CeleryInstrumentor().instrument()


### PR DESCRIPTION
# Description

Don't detach a None token in postrun.

Avoids this in celery logs:

```
[2024-10-28 12:14:18,868: ERROR/MainProcess] Failed to detach context
    Traceback (most recent call last):
      File "/home/rm/src/opentelemetry-python-contrib/.tox/py310-test-instrumentation-celery-1/lib/python3.10/site-packages/opentelemetry/context/__init__.py", line 152, in detach
        _RUNTIME_CONTEXT.detach(token)
      File "/home/rm/src/opentelemetry-python-contrib/.tox/py310-test-instrumentation-celery-1/lib/python3.10/site-packages/opentelemetry/context/contextvars_context.py", line 50, in detach
        self._current_context.reset(token)  # type: ignore
    TypeError: expected an instance of Token, got None
```

Since celery catches everything this does not change anything in practice. I've added a test that exercise the error but I have no clue on how to get celery stdout. I've tested that with `pytest -s` we don't get the message.

Closes #2855 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
