### PR TITLE
Update tests to work with SQLAlchemy 2

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlalchemy.py
@@ -17,7 +17,10 @@ from unittest import mock
 
 import pytest
 import sqlalchemy
-from sqlalchemy import create_engine
+from sqlalchemy import (
+    create_engine,
+    text,
+)
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -43,12 +46,14 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
-        cnx.execute("/* leading comment */ SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
+        cnx.execute(text("/* leading comment */ SELECT	1 + 1;")).fetchall()
         cnx.execute(
-            "/* leading comment */ SELECT	1 + 1; /* trailing comment */"
+            text(
+                "/* leading comment */ SELECT	1 + 1; /* trailing comment */"
+            )
         ).fetchall()
-        cnx.execute("SELECT	1 + 1; /* trailing comment */").fetchall()
+        cnx.execute(text("SELECT	1 + 1; /* trailing comment */")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 5)
@@ -76,9 +81,9 @@ class TestSqlalchemyInstrumentation(TestBase):
         )
 
         cnx_1 = engine_1.connect()
-        cnx_1.execute("SELECT	1 + 1;").fetchall()
+        cnx_1.execute(text("SELECT	1 + 1;")).fetchall()
         cnx_2 = engine_2.connect()
-        cnx_2.execute("SELECT	1 + 1;").fetchall()
+        cnx_2.execute(text("SELECT	1 + 1;")).fetchall()
 
         spans = self.memory_exporter.get_finished_spans()
         # 2 queries + 2 engine connect
@@ -111,7 +116,7 @@ class TestSqlalchemyInstrumentation(TestBase):
                 engine=engine.sync_engine, tracer_provider=self.tracer_provider
             )
             async with engine.connect() as cnx:
-                await cnx.execute(sqlalchemy.text("SELECT	1 + 1;"))
+                await cnx.execute(text("SELECT	1 + 1;"))
             spans = self.memory_exporter.get_finished_spans()
             self.assertEqual(len(spans), 2)
             # first span - the connection to the db
@@ -144,7 +149,7 @@ class TestSqlalchemyInstrumentation(TestBase):
                 tracer_provider=self.tracer_provider,
             )
             cnx = engine.connect()
-            cnx.execute("SELECT	1 + 1;").fetchall()
+            cnx.execute(text("SELECT	1 + 1;")).fetchall()
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)
@@ -156,7 +161,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -187,7 +192,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         # sqlcommenter
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
@@ -207,7 +212,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         # sqlcommenter
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
@@ -233,7 +238,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -258,7 +263,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
             engine = create_async_engine("sqlite+aiosqlite:///:memory:")
             async with engine.connect() as cnx:
-                await cnx.execute(sqlalchemy.text("SELECT	1 + 1;"))
+                await cnx.execute(text("SELECT	1 + 1;"))
             spans = self.memory_exporter.get_finished_spans()
             self.assertEqual(len(spans), 2)
             # first span - the connection to the db
@@ -299,7 +304,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
             engine = create_async_engine("sqlite+aiosqlite:///:memory:")
             async with engine.connect() as cnx:
-                await cnx.execute(sqlalchemy.text("SELECT  1;"))
+                await cnx.execute(text("SELECT  1;"))
             # sqlcommenter
             self.assertRegex(
                 self.caplog.records[1].getMessage(),
@@ -330,7 +335,7 @@ class TestSqlalchemyInstrumentation(TestBase):
 
             engine = create_async_engine("sqlite+aiosqlite:///:memory:")
             async with engine.connect() as cnx:
-                await cnx.execute(sqlalchemy.text("SELECT  1;"))
+                await cnx.execute(text("SELECT  1;"))
             # sqlcommenter
             self.assertRegex(
                 self.caplog.records[1].getMessage(),
@@ -346,7 +351,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
 
         self.assertEqual(len(spans), 2)
@@ -359,10 +364,10 @@ class TestSqlalchemyInstrumentation(TestBase):
 
         self.memory_exporter.clear()
         SQLAlchemyInstrumentor().uninstrument()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         engine2 = create_engine("sqlite:///:memory:")
         cnx2 = engine2.connect()
-        cnx2.execute("SELECT	2 + 2;").fetchall()
+        cnx2.execute(text("SELECT	2 + 2;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -371,7 +376,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=self.tracer_provider,
         )
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
 
@@ -384,13 +389,13 @@ class TestSqlalchemyInstrumentation(TestBase):
         engine = create_engine("sqlite:///:memory:")
 
         cnx = engine.connect()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
 
         self.memory_exporter.clear()
         SQLAlchemyInstrumentor().uninstrument()
-        cnx.execute("SELECT	1 + 1;").fetchall()
+        cnx.execute(text("SELECT	1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -401,7 +406,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             tracer_provider=trace.NoOpTracerProvider(),
         )
         cnx = engine.connect()
-        cnx.execute("SELECT 1 + 1;").fetchall()
+        cnx.execute(text("SELECT 1 + 1;")).fetchall()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
@@ -420,7 +425,7 @@ class TestSqlalchemyInstrumentation(TestBase):
             # collection
             weakref.finalize(engine, callback)
             with engine.connect() as conn:
-                conn.execute("SELECT 1 + 1;").fetchall()
+                conn.execute(text("SELECT 1 + 1;")).fetchall()
 
         for _ in range(0, 5):
             make_shortlived_engine()

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlcommenter.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/tests/test_sqlcommenter.py
@@ -14,7 +14,10 @@
 import logging
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import (
+    create_engine,
+    text,
+)
 
 from opentelemetry import context
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -37,7 +40,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             engine=engine, tracer_provider=self.tracer_provider
         )
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
 
         self.assertEqual(self.caplog.records[-2].getMessage(), "SELECT 1;")
 
@@ -50,7 +53,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             commenter_options={"db_framework": False},
         )
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)',traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -68,7 +71,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
             },
         )
         cnx = engine.connect()
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)'\*/;",
@@ -90,7 +93,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
         )
         context.attach(sqlcommenter_context)
 
-        cnx.execute("SELECT  1;").fetchall()
+        cnx.execute(text("SELECT  1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT  1 /\*db_driver='(.*)',flask=1,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -105,7 +108,7 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
         self.assertRegex(
             self.caplog.records[-2].getMessage(),
             r"SELECT 1 /\*db_driver='(.*)',traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
@@ -120,5 +123,5 @@ class TestSqlalchemyInstrumentationWithSQLCommenter(TestBase):
 
         engine = create_engine("sqlite:///:memory:")
         cnx = engine.connect()
-        cnx.execute("SELECT 1;").fetchall()
+        cnx.execute(text("SELECT 1;")).fetchall()
         self.assertEqual(self.caplog.records[-2].getMessage(), "SELECT 1;")


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2975

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run unit tests via `tox -e py312-test-instrumentation-sqlalchemy-1` as current, then with temporary update to `test-requirements-1.txt` with `SQLAlchemy==2.0.35`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
