### PR TITLE
opentelemetry-sdk-extension-aws: make eks detector less chatty

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_eks.py
@@ -43,6 +43,10 @@ class AwsEksResourceDetectorTest(unittest.TestCase):
         return_value=True,
     )
     @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_k8s",
+        return_value=True,
+    )
+    @patch(
         "opentelemetry.sdk.extension.aws.resource.eks._get_cluster_info",
         return_value=f"""{{
   "kind": "ConfigMap",
@@ -88,6 +92,7 @@ class AwsEksResourceDetectorTest(unittest.TestCase):
         self,
         mock_open_function,
         mock_get_cluster_info,
+        mock_is_k8s,
         mock_is_eks,
         mock_get_k8_cred_value,
     ):
@@ -104,8 +109,32 @@ class AwsEksResourceDetectorTest(unittest.TestCase):
         "opentelemetry.sdk.extension.aws.resource.eks._is_eks",
         return_value=False,
     )
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_k8s",
+        return_value=True,
+    )
     def test_if_no_eks_env_var_and_should_raise(
-        self, mock_is_eks, mock_get_k8_cred_value
+        self, mock_is_k8s, mock_is_eks, mock_get_k8_cred_value
     ):
         with self.assertRaises(RuntimeError):
             AwsEksResourceDetector(raise_on_error=True).detect()
+
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._get_k8s_cred_value",
+        return_value="MOCK_TOKEN",
+    )
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_eks",
+        return_value=False,
+    )
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.eks._is_k8s",
+        return_value=False,
+    )
+    def test_if_no_eks_paths_should_not_raise(
+        self, mock_is_k8s, mock_is_eks, mock_get_k8_cred_value
+    ):
+        try:
+            AwsEksResourceDetector(raise_on_error=True).detect()
+        except RuntimeError:
+            self.fail("Should not raise")


### PR DESCRIPTION
# Description

Don't print warnings if we are not running inside an eks instance so we can load the resource detector more generally and avoid warnings in stderr.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  tox -e py310-test-sdk-extension-aws-1

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
