### PR TITLE
Add `opentelemetry-instrumentation-vertexai>=2.0b0` to `opentelemetry-bootstrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3275](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3275))
 - `opentelemetry-instrumentation` make it simpler to initialize auto-instrumentation programmatically
   ([#3273](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3273))
+- Add `opentelemetry-instrumentation-vertexai>=2.0b0` to `opentelemetry-bootstrap`
+  ([#3307](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3307))
+
 
 ### Fixed
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -21,6 +21,10 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-openai-v2",
     },
     {
+        "library": "google-cloud-aiplatform >= 1.64",
+        "instrumentation": "opentelemetry-instrumentation-vertexai>=2.0b0",
+    },
+    {
         "library": "aio_pika >= 7.2.0, < 10.0.0",
         "instrumentation": "opentelemetry-instrumentation-aio-pika==0.52b0.dev",
     },

--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -64,15 +64,14 @@ packages_to_exclude = [
     # development. This filter will get removed once it is further along in its
     # development lifecycle and ready to be included by default.
     "opentelemetry-instrumentation-google-genai",
-    "opentelemetry-instrumentation-vertexai",  # not released yet
 ]
 
-# We should not put any version limit for instrumentations that are released independently
-unversioned_packages = [
-    "opentelemetry-instrumentation-openai-v2",
-    "opentelemetry-instrumentation-vertexai",
-    "opentelemetry-instrumentation-google-genai",
-]
+# Static version specifiers for instrumentations that are released independently
+independent_packages = {
+    "opentelemetry-instrumentation-openai-v2": "",
+    "opentelemetry-instrumentation-vertexai": ">=2.0b0",
+    "opentelemetry-instrumentation-google-genai": "",
+}
 
 
 def main():
@@ -80,7 +79,7 @@ def main():
     default_instrumentations = ast.List(elts=[])
     libraries = ast.List(elts=[])
     for pkg in get_instrumentation_packages(
-        unversioned_packages=unversioned_packages
+        independent_packages=independent_packages
     ):
         pkg_name = pkg.get("name")
         if pkg_name in packages_to_exclude:

--- a/scripts/otel_packaging.py
+++ b/scripts/otel_packaging.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import subprocess
 from subprocess import CalledProcessError
@@ -24,8 +26,10 @@ instrumentations_path = os.path.join(root_path, "instrumentation")
 genai_instrumentations_path = os.path.join(root_path, "instrumentation-genai")
 
 
-def get_instrumentation_packages(unversioned_packages=None):
-    unversioned_packages = unversioned_packages or []
+def get_instrumentation_packages(
+    independent_packages: dict[str, str] | None = None,
+):
+    independent_packages = independent_packages or {}
     pkg_paths = []
     for pkg in os.listdir(instrumentations_path):
         pkg_path = os.path.join(instrumentations_path, pkg)
@@ -63,8 +67,11 @@ def get_instrumentation_packages(unversioned_packages=None):
                 "instruments"
             ],
         }
-        if instrumentation["name"] in unversioned_packages:
-            instrumentation["requirement"] = instrumentation["name"]
+        if instrumentation["name"] in independent_packages:
+            specifier = independent_packages[instrumentation["name"]]
+            instrumentation["requirement"] = (
+                f"{instrumentation['name']}{specifier}"
+            )
         else:
             instrumentation["requirement"] = "==".join(
                 (


### PR DESCRIPTION
# Description

Adds `opentelemetry-instrumentation-vertexai>=2.0b0` to opentelemetry-bootstrap command. This version specifier should allow any future beta (prelease) versions as well.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
$ opentelemetry-bootstrap
opentelemetry-instrumentation-asyncio==0.52b0.dev
opentelemetry-instrumentation-dbapi==0.52b0.dev
opentelemetry-instrumentation-logging==0.52b0.dev
opentelemetry-instrumentation-sqlite3==0.52b0.dev
opentelemetry-instrumentation-threading==0.52b0.dev
opentelemetry-instrumentation-urllib==0.52b0.dev
opentelemetry-instrumentation-wsgi==0.52b0.dev
opentelemetry-instrumentation-vertexai>=2.0b0
opentelemetry-instrumentation-asgi==0.52b0.dev
opentelemetry-instrumentation-grpc==0.52b0.dev
opentelemetry-instrumentation-requests==0.52b0.dev
opentelemetry-instrumentation-tortoiseorm==0.52b0.dev
opentelemetry-instrumentation-urllib3==0.52b0.dev
```

And tested with `opentelemetry-bootstrap -a`.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
