### PR TITLE
fix: missing contrib_repo_sha in new core_contrib_test workflow

### DIFF
--- a/.github/workflows/core_contrib_test_0.yml
+++ b/.github/workflows/core_contrib_test_0.yml
@@ -9,10 +9,12 @@ on:
       CORE_REPO_SHA:
         required: true
         type: string
-
+      CONTRIB_REPO_SHA:
+        required: true
+        type: string
 env:
   CORE_REPO_SHA: ${{ inputs.CORE_REPO_SHA }}
-  CONTRIB_REPO_SHA: main
+  CONTRIB_REPO_SHA: ${{ inputs.CONTRIB_REPO_SHA }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
@@ -9,10 +9,12 @@ on:
       CORE_REPO_SHA:
         required: true
         type: string
-
+      CONTRIB_REPO_SHA:
+        required: true
+        type: string
 env:
   CORE_REPO_SHA: ${% raw %}{{ inputs.CORE_REPO_SHA }}{% endraw %}
-  CONTRIB_REPO_SHA: main
+  CONTRIB_REPO_SHA: ${% raw %}{{ inputs.CONTRIB_REPO_SHA }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
 jobs:


### PR DESCRIPTION
Missed `CONTRIB_REPO_SHA`