### PR TITLE
[release/v1.28.x-0.49bx] Remove updating CHANGELOG step in release workflow (#3000)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,36 +119,3 @@ jobs:
           # the step below is creating a pull request against main
           ref: main
 
-      - name: Copy change log updates to main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "VERSION=${STABLE_VERSION}\/${UNSTABLE_VERSION}" >> $GITHUB_ENV
-          echo "RELEASE_TAG=$STABLE_VERSION" >> $GITHUB_ENV
-          ./scripts/merge_changelog_to_main.sh
-
-      - name: Use CLA approved github bot
-        run: .github/scripts/use-cla-approved-github-bot.sh
-
-      - name: Create pull request against main
-        env:
-          # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-        run: |
-          message="Copy change log updates from $GITHUB_REF_NAME"
-          body="Copy log updates from \`$GITHUB_REF_NAME\`."
-          branch="opentelemetrybot/copy-change-log-updates-from-${GITHUB_REF_NAME//\//-}"
-
-          if [[ -z $PRIOR_VERSION_WHEN_PATCH ]]; then
-            if git diff --quiet; then
-              echo there are no updates needed to the change log on main, not creating pull request
-              exit 0 # success
-            fi
-          fi
-
-          git commit -a -m "$message"
-          git push origin HEAD:$branch
-          gh pr create --title "$message" \
-                       --body "$body" \
-                       --head $branch \
-                       --base main


### PR DESCRIPTION
Clean cherry-pick of https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3000 to the [release/v1.28.x-0.49bx](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/release/v1.28.x-0.49bx) branch.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/4281