### PR TITLE
Improves aiohttp_client instrumentation example

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -22,6 +22,7 @@ Explicitly instrumenting a single client session:
 
 .. code:: python
 
+    import asyncio
     import aiohttp
     from opentelemetry.instrumentation.aiohttp_client import create_trace_config
     import yarl
@@ -29,17 +30,21 @@ Explicitly instrumenting a single client session:
     def strip_query_params(url: yarl.URL) -> str:
         return str(url.with_query(None))
 
-    async with aiohttp.ClientSession(trace_configs=[create_trace_config(
+    async def get(url):
+        async with aiohttp.ClientSession(trace_configs=[create_trace_config(
             # Remove all query params from the URL attribute on the span.
             url_filter=strip_query_params,
-    )]) as session:
-        async with session.get(url) as response:
-            await response.text()
+        )]) as session:
+            async with session.get(url) as response:
+                await response.text()
+
+    asyncio.run(get("https://example.com"))
 
 Instrumenting all client sessions:
 
 .. code:: python
 
+    import asyncio
     import aiohttp
     from opentelemetry.instrumentation.aiohttp_client import (
         AioHttpClientInstrumentor
@@ -49,9 +54,12 @@ Instrumenting all client sessions:
     AioHttpClientInstrumentor().instrument()
 
     # Create a session and make an HTTP get request
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
-            await response.text()
+    async def get(url):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                await response.text()
+
+    asyncio.run(get("https://example.com"))
 
 Configuration
 -------------


### PR DESCRIPTION
# Description

The current instrumentation examples inside `aiohttp_client` doesn't run. This PR fixes the examples, so they run. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6.  Install common dependencies: 
   ```
  pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
    ../opentelemetry-python/opentelemetry-semantic-conventions/ \
    ../opentelemetry-python/opentelemetry-api/ \
    ../opentelemetry-python/opentelemetry-sdk/ \
    ../opentelemetry-python/opentelemetry-proto/ \
    ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
  ```
7. Install `aiohttp_client` specific requirements:
  ```
  pip install -r instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
  ```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
