### PR TITLE
VertexAI fix RST title underline

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/README.rst
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry VertexAI Instrumentation
-====================================
+======================================
 
 |pypi|
 


### PR DESCRIPTION
# Description

This makes twine/PyPI happy:

```
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 2: Warning: Title underline too short.

         OpenTelemetry VertexAI Instrumentation
         ====================================
```
See failed release workflow https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/13504058843/job/37729358495

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Built a dist and checked with twine:
```console
$ uvx twine check dist/*
Checking dist/opentelemetry_instrumentation_vertexai-2.1b0.dev0-py3-none-any.whl: PASSED
Checking dist/opentelemetry_instrumentation_vertexai-2.1b0.dev0.tar.gz: PASSED
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Documentation has been updated
