### PR TITLE
opentelemetry-instrumentation: stick to latest semantic conventions package

### DIFF
--- a/opentelemetry-instrumentation/pyproject.toml
+++ b/opentelemetry-instrumentation/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.4",
-  "opentelemetry-semantic-conventions >= 0.48b0",
+  "opentelemetry-semantic-conventions == 0.49b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
   "packaging >= 18.0",
 ]


### PR DESCRIPTION
# Description

To match the instrumentations.

Will hopefully fix pip not able to handle the situation:

```
  opentelemetry-instrumentation 0.49b0 depends on opentelemetry-semantic-conventions>=0.48b0
  opentelemetry-instrumentation-dbapi 0.49b0 depends on opentelemetry-semantic-conventions==0.49b0
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
