### PR TITLE
1.30.1 backports: scripts/generate_instrumentation_bootstrap: don't force genai instrumentations versions (#3278)

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -18,11 +18,7 @@
 libraries = [
     {
         "library": "openai >= 1.26.0",
-        "instrumentation": "opentelemetry-instrumentation-openai-v2==2.2b0.dev",
-    },
-    {
-        "library": "google-cloud-aiplatform >= 1.64",
-        "instrumentation": "opentelemetry-instrumentation-vertexai==2.1b0.dev",
+        "instrumentation": "opentelemetry-instrumentation-openai-v2",
     },
     {
         "library": "aio_pika >= 7.2.0, < 10.0.0",

--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -60,6 +60,13 @@ gen_path = os.path.join(
 # See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2787
 packages_to_exclude = [
     "opentelemetry-instrumentation-aws-lambda",
+    "opentelemetry-instrumentation-vertexai",  # not released yet
+]
+
+# We should not put any version limit for instrumentations that are released independently
+unversioned_packages = [
+    "opentelemetry-instrumentation-openai-v2",
+    "opentelemetry-instrumentation-vertexai",
 ]
 
 
@@ -67,8 +74,11 @@ def main():
     # pylint: disable=no-member
     default_instrumentations = ast.List(elts=[])
     libraries = ast.List(elts=[])
-    for pkg in get_instrumentation_packages():
-        if pkg.get("name") in packages_to_exclude:
+    for pkg in get_instrumentation_packages(
+        unversioned_packages=unversioned_packages
+    ):
+        pkg_name = pkg.get("name")
+        if pkg_name in packages_to_exclude:
             continue
         if not pkg["instruments"]:
             default_instrumentations.elts.append(ast.Str(pkg["requirement"]))

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -24,7 +24,8 @@ instrumentations_path = os.path.join(root_path, "instrumentation")
 genai_instrumentations_path = os.path.join(root_path, "instrumentation-genai")
 
 
-def get_instrumentation_packages():
+def get_instrumentation_packages(unversioned_packages=None):
+    unversioned_packages = unversioned_packages or []
     pkg_paths = []
     for pkg in os.listdir(instrumentations_path):
         pkg_path = os.path.join(instrumentations_path, pkg)
@@ -62,12 +63,15 @@ def get_instrumentation_packages():
                 "instruments"
             ],
         }
-        instrumentation["requirement"] = "==".join(
-            (
-                instrumentation["name"],
-                instrumentation["version"],
+        if instrumentation["name"] in unversioned_packages:
+            instrumentation["requirement"] = instrumentation["name"]
+        else:
+            instrumentation["requirement"] = "==".join(
+                (
+                    instrumentation["name"],
+                    instrumentation["version"],
+                )
             )
-        )
         yield instrumentation
 
 


### PR DESCRIPTION
Since genai instrumentations are released on their own we cannot have a fixed required version on this side.
While at it add vertexai to the list of excluded packages since:
- it has not been released yet

Backported from e4a5b541357d4bf291ac73f16fb2a8e31e8f2bda
