### PR TITLE
Fix component owners workflow permissions

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -10,6 +10,10 @@ jobs:
   run_self:
     runs-on: ubuntu-latest
     name: Auto Assign Owners
+    permissions: 
+      contents: read          # to read changed files 
+      issues: write           # to read/write issue assignees 
+      pull-requests: write    # to read/write PR reviewers 
     # Don't fail tests if this workflow fails. Some pending issues:
     # - https://github.com/dyladan/component-owners/issues/8
     continue-on-error: true


### PR DESCRIPTION
# Description

The component owners workflow fails miserably in forks with restricted permissions because it's misconfigured:
- https://github.com/dyladan/component-owners/issues/21

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The official documentation for the action has been consulted:
https://github.com/dyladan/component-owners/blob/58bd86e9814d23f1525d0a970682cead459fa783/README.md?plain=1#L54-L57

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
