### PR TITLE
Update package metadata adding "Repository" to project urls

### DIFF
--- a/_template/pyproject.toml
+++ b/_template/pyproject.toml
@@ -41,6 +41,7 @@ REPLACE_ME = "opentelemetry.instrumentation.<REPLACE>"
 # url of the instrumentation e.g
 # Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-sqlalchemy"
 Homepage = "<REPLACE ME>"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 # REPLACE ME: the path to the version file e.g

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/pyproject.toml
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/exporter/opentelemetry-exporter-prometheus-remote-write"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/exporter/prometheus_remote_write/version.py"

--- a/exporter/opentelemetry-exporter-richconsole/pyproject.toml
+++ b/exporter/opentelemetry-exporter-richconsole/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/exporter/opentelemetry-exporter-richconsole"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/exporter/richconsole/version.py"

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
@@ -40,6 +40,7 @@ openai = "opentelemetry.instrumentation.openai_v2:OpenAIInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-openai-v2"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/openai_v2/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aio-pika/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aio-pika/pyproject.toml
@@ -40,6 +40,7 @@ aio-pika = "opentelemetry.instrumentation.aio_pika:AioPikaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aio-pika"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aio_pika/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/pyproject.toml
@@ -42,6 +42,7 @@ aiohttp-client = "opentelemetry.instrumentation.aiohttp_client:AioHttpClientInst
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiohttp-client"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aiohttp_client/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/pyproject.toml
@@ -42,6 +42,7 @@ aiohttp-server = "opentelemetry.instrumentation.aiohttp_server:AioHttpServerInst
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiohttp-server"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aiohttp_server/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aiokafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiokafka/pyproject.toml
@@ -38,6 +38,7 @@ aiokafka = "opentelemetry.instrumentation.aiokafka:AIOKafkaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiokafka"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aiokafka/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aiopg/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/pyproject.toml
@@ -41,6 +41,7 @@ aiopg = "opentelemetry.instrumentation.aiopg:AiopgInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiopg"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aiopg/version.py"

--- a/instrumentation/opentelemetry-instrumentation-asgi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-asgi/pyproject.toml
@@ -39,6 +39,7 @@ instruments = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/asgi/version.py"

--- a/instrumentation/opentelemetry-instrumentation-asyncio/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-asyncio/pyproject.toml
@@ -39,6 +39,7 @@ asyncio = "opentelemetry.instrumentation.asyncio:AsyncioInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncio"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/asyncio/version.py"

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/pyproject.toml
@@ -40,6 +40,7 @@ asyncpg = "opentelemetry.instrumentation.asyncpg:AsyncPGInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncpg"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/asyncpg/version.py"

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/pyproject.toml
@@ -38,6 +38,7 @@ aws-lambda = "opentelemetry.instrumentation.aws_lambda:AwsLambdaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aws-lambda"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/aws_lambda/version.py"

--- a/instrumentation/opentelemetry-instrumentation-boto/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-boto/pyproject.toml
@@ -39,6 +39,7 @@ boto = "opentelemetry.instrumentation.boto:BotoInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/boto/version.py"

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml
@@ -41,6 +41,7 @@ boto3 = "opentelemetry.instrumentation.boto3sqs:Boto3SQSInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto3sqs"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/boto3sqs/version.py"

--- a/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/pyproject.toml
@@ -41,6 +41,7 @@ botocore = "opentelemetry.instrumentation.botocore:BotocoreInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-botocore"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/botocore/version.py"

--- a/instrumentation/opentelemetry-instrumentation-cassandra/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/pyproject.toml
@@ -42,6 +42,7 @@ cassandra = "opentelemetry.instrumentation.cassandra:CassandraInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-cassandra"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/cassandra/version.py"

--- a/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-celery/pyproject.toml
@@ -40,6 +40,7 @@ celery = "opentelemetry.instrumentation.celery:CeleryInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-celery"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/celery/version.py"

--- a/instrumentation/opentelemetry-instrumentation-click/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-click/pyproject.toml
@@ -40,6 +40,7 @@ click = "opentelemetry.instrumentation.click:ClickInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-click"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/click/version.py"

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -40,6 +40,7 @@ confluent_kafka = "opentelemetry.instrumentation.confluent_kafka:ConfluentKafkaI
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-confluent-kafka"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/confluent_kafka/version.py"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/pyproject.toml
@@ -36,6 +36,7 @@ instruments = []
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-dbapi"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/dbapi/version.py"

--- a/instrumentation/opentelemetry-instrumentation-django/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-django/pyproject.toml
@@ -45,6 +45,7 @@ django = "opentelemetry.instrumentation.django:DjangoInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/django/version.py"

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/pyproject.toml
@@ -41,6 +41,7 @@ elasticsearch = "opentelemetry.instrumentation.elasticsearch:ElasticsearchInstru
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-elasticsearch"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/elasticsearch/version.py"

--- a/instrumentation/opentelemetry-instrumentation-falcon/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-falcon/pyproject.toml
@@ -43,6 +43,7 @@ falcon = "opentelemetry.instrumentation.falcon:FalconInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-falcon"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/falcon/version.py"

--- a/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml
@@ -42,6 +42,7 @@ fastapi = "opentelemetry.instrumentation.fastapi:FastAPIInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/fastapi/version.py"

--- a/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml
@@ -43,6 +43,7 @@ flask = "opentelemetry.instrumentation.flask:FlaskInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/flask/version.py"

--- a/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-grpc/pyproject.toml
@@ -44,6 +44,7 @@ grpc_aio_server = "opentelemetry.instrumentation.grpc:GrpcAioInstrumentorServer"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/grpc/version.py"

--- a/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-httpx/pyproject.toml
@@ -42,6 +42,7 @@ httpx = "opentelemetry.instrumentation.httpx:HTTPXClientInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-httpx"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/httpx/version.py"

--- a/instrumentation/opentelemetry-instrumentation-jinja2/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/pyproject.toml
@@ -40,6 +40,7 @@ jinja2 = "opentelemetry.instrumentation.jinja2:Jinja2Instrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-jinja2"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/jinja2/version.py"

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/pyproject.toml
@@ -41,6 +41,7 @@ kafka = "opentelemetry.instrumentation.kafka:KafkaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-kafka-python"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/kafka/version.py"

--- a/instrumentation/opentelemetry-instrumentation-logging/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-logging/pyproject.toml
@@ -37,6 +37,7 @@ logging = "opentelemetry.instrumentation.logging:LoggingInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-logging"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/logging/version.py"

--- a/instrumentation/opentelemetry-instrumentation-mysql/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-mysql/pyproject.toml
@@ -40,6 +40,7 @@ mysql = "opentelemetry.instrumentation.mysql:MySQLInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-mysql"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/mysql/version.py"

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/pyproject.toml
@@ -40,6 +40,7 @@ mysqlclient = "opentelemetry.instrumentation.mysqlclient:MySQLClientInstrumentor
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-mysqlclient"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/mysqlclient/version.py"

--- a/instrumentation/opentelemetry-instrumentation-pika/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pika/pyproject.toml
@@ -41,6 +41,7 @@ pika = "opentelemetry.instrumentation.pika:PikaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pika"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/pika/version.py"

--- a/instrumentation/opentelemetry-instrumentation-psycopg/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/pyproject.toml
@@ -41,6 +41,7 @@ psycopg = "opentelemetry.instrumentation.psycopg:PsycopgInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-psycopg"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/psycopg/version.py"

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/pyproject.toml
@@ -40,6 +40,7 @@ psycopg2 = "opentelemetry.instrumentation.psycopg2:Psycopg2Instrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-psycopg2"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/psycopg2/version.py"

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/pyproject.toml
@@ -41,6 +41,7 @@ pymemcache = "opentelemetry.instrumentation.pymemcache:PymemcacheInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymemcache"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/pymemcache/version.py"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/pyproject.toml
@@ -40,6 +40,7 @@ pymongo = "opentelemetry.instrumentation.pymongo:PymongoInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymongo"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/pymongo/version.py"

--- a/instrumentation/opentelemetry-instrumentation-pymysql/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/pyproject.toml
@@ -40,6 +40,7 @@ pymysql = "opentelemetry.instrumentation.pymysql:PyMySQLInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymysql"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/pymysql/version.py"

--- a/instrumentation/opentelemetry-instrumentation-pyramid/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/pyproject.toml
@@ -43,6 +43,7 @@ pyramid = "opentelemetry.instrumentation.pyramid:PyramidInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pyramid"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/pyramid/version.py"

--- a/instrumentation/opentelemetry-instrumentation-redis/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-redis/pyproject.toml
@@ -41,6 +41,7 @@ redis = "opentelemetry.instrumentation.redis:RedisInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-redis"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/redis/version.py"

--- a/instrumentation/opentelemetry-instrumentation-remoulade/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-remoulade/pyproject.toml
@@ -40,6 +40,7 @@ remoulade = "opentelemetry.instrumentation.remoulade:RemouladeInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-remoulade"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/remoulade/version.py"

--- a/instrumentation/opentelemetry-instrumentation-requests/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-requests/pyproject.toml
@@ -41,6 +41,7 @@ requests = "opentelemetry.instrumentation.requests:RequestsInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-requests"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/requests/version.py"

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/pyproject.toml
@@ -42,6 +42,7 @@ sqlalchemy = "opentelemetry.instrumentation.sqlalchemy:SQLAlchemyInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-sqlalchemy"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/sqlalchemy/version.py"

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/pyproject.toml
@@ -38,6 +38,7 @@ sqlite3 = "opentelemetry.instrumentation.sqlite3:SQLite3Instrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-sqlite3"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/sqlite3/version.py"

