### PR TITLE
fixed: asyncpg connection params are a namedtuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `opentelemetry-instrumentation-redis` Add missing entry in doc string for `def _instrument`
   ([#3247](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3247))
+- `opentelemetry-instrumentation-asyncpg` Fix fallback for empty queries.
+  ([#3253](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3253))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -150,8 +150,10 @@ class AsyncPGInstrumentor(BaseInstrumentor):
 
     async def _do_execute(self, func, instance, args, kwargs):
         exception = None
-        params = getattr(instance, "_params", {})
-        name = args[0] if args[0] else params.get("database", "postgresql")
+        params = getattr(instance, "_params", None)
+        name = (
+            args[0] if args[0] else getattr(params, "database", "postgresql")
+        )
 
         try:
             # Strip leading comments so we get the operation name.
@@ -185,11 +187,11 @@ class AsyncPGInstrumentor(BaseInstrumentor):
     async def _do_cursor_execute(self, func, instance, args, kwargs):
         """Wrap cursor based functions. For every call this will generate a new span."""
         exception = None
-        params = getattr(instance._connection, "_params", {})
+        params = getattr(instance._connection, "_params", None)
         name = (
             instance._query
             if instance._query
-            else params.get("database", "postgresql")
+            else getattr(params, "database", "postgresql")
         )
 
         try:


### PR DESCRIPTION
Follow-up on the apparently abbandonned https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2114.
Closes #2114

# Description

The asyncpg instrumentation attempts to fall back on using the database name as the span name in case the first argument to the instrumented method is falsey.

Any attempt to do so results in errors simliar to this (truncated traceback):
```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/asyncpg/pool.py", line 597, in fetch
    return await con.fetch(
           ^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/opentelemetry/instrumentation/asyncpg/__init__.py", line 154, in _do_execute
    name = args[0] if args[0] else params.get("database", "postgresql")
                                   ^^^^^^^^^^
AttributeError: 'ConnectionParameters' object has no attribute 'get'
```

This has probably never worked since asyncpg defines the `_params` attribute as an instance of `ConnectionParams`
(https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connection.py#L62) which is a NamedTuple instance and thus don't define `get`. The proper way of safely accessing properties on a NamedTuple is using `getattr`.

The only case that I've actually found which triggers this branch is if the supplied query is an empty string. This is something that causes an `AttributeError` for `Connection.execute` but is fine for `fetch()`, `fetchval()`, `fetchrow()` and `executemany()`.

The tests have been expanded to check these cases. Also, more status code validation has been added where it was missing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] docker-tests for asyncpg instrumentation extended and passed

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
