### PR TITLE
[release/v1.28.x-0.49bx] opentelemetry-instrumentation-httpx: make instrument_client a staticmethod again (#3003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-httpx`: instrument_client is a static method again
+  ([#3003](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3003))
+
 ### Breaking changes
 
 - `opentelemetry-instrumentation-sqlalchemy` teach instruments version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The following components are released independently and maintain individual CHANGELOG files.
 > Use [this search for a list of all CHANGELOG.md files in this repo](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib+path%3A**%2FCHANGELOG.md&type=code).
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+- `opentelemetry-instrumentation-httpx`: instrument_client is a static method again
+  ([#3003](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3003))
+
+### Breaking changes
+
 ## Version 1.28.1/0.49b1 (2024-11-08)
 
 ### Added
@@ -17,9 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2976](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2976))
 
 ### Fixed
-
-- `opentelemetry-instrumentation-httpx`: instrument_client is a static method again
-  ([#3003](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3003))
 
 ### Breaking changes
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -938,8 +938,9 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
 
         return response
 
+    @classmethod
     def instrument_client(
-        self,
+        cls,
         client: typing.Union[httpx.Client, httpx.AsyncClient],
         tracer_provider: TracerProvider = None,
         request_hook: typing.Union[
@@ -996,7 +997,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_request",
                 partial(
-                    self._handle_request_wrapper,
+                    cls._handle_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     request_hook=request_hook,
@@ -1008,7 +1009,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_request",
                     partial(
-                        self._handle_request_wrapper,
+                        cls._handle_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         request_hook=request_hook,
@@ -1021,7 +1022,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                 client._transport,
                 "handle_async_request",
                 partial(
-                    self._handle_async_request_wrapper,
+                    cls._handle_async_request_wrapper,
                     tracer=tracer,
                     sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                     async_request_hook=async_request_hook,
@@ -1033,7 +1034,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     transport,
                     "handle_async_request",
                     partial(
-                        self._handle_async_request_wrapper,
+                        cls._handle_async_request_wrapper,
                         tracer=tracer,
                         sem_conv_opt_in_mode=sem_conv_opt_in_mode,
                         async_request_hook=async_request_hook,

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -910,9 +910,16 @@ class BaseTestCases:
 
             self.assert_span(num_spans=0)
 
-        def test_instrument_client(self):
+        def test_instrument_client_called_on_the_instance(self):
             client = self.create_client()
             HTTPXClientInstrumentor().instrument_client(client)
+            result = self.perform_request(self.URL, client=client)
+            self.assertEqual(result.text, "Hello!")
+            self.assert_span(num_spans=1)
+
+        def test_instrument_client_called_on_the_class(self):
+            client = self.create_client()
+            HTTPXClientInstrumentor.instrument_client(client)
             result = self.perform_request(self.URL, client=client)
             self.assertEqual(result.text, "Hello!")
             self.assert_span(num_spans=1)


### PR DESCRIPTION
Clean cherry-pick of https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3003 to the [release/v1.28.x-0.49bx](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/release/v1.28.x-0.49bx) branch.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/4281