### PR TITLE
Prevent RuntimeError for Flask on context.detach with the same token

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -536,6 +536,7 @@ def _wrapped_teardown_request(
 
         if flask.request.environ.get(_ENVIRON_TOKEN, None):
             context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+            flask.request.environ[_ENVIRON_TOKEN] = None
 
     return _teardown_request
 


### PR DESCRIPTION
# Description

This happens for me when using werkzeug's debug=True. In this case, the token was already detached. But when I enter an expression into the debug console, we attempt to detach the token once more.

This causes a RuntimeError, as expected: https://peps.python.org/pep-0567/#contextvars-contextvar.

But if we set _ENVIRON_TOKEN to None after we detach, this won't happen.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Create a simple Flask app with instrumented spans
- Raise an error in one of the routes and open the debugger web page
- Click the shell icon and enter the debugger PIN
- Try to examine any variables in the context
    - doing so will produce a RuntimeError in the logs, since the token was already used to detach the context on the original request

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [X] No.
