### PR TITLE
click: ignore click based servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-httpx` Fix `RequestInfo`/`ResponseInfo` type hints
   ([#3105](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3105))
+- `opentelemetry-instrumentation-click` Disable tracing of well-known server click commands
+  ([#3174](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3174))
 
 
 ## Version 1.29.0/0.50b0 (2024-12-11)

--- a/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
@@ -47,6 +47,12 @@ from typing import Collection
 import click
 from wrapt import wrap_function_wrapper
 
+try:
+    from flask.cli import ScriptInfo as FlaskScriptInfo
+except ImportError:
+    FlaskScripInfo = None
+
+
 from opentelemetry import trace
 from opentelemetry.instrumentation.click.package import _instruments
 from opentelemetry.instrumentation.click.version import __version__
@@ -66,6 +72,20 @@ from opentelemetry.trace.status import StatusCode
 _logger = getLogger(__name__)
 
 
+def _skip_servers(ctx: click.Context):
+    # flask run
+    if (
+        ctx.info_name == "run"
+        and FlaskScriptInfo
+        and isinstance(ctx.obj, FlaskScriptInfo)
+    ):
+        return True
+    # uvicorn
+    if ctx.info_name == "uvicorn":
+        return True
+    return False
+
+
 def _command_invoke_wrapper(wrapped, instance, args, kwargs, tracer):
     # Subclasses of Command include groups and CLI runners, but
     # we only want to instrument the actual commands which are
@@ -74,6 +94,12 @@ def _command_invoke_wrapper(wrapped, instance, args, kwargs, tracer):
         return wrapped(*args, **kwargs)
 
     ctx = args[0]
+
+    # we don't want to create a root span for long running processes like servers
+    # otherwise all requests would have the same trace id
+    if _skip_servers(ctx):
+        return wrapped(*args, **kwargs)
+
     span_name = ctx.info_name
     span_attributes = {
         PROCESS_COMMAND_ARGS: sys.argv,

--- a/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 """
-Instrument `click`_ CLI applications.
+Instrument `click`_ CLI applications. The instrumentor will avoid instrumenting
+well-known servers (e.g. *flask run* and *uvicorn*) to avoid unexpected effects
+like every request having the same Trace ID.
 
 .. _click: https://pypi.org/project/click/
 

--- a/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-click/src/opentelemetry/instrumentation/click/__init__.py
@@ -50,7 +50,7 @@ from wrapt import wrap_function_wrapper
 try:
     from flask.cli import ScriptInfo as FlaskScriptInfo
 except ImportError:
-    FlaskScripInfo = None
+    FlaskScriptInfo = None
 
 
 from opentelemetry import trace

--- a/instrumentation/opentelemetry-instrumentation-click/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-click/test-requirements.txt
@@ -1,7 +1,12 @@
 asgiref==3.8.1
+blinker==1.7.0
 click==8.1.7
 Deprecated==1.2.14
+Flask==3.0.2
 iniconfig==2.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.4
+MarkupSafe==2.1.2
 packaging==24.0
 pluggy==1.5.0
 py-cpuinfo==9.0.0
@@ -9,7 +14,11 @@ pytest==7.4.4
 pytest-asyncio==0.23.5
 tomli==2.0.1
 typing_extensions==4.12.2
+Werkzeug==3.0.6
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation
 -e instrumentation/opentelemetry-instrumentation-click
+-e instrumentation/opentelemetry-instrumentation-flask
+-e instrumentation/opentelemetry-instrumentation-wsgi
+-e util/opentelemetry-util-http


### PR DESCRIPTION
# Description

We don't want to create a root span for long running processes like development web servers otherwise all requests would have the same trace id which is unfortunate.

Fixes #3171
Fixes #3172

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-instrumentation-flask

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
