### PR TITLE
Updating workflows and RELEASING.md to allow vertexai individual release

### DIFF
--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -9,6 +9,7 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
+        - opentelemetry-instrumentation-vertexai
         description: 'Package to be released'
         required: true
 jobs:

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -9,6 +9,7 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
+        - opentelemetry-instrumentation-vertexai
         description: 'Package to be released'
         required: true
 

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -9,6 +9,7 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
+        - opentelemetry-instrumentation-vertexai
         description: 'Package to be released'
         required: true
 jobs:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@
 > - opentelemetry-resource-detector-azure
 > - opentelemetry-sdk-extension-aws
 > - opentelemetry-instrumentation-openai-v2
->
+> - opentelemetry-instrumentation-vertexai
 > These libraries are also excluded from the general release.
 
 Package release preparation is handled by the [`[Package] Prepare release`](./.github/workflows/package-prepare-release.yml) workflow that allows


### PR DESCRIPTION
# Description

This was missed in the boilerplate PR. Updating releasing instructions and the workflows.

# How Has This Been Tested?

Ran `./scripts/build_a_package.sh` but it's hard to test without running the workflow.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
N/A
