### PR TITLE
Remove unnecessary configuration of logs exporter in Gen AI samples

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/zero-code/.env
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/zero-code/.env
@@ -12,10 +12,11 @@ OPENAI_API_KEY=sk-YOUR_API_KEY
 
 OTEL_SERVICE_NAME=opentelemetry-python-openai
 
-# Change to 'false' to disable logging
+# Change to 'false' to disable collection of python logging logs
 OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-# Change to 'console' if your OTLP endpoint doesn't support logs
-# TODO: this should not be necessary once https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3042 is released
-OTEL_LOGS_EXPORTER=otlp
+
+# Uncomment if your OTLP endpoint doesn't support logs
+# OTEL_LOGS_EXPORTER=console
+
 # Change to 'false' to hide prompt and completion content
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/examples/zero-code/.env
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/examples/zero-code/.env
@@ -4,10 +4,11 @@
 
 OTEL_SERVICE_NAME=opentelemetry-python-vertexai
 
-# Change to 'false' to disable logging
+# Change to 'false' to disable collection of python logging logs
 OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-# Change to 'console' if your OTLP endpoint doesn't support logs
-# TODO: this should not be necessary once https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3042 is released
-OTEL_LOGS_EXPORTER=otlp
+
+# Uncomment if your OTLP endpoint doesn't support logs
+# OTEL_LOGS_EXPORTER=console
+
 # Change to 'false' to hide prompt and completion content
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true


### PR DESCRIPTION
# Description

It is no longer necessary, since https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3042 we now set up the logging pipeline by default with OTLP exporter.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Tested the OpenAI zero code sample with Ollama and verified logs were sent to local OTLP endpoint.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
