### PR TITLE
NoOpTracerProvider test case for httpx instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -1292,6 +1292,26 @@ class TestAsyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):
         self.perform_request(self.URL, client=self.client2)
         self.assert_span(num_spans=2)
 
+    async def test_no_op_tracer_provider(self):
+        HTTPXClientInstrumentor().uninstrument()
+        HTTPXClientInstrumentor().instrument(
+            tracer_provider=trace.NoOpTracerProvider()
+        )
+        async with httpx.AsyncClient() as client:
+            await client.get("http://test.com")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+    def test_no_op_tracer_provider_sync(self):
+        HTTPXClientInstrumentor().uninstrument()
+        HTTPXClientInstrumentor().instrument(
+            tracer_provider=trace.NoOpTracerProvider()
+        )
+        with httpx.Client() as client:
+            client.get("http://test.com")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
     def test_async_response_hook_does_nothing_if_not_coroutine(self):
         HTTPXClientInstrumentor().instrument(
             tracer_provider=self.tracer_provider,


### PR DESCRIPTION
# Description

Add the test NoOpTracerProvider otel instrumentation for httpx implementing the async and sync clients

Fixes #979 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
```
tox -e py311-test-instrumentation-httpx
python3 -m venv path/to/venv
source path/to/venv/bin/activate
python3 -m pip install pre-commit
pip install pre-commit -c dev-requirements.txt
pre-commit install
pre-commit run -a
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
