### PR TITLE
Small fixes for google-genai before releasing

### DIFF
--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -10,6 +10,7 @@ on:
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
         - opentelemetry-instrumentation-vertexai
+        - opentelemetry-instrumentation-google-genai
         description: 'Package to be released'
         required: true
 run-name: "[Package][${{ inputs.package }}] Prepare patch release"

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -10,6 +10,7 @@ on:
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
         - opentelemetry-instrumentation-vertexai
+        - opentelemetry-instrumentation-google-genai
         description: 'Package to be released'
         required: true
 

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -10,6 +10,7 @@ on:
         - opentelemetry-sdk-extension-aws
         - opentelemetry-instrumentation-openai-v2
         - opentelemetry-instrumentation-vertexai
+        - opentelemetry-instrumentation-google-genai
         description: 'Package to be released'
         required: true
 run-name: "[Package][${{ inputs.package }}] Release"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,7 @@
 > - opentelemetry-sdk-extension-aws
 > - opentelemetry-instrumentation-openai-v2
 > - opentelemetry-instrumentation-vertexai
+> - opentelemetry-instrumentation-google-genai
 >
 > These libraries are also excluded from the general release.
 
@@ -79,6 +80,8 @@ The workflow will create a pull request that should be merged in order to procee
 > - opentelemetry-resource-detector-azure
 > - opentelemetry-sdk-extension-aws
 > - opentelemetry-instrumentation-openai-v2
+> - opentelemetry-instrumentation-vertexai
+> - opentelemetry-instrumentation-google-genai
 >
 > These libraries are also excluded from the general patch release.
 

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
@@ -17,4 +17,4 @@
 #   This version should stay below "1.0" until the fundamentals
 #   in "TODOS.md" have been addressed. Please revisit the TODOs
 #   listed there before bumping to a stable version.
-__version__ = "0.0.2.dev"
+__version__ = "0.1b0.dev"


### PR DESCRIPTION
# Description

- Change version to `0.1b0.dev` to match the rest of contrib. The first release will then be `0.1b0`.
- Add to the independent release workflows and README.md

cc @michaelsafyan 

## Type of change

Please delete options that are not relevant.

- [x] tooling

# How Has This Been Tested?

I also checked the dists

```
$ uvx twine check dist/*
Checking dist/opentelemetry_instrumentation_google_genai-0.1b0.dev0-py3-none-any.whl: PASSED
Checking dist/opentelemetry_instrumentation_google_genai-0.1b0.dev0.tar.gz: PASSED
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
