### PR TITLE
botocore: don't crash when sending content as string with InvokeModel

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
@@ -386,6 +386,10 @@ def extract_tool_results(
     if not content:
         return
 
+    # langchain sends content as string with InvokeModel and Anthropic Claude
+    if isinstance(content, str):
+        return
+
     # Converse format
     tool_results = [
         item["toolResult"] for item in content if "toolResult" in item

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content_user_content_as_string.yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content_user_content_as_string.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "say this is a test"
+          }
+        ],
+        "max_tokens": 10,
+        "anthropic_version": "bedrock-2023-05-31"
+      }
+    headers:
+      Content-Length:
+      - '126'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/linux#6.1.0-1034-oem md/arch#x86_64
+        lang/python#3.10.12 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250306T091535Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-fcd0825a-03f328cca8cde3e741cd83b4;Parent=5a8eccf8d7b031e7;Sampled=1
+      amz-sdk-invocation-id:
+      - e8a6c9c5-8a45-4ad7-881b-0761d121abc7
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20240620-v1%3A0/invoke
+  response:
+    body:
+      string: |-
+        {
+          "id": "msg_bdrk_01SjMAZgb8kNMweUzf3moSbU",
+          "type": "message",
+          "role": "assistant",
+          "model": "claude-3-5-sonnet-20240620",
+          "content": [
+            {
+              "type": "text",
+              "text": "This is a test."
+            }
+          ],
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 12,
+            "output_tokens": 8
+          }
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Mar 2025 09:15:36 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '12'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '544'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '8'
+      x-amzn-RequestId:
+      - e97cb4f9-61fe-4a62-a29a-a582ddd17414
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_bedrock.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_bedrock.py
@@ -1256,6 +1256,53 @@ def test_invoke_model_with_content(
     assert_message_in_logs(logs[1], "gen_ai.choice", choice_body, span)
 
 
+@pytest.mark.vcr()
+def test_invoke_model_with_content_user_content_as_string(
+    span_exporter,
+    log_exporter,
+    bedrock_runtime_client,
+    instrument_with_content,
+):
+    llm_model_value = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    max_tokens = 10
+    body = json.dumps(
+        {
+            "messages": [{"role": "user", "content": "say this is a test"}],
+            "max_tokens": max_tokens,
+            "anthropic_version": "bedrock-2023-05-31",
+        }
+    )
+    response = bedrock_runtime_client.invoke_model(
+        body=body,
+        modelId=llm_model_value,
+    )
+
+    (span,) = span_exporter.get_finished_spans()
+    assert_completion_attributes_from_streaming_body(
+        span,
+        llm_model_value,
+        response,
+        "chat",
+        request_max_tokens=max_tokens,
+    )
+
+    logs = log_exporter.get_finished_logs()
+    assert len(logs) == 2
+    user_content = {"content": "say this is a test"}
+    assert_message_in_logs(logs[0], "gen_ai.user.message", user_content, span)
+
+    message = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "This is a test."}],
+    }
+    choice_body = {
+        "index": 0,
+        "finish_reason": "end_turn",
+        "message": message,
+    }
+    assert_message_in_logs(logs[1], "gen_ai.choice", choice_body, span)
+
+
 @pytest.mark.parametrize(
     "model_family",
     ["amazon.nova", "anthropic.claude"],


### PR DESCRIPTION
# Description

Don't assume content is always a dict when extracting tool calls as apparently langchain sends the content as string with InvokeModel and Claude.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-instrumentation-botocore-1

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
