### PR TITLE
Run pyright on Vertex AI instrumentation

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
@@ -39,7 +39,7 @@ API
 ---
 """
 
-from typing import Collection
+from typing import Any, Collection
 
 from opentelemetry._events import get_event_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -52,7 +52,7 @@ class VertexAIInstrumentor(BaseInstrumentor):
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
+    def _instrument(self, **kwargs: Any):
         """Enable VertexAI instrumentation."""
         tracer_provider = kwargs.get("tracer_provider")
         _tracer = get_tracer(
@@ -70,5 +70,5 @@ class VertexAIInstrumentor(BaseInstrumentor):
         )
         # TODO: implemented in later PR
 
-    def _uninstrument(self, **kwargs) -> None:
+    def _uninstrument(self, **kwargs: Any) -> None:
         """TODO: implemented in later PR"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,13 @@ pythonVersion = "3.8"
 reportPrivateUsage = false  # Ignore private attributes added by instrumentation packages.
 # Add progressively instrumentation packages here.
 include = [
-  "instrumentation/opentelemetry-instrumentation-threading/**/*.py"
+  "instrumentation/opentelemetry-instrumentation-threading/**/*.py",
+  "instrumentation-genai/opentelemetry-instrumentation-vertexai/**/*.py",
 ]
 # We should also add type hints to the test suite - It helps on finding bugs.
 # We are excluding for now because it's easier, and more important to add to the instrumentation packages.
 exclude = [
   "instrumentation/opentelemetry-instrumentation-threading/tests/**",
+  "instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/**/*.py",
+  "instrumentation-genai/opentelemetry-instrumentation-vertexai/examples/**/*.py",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -994,5 +994,6 @@ deps =
   {[testenv]test_deps}
   {toxinidir}/opentelemetry-instrumentation
   {toxinidir}/util/opentelemetry-util-http
+  {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai[instruments]
 commands =
   pyright


### PR DESCRIPTION
# Description

Follow up to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3116, adds typechecking to the vertexai instrumentation. This instrumentation is WIP and only has boilerplate so far, so this is very simple.

The interesting part is how to make dependencies needed for typechecking available to pyright.

## Type of change

Please delete options that are not relevant.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] `tox -e typecheck`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
