### PR TITLE
GenAI: Use common env var for content recording

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Use generic `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable
+  to control if content of prompt, completion, and other messages is captured.
+  ([#2947](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2947))
+
 - Update OpenAI instrumentation to Semantic Conventions v1.28.0: add new attributes
   and switch prompts and completions to log-based events.
   ([#2925](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2925))

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -27,14 +27,14 @@ from opentelemetry.semconv._incubating.attributes import (
     server_attributes as ServerAttributes,
 )
 
-OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT = (
-    "OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT"
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = (
+    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 )
 
 
 def is_content_enabled() -> bool:
     capture_content = environ.get(
-        OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT, "false"
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "false"
     )
 
     return capture_content.lower() == "true"

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
@@ -7,7 +7,7 @@ from openai import OpenAI
 
 from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 from opentelemetry.instrumentation.openai_v2.utils import (
-    OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT,
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
 )
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider
@@ -85,7 +85,7 @@ def instrument_no_content(tracer_provider, event_logger_provider):
 @pytest.fixture(scope="function")
 def instrument_with_content(tracer_provider, event_logger_provider):
     os.environ.update(
-        {OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
     )
     instrumentor = OpenAIInstrumentor()
     instrumentor.instrument(
@@ -94,7 +94,7 @@ def instrument_with_content(tracer_provider, event_logger_provider):
     )
 
     yield instrumentor
-    os.environ.pop(OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT, None)
+    os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
     instrumentor.uninstrument()
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -713,6 +713,7 @@ def assert_message_in_logs(log, event_name, expected_content, parent_span):
     if not expected_content:
         assert not log.log_record.body
     else:
+        assert log.log_record.body
         assert dict(log.log_record.body) == remove_none_values(
             expected_content
         )


### PR DESCRIPTION
Based on the discussion in GenAI SIG, changing the env var name to a generic one (so that users can configure content capturing in the same way for all genai instrumentations).

```diff
- OTEL_INSTRUMENTATION_OPENAI_CAPTURE_MESSAGE_CONTENT
+ OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
```

This has never been released, so it's not breaking.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
