### PR TITLE
cassandra: fix tests for py313

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-cassandra/tests/test_cassandra_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/tests/test_cassandra_integration.py
@@ -42,7 +42,9 @@ class TestCassandraIntegration(TestBase):
         super().tearDown()
         with self.disable_logging():
             CassandraInstrumentor().uninstrument()
-
+    @property
+    def _mocked_session(self):
+        return cassandra.cluster.Session(cluster=mock.Mock(), hosts=[])
     def test_instrument_uninstrument(self):
         instrumentation = CassandraInstrumentor()
         instrumentation.instrument()
@@ -67,7 +69,7 @@ class TestCassandraIntegration(TestBase):
     ):
         mock_create_response_future.return_value = mock.Mock()
         mock_session_init.return_value = None
-        mock_connect.return_value = cassandra.cluster.Session()
+        mock_connect.return_value = self._mocked_session
 
         CassandraInstrumentor().instrument()
 
@@ -100,7 +102,7 @@ class TestCassandraIntegration(TestBase):
     ):
         mock_create_response_future.return_value = mock.Mock()
         mock_session_init.return_value = None
-        mock_connect.return_value = cassandra.cluster.Session()
+        mock_connect.return_value = self._mocked_session
 
         resource = resources.Resource.create({})
         result = self.create_tracer_provider(resource=resource)
@@ -124,7 +126,7 @@ class TestCassandraIntegration(TestBase):
     ):
         mock_create_response_future.return_value = mock.Mock()
         mock_session_init.return_value = None
-        mock_connect.return_value = cassandra.cluster.Session()
+        mock_connect.return_value = self._mocked_session
 
         tracer_provider = trace_api.NoOpTracerProvider()
         CassandraInstrumentor().instrument(tracer_provider=tracer_provider)

--- a/instrumentation/opentelemetry-instrumentation-cassandra/tests/test_cassandra_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/tests/test_cassandra_integration.py
@@ -42,9 +42,11 @@ class TestCassandraIntegration(TestBase):
         super().tearDown()
         with self.disable_logging():
             CassandraInstrumentor().uninstrument()
+
     @property
     def _mocked_session(self):
         return cassandra.cluster.Session(cluster=mock.Mock(), hosts=[])
+
     def test_instrument_uninstrument(self):
         instrumentation = CassandraInstrumentor()
         instrumentation.instrument()


### PR DESCRIPTION
# Description

To make lint CI green for Cassandra instrumentation in py313 PR #3134 