### PR TITLE
opentelemetry-sdk-extension-aws: make ec2 resource detector silent when loaded outside AWS

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/CHANGELOG.md
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Make ec2 resource detector silent when loaded outside AWS
+  ([#3120](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3120))
 - Make ecs and beanstalk resource detector silent when loaded outside AWS
   ([#3076](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3076))
 - Make EKS resource detector don't warn when not running in EKS

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/ec2.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/ec2.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from opentelemetry.sdk.resources import Resource, ResourceDetector
@@ -27,39 +28,47 @@ logger = logging.getLogger(__name__)
 
 _AWS_METADATA_TOKEN_HEADER = "X-aws-ec2-metadata-token"
 _GET_METHOD = "GET"
+_AWS_METADATA_HOST = "169.254.169.254"
 
 
-def _aws_http_request(method, path, headers):
+def _aws_http_request(method, path, headers, timeout=None):
+    if timeout is None:
+        timeout = 5
     with urlopen(
         Request(
-            "http://169.254.169.254" + path, headers=headers, method=method
+            "http://" + _AWS_METADATA_HOST + path,
+            headers=headers,
+            method=method,
         ),
-        timeout=5,
+        timeout=timeout,
     ) as response:
         return response.read().decode("utf-8")
 
 
-def _get_token():
+def _get_token(timeout=None):
     return _aws_http_request(
         "PUT",
         "/latest/api/token",
         {"X-aws-ec2-metadata-token-ttl-seconds": "60"},
+        timeout,
     )
 
 
-def _get_identity(token):
+def _get_identity(token, timeout=None):
     return _aws_http_request(
         _GET_METHOD,
         "/latest/dynamic/instance-identity/document",
         {_AWS_METADATA_TOKEN_HEADER: token},
+        timeout,
     )
 
 
-def _get_host(token):
+def _get_host(token, timeout=None):
     return _aws_http_request(
         _GET_METHOD,
         "/latest/meta-data/hostname",
         {_AWS_METADATA_TOKEN_HEADER: token},
+        timeout,
     )
 
 
@@ -72,7 +81,12 @@ class AwsEc2ResourceDetector(ResourceDetector):
 
     def detect(self) -> "Resource":
         try:
-            token = _get_token()
+            # If can't get a token quick assume we are not on ec2
+            try:
+                token = _get_token(timeout=1)
+            except URLError:
+                return Resource.get_empty()
+
             identity_dict = json.loads(_get_identity(token))
             hostname = _get_host(token)
 

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/ec2.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/ec2.py
@@ -84,7 +84,12 @@ class AwsEc2ResourceDetector(ResourceDetector):
             # If can't get a token quick assume we are not on ec2
             try:
                 token = _get_token(timeout=1)
-            except URLError:
+            except URLError as exception:
+                logger.debug(
+                    "%s failed to get token: %s",
+                    self.__class__.__name__,
+                    exception,
+                )
                 return Resource.get_empty()
 
             identity_dict = json.loads(_get_identity(token))

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_ec2.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_ec2.py
@@ -82,5 +82,14 @@ class AwsEc2ResourceDetectorTest(unittest.TestCase):
     def test_empty_resource_if_token_returns_an_url_error(
         self, mock_get_token
     ):
-        actual = AwsEc2ResourceDetector().detect()
+        with self.assertLogs(
+            "opentelemetry.sdk.extension.aws.resource.ec2", level="DEBUG"
+        ) as logger:
+            actual = AwsEc2ResourceDetector().detect()
+            self.assertEqual(
+                logger.output,
+                [
+                    "DEBUG:opentelemetry.sdk.extension.aws.resource.ec2:AwsEc2ResourceDetector failed to get token: <urlopen error Something went wrong>"
+                ],
+            )
         self.assertDictEqual(actual.attributes.copy(), OrderedDict())

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_ec2.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test_ec2.py
@@ -15,6 +15,7 @@
 import unittest
 from collections import OrderedDict
 from unittest.mock import patch
+from urllib.error import URLError
 
 from opentelemetry.sdk.extension.aws.resource.ec2 import (  # pylint: disable=no-name-in-module
     AwsEc2ResourceDetector,
@@ -73,3 +74,13 @@ class AwsEc2ResourceDetectorTest(unittest.TestCase):
         self.assertDictEqual(
             actual.attributes.copy(), OrderedDict(MockEc2ResourceAttributes)
         )
+
+    @patch(
+        "opentelemetry.sdk.extension.aws.resource.ec2._get_token",
+        side_effect=URLError("Something went wrong"),
+    )
+    def test_empty_resource_if_token_returns_an_url_error(
+        self, mock_get_token
+    ):
+        actual = AwsEc2ResourceDetector().detect()
+        self.assertDictEqual(actual.attributes.copy(), OrderedDict())


### PR DESCRIPTION
# Description

Assume that if we fail to get the token quickly (for some definition of quickly, timeout is 1 second, the call to get a tokens takes a bunch of ms usually) we are not on AWS.

Fixes #3075

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-sdk-extension-aws-1

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
