### PR TITLE
Introducing tox-uv 

### DIFF
--- a/.github/workflows/core_contrib_test_0.yml
+++ b/.github/workflows/core_contrib_test_0.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-openai-v2-0 -- -ra
@@ -58,7 +58,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-openai-v2-1 -- -ra
@@ -80,7 +80,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-vertexai-0 -- -ra
@@ -102,7 +102,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-vertexai-1 -- -ra
@@ -124,7 +124,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-container -- -ra
@@ -146,7 +146,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-azure-0 -- -ra
@@ -168,7 +168,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-azure-1 -- -ra
@@ -190,7 +190,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-sdk-extension-aws-0 -- -ra
@@ -212,7 +212,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-sdk-extension-aws-1 -- -ra
@@ -234,7 +234,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-distro -- -ra
@@ -256,7 +256,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-opentelemetry-instrumentation -- -ra
@@ -278,7 +278,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiohttp-client -- -ra
@@ -300,7 +300,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiohttp-server -- -ra
@@ -322,7 +322,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiopg -- -ra
@@ -344,7 +344,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aws-lambda -- -ra
@@ -366,7 +366,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-botocore -- -ra
@@ -388,7 +388,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-boto3sqs -- -ra
@@ -410,7 +410,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-0 -- -ra
@@ -432,7 +432,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-1 -- -ra
@@ -454,7 +454,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-2 -- -ra
@@ -476,7 +476,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-dbapi -- -ra
@@ -498,7 +498,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-boto -- -ra
@@ -520,7 +520,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-click -- -ra
@@ -542,7 +542,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-0 -- -ra
@@ -564,7 +564,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-1 -- -ra
@@ -586,7 +586,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-2 -- -ra
@@ -608,7 +608,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-0 -- -ra
@@ -630,7 +630,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-1 -- -ra
@@ -652,7 +652,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-2 -- -ra
@@ -674,7 +674,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-3 -- -ra
@@ -696,7 +696,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-fastapi -- -ra
@@ -718,7 +718,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-0 -- -ra
@@ -740,7 +740,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-1 -- -ra
@@ -762,7 +762,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-2 -- -ra
@@ -784,7 +784,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib -- -ra
@@ -806,7 +806,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib3-0 -- -ra
@@ -828,7 +828,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib3-1 -- -ra
@@ -850,7 +850,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-requests -- -ra
@@ -872,7 +872,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-starlette -- -ra
@@ -894,7 +894,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-jinja2 -- -ra
@@ -916,7 +916,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-logging -- -ra
@@ -938,7 +938,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-exporter-richconsole -- -ra
@@ -960,7 +960,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-exporter-prometheus-remote-write -- -ra
@@ -982,7 +982,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysql-0 -- -ra
@@ -1004,7 +1004,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysql-1 -- -ra
@@ -1026,7 +1026,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysqlclient -- -ra
@@ -1048,7 +1048,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-psycopg2 -- -ra
@@ -1070,7 +1070,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-psycopg -- -ra
@@ -1092,7 +1092,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-0 -- -ra
@@ -1114,7 +1114,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-1 -- -ra
@@ -1136,7 +1136,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-2 -- -ra
@@ -1158,7 +1158,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-3 -- -ra
@@ -1180,7 +1180,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-4 -- -ra
@@ -1202,7 +1202,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymongo -- -ra
@@ -1224,7 +1224,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymysql -- -ra
@@ -1246,7 +1246,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pyramid -- -ra
@@ -1268,7 +1268,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asgi -- -ra
@@ -1290,7 +1290,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asyncpg -- -ra
@@ -1312,7 +1312,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlite3 -- -ra
@@ -1334,7 +1334,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-wsgi -- -ra
@@ -1356,7 +1356,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-grpc-0 -- -ra
@@ -1378,7 +1378,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-grpc-1 -- -ra
@@ -1400,7 +1400,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlalchemy-1 -- -ra
@@ -1422,7 +1422,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlalchemy-2 -- -ra
@@ -1444,7 +1444,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-redis -- -ra
@@ -1466,7 +1466,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-remoulade -- -ra
@@ -1488,7 +1488,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-celery -- -ra
@@ -1510,7 +1510,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-system-metrics -- -ra
@@ -1532,7 +1532,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-threading -- -ra
@@ -1554,7 +1554,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-tornado -- -ra
@@ -1576,7 +1576,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-tortoiseorm -- -ra
@@ -1598,7 +1598,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-httpx-0 -- -ra
@@ -1620,7 +1620,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-httpx-1 -- -ra
@@ -1642,7 +1642,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-util-http -- -ra
@@ -1664,7 +1664,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-aws-xray-0 -- -ra
@@ -1686,7 +1686,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-aws-xray-1 -- -ra
@@ -1708,7 +1708,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-ot-trace -- -ra
@@ -1730,7 +1730,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sio-pika-0 -- -ra
@@ -1752,7 +1752,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sio-pika-1 -- -ra
@@ -1774,7 +1774,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-0 -- -ra
@@ -1796,7 +1796,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-1 -- -ra
@@ -1818,7 +1818,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-2 -- -ra
@@ -1840,7 +1840,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-3 -- -ra
@@ -1862,7 +1862,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiokafka -- -ra
@@ -1884,7 +1884,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-kafka-python -- -ra
@@ -1906,7 +1906,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-kafka-pythonng -- -ra
@@ -1928,7 +1928,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-confluent-kafka -- -ra
@@ -1950,7 +1950,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asyncio -- -ra
@@ -1972,7 +1972,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-cassandra -- -ra
@@ -1994,7 +1994,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-processor-baggage -- -ra

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
@@ -37,7 +37,7 @@ jobs:
           architecture: "x64"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e {{ job_data.tox_env }} -- -ra

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e {{ job_data.tox_env }}

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -57,7 +57,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e {{ job_data }}

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
@@ -30,7 +30,7 @@ jobs:
           python-version: "{{ job_data.python_version }}"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
       {%- if job_data.os == "windows-latest" %}
 
       - name: Configure git to support long filenames

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-openai-v2
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-vertexai
@@ -65,7 +65,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-resource-detector-container
@@ -83,7 +83,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-resource-detector-azure
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-sdk-extension-aws
@@ -119,7 +119,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-distro
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-opentelemetry-instrumentation
@@ -155,7 +155,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aiohttp-client
@@ -173,7 +173,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aiohttp-server
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aiopg
@@ -209,7 +209,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aws-lambda
@@ -227,7 +227,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-botocore
@@ -245,7 +245,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-boto3sqs
@@ -263,7 +263,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-django
@@ -281,7 +281,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-dbapi
@@ -299,7 +299,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-boto
@@ -317,7 +317,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-click
@@ -335,7 +335,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-elasticsearch
@@ -353,7 +353,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-falcon
@@ -371,7 +371,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-fastapi
@@ -389,7 +389,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-flask
@@ -407,7 +407,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-urllib
@@ -425,7 +425,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-urllib3
@@ -443,7 +443,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-requests
@@ -461,7 +461,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-starlette
@@ -479,7 +479,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-jinja2
@@ -497,7 +497,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-logging
@@ -515,7 +515,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-exporter-richconsole
@@ -533,7 +533,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-exporter-prometheus-remote-write
@@ -551,7 +551,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-mysql
@@ -569,7 +569,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-mysqlclient
@@ -587,7 +587,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-psycopg2
@@ -605,7 +605,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-psycopg
@@ -623,7 +623,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-pymemcache
@@ -641,7 +641,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-pymongo
@@ -659,7 +659,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-pymysql
@@ -677,7 +677,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-pyramid
@@ -695,7 +695,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-asgi
@@ -713,7 +713,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-asyncpg
@@ -731,7 +731,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-sqlite3
@@ -749,7 +749,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-wsgi
@@ -767,7 +767,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-grpc
@@ -785,7 +785,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-sqlalchemy
@@ -803,7 +803,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-redis
@@ -821,7 +821,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-remoulade
@@ -839,7 +839,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-celery
@@ -857,7 +857,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-system-metrics
@@ -875,7 +875,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-threading
@@ -893,7 +893,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-tornado
@@ -911,7 +911,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-tortoiseorm
@@ -929,7 +929,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-httpx
@@ -947,7 +947,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-util-http
@@ -965,7 +965,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-propagator-aws-xray
@@ -983,7 +983,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-propagator-ot-trace
@@ -1001,7 +1001,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-sio-pika
@@ -1019,7 +1019,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aio-pika
@@ -1037,7 +1037,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-aiokafka
@@ -1055,7 +1055,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-kafka-python
@@ -1073,7 +1073,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-confluent-kafka
@@ -1091,7 +1091,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-asyncio
@@ -1109,7 +1109,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-instrumentation-cassandra
@@ -1127,7 +1127,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e lint-processor-baggage

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e spellcheck
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e docker-tests
@@ -67,7 +67,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e docs
@@ -85,7 +85,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e generate
@@ -109,7 +109,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e generate-workflows
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e shellcheck
@@ -148,7 +148,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e ruff
@@ -166,7 +166,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e typecheck

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-openai-v2-0 -- -ra
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-openai-v2-1 -- -ra
@@ -65,7 +65,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-openai-v2-0 -- -ra
@@ -83,7 +83,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-openai-v2-1 -- -ra
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-openai-v2-0 -- -ra
@@ -119,7 +119,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-openai-v2-1 -- -ra
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-openai-v2-0 -- -ra
@@ -155,7 +155,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-openai-v2-1 -- -ra
@@ -173,7 +173,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-openai-v2-0 -- -ra
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-openai-v2-1 -- -ra
@@ -209,7 +209,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-openai-v2-0 -- -ra
@@ -227,7 +227,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-openai-v2-1 -- -ra
@@ -245,7 +245,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-openai-v2-0 -- -ra
@@ -263,7 +263,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-openai-v2-1 -- -ra
@@ -281,7 +281,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-vertexai-0 -- -ra
@@ -299,7 +299,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-vertexai-1 -- -ra
@@ -317,7 +317,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-vertexai-0 -- -ra
@@ -335,7 +335,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-vertexai-1 -- -ra
@@ -353,7 +353,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-vertexai-0 -- -ra
@@ -371,7 +371,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-vertexai-1 -- -ra
@@ -389,7 +389,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-vertexai-0 -- -ra
@@ -407,7 +407,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-vertexai-1 -- -ra
@@ -425,7 +425,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-vertexai-0 -- -ra
@@ -443,7 +443,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-vertexai-1 -- -ra
@@ -461,7 +461,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-vertexai-0 -- -ra
@@ -479,7 +479,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-vertexai-1 -- -ra
@@ -497,7 +497,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-container -- -ra
@@ -515,7 +515,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-resource-detector-container -- -ra
@@ -533,7 +533,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-resource-detector-container -- -ra
@@ -551,7 +551,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-resource-detector-container -- -ra
@@ -569,7 +569,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-resource-detector-container -- -ra
@@ -587,7 +587,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-resource-detector-container -- -ra
@@ -605,7 +605,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-resource-detector-container -- -ra
@@ -623,7 +623,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-azure-0 -- -ra
@@ -641,7 +641,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-resource-detector-azure-1 -- -ra
@@ -659,7 +659,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-resource-detector-azure-0 -- -ra
@@ -677,7 +677,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-resource-detector-azure-1 -- -ra
@@ -695,7 +695,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-resource-detector-azure-0 -- -ra
@@ -713,7 +713,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-resource-detector-azure-1 -- -ra
@@ -731,7 +731,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-resource-detector-azure-0 -- -ra
@@ -749,7 +749,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-resource-detector-azure-1 -- -ra
@@ -767,7 +767,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-resource-detector-azure-0 -- -ra
@@ -785,7 +785,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-resource-detector-azure-1 -- -ra
@@ -803,7 +803,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-resource-detector-azure-0 -- -ra
@@ -821,7 +821,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-resource-detector-azure-1 -- -ra
@@ -839,7 +839,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-resource-detector-azure-0 -- -ra
@@ -857,7 +857,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-resource-detector-azure-1 -- -ra
@@ -875,7 +875,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-sdk-extension-aws-0 -- -ra
@@ -893,7 +893,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-sdk-extension-aws-1 -- -ra
@@ -911,7 +911,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-sdk-extension-aws-0 -- -ra
@@ -929,7 +929,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-sdk-extension-aws-1 -- -ra
@@ -947,7 +947,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-sdk-extension-aws-0 -- -ra
@@ -965,7 +965,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-sdk-extension-aws-1 -- -ra
@@ -983,7 +983,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-sdk-extension-aws-0 -- -ra
@@ -1001,7 +1001,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-sdk-extension-aws-1 -- -ra
@@ -1019,7 +1019,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-sdk-extension-aws-0 -- -ra
@@ -1037,7 +1037,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-sdk-extension-aws-1 -- -ra
@@ -1055,7 +1055,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-sdk-extension-aws-0 -- -ra
@@ -1073,7 +1073,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-sdk-extension-aws-1 -- -ra
@@ -1091,7 +1091,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-sdk-extension-aws-0 -- -ra
@@ -1109,7 +1109,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-sdk-extension-aws-1 -- -ra
@@ -1127,7 +1127,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-distro -- -ra
@@ -1145,7 +1145,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-distro -- -ra
@@ -1163,7 +1163,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-distro -- -ra
@@ -1181,7 +1181,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-distro -- -ra
@@ -1199,7 +1199,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-distro -- -ra
@@ -1217,7 +1217,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-distro -- -ra
@@ -1235,7 +1235,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-distro -- -ra
@@ -1253,7 +1253,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-opentelemetry-instrumentation -- -ra
@@ -1271,7 +1271,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-opentelemetry-instrumentation -- -ra
@@ -1289,7 +1289,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-opentelemetry-instrumentation -- -ra
@@ -1307,7 +1307,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-opentelemetry-instrumentation -- -ra
@@ -1325,7 +1325,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-opentelemetry-instrumentation -- -ra
@@ -1343,7 +1343,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-opentelemetry-instrumentation -- -ra
@@ -1361,7 +1361,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-opentelemetry-instrumentation -- -ra
@@ -1379,7 +1379,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiohttp-client -- -ra
@@ -1397,7 +1397,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aiohttp-client -- -ra
@@ -1415,7 +1415,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aiohttp-client -- -ra
@@ -1433,7 +1433,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aiohttp-client -- -ra
@@ -1451,7 +1451,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aiohttp-client -- -ra
@@ -1469,7 +1469,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aiohttp-client -- -ra
@@ -1487,7 +1487,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aiohttp-client -- -ra
@@ -1505,7 +1505,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiohttp-server -- -ra
@@ -1523,7 +1523,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aiohttp-server -- -ra
@@ -1541,7 +1541,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aiohttp-server -- -ra
@@ -1559,7 +1559,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aiohttp-server -- -ra
@@ -1577,7 +1577,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aiohttp-server -- -ra
@@ -1595,7 +1595,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aiohttp-server -- -ra
@@ -1613,7 +1613,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aiohttp-server -- -ra
@@ -1631,7 +1631,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiopg -- -ra
@@ -1649,7 +1649,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aiopg -- -ra
@@ -1667,7 +1667,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aiopg -- -ra
@@ -1685,7 +1685,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aiopg -- -ra
@@ -1703,7 +1703,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aiopg -- -ra
@@ -1721,7 +1721,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aiopg -- -ra
@@ -1739,7 +1739,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aws-lambda -- -ra
@@ -1757,7 +1757,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aws-lambda -- -ra
@@ -1775,7 +1775,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aws-lambda -- -ra
@@ -1793,7 +1793,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aws-lambda -- -ra
@@ -1811,7 +1811,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aws-lambda -- -ra
@@ -1829,7 +1829,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aws-lambda -- -ra
@@ -1847,7 +1847,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aws-lambda -- -ra
@@ -1865,7 +1865,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-botocore -- -ra
@@ -1883,7 +1883,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-botocore -- -ra
@@ -1901,7 +1901,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-botocore -- -ra
@@ -1919,7 +1919,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-botocore -- -ra
@@ -1937,7 +1937,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-botocore -- -ra
@@ -1955,7 +1955,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-botocore -- -ra
@@ -1973,7 +1973,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-boto3sqs -- -ra
@@ -1991,7 +1991,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-boto3sqs -- -ra
@@ -2009,7 +2009,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-boto3sqs -- -ra
@@ -2027,7 +2027,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-boto3sqs -- -ra
@@ -2045,7 +2045,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-boto3sqs -- -ra
@@ -2063,7 +2063,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-boto3sqs -- -ra
@@ -2081,7 +2081,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-boto3sqs -- -ra
@@ -2099,7 +2099,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-0 -- -ra
@@ -2117,7 +2117,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-1 -- -ra
@@ -2135,7 +2135,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-django-2 -- -ra
@@ -2153,7 +2153,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-django-0 -- -ra
@@ -2171,7 +2171,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-django-1 -- -ra
@@ -2189,7 +2189,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-django-2 -- -ra
@@ -2207,7 +2207,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-django-1 -- -ra
@@ -2225,7 +2225,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-django-3 -- -ra
@@ -2243,7 +2243,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-django-1 -- -ra
@@ -2261,7 +2261,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-django-3 -- -ra
@@ -2279,7 +2279,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-django-1 -- -ra
@@ -2297,7 +2297,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-django-3 -- -ra
@@ -2315,7 +2315,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-django-3 -- -ra
@@ -2333,7 +2333,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-django-0 -- -ra
@@ -2351,7 +2351,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-django-1 -- -ra
@@ -2369,7 +2369,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-dbapi -- -ra
@@ -2387,7 +2387,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-dbapi -- -ra
@@ -2405,7 +2405,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-dbapi -- -ra
@@ -2423,7 +2423,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-dbapi -- -ra
@@ -2441,7 +2441,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-dbapi -- -ra
@@ -2459,7 +2459,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-dbapi -- -ra
@@ -2477,7 +2477,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-dbapi -- -ra
@@ -2495,7 +2495,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-boto -- -ra
@@ -2513,7 +2513,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-boto -- -ra
@@ -2531,7 +2531,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-boto -- -ra
@@ -2549,7 +2549,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-boto -- -ra
@@ -2567,7 +2567,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-click -- -ra
@@ -2585,7 +2585,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-click -- -ra
@@ -2603,7 +2603,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-click -- -ra
@@ -2621,7 +2621,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-click -- -ra
@@ -2639,7 +2639,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-click -- -ra
@@ -2657,7 +2657,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-click -- -ra
@@ -2675,7 +2675,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-click -- -ra
@@ -2693,7 +2693,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-0 -- -ra
@@ -2711,7 +2711,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-1 -- -ra
@@ -2729,7 +2729,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-elasticsearch-2 -- -ra
@@ -2747,7 +2747,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-elasticsearch-0 -- -ra
@@ -2765,7 +2765,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-elasticsearch-1 -- -ra
@@ -2783,7 +2783,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-elasticsearch-2 -- -ra
@@ -2801,7 +2801,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-elasticsearch-0 -- -ra
@@ -2819,7 +2819,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-elasticsearch-1 -- -ra
@@ -2837,7 +2837,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-elasticsearch-2 -- -ra
@@ -2855,7 +2855,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-elasticsearch-0 -- -ra
@@ -2873,7 +2873,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-elasticsearch-1 -- -ra
@@ -2891,7 +2891,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-elasticsearch-2 -- -ra
@@ -2909,7 +2909,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-elasticsearch-0 -- -ra
@@ -2927,7 +2927,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-elasticsearch-1 -- -ra
@@ -2945,7 +2945,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-elasticsearch-2 -- -ra
@@ -2963,7 +2963,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-elasticsearch-0 -- -ra
@@ -2981,7 +2981,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-elasticsearch-1 -- -ra
@@ -2999,7 +2999,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-elasticsearch-2 -- -ra
@@ -3017,7 +3017,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-elasticsearch-0 -- -ra
@@ -3035,7 +3035,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-elasticsearch-1 -- -ra
@@ -3053,7 +3053,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-elasticsearch-2 -- -ra
@@ -3071,7 +3071,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-0 -- -ra
@@ -3089,7 +3089,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-1 -- -ra
@@ -3107,7 +3107,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-2 -- -ra
@@ -3125,7 +3125,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-falcon-3 -- -ra
@@ -3143,7 +3143,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-falcon-0 -- -ra
@@ -3161,7 +3161,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-falcon-1 -- -ra
@@ -3179,7 +3179,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-falcon-2 -- -ra
@@ -3197,7 +3197,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-falcon-3 -- -ra
@@ -3215,7 +3215,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-falcon-1 -- -ra
@@ -3233,7 +3233,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-falcon-2 -- -ra
@@ -3251,7 +3251,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-falcon-3 -- -ra
@@ -3269,7 +3269,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-falcon-4 -- -ra
@@ -3287,7 +3287,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-falcon-1 -- -ra
@@ -3305,7 +3305,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-falcon-2 -- -ra
@@ -3323,7 +3323,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-falcon-3 -- -ra
@@ -3341,7 +3341,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-falcon-4 -- -ra
@@ -3359,7 +3359,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-falcon-1 -- -ra
@@ -3377,7 +3377,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-falcon-2 -- -ra
@@ -3395,7 +3395,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-falcon-3 -- -ra
@@ -3413,7 +3413,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-falcon-4 -- -ra
@@ -3431,7 +3431,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-falcon-4 -- -ra
@@ -3449,7 +3449,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-falcon-0 -- -ra
@@ -3467,7 +3467,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-falcon-1 -- -ra
@@ -3485,7 +3485,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-falcon-2 -- -ra
@@ -3503,7 +3503,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-falcon-3 -- -ra
@@ -3521,7 +3521,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-falcon-4 -- -ra
@@ -3539,7 +3539,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-fastapi -- -ra
@@ -3557,7 +3557,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-fastapi -- -ra
@@ -3575,7 +3575,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-fastapi -- -ra
@@ -3593,7 +3593,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-fastapi -- -ra
@@ -3611,7 +3611,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-fastapi -- -ra
@@ -3629,7 +3629,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-fastapi -- -ra
@@ -3647,7 +3647,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-fastapi -- -ra
@@ -3665,7 +3665,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-0 -- -ra
@@ -3683,7 +3683,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-1 -- -ra
@@ -3701,7 +3701,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-flask-2 -- -ra
@@ -3719,7 +3719,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-flask-0 -- -ra
@@ -3737,7 +3737,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-flask-1 -- -ra
@@ -3755,7 +3755,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-flask-2 -- -ra
@@ -3773,7 +3773,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-flask-0 -- -ra
@@ -3791,7 +3791,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-flask-1 -- -ra
@@ -3809,7 +3809,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-flask-2 -- -ra
@@ -3827,7 +3827,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-flask-0 -- -ra
@@ -3845,7 +3845,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-flask-1 -- -ra
@@ -3863,7 +3863,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-flask-2 -- -ra
@@ -3881,7 +3881,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-flask-0 -- -ra
@@ -3899,7 +3899,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-flask-1 -- -ra
@@ -3917,7 +3917,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-flask-2 -- -ra
@@ -3935,7 +3935,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-flask-0 -- -ra
@@ -3953,7 +3953,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-flask-1 -- -ra
@@ -3971,7 +3971,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-flask-2 -- -ra
@@ -3989,7 +3989,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-flask-0 -- -ra
@@ -4007,7 +4007,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-flask-1 -- -ra
@@ -4025,7 +4025,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib -- -ra
@@ -4043,7 +4043,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-urllib -- -ra
@@ -4061,7 +4061,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-urllib -- -ra
@@ -4079,7 +4079,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-urllib -- -ra
@@ -4097,7 +4097,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-urllib -- -ra
@@ -4115,7 +4115,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-urllib -- -ra
@@ -4133,7 +4133,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-urllib -- -ra
@@ -4151,7 +4151,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib3-0 -- -ra
@@ -4169,7 +4169,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-urllib3-1 -- -ra
@@ -4187,7 +4187,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-urllib3-0 -- -ra
@@ -4205,7 +4205,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-urllib3-1 -- -ra
@@ -4223,7 +4223,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-urllib3-0 -- -ra
@@ -4241,7 +4241,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-urllib3-1 -- -ra
@@ -4259,7 +4259,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-urllib3-0 -- -ra
@@ -4277,7 +4277,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-urllib3-1 -- -ra
@@ -4295,7 +4295,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-urllib3-0 -- -ra
@@ -4313,7 +4313,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-urllib3-1 -- -ra
@@ -4331,7 +4331,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-urllib3-0 -- -ra
@@ -4349,7 +4349,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-urllib3-1 -- -ra
@@ -4367,7 +4367,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-urllib3-0 -- -ra
@@ -4385,7 +4385,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-urllib3-1 -- -ra
@@ -4403,7 +4403,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-requests -- -ra
@@ -4421,7 +4421,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-requests -- -ra
@@ -4439,7 +4439,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-requests -- -ra
@@ -4457,7 +4457,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-requests -- -ra
@@ -4475,7 +4475,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-requests -- -ra
@@ -4493,7 +4493,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-requests -- -ra
@@ -4511,7 +4511,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-starlette -- -ra

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-starlette -- -ra
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-starlette -- -ra
@@ -65,7 +65,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-starlette -- -ra
@@ -83,7 +83,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-starlette -- -ra
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-starlette -- -ra
@@ -119,7 +119,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-starlette -- -ra
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-jinja2 -- -ra
@@ -155,7 +155,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-jinja2 -- -ra
@@ -173,7 +173,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-jinja2 -- -ra
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-jinja2 -- -ra
@@ -209,7 +209,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-jinja2 -- -ra
@@ -227,7 +227,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-jinja2 -- -ra
@@ -245,7 +245,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-jinja2 -- -ra
@@ -263,7 +263,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-logging -- -ra
@@ -281,7 +281,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-logging -- -ra
@@ -299,7 +299,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-logging -- -ra
@@ -317,7 +317,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-logging -- -ra
@@ -335,7 +335,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-logging -- -ra
@@ -353,7 +353,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-logging -- -ra
@@ -371,7 +371,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-logging -- -ra
@@ -389,7 +389,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-exporter-richconsole -- -ra
@@ -407,7 +407,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-exporter-richconsole -- -ra
@@ -425,7 +425,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-exporter-richconsole -- -ra
@@ -443,7 +443,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-exporter-richconsole -- -ra
@@ -461,7 +461,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-exporter-richconsole -- -ra
@@ -479,7 +479,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-exporter-richconsole -- -ra
@@ -497,7 +497,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-exporter-richconsole -- -ra
@@ -515,7 +515,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-exporter-prometheus-remote-write -- -ra
@@ -533,7 +533,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-exporter-prometheus-remote-write -- -ra
@@ -551,7 +551,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-exporter-prometheus-remote-write -- -ra
@@ -569,7 +569,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-exporter-prometheus-remote-write -- -ra
@@ -587,7 +587,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-exporter-prometheus-remote-write -- -ra
@@ -605,7 +605,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-exporter-prometheus-remote-write -- -ra
@@ -623,7 +623,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-exporter-prometheus-remote-write -- -ra
@@ -641,7 +641,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysql-0 -- -ra
@@ -659,7 +659,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysql-1 -- -ra
@@ -677,7 +677,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-mysql-0 -- -ra
@@ -695,7 +695,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-mysql-1 -- -ra
@@ -713,7 +713,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-mysql-0 -- -ra
@@ -731,7 +731,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-mysql-1 -- -ra
@@ -749,7 +749,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-mysql-0 -- -ra
@@ -767,7 +767,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-mysql-1 -- -ra
@@ -785,7 +785,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-mysql-0 -- -ra
@@ -803,7 +803,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-mysql-1 -- -ra
@@ -821,7 +821,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-mysql-0 -- -ra
@@ -839,7 +839,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-mysql-1 -- -ra
@@ -857,7 +857,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-mysql-0 -- -ra
@@ -875,7 +875,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-mysql-1 -- -ra
@@ -893,7 +893,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-mysqlclient -- -ra
@@ -911,7 +911,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-mysqlclient -- -ra
@@ -929,7 +929,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-mysqlclient -- -ra
@@ -947,7 +947,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-mysqlclient -- -ra
@@ -965,7 +965,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-mysqlclient -- -ra
@@ -983,7 +983,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-mysqlclient -- -ra
@@ -1001,7 +1001,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-mysqlclient -- -ra
@@ -1019,7 +1019,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-psycopg2 -- -ra
@@ -1037,7 +1037,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-psycopg2 -- -ra
@@ -1055,7 +1055,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-psycopg2 -- -ra
@@ -1073,7 +1073,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-psycopg2 -- -ra
@@ -1091,7 +1091,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-psycopg2 -- -ra
@@ -1109,7 +1109,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-psycopg2 -- -ra
@@ -1127,7 +1127,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-psycopg -- -ra
@@ -1145,7 +1145,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-psycopg -- -ra
@@ -1163,7 +1163,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-psycopg -- -ra
@@ -1181,7 +1181,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-psycopg -- -ra
@@ -1199,7 +1199,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-psycopg -- -ra
@@ -1217,7 +1217,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-psycopg -- -ra
@@ -1235,7 +1235,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-psycopg -- -ra
@@ -1253,7 +1253,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-0 -- -ra
@@ -1271,7 +1271,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-1 -- -ra
@@ -1289,7 +1289,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-2 -- -ra
@@ -1307,7 +1307,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-3 -- -ra
@@ -1325,7 +1325,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymemcache-4 -- -ra
@@ -1343,7 +1343,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymemcache-0 -- -ra
@@ -1361,7 +1361,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymemcache-1 -- -ra
@@ -1379,7 +1379,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymemcache-2 -- -ra
@@ -1397,7 +1397,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymemcache-3 -- -ra
@@ -1415,7 +1415,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymemcache-4 -- -ra
@@ -1433,7 +1433,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymemcache-0 -- -ra
@@ -1451,7 +1451,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymemcache-1 -- -ra
@@ -1469,7 +1469,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymemcache-2 -- -ra
@@ -1487,7 +1487,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymemcache-3 -- -ra
@@ -1505,7 +1505,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymemcache-4 -- -ra
@@ -1523,7 +1523,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymemcache-0 -- -ra
@@ -1541,7 +1541,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymemcache-1 -- -ra
@@ -1559,7 +1559,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymemcache-2 -- -ra
@@ -1577,7 +1577,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymemcache-3 -- -ra
@@ -1595,7 +1595,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymemcache-4 -- -ra
@@ -1613,7 +1613,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymemcache-0 -- -ra
@@ -1631,7 +1631,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymemcache-1 -- -ra
@@ -1649,7 +1649,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymemcache-2 -- -ra
@@ -1667,7 +1667,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymemcache-3 -- -ra
@@ -1685,7 +1685,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymemcache-4 -- -ra
@@ -1703,7 +1703,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymemcache-0 -- -ra
@@ -1721,7 +1721,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymemcache-1 -- -ra
@@ -1739,7 +1739,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymemcache-2 -- -ra
@@ -1757,7 +1757,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymemcache-3 -- -ra
@@ -1775,7 +1775,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymemcache-4 -- -ra
@@ -1793,7 +1793,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymemcache-0 -- -ra
@@ -1811,7 +1811,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymemcache-1 -- -ra
@@ -1829,7 +1829,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymemcache-2 -- -ra
@@ -1847,7 +1847,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymemcache-3 -- -ra
@@ -1865,7 +1865,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymemcache-4 -- -ra
@@ -1883,7 +1883,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymongo -- -ra
@@ -1901,7 +1901,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymongo -- -ra
@@ -1919,7 +1919,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymongo -- -ra
@@ -1937,7 +1937,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymongo -- -ra
@@ -1955,7 +1955,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymongo -- -ra
@@ -1973,7 +1973,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymongo -- -ra
@@ -1991,7 +1991,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymongo -- -ra
@@ -2009,7 +2009,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pymysql -- -ra
@@ -2027,7 +2027,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pymysql -- -ra
@@ -2045,7 +2045,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pymysql -- -ra
@@ -2063,7 +2063,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pymysql -- -ra
@@ -2081,7 +2081,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pymysql -- -ra
@@ -2099,7 +2099,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-pymysql -- -ra
@@ -2117,7 +2117,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pymysql -- -ra
@@ -2135,7 +2135,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-pyramid -- -ra
@@ -2153,7 +2153,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-pyramid -- -ra
@@ -2171,7 +2171,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-pyramid -- -ra
@@ -2189,7 +2189,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-pyramid -- -ra
@@ -2207,7 +2207,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-pyramid -- -ra
@@ -2225,7 +2225,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-pyramid -- -ra
@@ -2243,7 +2243,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asgi -- -ra
@@ -2261,7 +2261,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-asgi -- -ra
@@ -2279,7 +2279,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-asgi -- -ra
@@ -2297,7 +2297,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-asgi -- -ra
@@ -2315,7 +2315,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-asgi -- -ra
@@ -2333,7 +2333,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-asgi -- -ra
@@ -2351,7 +2351,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-asgi -- -ra
@@ -2369,7 +2369,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asyncpg -- -ra
@@ -2387,7 +2387,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-asyncpg -- -ra
@@ -2405,7 +2405,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-asyncpg -- -ra
@@ -2423,7 +2423,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-asyncpg -- -ra
@@ -2441,7 +2441,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-asyncpg -- -ra
@@ -2459,7 +2459,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-asyncpg -- -ra
@@ -2477,7 +2477,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlite3 -- -ra
@@ -2495,7 +2495,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-sqlite3 -- -ra
@@ -2513,7 +2513,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-sqlite3 -- -ra
@@ -2531,7 +2531,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-sqlite3 -- -ra
@@ -2549,7 +2549,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-sqlite3 -- -ra
@@ -2567,7 +2567,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-sqlite3 -- -ra
@@ -2585,7 +2585,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sqlite3 -- -ra
@@ -2603,7 +2603,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-wsgi -- -ra
@@ -2621,7 +2621,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-wsgi -- -ra
@@ -2639,7 +2639,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-wsgi -- -ra
@@ -2657,7 +2657,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-wsgi -- -ra
@@ -2675,7 +2675,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-wsgi -- -ra
@@ -2693,7 +2693,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-wsgi -- -ra
@@ -2711,7 +2711,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-wsgi -- -ra
@@ -2729,7 +2729,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-grpc-0 -- -ra
@@ -2747,7 +2747,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-grpc-1 -- -ra
@@ -2765,7 +2765,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-grpc-0 -- -ra
@@ -2783,7 +2783,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-grpc-1 -- -ra
@@ -2801,7 +2801,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-grpc-0 -- -ra
@@ -2819,7 +2819,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-grpc-1 -- -ra
@@ -2837,7 +2837,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-grpc-0 -- -ra
@@ -2855,7 +2855,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-grpc-1 -- -ra
@@ -2873,7 +2873,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-grpc-0 -- -ra
@@ -2891,7 +2891,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-grpc-1 -- -ra
@@ -2909,7 +2909,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-grpc-1 -- -ra
@@ -2927,7 +2927,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlalchemy-1 -- -ra
@@ -2945,7 +2945,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sqlalchemy-2 -- -ra
@@ -2963,7 +2963,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-sqlalchemy-1 -- -ra
@@ -2981,7 +2981,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-sqlalchemy-2 -- -ra
@@ -2999,7 +2999,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-sqlalchemy-1 -- -ra
@@ -3017,7 +3017,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-sqlalchemy-2 -- -ra
@@ -3035,7 +3035,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-sqlalchemy-1 -- -ra
@@ -3053,7 +3053,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-sqlalchemy-2 -- -ra
@@ -3071,7 +3071,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-sqlalchemy-1 -- -ra
@@ -3089,7 +3089,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-sqlalchemy-2 -- -ra
@@ -3107,7 +3107,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-sqlalchemy-1 -- -ra
@@ -3125,7 +3125,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-sqlalchemy-2 -- -ra
@@ -3143,7 +3143,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sqlalchemy-0 -- -ra
@@ -3161,7 +3161,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sqlalchemy-1 -- -ra
@@ -3179,7 +3179,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sqlalchemy-2 -- -ra
@@ -3197,7 +3197,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-redis -- -ra
@@ -3215,7 +3215,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-redis -- -ra
@@ -3233,7 +3233,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-redis -- -ra
@@ -3251,7 +3251,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-redis -- -ra
@@ -3269,7 +3269,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-redis -- -ra
@@ -3287,7 +3287,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-redis -- -ra
@@ -3305,7 +3305,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-redis -- -ra
@@ -3323,7 +3323,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-remoulade -- -ra
@@ -3341,7 +3341,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-remoulade -- -ra
@@ -3359,7 +3359,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-remoulade -- -ra
@@ -3377,7 +3377,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-remoulade -- -ra
@@ -3395,7 +3395,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-remoulade -- -ra
@@ -3413,7 +3413,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-remoulade -- -ra
@@ -3431,7 +3431,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-celery -- -ra
@@ -3449,7 +3449,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-celery -- -ra
@@ -3467,7 +3467,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-celery -- -ra
@@ -3485,7 +3485,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-celery -- -ra
@@ -3503,7 +3503,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-celery -- -ra
@@ -3521,7 +3521,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-celery -- -ra
@@ -3539,7 +3539,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-celery -- -ra
@@ -3557,7 +3557,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-system-metrics -- -ra
@@ -3575,7 +3575,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-system-metrics -- -ra
@@ -3593,7 +3593,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-system-metrics -- -ra
@@ -3611,7 +3611,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-system-metrics -- -ra
@@ -3629,7 +3629,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-system-metrics -- -ra
@@ -3647,7 +3647,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-system-metrics -- -ra
@@ -3665,7 +3665,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-system-metrics -- -ra
@@ -3683,7 +3683,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-threading -- -ra
@@ -3701,7 +3701,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-threading -- -ra
@@ -3719,7 +3719,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-threading -- -ra
@@ -3737,7 +3737,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-threading -- -ra
@@ -3755,7 +3755,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-threading -- -ra
@@ -3773,7 +3773,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-threading -- -ra
@@ -3791,7 +3791,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-threading -- -ra
@@ -3809,7 +3809,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-tornado -- -ra
@@ -3827,7 +3827,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-tornado -- -ra
@@ -3845,7 +3845,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-tornado -- -ra
@@ -3863,7 +3863,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-tornado -- -ra
@@ -3881,7 +3881,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-tornado -- -ra
@@ -3899,7 +3899,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-tornado -- -ra
@@ -3917,7 +3917,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-tornado -- -ra
@@ -3935,7 +3935,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-tortoiseorm -- -ra
@@ -3953,7 +3953,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-tortoiseorm -- -ra
@@ -3971,7 +3971,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-tortoiseorm -- -ra
@@ -3989,7 +3989,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-tortoiseorm -- -ra
@@ -4007,7 +4007,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-tortoiseorm -- -ra
@@ -4025,7 +4025,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-tortoiseorm -- -ra
@@ -4043,7 +4043,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-tortoiseorm -- -ra
@@ -4061,7 +4061,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-httpx-0 -- -ra
@@ -4079,7 +4079,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-httpx-1 -- -ra
@@ -4097,7 +4097,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-httpx-0 -- -ra
@@ -4115,7 +4115,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-httpx-1 -- -ra
@@ -4133,7 +4133,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-httpx-0 -- -ra
@@ -4151,7 +4151,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-httpx-1 -- -ra
@@ -4169,7 +4169,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-httpx-0 -- -ra
@@ -4187,7 +4187,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-httpx-1 -- -ra
@@ -4205,7 +4205,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-httpx-0 -- -ra
@@ -4223,7 +4223,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-httpx-1 -- -ra
@@ -4241,7 +4241,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-httpx-1 -- -ra
@@ -4259,7 +4259,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-httpx-0 -- -ra
@@ -4277,7 +4277,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-httpx-1 -- -ra
@@ -4295,7 +4295,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-util-http -- -ra
@@ -4313,7 +4313,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-util-http -- -ra
@@ -4331,7 +4331,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-util-http -- -ra
@@ -4349,7 +4349,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-util-http -- -ra
@@ -4367,7 +4367,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-util-http -- -ra
@@ -4385,7 +4385,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-util-http -- -ra
@@ -4403,7 +4403,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-util-http -- -ra
@@ -4421,7 +4421,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-aws-xray-0 -- -ra
@@ -4439,7 +4439,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-aws-xray-1 -- -ra
@@ -4457,7 +4457,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-propagator-aws-xray-0 -- -ra
@@ -4475,7 +4475,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-propagator-aws-xray-1 -- -ra
@@ -4493,7 +4493,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-propagator-aws-xray-0 -- -ra
@@ -4511,7 +4511,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-propagator-aws-xray-1 -- -ra

