### PR TITLE
pymssql: fix entry_point for auto-instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymssql/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-pymssql/pyproject.toml
@@ -37,7 +37,7 @@ instruments = [
 ]
 
 [project.entry-points.opentelemetry_instrumentor]
-pymssql = "opentelemetry.instrumentation.pymssql:pymssqlInstrumentor"
+pymssql = "opentelemetry.instrumentation.pymssql:PyMSSQLInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymssql"

--- a/instrumentation/opentelemetry-instrumentation-pymssql/tests/test_pymssql_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-pymssql/tests/test_pymssql_integration.py
@@ -20,6 +20,7 @@ import opentelemetry.instrumentation.pymssql
 from opentelemetry.instrumentation.pymssql import PyMSSQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.util._importlib_metadata import entry_points
 
 
 def mock_connect(*args, **kwargs):
@@ -182,3 +183,15 @@ class TestPyMSSQLIntegration(TestBase):
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
+
+    def test_load_entry_point(self):
+        self.assertIs(
+            next(
+                iter(
+                    entry_points(
+                        group="opentelemetry_instrumentor", name="pymssql"
+                    )
+                )
+            ).load(),
+            PyMSSQLInstrumentor,
+        )


### PR DESCRIPTION
# Description

I was testing the new instrumentation:
```
opentelemetry-instrument --traces_exporter console --metrics_exporter none --logs_exporter none python -c 'import pymssql'
```
And got:
`AttributeError: module 'opentelemetry.instrumentation.pymssql' has no attribute 'pymssqlInstrumentor'. Did you mean: 'PyMSSQLInstrumentor'?` 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
