### PR TITLE
[release/v1.28.x-0.49bx] Add openai instrumentation to opentelemetry-bootstrap (#2996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The following components are released independently and maintain individual CHANGELOG files.
 > Use [this search for a list of all CHANGELOG.md files in this repo](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib+path%3A**%2FCHANGELOG.md&type=code).
 
+## Unreleased
+
+### Added
+
+- Add `opentelemetry-instrumentation-openai-v2` to `opentelemetry-bootstrap`
+  ([#2996](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2996))
+
+### Fixed
+
+### Breaking changes
+
 ## Version 1.28.1/0.49b1 (2024-11-08)
 
 ### Added
 
 - `opentelemetry-instrumentation-sqlalchemy` Update unit tests to run with SQLALchemy 2
   ([#2976](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2976))
-  - Add `opentelemetry-instrumentation-openai-v2` to `opentelemetry-bootstrap`
-  ([#2996](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2996))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-sqlalchemy` Update unit tests to run with SQLALchemy 2
   ([#2976](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2976))
+  - Add `opentelemetry-instrumentation-openai-v2` to `opentelemetry-bootstrap`
+  ([#2996](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2996))
 
 ### Fixed
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "openai >= 1.0.0",
+  "openai >= 1.26.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -18,7 +18,7 @@
 libraries = [
     {
         "library": "openai >= 1.26.0",
-        "instrumentation": "opentelemetry-instrumentation-openai-v2==2.1b0.dev",
+        "instrumentation": "opentelemetry-instrumentation-openai-v2==2.0.0.dev",
     },
     {
         "library": "aio_pika >= 7.2.0, < 10.0.0",

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -17,6 +17,10 @@
 
 libraries = [
     {
+        "library": "openai >= 1.26.0",
+        "instrumentation": "opentelemetry-instrumentation-openai-v2==2.1b0.dev",
+    },
+    {
         "library": "aio_pika >= 7.2.0, < 10.0.0",
         "instrumentation": "opentelemetry-instrumentation-aio-pika==0.49b1",
     },

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -21,14 +21,23 @@ import tomli
 scripts_path = os.path.dirname(os.path.abspath(__file__))
 root_path = os.path.dirname(scripts_path)
 instrumentations_path = os.path.join(root_path, "instrumentation")
+genai_instrumentations_path = os.path.join(root_path, "instrumentation-genai")
 
 
 def get_instrumentation_packages():
-    for pkg in sorted(os.listdir(instrumentations_path)):
+    pkg_paths = []
+    for pkg in os.listdir(instrumentations_path):
         pkg_path = os.path.join(instrumentations_path, pkg)
         if not os.path.isdir(pkg_path):
             continue
+        pkg_paths.append(pkg_path)
+    for pkg in os.listdir(genai_instrumentations_path):
+        pkg_path = os.path.join(genai_instrumentations_path, pkg)
+        if not os.path.isdir(pkg_path):
+            continue
+        pkg_paths.append(pkg_path)
 
+    for pkg_path in sorted(pkg_paths):
         try:
             version = subprocess.check_output(
                 "hatch version",


### PR DESCRIPTION
Clean cherry-pick of https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2996 to the [release/v1.28.x-0.49bx](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/release/v1.28.x-0.49bx) branch.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/4281