### PR TITLE
Added aiohttp-server instrumentation injection to module web_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `opentelemetry-instrumentation-aiohttp-server` injection to `aiohttp` module `web_app`.
 - `opentelemetry-instrumentation-confluent-kafka` Add support for confluent-kafka <=2.7.0
   ([#3100](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3100))
 - Add support to database stability opt-in in `_semconv` utilities and add tests

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
@@ -16,7 +16,7 @@ import urllib
 from timeit import default_timer
 from typing import Dict, List, Tuple, Union
 
-from aiohttp import web
+from aiohttp import web, web_app
 from multidict import CIMultiDictProxy
 
 from opentelemetry import metrics, trace
@@ -257,10 +257,12 @@ class AioHttpServerInstrumentor(BaseInstrumentor):
     """
 
     def _instrument(self, **kwargs):
-        self._original_app = web.Application
+        self._original_app = web_app.Application
+        setattr(web_app, "Application", _InstrumentedApplication)
         setattr(web, "Application", _InstrumentedApplication)
 
     def _uninstrument(self, **kwargs):
+        setattr(web_app, "Application", self._original_app)
         setattr(web, "Application", self._original_app)
 
     def instrumentation_dependencies(self):


### PR DESCRIPTION
# Description

Added `aiohttp-server`instrumentation  injection to module `web_app` because `Application` declared in `web_app` module, `web` only reimports this.
If we leave the injection only in module `web_app`, then the tests will fail, we need inject both.

[`Application` definition](https://github.com/aio-libs/aiohttp/blob/b1fd3463f1d47919235f86d01e4cda3822450868/aiohttp/web_app.py#L91)
[`Application` reimport](https://github.com/aio-libs/aiohttp/blob/b1fd3463f1d47919235f86d01e4cda3822450868/aiohttp/web.py#L143)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests works


# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
