### PR TITLE
Drop selective enabled for windows and regenerate workflows

### DIFF
--- a/.github/workflows/generate_workflows.py
+++ b/.github/workflows/generate_workflows.py
@@ -9,8 +9,6 @@ from generate_workflows_lib import (
 tox_ini_path = Path(__file__).parent.parent.parent.joinpath("tox.ini")
 workflows_directory_path = Path(__file__).parent
 
-generate_test_workflow(
-    tox_ini_path, workflows_directory_path, "ubuntu-latest", "windows-latest"
-)
+generate_test_workflow(tox_ini_path, workflows_directory_path, "ubuntu-latest")
 generate_lint_workflow(tox_ini_path, workflows_directory_path)
 generate_misc_workflow(tox_ini_path, workflows_directory_path)

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
@@ -55,14 +55,6 @@ def get_test_job_datas(tox_envs: list, operating_systems: list) -> list:
         "py312": "3.12",
     }
 
-    # we enable windows testing only for packages with windows specific code paths
-    per_tox_env_os_enablement = {
-        "windows-latest": {
-            "py312-test-instrumentation-botocore",
-            "py312-test-instrumentation-system-metrics",
-        },
-    }
-
     test_job_datas = []
 
     for operating_system in operating_systems:
@@ -78,14 +70,6 @@ def get_test_job_datas(tox_envs: list, operating_systems: list) -> list:
                 groups["python_version"]
             ]
             tox_env = tox_test_env_match.string
-
-            # if we have an entry for the os add only jobs for tox env manually configured
-            packages_manually_enabled = per_tox_env_os_enablement.get(
-                operating_system
-            )
-            if packages_manually_enabled:
-                if tox_env not in packages_manually_enabled:
-                    continue
 
             test_requirements = groups["test_requirements"]
 

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CORE_REPO_SHA: 6e29e0e5f19ee08eaf683166f2867dd2d383f67e
+  CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CORE_REPO_SHA: 6e29e0e5f19ee08eaf683166f2867dd2d383f67e
+  CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CORE_REPO_SHA: 6e29e0e5f19ee08eaf683166f2867dd2d383f67e
+  CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  CORE_REPO_SHA: 6e29e0e5f19ee08eaf683166f2867dd2d383f67e
+  CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -3903,45 +3903,3 @@ jobs:
 
       - name: Run tests
         run: tox -e pypy3-test-processor-baggage -- -ra
-
-  py312-test-instrumentation-botocore_windows-latest:
-    name: instrumentation-botocore 3.12 Windows
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Configure git to support long filenames
-        run: git config --system core.longpaths true
-
-      - name: Run tests
-        run: tox -e py312-test-instrumentation-botocore -- -ra
-
-  py312-test-instrumentation-system-metrics_windows-latest:
-    name: instrumentation-system-metrics 3.12 Windows
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Configure git to support long filenames
-        run: git config --system core.longpaths true
-
-      - name: Run tests
-        run: tox -e py312-test-instrumentation-system-metrics -- -ra


### PR DESCRIPTION
# Description

Selective enablement on windows testing broke core that is testing everything on windows :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  tox -e generate_workflows

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
