### PR TITLE
Use python dict instead of string as attribute value to enable parsing

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/utils.py
@@ -95,8 +95,6 @@ def set_attributes_from_context(span, context):
                     SpanAttributes.MESSAGING_DESTINATION, routing_key
                 )
 
-            value = str(value)
-
         elif key == "id":
             attribute_name = SpanAttributes.MESSAGING_MESSAGE_ID
 


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3169