### PR TITLE
opentelemetry-instrumentation-openai-v2: add codefromthecrypt and fix yaml fixture

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -73,3 +73,4 @@ components:
     - lzchen
     - gyliu513
     - nirga
+    - codefromthecrypt

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_chat_completion_404.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_chat_completion_404.yaml
@@ -24,7 +24,7 @@ interactions:
       host:
       - api.openai.com
       user-agent:
-      - OpenAI/Python 1.26.0
+      - OpenAI/Python 1.54.3
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -34,7 +34,9 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.26.0
+      - 1.54.3
+      x-stainless-retry-count:
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -56,13 +58,13 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8dd0709dffd19c8c-SIN
+      - 8e0ca7056be15f93-SIN
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 04 Nov 2024 00:20:44 GMT
+      - Mon, 11 Nov 2024 07:43:38 GMT
       Server:
       - cloudflare
       Set-Cookie: test_set_cookie
@@ -80,7 +82,7 @@ interactions:
       vary:
       - Origin
       x-request-id:
-      - req_e08854c4f7d5104af6fdc755caed30fc
+      - req_75175efff56c313161c136c479e082ac
     status:
       code: 404
       message: Not Found

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
@@ -161,7 +161,7 @@ class PrettyPrintJSONBody:
         return yaml.load(cassette_string, Loader=yaml.Loader)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def fixture_vcr(vcr):
     vcr.register_serializer("yaml", PrettyPrintJSONBody)
     return vcr


### PR DESCRIPTION
# Description

Before, the pretty-print formatter for openai test yaml wasn't consistently loaded (from #2945).
This also, adds myself into the contributors so I automatically get notified on PRs (as I missed the problem in #2984)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I deleted one test yaml and ran the test two ways to make sure it recreates correctly
- [x] `tox -e py312-test-instrumentation-openai-v2-0`
- [x] `tox -e py312-test-instrumentation-openai-v2-1`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
