### PR TITLE
Add `run-name` with package name to single-package release workflows

### DIFF
--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -12,6 +12,8 @@ on:
         - opentelemetry-instrumentation-vertexai
         description: 'Package to be released'
         required: true
+run-name: "[Package][${{ inputs.package }}] Prepare patch release"
+
 jobs:
   prepare-patch-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -13,6 +13,7 @@ on:
         description: 'Package to be released'
         required: true
 
+run-name: "[Package][${{ inputs.package }}] Prepare release"
 jobs:
   prereqs:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -12,6 +12,7 @@ on:
         - opentelemetry-instrumentation-vertexai
         description: 'Package to be released'
         required: true
+run-name: "[Package][${{ inputs.package }}] Release"
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,7 @@
 > - opentelemetry-sdk-extension-aws
 > - opentelemetry-instrumentation-openai-v2
 > - opentelemetry-instrumentation-vertexai
+>
 > These libraries are also excluded from the general release.
 
 Package release preparation is handled by the [`[Package] Prepare release`](./.github/workflows/package-prepare-release.yml) workflow that allows


### PR DESCRIPTION
# Description

Right now the individual package release workflows don't show the package they ran for:
<img width="490" alt="Screenshot 2025-02-21 at 3 58 49 PM" src="https://github.com/user-attachments/assets/eba0f264-0667-43c5-ac70-b952e03857e3" />

[`run-name`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#run-name) should make it look like `[Package][opentelemetry-instrumentation-foo] Prepare release`

## Type of change

Tooling

# How Has This Been Tested?

N/A

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