--- a/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
@@ -42,6 +42,7 @@ starlette = "opentelemetry.instrumentation.starlette:StarletteInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-starlette"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/starlette/version.py"

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/pyproject.toml
@@ -40,6 +40,7 @@ system_metrics = "opentelemetry.instrumentation.system_metrics:SystemMetricsInst
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/system_metrics/version.py"

--- a/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-threading/pyproject.toml
@@ -38,6 +38,7 @@ threading = "opentelemetry.instrumentation.threading:ThreadingInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-threading"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/threading/version.py"

--- a/instrumentation/opentelemetry-instrumentation-tornado/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-tornado/pyproject.toml
@@ -40,6 +40,7 @@ tornado = "opentelemetry.instrumentation.tornado:TornadoInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tornado"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/tornado/version.py"

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/pyproject.toml
@@ -41,6 +41,7 @@ tortoiseorm = "opentelemetry.instrumentation.tortoiseorm:TortoiseORMInstrumentor
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tortoiseorm"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/tortoiseorm/version.py"

--- a/instrumentation/opentelemetry-instrumentation-urllib/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-urllib/pyproject.toml
@@ -39,6 +39,7 @@ urllib = "opentelemetry.instrumentation.urllib:URLLibInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/urllib/version.py"

--- a/instrumentation/opentelemetry-instrumentation-urllib3/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/pyproject.toml
@@ -42,6 +42,7 @@ urllib3 = "opentelemetry.instrumentation.urllib3:URLLib3Instrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/urllib3/version.py"

--- a/instrumentation/opentelemetry-instrumentation-wsgi/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/pyproject.toml
@@ -36,6 +36,7 @@ instruments = []
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-wsgi"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/wsgi/version.py"

--- a/opentelemetry-contrib-instrumentations/pyproject.toml
+++ b/opentelemetry-contrib-instrumentations/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-contrib-instrumentations"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/contrib-instrumentations/version.py"

--- a/opentelemetry-distro/pyproject.toml
+++ b/opentelemetry-distro/pyproject.toml
@@ -44,6 +44,7 @@ distro = "opentelemetry.distro:OpenTelemetryDistro"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/distro/version.py"

--- a/opentelemetry-instrumentation/pyproject.toml
+++ b/opentelemetry-instrumentation/pyproject.toml
@@ -40,6 +40,7 @@ instrumentation = "opentelemetry.instrumentation.environment_variables"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/instrumentation/version.py"

--- a/processor/opentelemetry-processor-baggage/pyproject.toml
+++ b/processor/opentelemetry-processor-baggage/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/processor/opentelemetry-processor-baggage"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/processor/baggage/version.py"

--- a/propagator/opentelemetry-propagator-aws-xray/pyproject.toml
+++ b/propagator/opentelemetry-propagator-aws-xray/pyproject.toml
@@ -34,6 +34,7 @@ xray-lambda = "opentelemetry.propagators.aws:AwsXRayLambdaPropagator"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/propagator/opentelemetry-propagator-aws-xray"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/propagators/aws/version.py"

--- a/propagator/opentelemetry-propagator-ot-trace/pyproject.toml
+++ b/propagator/opentelemetry-propagator-ot-trace/pyproject.toml
@@ -34,6 +34,7 @@ ottrace = "opentelemetry.propagators.ot_trace:OTTracePropagator"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/propagator/opentelemetry-propagator-ot-trace"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/propagators/ot_trace/version.py"

--- a/resource/opentelemetry-resource-detector-azure/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-azure/pyproject.toml
@@ -36,6 +36,7 @@ azure_vm = "opentelemetry.resource.detector.azure.vm:AzureVMResourceDetector"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/resource/opentelemetry-resource-detector-azure"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/resource/detector/azure/version.py"

--- a/resource/opentelemetry-resource-detector-container/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-container/pyproject.toml
@@ -33,6 +33,7 @@ container = "opentelemetry.resource.detector.container:ContainerResourceDetector
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/resource/opentelemetry-resource-detector-container"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/resource/detector/container/version.py"

--- a/sdk-extension/opentelemetry-sdk-extension-aws/pyproject.toml
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/pyproject.toml
@@ -40,6 +40,7 @@ aws_lambda = "opentelemetry.sdk.extension.aws.resource._lambda:AwsLambdaResource
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/sdk-extension/opentelemetry-sdk-extension-aws"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/sdk/extension/aws/version.py"

--- a/util/opentelemetry-util-http/pyproject.toml
+++ b/util/opentelemetry-util-http/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-http"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
 
 [tool.hatch.version]
 path = "src/opentelemetry/util/http/version.py"


### PR DESCRIPTION
Add "Repository" label to project urls pointing to the opentelemetry-python repo root url.

Having within project urls one entry with the same value for all packages released by the project will help tools for automatic dependency management to suggest coherent upgrades for related packages.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR is dual of https://github.com/open-telemetry/opentelemetry-python/pull/4363.
