### PR TITLE
exporter/prometheus_remote_write: sort labels before exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2922](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2922))
 - `opentelemetry-instrumentation-celery` Don't detach context without a None token
   ([#2927](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2927))
+- `opentelemetry-exporter-prometheus-remote-write`: sort labels before exporting
+  ([#2940](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2940))
 
 ### Breaking changes
 

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -16,7 +16,7 @@ import logging
 import re
 from collections import defaultdict
 from itertools import chain
-from typing import Dict, Sequence
+from typing import Dict, Mapping, Sequence
 
 import requests
 import snappy
@@ -253,12 +253,14 @@ class PrometheusRemoteWriteMetricsExporter(MetricExporter):
         return self._convert_to_timeseries(sample_sets, resource_labels)
 
     def _convert_to_timeseries(
-        self, sample_sets: Sequence[tuple], resource_labels: Sequence
+        self, sample_sets: Mapping[tuple, Sequence], resource_labels: Sequence
     ) -> Sequence[TimeSeries]:
         timeseries = []
         for labels, samples in sample_sets.items():
             ts = TimeSeries()
-            for label_name, label_value in chain(resource_labels, labels):
+            for label_name, label_value in sorted(
+                chain(resource_labels, labels)
+            ):
                 # Previous implementation did not str() the names...
                 ts.labels.append(self._label(label_name, str(label_value)))
             for value, timestamp in samples:

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -22,6 +22,8 @@ from opentelemetry.exporter.prometheus_remote_write import (
     PrometheusRemoteWriteMetricsExporter,
 )
 from opentelemetry.exporter.prometheus_remote_write.gen.types_pb2 import (  # pylint: disable=E0611
+    Label,
+    Sample,
     TimeSeries,
 )
 from opentelemetry.sdk.metrics.export import (
@@ -153,6 +155,38 @@ def test_parse_metric(metric, prom_rw):
         for sample in single_series.samples:
             assert sample.timestamp == timestamp
             assert sample.value in values
+
+
+def test_convert_to_timeseries(prom_rw):
+    resource_labels = (("service_name", "foo"), ("bool_value", True))
+    sample_sets = {
+        (("foo", "bar"), ("baz", 42), ("__name__", "test_histogram_tu")): [
+            (1, 1641946016139)
+        ],
+        (("baz", "42"), ("foo", "bar")): [(4, 1641946016139)],
+    }
+    timeseries = prom_rw._convert_to_timeseries(sample_sets, resource_labels)
+    assert timeseries == [
+        TimeSeries(
+            labels=[
+                Label(name="__name__", value="test_histogram_tu"),
+                Label(name="baz", value="42"),
+                Label(name="bool_value", value="True"),
+                Label(name="foo", value="bar"),
+                Label(name="service_name", value="foo"),
+            ],
+            samples=[Sample(value=1, timestamp=1641946016139)],
+        ),
+        TimeSeries(
+            labels=[
+                Label(name="baz", value="42"),
+                Label(name="bool_value", value="True"),
+                Label(name="foo", value="bar"),
+                Label(name="service_name", value="foo"),
+            ],
+            samples=[Sample(value=4, timestamp=1641946016139)],
+        ),
+    ]
 
 
 class TestValidation(unittest.TestCase):


### PR DESCRIPTION
# Description

Sort labels lexicographically before exporting them.  

Co-authored-by: fstolba / fst0

Fixes #2920
Closes #2784

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
