### PR TITLE
Cherry-pick opentelemetry-docker-tests: bump grpcio to 1.63.2 (#3290)

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -25,7 +25,7 @@ docopt==0.6.2
 exceptiongroup==1.2.0
 flaky==3.7.0
 greenlet==3.0.3
-grpcio==1.62.1
+grpcio==1.63.2
 idna==2.10
 iniconfig==2.0.0
 jsonschema==3.2.0


### PR DESCRIPTION
Cherry pick #3290 to opentelemetry-instrumentation-vertexai release branch.