### PR TITLE
opentelemetry-instrumentation-httpx: make instrument_client a staticmethod again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-httpx`: instrument_client is a static method again
+  ([#3003](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3003))
+
 ### Breaking changes
 
 - `opentelemetry-instrumentation-sqlalchemy` teach instruments version

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -938,8 +938,9 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
 
         return response
 
-    @staticmethod
+    @classmethod
     def instrument_client(
+        cls,
         client: typing.Union[httpx.Client, httpx.AsyncClient],
         tracer_provider: TracerProvider = None,
         request_hook: typing.Union[
@@ -996,7 +997,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_request",
                 partial(
-                    HTTPXClientInstrumentor._handle_request_wrapper,
+                    cls._handle_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     request_hook=request_hook,
@@ -1008,7 +1009,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_request",
                     partial(
-                        HTTPXClientInstrumentor._handle_request_wrapper,
+                        cls._handle_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         request_hook=request_hook,
@@ -1021,7 +1022,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_async_request",
                 partial(
-                    HTTPXClientInstrumentor._handle_async_request_wrapper,
+                    cls._handle_async_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     async_request_hook=async_request_hook,
@@ -1033,7 +1034,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_async_request",
                     partial(
-                        HTTPXClientInstrumentor._handle_async_request_wrapper,
+                        cls._handle_async_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         async_request_hook=async_request_hook,

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -938,8 +938,8 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
 
         return response
 
+    @staticmethod
     def instrument_client(
-        self,
         client: typing.Union[httpx.Client, httpx.AsyncClient],
         tracer_provider: TracerProvider = None,
         request_hook: typing.Union[
@@ -996,7 +996,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_request",
                 partial(
-                    self._handle_request_wrapper,
+                    HTTPXClientInstrumentor._handle_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     request_hook=request_hook,
@@ -1008,7 +1008,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_request",
                     partial(
-                        self._handle_request_wrapper,
+                        HTTPXClientInstrumentor._handle_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         request_hook=request_hook,
@@ -1021,7 +1021,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_async_request",
                 partial(
-                    self._handle_async_request_wrapper,
+                    HTTPXClientInstrumentor._handle_async_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     async_request_hook=async_request_hook,
@@ -1033,7 +1033,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_async_request",
                     partial(
-                        self._handle_async_request_wrapper,
+                        HTTPXClientInstrumentor._handle_async_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         async_request_hook=async_request_hook,

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -917,6 +917,13 @@ class BaseTestCases:
             self.assertEqual(result.text, "Hello!")
             self.assert_span(num_spans=1)
 
+        def test_instrument_client_a_static_method(self):
+            client = self.create_client()
+            HTTPXClientInstrumentor.instrument_client(client)
+            result = self.perform_request(self.URL, client=client)
+            self.assertEqual(result.text, "Hello!")
+            self.assert_span(num_spans=1)
+
         def test_instrumentation_without_client(self):
             HTTPXClientInstrumentor().instrument()
             results = [

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -910,14 +910,14 @@ class BaseTestCases:
 
             self.assert_span(num_spans=0)
 
-        def test_instrument_client(self):
+        def test_instrument_client_called_on_the_instance(self):
             client = self.create_client()
             HTTPXClientInstrumentor().instrument_client(client)
             result = self.perform_request(self.URL, client=client)
             self.assertEqual(result.text, "Hello!")
             self.assert_span(num_spans=1)
 
-        def test_instrument_client_a_static_method(self):
+        def test_instrument_client_called_on_the_class(self):
             client = self.create_client()
             HTTPXClientInstrumentor.instrument_client(client)
             result = self.perform_request(self.URL, client=client)


### PR DESCRIPTION
# Description

Fixes #2998

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
