### PR TITLE
opentelemetry-docker-tests: bump grpcio to 1.63.2

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -25,7 +25,7 @@ docopt==0.6.2
 exceptiongroup==1.2.0
 flaky==3.7.0
 greenlet==3.0.3
-grpcio==1.62.1
+grpcio==1.63.2
 idna==2.10
 iniconfig==2.0.0
 jsonschema==3.2.0


### PR DESCRIPTION
# Description

To match the baseline added to opencensus exporter in https://github.com/open-telemetry/opentelemetry-python/commit/f42041ad933bb49c244032545aa72bbefbc69ef7. Hopefully fixes CI.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