--- a/.github/workflows/test_2.yml
+++ b/.github/workflows/test_2.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-propagator-aws-xray-0 -- -ra
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-propagator-aws-xray-1 -- -ra
@@ -65,7 +65,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-propagator-aws-xray-0 -- -ra
@@ -83,7 +83,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-propagator-aws-xray-1 -- -ra
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-propagator-aws-xray-0 -- -ra
@@ -119,7 +119,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-propagator-aws-xray-1 -- -ra
@@ -137,7 +137,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-propagator-aws-xray-0 -- -ra
@@ -155,7 +155,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-propagator-aws-xray-1 -- -ra
@@ -173,7 +173,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-propagator-ot-trace -- -ra
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-propagator-ot-trace -- -ra
@@ -209,7 +209,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-propagator-ot-trace -- -ra
@@ -227,7 +227,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-propagator-ot-trace -- -ra
@@ -245,7 +245,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-propagator-ot-trace -- -ra
@@ -263,7 +263,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-propagator-ot-trace -- -ra
@@ -281,7 +281,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-propagator-ot-trace -- -ra
@@ -299,7 +299,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sio-pika-0 -- -ra
@@ -317,7 +317,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-sio-pika-1 -- -ra
@@ -335,7 +335,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-sio-pika-0 -- -ra
@@ -353,7 +353,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-sio-pika-1 -- -ra
@@ -371,7 +371,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-sio-pika-0 -- -ra
@@ -389,7 +389,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-sio-pika-1 -- -ra
@@ -407,7 +407,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-sio-pika-0 -- -ra
@@ -425,7 +425,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-sio-pika-1 -- -ra
@@ -443,7 +443,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-sio-pika-0 -- -ra
@@ -461,7 +461,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-sio-pika-1 -- -ra
@@ -479,7 +479,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-sio-pika-0 -- -ra
@@ -497,7 +497,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-sio-pika-1 -- -ra
@@ -515,7 +515,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sio-pika-0 -- -ra
@@ -533,7 +533,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-sio-pika-1 -- -ra
@@ -551,7 +551,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-0 -- -ra
@@ -569,7 +569,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-1 -- -ra
@@ -587,7 +587,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-2 -- -ra
@@ -605,7 +605,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aio-pika-3 -- -ra
@@ -623,7 +623,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aio-pika-0 -- -ra
@@ -641,7 +641,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aio-pika-1 -- -ra
@@ -659,7 +659,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aio-pika-2 -- -ra
@@ -677,7 +677,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aio-pika-3 -- -ra
@@ -695,7 +695,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aio-pika-0 -- -ra
@@ -713,7 +713,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aio-pika-1 -- -ra
@@ -731,7 +731,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aio-pika-2 -- -ra
@@ -749,7 +749,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aio-pika-3 -- -ra
@@ -767,7 +767,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aio-pika-0 -- -ra
@@ -785,7 +785,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aio-pika-1 -- -ra
@@ -803,7 +803,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aio-pika-2 -- -ra
@@ -821,7 +821,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aio-pika-3 -- -ra
@@ -839,7 +839,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aio-pika-0 -- -ra
@@ -857,7 +857,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aio-pika-1 -- -ra
@@ -875,7 +875,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aio-pika-2 -- -ra
@@ -893,7 +893,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aio-pika-3 -- -ra
@@ -911,7 +911,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aio-pika-0 -- -ra
@@ -929,7 +929,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aio-pika-1 -- -ra
@@ -947,7 +947,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aio-pika-2 -- -ra
@@ -965,7 +965,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aio-pika-3 -- -ra
@@ -983,7 +983,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aio-pika-0 -- -ra
@@ -1001,7 +1001,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aio-pika-1 -- -ra
@@ -1019,7 +1019,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aio-pika-2 -- -ra
@@ -1037,7 +1037,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aio-pika-3 -- -ra
@@ -1055,7 +1055,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-aiokafka -- -ra
@@ -1073,7 +1073,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-aiokafka -- -ra
@@ -1091,7 +1091,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-aiokafka -- -ra
@@ -1109,7 +1109,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-aiokafka -- -ra
@@ -1127,7 +1127,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-aiokafka -- -ra
@@ -1145,7 +1145,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-aiokafka -- -ra
@@ -1163,7 +1163,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-aiokafka -- -ra
@@ -1181,7 +1181,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-kafka-python -- -ra
@@ -1199,7 +1199,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-kafka-python -- -ra
@@ -1217,7 +1217,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-kafka-python -- -ra
@@ -1235,7 +1235,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-kafka-python -- -ra
@@ -1253,7 +1253,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-kafka-pythonng -- -ra
@@ -1271,7 +1271,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-kafka-pythonng -- -ra
@@ -1289,7 +1289,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-kafka-pythonng -- -ra
@@ -1307,7 +1307,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-kafka-pythonng -- -ra
@@ -1325,7 +1325,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-kafka-pythonng -- -ra
@@ -1343,7 +1343,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-kafka-pythonng -- -ra
@@ -1361,7 +1361,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-kafka-python -- -ra
@@ -1379,7 +1379,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-kafka-pythonng -- -ra
@@ -1397,7 +1397,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-confluent-kafka -- -ra
@@ -1415,7 +1415,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-confluent-kafka -- -ra
@@ -1433,7 +1433,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-confluent-kafka -- -ra
@@ -1451,7 +1451,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-confluent-kafka -- -ra
@@ -1469,7 +1469,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-confluent-kafka -- -ra
@@ -1487,7 +1487,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-confluent-kafka -- -ra
@@ -1505,7 +1505,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-asyncio -- -ra
@@ -1523,7 +1523,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-asyncio -- -ra
@@ -1541,7 +1541,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-asyncio -- -ra
@@ -1559,7 +1559,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-asyncio -- -ra
@@ -1577,7 +1577,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-asyncio -- -ra
@@ -1595,7 +1595,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-asyncio -- -ra
@@ -1613,7 +1613,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-instrumentation-cassandra -- -ra
@@ -1631,7 +1631,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-instrumentation-cassandra -- -ra
@@ -1649,7 +1649,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-instrumentation-cassandra -- -ra
@@ -1667,7 +1667,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-cassandra -- -ra
@@ -1685,7 +1685,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-instrumentation-cassandra -- -ra
@@ -1703,7 +1703,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-cassandra -- -ra
@@ -1721,7 +1721,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-cassandra -- -ra
@@ -1739,7 +1739,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py38-test-processor-baggage -- -ra
@@ -1757,7 +1757,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py39-test-processor-baggage -- -ra
@@ -1775,7 +1775,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py310-test-processor-baggage -- -ra
@@ -1793,7 +1793,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py311-test-processor-baggage -- -ra
@@ -1811,7 +1811,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py312-test-processor-baggage -- -ra
@@ -1829,7 +1829,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e py313-test-processor-baggage -- -ra
@@ -1847,7 +1847,7 @@ jobs:
           python-version: "pypy-3.8"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox-uv
 
       - name: Run tests
         run: tox -e pypy3-test-processor-baggage -- -ra

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ To install `tox`, run:
 pip install tox
 ```
 
+You can also run tox with `uv` support. By default [tox.ini](./tox.ini) will automatically create a provisioned tox environment with `tox-uv`, but you can install it at host level:
+
+```sh
+pip install tox-uv
+```
+
 You can run `tox` with the following arguments:
 
 * `tox` to run all existing tox commands, including unit tests for all packages
@@ -89,7 +95,7 @@ for more detail on available tox commands.
 
 ### Troubleshooting
 
-Some packages may require additional system-wide dependencies to be installed. For example, you may need to install `libpq-dev` to run the postgresql client libraries instrumentation tests or `libsnappy-dev` to run the prometheus exporter tests. If you encounter a build error, please check the installation instructions for the package you are trying to run tests for. 
+Some packages may require additional system-wide dependencies to be installed. For example, you may need to install `libpq-dev` to run the postgresql client libraries instrumentation tests or `libsnappy-dev` to run the prometheus exporter tests. If you encounter a build error, please check the installation instructions for the package you are trying to run tests for.
 
 For `docs` building, you may need to install `mysql-client` and other required dependencies as necessary. Ensure the Python version used in your local setup matches the version used in the [CI](./.github/workflows/) to maintain compatibility when building the documentation.
 
@@ -139,7 +145,7 @@ git remote add fork https://github.com/YOUR_GITHUB_USERNAME/opentelemetry-python
 make sure you have all supported versions of Python installed, install `tox` only for the first time:
 
 ```sh
-pip install tox
+pip install tox tox-uv
 ```
 
 Run tests in the root of the repository (this will run all tox environments and may take some time):

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,6 @@
 [tox]
+requires =
+  tox-uv>=1
 isolated_build = True
 skipsdist = True
 skip_missing_interpreters = True


### PR DESCRIPTION
# Description
I was working on #2667 and realized our tox setup was not prepared to adopt tox-uv, so after some rework I'm opening this PR with less intrusive changes to tox.ini file. So basically, this is a new version of #2667

uv makes pip install faster. It works like this: `uv pip install` and we can have tests running faster locally and in CI. The tool is from the creators of ruff. 

The main improvement I see here is the Dependency caching and fast resolution of packages during pip install. We can benefit from this for local development to avoid slow tests, mainly the git clones in contrib tests.

This PR also introduces the usage of [tox-uv](https://github.com/tox-dev/tox-uv) which is a tox plugin that supports venv runner with uv.