### PR TITLE
Add check before iterating over dist.requires at load_instrumentor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-httpx` Fix `RequestInfo`/`ResponseInfo` type hints
   ([#3105](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3105))
+- `opentelemetry-instrumentation` Fix `get_dist_dependency_conflicts` if no distribution requires
+  ([#3168](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3168))
 
 
 ## Version 1.29.0/0.50b0 (2024-12-11)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -47,13 +47,14 @@ def get_dist_dependency_conflicts(
     extra = "extra"
     instruments = "instruments"
     instruments_marker = {extra: instruments}
-    for dep in dist.requires:
-        if extra not in dep or instruments not in dep:
-            continue
+    if dist.requires:
+        for dep in dist.requires:
+            if extra not in dep or instruments not in dep:
+                continue
 
-        req = Requirement(dep)
-        if req.marker.evaluate(instruments_marker):
-            instrumentation_deps.append(req)
+            req = Requirement(dep)
+            if req.marker.evaluate(instruments_marker):
+                instrumentation_deps.append(req)
 
     return get_dependency_conflicts(instrumentation_deps)
 

--- a/opentelemetry-instrumentation/tests/test_dependencies.py
+++ b/opentelemetry-instrumentation/tests/test_dependencies.py
@@ -86,3 +86,19 @@ class TestDependencyConflicts(TestBase):
             str(conflict),
             'DependencyConflict: requested: "test-pkg~=1.0; extra == "instruments"" but found: "None"',
         )
+
+    def test_get_dist_dependency_conflicts_requires_none(self):
+        class MockDistribution(Distribution):
+            def locate_file(self, path):
+                pass
+
+            def read_text(self, filename):
+                pass
+
+            @property
+            def requires(self):
+                return None
+
+        dist = MockDistribution()
+        conflict = get_dist_dependency_conflicts(dist)
+        self.assertTrue(conflict is None)


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3167

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e  py312-test-opentelemetry-instrumentation`
- [x] Used local changes to install `opentelemetry-distro` and auto-instrument a Flask app (see [Steps to Reproduce](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3167))

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
