### PR TITLE
fix (ci): Allow opentelemetry-python forks to use CI

### DIFF
--- a/.github/workflows/core_contrib_test_0.yml
+++ b/.github/workflows/core_contrib_test_0.yml
@@ -6,14 +6,22 @@ name: Core Contrib Test 0
 on:
   workflow_call:
     inputs:
+      CORE_REPO:
+        required: false
+        type: string
       CORE_REPO_SHA:
         required: true
+        type: string
+      CONTRIB_REPO:
+        required: false
         type: string
       CONTRIB_REPO_SHA:
         required: true
         type: string
 env:
+  CORE_REPO: ${{ inputs.CORE_REPO || 'open-telemetry/opentelemetry-python' }}
   CORE_REPO_SHA: ${{ inputs.CORE_REPO_SHA }}
+  CONTRIB_REPO: ${{ inputs.CONTRIB_REPO || 'open-telemetry/opentelemetry-python-contrib' }}
   CONTRIB_REPO_SHA: ${{ inputs.CONTRIB_REPO_SHA }}
   PIP_EXISTS_ACTION: w
 
@@ -26,7 +34,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -48,7 +56,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -70,7 +78,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -92,7 +100,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -114,7 +122,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -136,7 +144,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -158,7 +166,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -180,7 +188,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -202,7 +210,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -224,7 +232,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -246,7 +254,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -268,7 +276,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -290,7 +298,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -312,7 +320,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -334,7 +342,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -356,7 +364,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -378,7 +386,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -400,7 +408,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -422,7 +430,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -444,7 +452,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -466,7 +474,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -488,7 +496,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -510,7 +518,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -532,7 +540,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -554,7 +562,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -576,7 +584,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -598,7 +606,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -620,7 +628,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -642,7 +650,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -664,7 +672,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -686,7 +694,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -708,7 +716,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -730,7 +738,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -752,7 +760,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -774,7 +782,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -796,7 +804,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -818,7 +826,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -840,7 +848,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -862,7 +870,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -884,7 +892,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -906,7 +914,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -928,7 +936,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -950,7 +958,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -972,7 +980,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -994,7 +1002,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1016,7 +1024,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1038,7 +1046,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1060,7 +1068,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1082,7 +1090,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1104,7 +1112,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1126,7 +1134,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1148,7 +1156,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1170,7 +1178,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1192,7 +1200,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1214,7 +1222,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1236,7 +1244,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1258,7 +1266,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1280,7 +1288,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1302,7 +1310,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1324,7 +1332,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1346,7 +1354,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1368,7 +1376,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1390,7 +1398,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1412,7 +1420,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1434,7 +1442,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1456,7 +1464,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1478,7 +1486,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1500,7 +1508,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1522,7 +1530,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1544,7 +1552,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1566,7 +1574,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1588,7 +1596,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1610,7 +1618,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1632,7 +1640,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1654,7 +1662,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1676,7 +1684,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1698,7 +1706,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1720,7 +1728,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1742,7 +1750,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1764,7 +1772,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1786,7 +1794,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1808,7 +1816,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1830,7 +1838,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1852,7 +1860,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1874,7 +1882,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1896,7 +1904,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1918,7 +1926,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1940,7 +1948,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1962,7 +1970,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8
@@ -1984,7 +1992,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${{ env.CONTRIB_REPO }}
           ref: ${{ env.CONTRIB_REPO_SHA }}
 
       - name: Set up Python 3.8

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
@@ -6,14 +6,22 @@ name: Core Contrib Test {{ file_number }}
 on:
   workflow_call:
     inputs:
+      CORE_REPO:
+        required: false
+        type: string
       CORE_REPO_SHA:
         required: true
+        type: string
+      CONTRIB_REPO:
+        required: false
         type: string
       CONTRIB_REPO_SHA:
         required: true
         type: string
 env:
+  CORE_REPO: ${% raw %}{{ inputs.CORE_REPO || 'open-telemetry/opentelemetry-python' }}{% endraw %}
   CORE_REPO_SHA: ${% raw %}{{ inputs.CORE_REPO_SHA }}{% endraw %}
+  CONTRIB_REPO: ${% raw %}{{ inputs.CONTRIB_REPO || 'open-telemetry/opentelemetry-python-contrib' }}{% endraw %}
   CONTRIB_REPO_SHA: ${% raw %}{{ inputs.CONTRIB_REPO_SHA }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
@@ -27,7 +35,7 @@ jobs:
       - name: Checkout contrib repo @ SHA - ${% raw %}{{ env.CONTRIB_REPO_SHA }}{% endraw %}
         uses: actions/checkout@v4
         with:
-          repository: open-telemetry/opentelemetry-python-contrib
+          repository: ${% raw %}{{ env.CONTRIB_REPO }}{% endraw %}
           ref: ${% raw %}{{ env.CONTRIB_REPO_SHA }}{% endraw %}
 
       - name: Set up Python 3.8

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_2.yml
+++ b/.github/workflows/test_2.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
 
 env:
+  CORE_REPO: open-telemetry/opentelemetry-python
   CORE_REPO_SHA: main
+  CONTRIB_REPO: open-telemetry/opentelemetry-python-contrib
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,9 +242,12 @@ tox -e py312-test-instrumentation-aiopg
 
 ### Testing against a different Core repo branch/commit
 
-Some of the tox targets install packages from the [OpenTelemetry Python Core Repository](https://github.com/open-telemetry/opentelemetry-python) via pip. The version of the packages installed defaults to the main branch in that repository when tox is run locally. It is possible to install packages tagged with a specific git commit hash by setting an environment variable before running tox as per the following example:
+Some of the tox targets install packages from the [OpenTelemetry Python Core Repository](https://github.com/open-telemetry/opentelemetry-python) via pip.
+The version of the packages installed defaults to the main branch in that repository when tox is run locally.
+It is possible to install packages tagged with a specific git commit hash (optionally in a specific fork) by setting these environment variables before running tox as per the following example:
 
 ```sh
+CORE_REPO=check-spelling-sandbox/opentelemetry-python
 CORE_REPO_SHA=c49ad57bfe35cfc69bfa863d74058ca9bec55fc3 tox
 ```
 

--- a/tox.ini
+++ b/tox.ini
@@ -682,10 +682,11 @@ allowlist_externals =
   sh
 
 setenv =
+  ; override CORE_REPO via env variable when testing in forks
+  CORE_REPO=git+https://github.com/{env:CORE_REPO:open-telemetry/opentelemetry-python}.git@{env:CORE_REPO_SHA}
   ; override CORE_REPO_SHA via env variable when testing other branches/commits than main
   ; i.e: CORE_REPO_SHA=dde62cebffe519c35875af6d06fae053b3be65ec tox -e <env to test>
   CORE_REPO_SHA={env:CORE_REPO_SHA:main}
-  CORE_REPO=git+https://github.com/open-telemetry/opentelemetry-python.git@{env:CORE_REPO_SHA}
 
 commands_pre =
 ; In order to get a health coverage report,


### PR DESCRIPTION
# Description

Adds `CORE_REPO` and `CONTRIB_REPO` inputs and corresponding environment variables to allow people to use CI in forks of https://github.com/open-telemetry/opentelemetry-python

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] [Test A](https://github.com/check-spelling-sandbox/opentelemetry-python/pull/1)
       <img width="852" alt="image" src="https://github.com/user-attachments/assets/0ccbf8d8-0d65-4e26-ae26-f4dbd6553b06" />

# Does This PR Require a Core Repo Change?

There is a corresponding change that should be made but it it can be done after this is merged.

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
