### PR TITLE
docs: add missing autodoc for click and aiohttp-server

### DIFF
--- a/docs/instrumentation/aiohttp_server/aiohttp_server.rst
+++ b/docs/instrumentation/aiohttp_server/aiohttp_server.rst
@@ -1,0 +1,7 @@
+.. include:: ../../../instrumentation/opentelemetry-instrumentation-aiohttp-server/README.rst
+    :end-before: References
+
+.. automodule:: opentelemetry.instrumentation.aiohttp_server
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/instrumentation/click/click.rst
+++ b/docs/instrumentation/click/click.rst
@@ -1,0 +1,7 @@
+.. include:: ../../../instrumentation/opentelemetry-instrumentation-click/README.rst
+    :end-before: References
+
+.. automodule:: opentelemetry.instrumentation.click
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/nitpick-exceptions.ini
+++ b/docs/nitpick-exceptions.ini
@@ -29,6 +29,7 @@ py-class=
     httpx.SyncByteStream
     httpx.AsyncByteStream
     httpx.Response
+    aiohttp.web_request.Request
     yarl.URL
     cimpl.Producer
     cimpl.Consumer
@@ -65,7 +66,7 @@ any=
 
 py-obj=
     opentelemetry.propagators.textmap.CarrierT
-    
+
 py-func=
     poll
     flush

--- a/instrumentation/opentelemetry-instrumentation-click/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-click/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry click Instrumentation
-===========================
+====================================
 
 |pypi|
 


### PR DESCRIPTION
# Description
Add missing docs for opentelemetry-instrumentation-click and opentelemetry-instrumentation-aiohttp-server