### PR TITLE
wsgi: always record span status code to have it available in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3111](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3111))
 - `opentelemetry-instrumentation-falcon` add support version to v4
   ([#3086](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3086))
-- `opentelemetry-instrumentation-wsgi` remove is_recording method to record status code in all metrics
+- `opentelemetry-instrumentation-wsgi` always record span status code to have it available in metrics
   ([#3148](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3148))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3111](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3111))
 - `opentelemetry-instrumentation-falcon` add support version to v4
   ([#3086](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3086))
-
+- `opentelemetry-instrumentation-wsgi` remove is_recording method to record status code in all metrics
+  ([#3148](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3148))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -480,11 +480,7 @@ def add_response_attributes(
     """Adds HTTP response attributes to span using the arguments
     passed to a PEP3333-conforming start_response callable.
     """
-    if not span.is_recording():
-        return
     status_code_str, _ = start_response_status.split(" ", 1)
-
-    status_code = 0
     try:
         status_code = int(status_code_str)
     except ValueError:

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -779,6 +779,18 @@ class TestWsgiAttributes(unittest.TestCase):
         self.span.set_attribute.assert_has_calls(expected, any_order=True)
         self.span.set_attribute.assert_has_calls(expected_new, any_order=True)
 
+    def test_response_attributes_noop(self):
+        mock_span = mock.Mock()
+        mock_span.is_recording.return_value = False
+
+        attrs = {}
+        otel_wsgi.add_response_attributes(mock_span, "404 Not Found", {}, duration_attrs=attrs)
+
+        self.assertEqual(mock_span.set_attribute.call_count, 0)
+        self.assertEqual(mock_span.is_recording.call_count, 2)
+        self.assertEqual(attrs[SpanAttributes.HTTP_STATUS_CODE], 404)
+
+
     def test_credential_removal(self):
         self.environ["HTTP_HOST"] = "username:password@mock"
         self.environ["PATH_INFO"] = "/status/200"

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -784,12 +784,13 @@ class TestWsgiAttributes(unittest.TestCase):
         mock_span.is_recording.return_value = False
 
         attrs = {}
-        otel_wsgi.add_response_attributes(mock_span, "404 Not Found", {}, duration_attrs=attrs)
+        otel_wsgi.add_response_attributes(
+            mock_span, "404 Not Found", {}, duration_attrs=attrs
+        )
 
         self.assertEqual(mock_span.set_attribute.call_count, 0)
         self.assertEqual(mock_span.is_recording.call_count, 2)
         self.assertEqual(attrs[SpanAttributes.HTTP_STATUS_CODE], 404)
-
 
     def test_credential_removal(self):
         self.environ["HTTP_HOST"] = "username:password@mock"


### PR DESCRIPTION
# Description

The same bug reported [here](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2627)

The histograms records are set without status_code attribute due to the decision is based on the span `is_recording `method. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Local with this configuration:
python = ">=3.9,<4"
flask-restx = "1.3.0"
flask = "^3.1.0"
opentelemetry-instrumentation-flask = "^0.50b0"
opentelemetry-api = "^1.29.0"
opentelemetry-sdk = "^1.29.0"
opentelemetry-instrumentation-wsgi = "^0.50b0"
opentelemetry-semantic-conventions = "^0.50b0"

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated

