### PR TITLE
docs: move `AwsLambdaInstrumentor().instrument()` to after the lambda function

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -29,7 +29,6 @@ Usage
 
     # Enable instrumentation
     BotocoreInstrumentor().instrument()
-    AwsLambdaInstrumentor().instrument()
 
     # Lambda function
     def lambda_handler(event, context):
@@ -38,6 +37,8 @@ Usage
             print(bucket.name)
 
         return "200 OK"
+
+    AwsLambdaInstrumentor().instrument()
 
 API
 ---


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2056#issuecomment-2531619571

`tox -e docs` doesn't work...

```bash
        File "/private/var/folders/q1/wn12m6td0tx0dy1s84xzrxbm0000gn/T/pip-install-nycnab7m/mysqlclient_22dcb881261f49e7b709df7ab13fc6ed/setup_posix.py", line 31, in mysql_config
          raise OSError("{} not found".format(_mysql_config_path))
      OSError: mysql_config not found
      [end of output]
```