### PR TITLE
Improve django instrumentation example

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -129,6 +129,8 @@ The hooks can be configured as follows:
 
 .. code:: python
 
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
+
     def request_hook(span, request):
         pass
 


### PR DESCRIPTION
# Description

There's one instrumentation example inside `django` that doesn't run. This PR fixes the example, so it runs.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6. Install common dependencies:
```
pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
 ../opentelemetry-python/opentelemetry-semantic-conventions/ \
 ../opentelemetry-python/opentelemetry-api/ \
 ../opentelemetry-python/opentelemetry-sdk/ \
 ../opentelemetry-python/opentelemetry-proto/ \
 ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
```
7. Install `django` specific requirements:
```
pip install -r instrumentation/opentelemetry-instrumentation-django/test-requirements.txt
```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
