### PR TITLE
urllib: don't assume we control the bucket metrics data points get in

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
@@ -414,16 +414,16 @@ class TestUrllibMetricsInstrumentation(TestBase):
             ) = metrics[:3]
 
             self.assertEqual(
-                client_duration.data.data_points[0].bucket_counts[1],
+                sum(client_duration.data.data_points[0].bucket_counts),
                 1,
             )
 
             self.assertEqual(
-                client_request_size.data.data_points[0].bucket_counts[0],
+                sum(client_request_size.data.data_points[0].bucket_counts),
                 1,
             )
             self.assertEqual(
-                client_response_size.data.data_points[0].bucket_counts[2],
+                sum(client_response_size.data.data_points[0].bucket_counts),
                 1,
             )
 
@@ -439,15 +439,15 @@ class TestUrllibMetricsInstrumentation(TestBase):
             ) = metrics[:3]
 
             self.assertEqual(
-                client_duration.data.data_points[0].bucket_counts[1],
+                sum(client_duration.data.data_points[0].bucket_counts),
                 2,
             )
             self.assertEqual(
-                client_request_size.data.data_points[0].bucket_counts[0],
+                sum(client_request_size.data.data_points[0].bucket_counts),
                 2,
             )
             self.assertEqual(
-                client_response_size.data.data_points[0].bucket_counts[2],
+                sum(client_response_size.data.data_points[0].bucket_counts),
                 2,
             )
 
@@ -467,15 +467,15 @@ class TestUrllibMetricsInstrumentation(TestBase):
             self.assertEqual(len(metrics), 3)
 
             self.assertEqual(
-                client_duration.data.data_points[0].bucket_counts[1],
+                sum(client_duration.data.data_points[0].bucket_counts),
                 2,
             )
             self.assertEqual(
-                client_request_size.data.data_points[0].bucket_counts[0],
+                sum(client_request_size.data.data_points[0].bucket_counts),
                 2,
             )
 
             self.assertEqual(
-                client_response_size.data.data_points[0].bucket_counts[2],
+                sum(client_response_size.data.data_points[0].bucket_counts),
                 2,
             )


### PR DESCRIPTION
# Description

Instead of expecting an entry in a specific bucket, just sum all of them and assert we have the correct number of entries.
Fixes #3320

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py318-test-instrumentation-urllib

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
