### PR TITLE
Fix eachdist.py patch release to respect "all" and "excluded"

### DIFF
--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -667,6 +667,9 @@ def update_dependencies(targets, version, packages):
 
 def update_patch_dependencies(targets, version, prev_version, packages):
     print("updating patch dependencies")
+    if "all" in packages:
+        packages.extend(targets)
+
     # PEP 508 allowed specifier operators
     operators = ["==", "!=", "<=", ">=", "<", ">", "===", "~=", "="]
     operators_pattern = "|".join(re.escape(op) for op in operators)
@@ -715,10 +718,12 @@ def release_args(args):
     versions = args.versions
     updated_versions = []
 
+    # remove excluded packages
     excluded = cfg["exclude_release"]["packages"].split()
     targets = [
         target for target in targets if basename(target) not in excluded
     ]
+
     for group in versions.split(","):
         mcfg = cfg[group]
         version = mcfg["version"]
@@ -742,10 +747,18 @@ def patch_release_args(args):
     targets = list(find_targets_unordered(rootpath))
     cfg = ConfigParser()
     cfg.read(str(find_projectroot() / "eachdist.ini"))
+
+    # remove excluded packages
+    excluded = cfg["exclude_release"]["packages"].split()
+    targets = [
+        target for target in targets if basename(target) not in excluded
+    ]
+
     # stable
     mcfg = cfg["stable"]
     packages = mcfg["packages"].split()
     print(f"update stable packages to {args.stable_version}")
+
     update_patch_dependencies(
         targets, args.stable_version, args.stable_version_prev, packages
     )


### PR DESCRIPTION
These are not needed in the core eachdist.py so I missed it in https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3013

Tested manually running the release script 
```console
.github/scripts/update-version-patch.sh 1.28.2 0.49b2 1.28.1 0.49b1
```

Generates this diff status:
<details><summary>Details</summary>
<p>

```console
 M _template/version.py
 M eachdist.ini
 M exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/version.py
 M exporter/opentelemetry-exporter-richconsole/pyproject.toml
 M exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/version.py
 M instrumentation/opentelemetry-instrumentation-aio-pika/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aio-pika/src/opentelemetry/instrumentation/aio_pika/version.py
 M instrumentation/opentelemetry-instrumentation-aiohttp-client/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/version.py
 M instrumentation/opentelemetry-instrumentation-aiohttp-server/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/version.py
 M instrumentation/opentelemetry-instrumentation-aiokafka/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aiokafka/src/opentelemetry/instrumentation/aiokafka/version.py
 M instrumentation/opentelemetry-instrumentation-aiopg/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/version.py
 M instrumentation/opentelemetry-instrumentation-asgi/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/version.py
 M instrumentation/opentelemetry-instrumentation-asyncio/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-asyncio/src/opentelemetry/instrumentation/asyncio/version.py
 M instrumentation/opentelemetry-instrumentation-asyncpg/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/version.py
 M instrumentation/opentelemetry-instrumentation-aws-lambda/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/version.py
 M instrumentation/opentelemetry-instrumentation-boto/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-boto/src/opentelemetry/instrumentation/boto/version.py
 M instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/version.py
 M instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/version.py
 M instrumentation/opentelemetry-instrumentation-cassandra/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-cassandra/src/opentelemetry/instrumentation/cassandra/version.py
 M instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/version.py
 M instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
 M instrumentation/opentelemetry-instrumentation-dbapi/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/version.py
 M instrumentation/opentelemetry-instrumentation-django/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/version.py
 M instrumentation/opentelemetry-instrumentation-elasticsearch/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/version.py
 M instrumentation/opentelemetry-instrumentation-falcon/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/version.py
 M instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/version.py
 M instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/version.py
 M instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/version.py
 M instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/version.py
 M instrumentation/opentelemetry-instrumentation-jinja2/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-jinja2/src/opentelemetry/instrumentation/jinja2/version.py
 M instrumentation/opentelemetry-instrumentation-kafka-python/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/version.py
 M instrumentation/opentelemetry-instrumentation-logging/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/version.py
 M instrumentation/opentelemetry-instrumentation-mysql/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/version.py
 M instrumentation/opentelemetry-instrumentation-mysqlclient/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/version.py
 M instrumentation/opentelemetry-instrumentation-pika/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/version.py
 M instrumentation/opentelemetry-instrumentation-psycopg/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/version.py
 M instrumentation/opentelemetry-instrumentation-psycopg2/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/version.py
 M instrumentation/opentelemetry-instrumentation-pymemcache/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-pymemcache/src/opentelemetry/instrumentation/pymemcache/version.py
 M instrumentation/opentelemetry-instrumentation-pymongo/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/version.py
 M instrumentation/opentelemetry-instrumentation-pymysql/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/version.py
 M instrumentation/opentelemetry-instrumentation-pyramid/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/version.py
 M instrumentation/opentelemetry-instrumentation-redis/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/version.py
 M instrumentation/opentelemetry-instrumentation-remoulade/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-remoulade/src/opentelemetry/instrumentation/remoulade/version.py
 M instrumentation/opentelemetry-instrumentation-requests/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/version.py
 M instrumentation/opentelemetry-instrumentation-sqlalchemy/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
 M instrumentation/opentelemetry-instrumentation-sqlite3/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/version.py
 M instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/version.py
 M instrumentation/opentelemetry-instrumentation-system-metrics/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/version.py
 M instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/version.py
 M instrumentation/opentelemetry-instrumentation-tornado/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/version.py
 M instrumentation/opentelemetry-instrumentation-tortoiseorm/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/version.py
 M instrumentation/opentelemetry-instrumentation-urllib/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/version.py
 M instrumentation/opentelemetry-instrumentation-urllib3/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/version.py
 M instrumentation/opentelemetry-instrumentation-wsgi/pyproject.toml
 M instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/version.py
 M opentelemetry-contrib-instrumentations/pyproject.toml
 M opentelemetry-contrib-instrumentations/src/opentelemetry/contrib-instrumentations/version.py
 M opentelemetry-distro/pyproject.toml
 M opentelemetry-distro/src/opentelemetry/distro/version.py
 M opentelemetry-instrumentation/pyproject.toml
 M opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
 M processor/opentelemetry-processor-baggage/src/opentelemetry/processor/baggage/version.py
 M propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/version.py
 M resource/opentelemetry-resource-detector-container/src/opentelemetry/resource/detector/container/version.py
 M util/opentelemetry-util-http/src/opentelemetry/util/http/version.py
```

</p>
</details> 
