### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.8"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
# Description

Last build for Readthedocs failed https://readthedocs.org/projects/opentelemetry-python-contrib/builds/27075004/ 

Trying the same OS/python version used at CI