### PR TITLE
Populate both origin and hostname correctly to span attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -76,12 +76,7 @@ def set_attributes_from_context(span, context):
 
         attribute_name = None
 
-        # Celery 4.0 uses `origin` instead of `hostname`; this change preserves
-        # the same name for the tag despite Celery version
-        if key == "origin":
-            key = "hostname"
-
-        elif key == "delivery_info":
+        if key == "delivery_info":
             # Get also destination from this
             routing_key = value.get("routing_key")
 


### PR DESCRIPTION
# Description

Previously, the hostname was conflated with the origin; however, they are distinct concepts, as detailed in the issue below.

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3096

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested end-to-end with a demo app available here https://github.com/shivanshuraj1333/celery-opentelemetry-instrumentation

Below are the new attributes in spans and metrics after the change:

Celery host:
```
 -------------- celery@7c2c2cd6a5b5 v5.4.0 (opalescent)
--- ***** ----- 
-- ******* ---- Linux-6.10.14-linuxkit-aarch64-with 2024-12-12 13:27:37
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         myproject:0xffff91429160
- ** ---------- .> transport:   amqp://guest:**@rabbitmq:5672//
- ** ---------- .> results:     rpc://
- *** --- * --- .> concurrency: 11 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** ----- 
 -------------- [queues]
                .> queue1           exchange=queue1(direct) key=queue1
                .> queue2           exchange=queue2(direct) key=queue2
                .> queue3           exchange=queue3(direct) key=queue3
                .> queue4           exchange=queue4(direct) key=queue4
```

Stack Trace Dump from Celery:
```
[2024-12-12 13:31:30,356: DEBUG/MainProcess] TaskPool: Apply <function fast_trace_task at 0xffff91106ca0> (args:('tasks.tasks.multiply', '9717beb8-39fa-4b03-8b6a-464d2df5472b', {'argsrepr': '[3, 4]', 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'id': '9717beb8-39fa-4b03-8b6a-464d2df5472b', 'ignore_result': False, 'kwargsrepr': '{}', 'lang': 'py', 'origin': 'gen8@b98c7aca4628', 'parent_id': None, 'replaced_task_nesting': 0, 'retries': 0, 'root_id': '9717beb8-39fa-4b03-8b6a-464d2df5472b', 'shadow': None, 'stamped_headers': None, 'stamps': {}, 'task': 'tasks.tasks.multiply', 'timelimit': [None, None], 'traceparent': '00-ef2b1df22bc3e7bdd1b1dab863760cd3-ee4a9e13ef330488-01', 'properties': {'content_type': 'application/json', 'content_encoding': 'utf-8', 'application_headers': {'argsrepr': '[3, 4]', 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'id': '9717beb8-39fa-4b03-8b6a-464d2df5472b', 'ignore_result': False, 'kwargsrepr': '{}', 'lang': 'py', 'origin': 'gen8@b98c7aca4628', 'parent_id': None, 'replaced_task_nesting': 0, 'retries': 0, 'root_id':... kwargs:{})
```

Span attributes:
```
Resource SchemaURL: 
2024-12-12T13:33:33.122120922Z Resource attributes:
2024-12-12T13:33:33.122121922Z      -> telemetry.sdk.language: Str(python)
2024-12-12T13:33:33.122122964Z      -> telemetry.sdk.name: Str(opentelemetry)
2024-12-12T13:33:33.122139380Z      -> telemetry.sdk.version: Str(1.29.0)
2024-12-12T13:33:33.122140714Z      -> service.name: Str(worker1)
2024-12-12T13:33:33.122141922Z      -> telemetry.auto.version: Str(0.50b0)
2024-12-12T13:33:33.122143172Z ScopeSpans #0
2024-12-12T13:33:33.122144297Z ScopeSpans SchemaURL: 
2024-12-12T13:33:33.122149005Z InstrumentationScope opentelemetry.instrumentation.celery 0.50b0
2024-12-12T13:33:33.122150964Z Span #0
2024-12-12T13:33:33.122151922Z     Trace ID       : 53ed5fb0e35189cd037e18c2885505e7
2024-12-12T13:33:33.122152922Z     Parent ID      : 2901ac2e8ccccb1e
2024-12-12T13:33:33.122153880Z     ID             : 7166553679d195c5
2024-12-12T13:33:33.122154839Z     Name           : run/tasks.tasks.multiply
2024-12-12T13:33:33.122155755Z     Kind           : Consumer
2024-12-12T13:33:33.122156672Z     Start time     : 2024-12-12 13:33:30.452448296 +0000 UTC
2024-12-12T13:33:33.122157755Z     End time       : 2024-12-12 13:33:32.45406488 +0000 UTC
2024-12-12T13:33:33.122158714Z     Status code    : Unset
2024-12-12T13:33:33.122159589Z     Status message : 
2024-12-12T13:33:33.122160464Z Attributes:
2024-12-12T13:33:33.122161339Z      -> celery.action: Str(run)
2024-12-12T13:33:33.122162339Z      -> celery.state: Str(SUCCESS)
2024-12-12T13:33:33.122163255Z      -> messaging.conversation_id: Str(1be3f640-b36d-4951-9a88-d2fa7758c51e)
2024-12-12T13:33:33.122164297Z      -> messaging.destination: Str(queue2)
2024-12-12T13:33:33.122165964Z      -> celery.delivery_info: Str({'exchange': '', 'routing_key': 'queue2', 'priority': 0, 'redelivered': False})
2024-12-12T13:33:33.122170005Z      -> celery.hostname: Str(celery@7c2c2cd6a5b5)
2024-12-12T13:33:33.122170964Z      -> messaging.message.id: Str(1be3f640-b36d-4951-9a88-d2fa7758c51e)
2024-12-12T13:33:33.122172047Z      -> celery.reply_to: Str(4774934f-b0d9-30c3-a69d-41830cb8848a)
2024-12-12T13:33:33.122173005Z      -> celery.origin: Str(gen8@b98c7aca4628)
2024-12-12T13:33:33.122173964Z      -> celery.task_name: Str(tasks.tasks.multiply)
2024-12-12T13:33:33.122174880Z 	{"kind": "exporter", "data_type": "traces", "name": "debug"}
```

Metrics attributes:
``
Metric #20
2024-12-12T13:34:11.430502384Z Descriptor:
2024-12-12T13:34:11.430506343Z      -> Name: flower_task_prefetch_time_seconds
2024-12-12T13:34:11.430509718Z      -> Description: The time the task spent waiting at the celery worker to be executed.
2024-12-12T13:34:11.430515051Z      -> Unit: 
2024-12-12T13:34:11.430518926Z      -> DataType: Gauge
2024-12-12T13:34:11.430522551Z NumberDataPoints #0
2024-12-12T13:34:11.430526926Z Data point attributes:
2024-12-12T13:34:11.430530884Z      -> task: Str(tasks.tasks.add)
2024-12-12T13:34:11.430534384Z      -> worker: Str(celery@7c2c2cd6a5b5)
``

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
