### PR TITLE
opentelemetry-instrumentation-openai-v2: pin httpx dependency

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/test-requirements-0.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/test-requirements-0.txt
@@ -1,5 +1,6 @@
 openai==1.26.0
 pydantic==2.8.2
+httpx==0.27.2
 Deprecated==1.2.14
 importlib-metadata==6.11.0
 packaging==24.0

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/test-requirements-1.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/test-requirements-1.txt
@@ -1,5 +1,6 @@
 openai==1.26.0
 pydantic==2.8.2
+httpx==0.27.2
 Deprecated==1.2.14
 importlib-metadata==6.11.0
 packaging==24.0


### PR DESCRIPTION
# Description

As 0.28.0 broke compat with old openai client.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
