### PR TITLE
Fix typing for redis

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -159,7 +159,8 @@ _FIELD_TYPES = ["NUMERIC", "TEXT", "GEO", "TAG", "VECTOR"]
 
 
 def _set_connection_attributes(
-    span: Span, conn: Union[AsyncRedisInstance, RedisInstance],
+    span: Span,
+    conn: Union[AsyncRedisInstance, RedisInstance],
 ) -> None:
     if not span.is_recording() or not hasattr(conn, "connection_pool"):
         return
@@ -170,7 +171,8 @@ def _set_connection_attributes(
 
 
 def _build_span_name(
-    instance: Union[AsyncRedisInstance, RedisInstance], cmd_args: tuple[Any, ...]
+    instance: Union[AsyncRedisInstance, RedisInstance],
+    cmd_args: tuple[Any, ...],
 ) -> str:
     if len(cmd_args) > 0 and cmd_args[0]:
         if cmd_args[0] == "FT.SEARCH":

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -93,7 +93,7 @@ API
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Collection
+from typing import TYPE_CHECKING, Any, Callable, Collection, Optional, Union
 
 import redis
 from wrapt import wrap_function_wrapper
@@ -159,7 +159,7 @@ _FIELD_TYPES = ["NUMERIC", "TEXT", "GEO", "TAG", "VECTOR"]
 
 
 def _set_connection_attributes(
-    span: Span, conn: RedisInstance | AsyncRedisInstance
+    span: Span, conn: Union[AsyncRedisInstance, RedisInstance],
 ) -> None:
     if not span.is_recording() or not hasattr(conn, "connection_pool"):
         return
@@ -170,7 +170,7 @@ def _set_connection_attributes(
 
 
 def _build_span_name(
-    instance: RedisInstance | AsyncRedisInstance, cmd_args: tuple[Any, ...]
+    instance: Union[AsyncRedisInstance, RedisInstance], cmd_args: tuple[Any, ...]
 ) -> str:
     if len(cmd_args) > 0 and cmd_args[0]:
         if cmd_args[0] == "FT.SEARCH":
@@ -185,7 +185,7 @@ def _build_span_name(
 
 
 def _build_span_meta_data_for_pipeline(
-    instance: PipelineInstance | AsyncPipelineInstance,
+    instance: Union[AsyncPipelineInstance, PipelineInstance],
 ) -> tuple[list[Any], str, str]:
     try:
         command_stack = (
@@ -217,8 +217,8 @@ def _build_span_meta_data_for_pipeline(
 # pylint: disable=R0915
 def _instrument(
     tracer: Tracer,
-    request_hook: _RequestHookT | None = None,
-    response_hook: _ResponseHookT | None = None,
+    request_hook: Optional[_RequestHookT] = None,
+    response_hook: Optional[_ResponseHookT] = None,
 ):
     def _traced_execute_command(
         func: Callable[..., R],


### PR DESCRIPTION
Followup to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3110

I believe [Pep 0604](https://peps.python.org/pep-0604/) which introduces union typing syntax is only supported for Python 3.10+. Since all instrumentations still support 3.8+, I believe we still need to adhere to the explicit `Optional` and `Union` typings.
