### PR TITLE
prometheus-remote-write: bump cramjam to 2.8.4 in test-requirements

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
@@ -3,7 +3,7 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 # We can drop this after bumping baseline to pypy-39
 cramjam==2.1.0; platform_python_implementation == "PyPy"
-cramjam==2.8.1; platform_python_implementation != "PyPy"
+cramjam==2.8.4; platform_python_implementation != "PyPy"
 Deprecated==1.2.14
 idna==3.7
 iniconfig==2.0.0


### PR DESCRIPTION
# Description
Bump needed for #3134 