### PR TITLE
Fix missing attributes in `openai_v2`

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
@@ -30,6 +30,7 @@ from .utils import (
     is_streaming,
     message_to_event,
     set_span_attribute,
+    set_span_attributes,
 )
 
 
@@ -40,7 +41,6 @@ def chat_completions_create(
 
     def traced_method(wrapped, instance, args, kwargs):
         span_attributes = {**get_llm_request_attributes(kwargs, instance)}
-
         span_name = f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
         with tracer.start_as_current_span(
             name=span_name,
@@ -48,6 +48,7 @@ def chat_completions_create(
             attributes=span_attributes,
             end_on_exit=False,
         ) as span:
+            set_span_attributes(span, span_attributes)
             if span.is_recording():
                 for message in kwargs.get("messages", []):
                     event_logger.emit(
@@ -90,6 +91,7 @@ def async_chat_completions_create(
             attributes=span_attributes,
             end_on_exit=False,
         ) as span:
+            set_span_attributes(span, span_attributes)
             if span.is_recording():
                 for message in kwargs.get("messages", []):
                     event_logger.emit(

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -164,7 +164,7 @@ def choice_to_event(choice, capture_content):
 
 
 def set_span_attributes(span, attributes: dict):
-    for field, value in attributes.model_dump(by_alias=True).items():
+    for field, value in attributes.items():
         set_span_attribute(span, field, value)
 
 


### PR DESCRIPTION
# Description
While testing i found out that there were missing attributes not getting set for some reason which are
- `gen_ai.operation.name`
- `gen_ai.system`
- `gen_ai.request.model`
- `server.address`


## Type of change
- There is an existing util function called `set_span_attributes` which simply takes a dict of attributes and sets the attributes to the span, used this function -- i fear that this is redundant as we already set the span attributes when using `start_as_current_span` but for some reason which i failed to find out the attributes do not get set unless using `set_span_attributes` -- also the tests were not failing in both scenarios which confused me a bit as well.


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] `tox -e py312-test-instrumentation-openai-v2-1`
- [x] `tox -e py312-test-instrumentation-openai-v2-0`

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
