### PR TITLE
AWS X-Ray Remote Sampler Part 1 - Initial Classes and Rules Poller Implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "opentelemetry-instrumentation-wsgi",
   "opentelemetry-propagator-ot-trace",
   "opentelemetry-propagator-aws-xray",
+  "opentelemetry-sampler-aws-xray",
   "opentelemetry-util-http",
   "opentelemetry-instrumentation-vertexai[instruments]",
   "opentelemetry-instrumentation-openai-v2[instruments]",
@@ -130,6 +131,7 @@ opentelemetry-instrumentation-urllib3 = { workspace = true }
 opentelemetry-instrumentation-wsgi = { workspace = true }
 opentelemetry-propagator-ot-trace = { workspace = true }
 opentelemetry-propagator-aws-xray = { workspace = true }
+opentelemetry-sampler-aws-xray = { workspace = true }
 opentelemetry-util-http = { workspace = true }
 opentelemetry-instrumentation-vertexai = { workspace = true }
 opentelemetry-instrumentation-openai-v2 = { workspace = true }
@@ -142,6 +144,7 @@ members = [
   "exporter/*",
   "opentelemetry-instrumentation",
   "propagator/*",
+  "sampler/*",
   "util/opentelemetry-util-http",
 ]
 # TODO: remove after python 3.8 is dropped

--- a/sampler/opentelemetry-sampler-aws-xray/CHANGELOG.md
+++ b/sampler/opentelemetry-sampler-aws-xray/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Update `opentelemetry-api` version to 1.16
+  ([#2961](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2961))
+
+## Version 1.0.2 (2024-08-05)
+
+See [common CHANGELOG](../../CHANGELOG.md) for the changes in this and prior versions.
+

--- a/sampler/opentelemetry-sampler-aws-xray/LICENSE
+++ b/sampler/opentelemetry-sampler-aws-xray/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sampler/opentelemetry-sampler-aws-xray/MANIFEST.rst
+++ b/sampler/opentelemetry-sampler-aws-xray/MANIFEST.rst
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/sampler/opentelemetry-sampler-aws-xray/README.rst
+++ b/sampler/opentelemetry-sampler-aws-xray/README.rst
@@ -1,0 +1,48 @@
+OpenTelemetry Sampler for AWS X-Ray Service
+==============================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-sampler-aws-xray.svg
+   :target: https://pypi.org/project/opentelemetry-sampler-aws-xray/
+
+
+This library provides the AWS X-Ray Remote Sampler for OpenTelemetry Python
+to use X-Ray Sampling Rules to sample spans.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-sampler-aws-xray
+
+
+Usage (AWS X-Ray Sampler)
+----------------------------
+
+
+Use the provided AWS X-Ray Remote Sampler by setting this sampler in your instrumented application:
+
+.. code-block:: python
+
+    from opentelemetry.samplers.aws import AwsXRayRemoteSampler
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.semconv.resource import ResourceAttributes
+    from opentelemetry.util.types import Attributes
+
+    resource = Resource.create(attributes={
+        ResourceAttributes.SERVICE_NAME: "myService",
+        ResourceAttributes.CLOUD_PLATFORM: "aws_ec2",
+    })
+    xraySampler = AwsXRayRemoteSampler(resource=resource, polling_interval=300)
+    trace.set_tracer_provider(TracerProvider(sampler=xraySampler))
+
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `AWS X-Ray Sampling <https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-sampling>`_

--- a/sampler/opentelemetry-sampler-aws-xray/pyproject.toml
+++ b/sampler/opentelemetry-sampler-aws-xray/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-sampler-aws-xray"
+dynamic = ["version"]
+description = "AWS X-Ray Sampler for OpenTelemetry"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.8"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.27",
+  "opentelemetry-sdk ~= 1.27",
+  "opentelemetry-instrumentation ~= 0.48b0",
+  "opentelemetry-semantic-conventions ~= 0.48b0",
+]
+
+[project.entry-points.opentelemetry_sampler]
+xray = "opentelemetry.samplers.aws:AwsXRaySampler"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/sampler/opentelemetry-sampler-aws-xray"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
+
+[tool.hatch.version]
+path = "src/opentelemetry/samplers/aws/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/README.md
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/README.md
@@ -1,0 +1,14 @@
+
+
+
+
+Usage:
+```
+
+from opentelemetry.samplers.aws.aws_xray_remote_sampler import AwsXRayRemoteSampler
+
+trace.set_tracer_provider(TracerProvider(sampler=ParentBased(xray_sampler)))
+tracer = trace.get_tracer(__name__)
+
+
+```

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/__init__.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/__init__.py
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry.samplers.aws.aws_xray_remote_sampler import (
+    AwsXRayRemoteSampler,
+)
+
+__all__ = ["AwsXRayRemoteSampler"]

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_aws_xray_sampling_client.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_aws_xray_sampling_client.py
@@ -1,0 +1,105 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from logging import getLogger
+from typing import Optional, List
+
+import requests
+
+from opentelemetry.samplers.aws._sampling_rule import _SamplingRule
+from opentelemetry.samplers.aws._sampling_target import _SamplingTargetResponse
+from opentelemetry.instrumentation.utils import suppress_instrumentation
+
+_logger = getLogger(__name__)
+DEFAULT_SAMPLING_PROXY_ENDPOINT = "http://127.0.0.1:2000"
+
+class _AwsXRaySamplingClient:
+    def __init__(self, endpoint: str = DEFAULT_SAMPLING_PROXY_ENDPOINT, log_level: Optional[str] = None):
+        # Override default log level
+        if log_level is not None:
+            _logger.setLevel(log_level)
+
+        self.__get_sampling_rules_endpoint = endpoint + "/GetSamplingRules"
+        self.__get_sampling_targets_endpoint = endpoint + "/SamplingTargets"
+
+        self.__session = requests.Session()
+
+    def get_sampling_rules(self) -> List[_SamplingRule]:
+        sampling_rules: List["_SamplingRule"] = []
+        headers = {"content-type": "application/json"}
+
+        with suppress_instrumentation():
+            try:
+                xray_response = self.__session.post(url=self.__get_sampling_rules_endpoint, headers=headers, timeout=20)
+                sampling_rules_response = xray_response.json()
+                if sampling_rules_response is None or "SamplingRuleRecords" not in sampling_rules_response:
+                    _logger.error(
+                        "SamplingRuleRecords is missing in getSamplingRules response: %s", sampling_rules_response
+                    )
+                    return []
+                sampling_rules_records = sampling_rules_response["SamplingRuleRecords"]
+                for record in sampling_rules_records:
+                    if "SamplingRule" not in record:
+                        _logger.error("SamplingRule is missing in SamplingRuleRecord")
+                    else:
+                        sampling_rules.append(_SamplingRule(**record["SamplingRule"]))
+
+            except requests.exceptions.RequestException as req_err:
+                _logger.error("Request error occurred: %s", req_err)
+            except json.JSONDecodeError as json_err:
+                _logger.error("Error in decoding JSON response: %s", json_err)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                _logger.error("Error occurred when attempting to fetch rules: %s", err)
+
+            return sampling_rules
+
+    def get_sampling_targets(self, statistics: List["dict[str, str | float | int]"]) -> _SamplingTargetResponse:
+        sampling_targets_response = _SamplingTargetResponse(
+            LastRuleModification=None, SamplingTargetDocuments=None, UnprocessedStatistics=None
+        )
+        headers = {"content-type": "application/json"}
+
+        with suppress_instrumentation():
+            try:
+                xray_response = self.__session.post(
+                    url=self.__get_sampling_targets_endpoint,
+                    headers=headers,
+                    timeout=20,
+                    json={"SamplingStatisticsDocuments": statistics},
+                )
+                xray_response_json = xray_response.json()
+                if (
+                    xray_response_json is None
+                    or "SamplingTargetDocuments" not in xray_response_json
+                    or "LastRuleModification" not in xray_response_json
+                ):
+                    _logger.debug("getSamplingTargets response is invalid. Unable to update targets.")
+                    return sampling_targets_response
+
+                sampling_targets_response = _SamplingTargetResponse(**xray_response_json)
+            except requests.exceptions.RequestException as req_err:
+                _logger.debug("Request error occurred: %s", req_err)
+            except json.JSONDecodeError as json_err:
+                _logger.debug("Error in decoding JSON response: %s", json_err)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                _logger.debug("Error occurred when attempting to fetch targets: %s", err)
+
+            return sampling_targets_response

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_clock.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_clock.py
@@ -1,0 +1,37 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+
+
+class _Clock:
+    def __init__(self):
+        self.__datetime = datetime.datetime
+
+    def now(self) -> datetime.datetime:
+        return self.__datetime.now()
+
+    # pylint: disable=no-self-use
+    def from_timestamp(self, timestamp: float) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(timestamp)
+
+    def time_delta(self, seconds: float) -> datetime.timedelta:
+        return datetime.timedelta(seconds=seconds)
+
+    def max(self) -> datetime.datetime:
+        return datetime.datetime.max

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_mock_clock.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_mock_clock.py
@@ -1,0 +1,36 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+
+from opentelemetry.samplers.aws._clock import _Clock
+
+
+class MockClock(_Clock):
+    def __init__(self, dt: datetime.datetime = datetime.datetime.now()):
+        self.time_now = dt
+        super()
+
+    def now(self) -> datetime.datetime:
+        return self.time_now
+
+    def add_time(self, seconds: float) -> None:
+        self.time_now += self.time_delta(seconds)
+
+    def set_time(self, dt: datetime.datetime) -> None:
+        self.time_now = dt

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_rule.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_rule.py
@@ -1,0 +1,79 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+# Disable snake_case naming style so this class can match the sampling rules response from X-Ray
+# pylint: disable=invalid-name
+class _SamplingRule:
+    def __init__(
+        self,
+        Attributes: Optional["dict[str, str]"] = None,
+        FixedRate: Optional[float] = None,
+        HTTPMethod: Optional[str] = None,
+        Host: Optional[str] = None,
+        Priority: Optional[int] = None,
+        ReservoirSize: Optional[int] = None,
+        ResourceARN: Optional[str] = None,
+        RuleARN: Optional[str] = None,
+        RuleName: Optional[str] = None,
+        ServiceName: Optional[str] = None,
+        ServiceType: Optional[str] = None,
+        URLPath: Optional[str] = None,
+        Version: Optional[int] = None,
+    ):
+        self.Attributes = Attributes if Attributes is not None else {}
+        self.FixedRate = FixedRate if FixedRate is not None else 0.0
+        self.HTTPMethod = HTTPMethod if HTTPMethod is not None else ""
+        self.Host = Host if Host is not None else ""
+        # Default to value with lower priority than default rule
+        self.Priority = Priority if Priority is not None else 10001
+        self.ReservoirSize = ReservoirSize if ReservoirSize is not None else 0
+        self.ResourceARN = ResourceARN if ResourceARN is not None else ""
+        self.RuleARN = RuleARN if RuleARN is not None else ""
+        self.RuleName = RuleName if RuleName is not None else ""
+        self.ServiceName = ServiceName if ServiceName is not None else ""
+        self.ServiceType = ServiceType if ServiceType is not None else ""
+        self.URLPath = URLPath if URLPath is not None else ""
+        self.Version = Version if Version is not None else 0
+
+    def __lt__(self, other: "_SamplingRule") -> bool:
+        if self.Priority == other.Priority:
+            # String order priority example:
+            # "A","Abc","a","ab","abc","abcdef"
+            return self.RuleName < other.RuleName
+        return self.Priority < other.Priority
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _SamplingRule):
+            return False
+        return (
+            self.FixedRate == other.FixedRate
+            and self.HTTPMethod == other.HTTPMethod
+            and self.Host == other.Host
+            and self.Priority == other.Priority
+            and self.ReservoirSize == other.ReservoirSize
+            and self.ResourceARN == other.ResourceARN
+            and self.RuleARN == other.RuleARN
+            and self.RuleName == other.RuleName
+            and self.ServiceName == other.ServiceName
+            and self.ServiceType == other.ServiceType
+            and self.URLPath == other.URLPath
+            and self.Version == other.Version
+            and self.Attributes == other.Attributes
+        )

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_rule_applier.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_rule_applier.py
@@ -1,0 +1,40 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+from opentelemetry.samplers.aws._clock import _Clock
+from opentelemetry.samplers.aws._sampling_rule import _SamplingRule
+from opentelemetry.samplers.aws._sampling_statistics_document import _SamplingStatisticsDocument
+from opentelemetry.samplers.aws._sampling_target import _SamplingTarget
+
+
+class _SamplingRuleApplier:
+    def __init__(
+        self,
+        sampling_rule: _SamplingRule,
+        client_id: str,
+        clock: _Clock,
+        statistics: Optional[_SamplingStatisticsDocument] = None,
+        target: Optional[_SamplingTarget] = None,
+    ):
+        self.__client_id = client_id
+        self._clock = clock
+        self.sampling_rule = sampling_rule
+
+        # (TODO) Just store Sampling Rules for now, rest of implementation for later

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_statistics_document.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_statistics_document.py
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from opentelemetry.samplers.aws._clock import _Clock
+
+# Disable snake_case naming style so this class can match the statistics document response from X-Ray
+# pylint: disable=invalid-name
+class _SamplingStatisticsDocument:
+    def __init__(self, clientID: str, ruleName: str, RequestCount: int = 0, BorrowCount: int = 0, SampleCount: int = 0):
+        self.ClientID = clientID
+        self.RuleName = ruleName
+        self.Timestamp = None
+
+        self.RequestCount = RequestCount
+        self.BorrowCount = BorrowCount
+        self.SampleCount = SampleCount
+
+    def snapshot(self, clock: _Clock):
+        return {
+            "ClientID": self.ClientID,
+            "RuleName": self.RuleName,
+            "Timestamp": clock.now().timestamp(),
+            "RequestCount": self.RequestCount,
+            "BorrowCount": self.BorrowCount,
+            "SampleCount": self.SampleCount,
+        }

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_target.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/_sampling_target.py
@@ -1,0 +1,78 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from logging import getLogger
+from typing import Optional, List
+
+_logger = getLogger(__name__)
+
+
+# Disable snake_case naming style so this class can match the sampling rules response from X-Ray
+# pylint: disable=invalid-name
+class _SamplingTarget:
+    def __init__(
+        self,
+        FixedRate: Optional[float] = None,
+        Interval: Optional[int] = None,
+        ReservoirQuota: Optional[int] = None,
+        ReservoirQuotaTTL: Optional[float] = None,
+        RuleName: Optional[str] = None,
+    ):
+        self.FixedRate = FixedRate if FixedRate is not None else 0.0
+        self.Interval = Interval  # can be None
+        self.ReservoirQuota = ReservoirQuota  # can be None
+        self.ReservoirQuotaTTL = ReservoirQuotaTTL  # can be None
+        self.RuleName = RuleName if RuleName is not None else ""
+
+
+class _UnprocessedStatistics:
+    def __init__(
+        self,
+        ErrorCode: Optional[str] = None,
+        Message: Optional[str] = None,
+        RuleName: Optional[str] = None,
+    ):
+        self.ErrorCode = ErrorCode if ErrorCode is not None else ""
+        self.Message = Message if ErrorCode is not None else ""
+        self.RuleName = RuleName if ErrorCode is not None else ""
+
+
+class _SamplingTargetResponse:
+    def __init__(
+        self,
+        LastRuleModification: Optional[float],
+        SamplingTargetDocuments: Optional[List[_SamplingTarget]] = None,
+        UnprocessedStatistics: Optional[List[_UnprocessedStatistics]] = None,
+    ):
+        self.LastRuleModification: float = LastRuleModification if LastRuleModification is not None else 0.0
+
+        self.SamplingTargetDocuments: List[_SamplingTarget] = []
+        if SamplingTargetDocuments is not None:
+            for document in SamplingTargetDocuments:
+                try:
+                    self.SamplingTargetDocuments.append(_SamplingTarget(**document))
+                except TypeError as e:
+                    _logger.debug("TypeError occurred: %s", e)
+
+        self.UnprocessedStatistics: List[_UnprocessedStatistics] = []
+        if UnprocessedStatistics is not None:
+            for unprocessed in UnprocessedStatistics:
+                try:
+                    self.UnprocessedStatistics.append(_UnprocessedStatistics(**unprocessed))
+                except TypeError as e:
+                    _logger.debug("TypeError occurred: %s", e)

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/aws_xray_remote_sampler.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/aws_xray_remote_sampler.py
@@ -1,0 +1,172 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from logging import getLogger
+from threading import Timer
+from typing import Optional, Sequence
+
+from typing_extensions import override
+
+from opentelemetry.samplers.aws._aws_xray_sampling_client import _AwsXRaySamplingClient, DEFAULT_SAMPLING_PROXY_ENDPOINT
+from opentelemetry.samplers.aws._clock import _Clock
+from opentelemetry.context import Context
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.sampling import Decision, ParentBased, Sampler, SamplingResult
+from opentelemetry.trace import Link, SpanKind
+from opentelemetry.trace.span import TraceState
+from opentelemetry.util.types import Attributes
+
+_logger = getLogger(__name__)
+
+DEFAULT_RULES_POLLING_INTERVAL_SECONDS = 300
+
+
+# Wrapper class to ensure that all XRay Sampler Functionality in _AwsXRayRemoteSampler
+# uses ParentBased logic to respect the parent span's sampling decision
+class AwsXRayRemoteSampler(Sampler):
+    def __init__(
+        self,
+        resource: Resource,
+        endpoint: Optional[str] = None,
+        polling_interval: Optional[int] = None,
+        log_level: Optional[str] = None,
+    ):
+        self._root = ParentBased(
+            _AwsXRayRemoteSampler(
+                resource=resource, endpoint=endpoint, polling_interval=polling_interval, log_level=log_level
+            )
+        )
+
+    # pylint: disable=no-self-use
+    @override
+    def should_sample(
+        self,
+        parent_context: Optional["Context"],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Optional[Attributes] = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
+    ) -> "SamplingResult":
+        return self._root.should_sample(
+            parent_context, trace_id, name, kind=kind, attributes=attributes, links=links, trace_state=trace_state
+        )
+
+    # pylint: disable=no-self-use
+    @override
+    def get_description(self) -> str:
+        return f"AwsXRayRemoteSampler{{root:{self._root.get_description()}}}"
+
+
+# _AwsXRayRemoteSampler contains all core XRay Sampler Functionality,
+# however it is NOT Parent-based (e.g. Sample logic runs for each span)
+# Not intended for external use, use Parent-based `AwsXRayRemoteSampler` instead.
+class _AwsXRayRemoteSampler(Sampler):
+    """
+    Remote Sampler for OpenTelemetry that gets sampling configurations from AWS X-Ray
+
+    Args:
+        resource: OpenTelemetry Resource (Required)
+        endpoint: proxy endpoint for AWS X-Ray Sampling (Optional)
+        polling_interval: Polling interval for getSamplingRules call (Optional)
+        log_level: custom log level configuration for remote sampler (Optional)
+    """
+
+    def __init__(
+        self,
+        resource: Resource,
+        endpoint: Optional[str] = None,
+        polling_interval: Optional[int] = None,
+        log_level: Optional[str] = None,
+    ):
+        # Override default log level
+        if log_level is not None:
+            _logger.setLevel(log_level)
+
+        if endpoint is None:
+            _logger.info("`endpoint` is `None`. Defaulting to %s", DEFAULT_SAMPLING_PROXY_ENDPOINT)
+            endpoint = DEFAULT_SAMPLING_PROXY_ENDPOINT
+        if polling_interval is None or polling_interval < 10:
+            _logger.info(
+                "`polling_interval` is `None` or too small. Defaulting to %s", DEFAULT_RULES_POLLING_INTERVAL_SECONDS
+            )
+            polling_interval = DEFAULT_RULES_POLLING_INTERVAL_SECONDS
+
+        self.__client_id = self.__generate_client_id()
+        self._clock = _Clock()
+        self.__xray_client = _AwsXRaySamplingClient(endpoint, log_level=log_level)
+
+        self.__polling_interval = polling_interval
+        self.__rule_polling_jitter = random.uniform(0.0, 5.0)
+
+        if resource is not None:
+            self.__resource = resource
+        else:
+            _logger.warning("OTel Resource provided is `None`. Defaulting to empty resource")
+            self.__resource = Resource.get_empty()
+
+        # Schedule the next rule poll now
+        # Python Timers only run once, so they need to be recreated for every poll
+        self._rules_timer = Timer(0, self.__start_sampling_rule_poller)
+        self._rules_timer.daemon = True  # Ensures that when the main thread exits, the Timer threads are killed
+        self._rules_timer.start()
+
+        # (TODO) set up the target poller to go off once after the default interval. Subsequent polls may use new intervals.
+
+    # pylint: disable=no-self-use
+    @override
+    def should_sample(
+        self,
+        parent_context: Optional["Context"],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Optional[Attributes] = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
+    ) -> "SamplingResult":
+        return SamplingResult(decision=Decision.DROP, attributes=attributes, trace_state=trace_state)
+
+
+    # pylint: disable=no-self-use
+    @override
+    def get_description(self) -> str:
+        description = "_AwsXRayRemoteSampler{remote sampling with AWS X-Ray}"
+        return description
+
+    def __get_and_update_sampling_rules(self) -> None:
+        sampling_rules = self.__xray_client.get_sampling_rules()
+        # (TODO) update rules cache with sampling rules
+
+    def __start_sampling_rule_poller(self) -> None:
+        self.__get_and_update_sampling_rules()
+        # Schedule the next sampling rule poll
+        self._rules_timer = Timer(
+            self.__polling_interval + self.__rule_polling_jitter, self.__start_sampling_rule_poller
+        )
+        self._rules_timer.daemon = True
+        self._rules_timer.start()
+
+    def __generate_client_id(self) -> str:
+        hex_chars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]
+        client_id_array: list[str] = []
+        for _ in range(0, 24):
+            client_id_array.append(random.choice(hex_chars))
+        return "".join(client_id_array)

--- a/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/version.py
+++ b/sampler/opentelemetry-sampler-aws-xray/src/opentelemetry/samplers/aws/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.0.0.dev"

--- a/sampler/opentelemetry-sampler-aws-xray/test-requirements-0.txt
+++ b/sampler/opentelemetry-sampler-aws-xray/test-requirements-0.txt
@@ -1,0 +1,6 @@
+pytest==7.4.4
+pytest-benchmark==4.0.0
+requests==2.32.3
+opentelemetry-api==1.27  # when updating, also update in pyproject.toml
+opentelemetry-sdk==1.27  # when updating, also update in pyproject.toml
+-e sampler/opentelemetry-sampler-aws-xray

--- a/sampler/opentelemetry-sampler-aws-xray/test-requirements-1.txt
+++ b/sampler/opentelemetry-sampler-aws-xray/test-requirements-1.txt
@@ -1,0 +1,6 @@
+pytest==7.4.4
+pytest-benchmark==4.0.0
+requests==2.32.3
+# test with the latest version of opentelemetry-api, sdk, and semantic conventions
+
+-e sampler/opentelemetry-sampler-aws-xray

--- a/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-rules-response-sample-2.json
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-rules-response-sample-2.json
@@ -1,0 +1,48 @@
+{
+    "NextToken": null,
+    "SamplingRuleRecords": [
+        {
+            "CreatedAt": 1.676038494E9,
+            "ModifiedAt": 1.676038494E9,
+            "SamplingRule": {
+                "Attributes": {
+                    "foo": "bar",
+                    "abc": "1234"
+                },
+                "FixedRate": 0.05,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 10000,
+                "ReservoirSize": 100,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-east-1:999999999999:sampling-rule/Default",
+                "RuleName": "Default",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        },
+        {
+            "CreatedAt": 1.67799933E9,
+            "ModifiedAt": 1.67799933E9,
+            "SamplingRule": {
+                "Attributes": {
+                    "abc": "1234"
+                },
+                "FixedRate": 0.11,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 20,
+                "ReservoirSize": 1,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+                "RuleName": "test",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        }
+    ]
+}

--- a/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-rules-response-sample.json
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-rules-response-sample.json
@@ -1,0 +1,65 @@
+{
+    "NextToken": null,
+    "SamplingRuleRecords": [
+        {
+            "CreatedAt": 1.67799933E9,
+            "ModifiedAt": 1.67799933E9,
+            "SamplingRule": {
+                "Attributes": {
+                    "foo": "bar",
+                    "doo": "baz"
+                },
+                "FixedRate": 0.05,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 1000,
+                "ReservoirSize": 10,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Rule1",
+                "RuleName": "Rule1",
+                "ServiceName": "*",
+                "ServiceType": "AWS::Foo::Bar",
+                "URLPath": "*",
+                "Version": 1
+            }
+        },
+        {
+            "CreatedAt": 0.0,
+            "ModifiedAt": 1.611564245E9,
+            "SamplingRule": {
+                "Attributes": {},
+                "FixedRate": 0.05,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 10000,
+                "ReservoirSize": 1,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Default",
+                "RuleName": "Default",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        },
+        {
+            "CreatedAt": 1.676038494E9,
+            "ModifiedAt": 1.676038494E9,
+            "SamplingRule": {
+                "Attributes": {},
+                "FixedRate": 0.2,
+                "HTTPMethod": "GET",
+                "Host": "*",
+                "Priority": 1,
+                "ReservoirSize": 10,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Rule2",
+                "RuleName": "Rule2",
+                "ServiceName": "FooBar",
+                "ServiceType": "*",
+                "URLPath": "/foo/bar",
+                "Version": 1
+            }
+        }
+    ]
+}

--- a/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-targets-response-sample.json
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/data/get-sampling-targets-response-sample.json
@@ -1,0 +1,20 @@
+{
+    "LastRuleModification": 1707551387.0,
+    "SamplingTargetDocuments": [
+        {
+            "FixedRate": 0.10,
+            "Interval": 10,
+            "ReservoirQuota": 30,
+            "ReservoirQuotaTTL": 1707764006.0,
+            "RuleName": "test"
+        },
+        {
+            "FixedRate": 0.05,
+            "Interval": 10,
+            "ReservoirQuota": 0,
+            "ReservoirQuotaTTL": 1707764006.0,
+            "RuleName": "Default"
+        }
+    ],
+    "UnprocessedStatistics": []
+}

--- a/sampler/opentelemetry-sampler-aws-xray/tests/data/test-remote-sampler_sampling-rules-response-sample.json
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/data/test-remote-sampler_sampling-rules-response-sample.json
@@ -1,0 +1,45 @@
+{
+    "NextToken": null,
+    "SamplingRuleRecords": [
+        {
+            "CreatedAt": 1.676038494E9,
+            "ModifiedAt": 1.676038494E9,
+            "SamplingRule": {
+                "Attributes": {},
+                "FixedRate": 1.0,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 10000,
+                "ReservoirSize": 0,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-east-1:999999999999:sampling-rule/Default",
+                "RuleName": "Default",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        },
+        {
+            "CreatedAt": 1.67799933E9,
+            "ModifiedAt": 1.67799933E9,
+            "SamplingRule": {
+                "Attributes": {
+                    "abc": "1234"
+                },
+                "FixedRate": 0,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 20,
+                "ReservoirSize": 0,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+                "RuleName": "test",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        }
+    ]
+}

--- a/sampler/opentelemetry-sampler-aws-xray/tests/data/test-remote-sampler_sampling-targets-response-sample.json
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/data/test-remote-sampler_sampling-targets-response-sample.json
@@ -1,0 +1,20 @@
+{
+    "LastRuleModification": 1707551387.0,
+    "SamplingTargetDocuments": [
+        {
+            "FixedRate": 0.0,
+            "Interval": 100000,
+            "ReservoirQuota": 100000,
+            "ReservoirQuotaTTL": 9999999999.0,
+            "RuleName": "test"
+        },
+        {
+            "FixedRate": 0.0,
+            "Interval": 1000,
+            "ReservoirQuota": 100,
+            "ReservoirQuotaTTL": 9999999999.0,
+            "RuleName": "Default"
+        }
+    ],
+    "UnprocessedStatistics": []
+}

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_aws_xray_remote_sampler.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_aws_xray_remote_sampler.py
@@ -1,0 +1,126 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import threading
+import time
+from logging import DEBUG
+from pytest import mark
+from unittest import TestCase
+from unittest.mock import patch
+
+
+from opentelemetry.samplers.aws.aws_xray_remote_sampler import AwsXRayRemoteSampler
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.sampling import Decision
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+
+def create_spans(sampled_array, thread_id, span_attributes, remote_sampler, number_of_spans):
+    sampled = 0
+    for _ in range(0, number_of_spans):
+        if remote_sampler.should_sample(None, 0, "name", attributes=span_attributes).decision != Decision.DROP:
+            sampled += 1
+    sampled_array[thread_id] = sampled
+
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    if kwargs["url"] == "http://127.0.0.1:2000/GetSamplingRules":
+        with open(f"{DATA_DIR}/test-remote-sampler_sampling-rules-response-sample.json", encoding="UTF-8") as file:
+            sample_response = json.load(file)
+            file.close()
+        return MockResponse(sample_response, 200)
+    if kwargs["url"] == "http://127.0.0.1:2000/SamplingTargets":
+        with open(f"{DATA_DIR}/test-remote-sampler_sampling-targets-response-sample.json", encoding="UTF-8") as file:
+            sample_response = json.load(file)
+            file.close()
+        return MockResponse(sample_response, 200)
+    return MockResponse(None, 404)
+
+
+class TestAwsXRayRemoteSampler(TestCase):
+    def setUp(self):
+        self.rs = None
+
+    def tearDown(self):
+        # Clean up timers
+        if self.rs is not None:
+            self.rs._root._root._rules_timer.cancel()
+
+    def test_create_remote_sampler_with_empty_resource(self):
+        self.rs = AwsXRayRemoteSampler(resource=Resource.get_empty())
+        self.assertIsNotNone(self.rs._root._root._rules_timer)
+        self.assertEqual(self.rs._root._root._AwsXRayRemoteSampler__polling_interval, 300)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__xray_client)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__resource)
+        self.assertTrue(len(self.rs._root._root._AwsXRayRemoteSampler__client_id), 24)
+
+    def test_create_remote_sampler_with_populated_resource(self):
+        self.rs = AwsXRayRemoteSampler(
+            resource=Resource.create({"service.name": "test-service-name", "cloud.platform": "test-cloud-platform"})
+        )
+        self.assertIsNotNone(self.rs._root._root._rules_timer)
+        self.assertEqual(self.rs._root._root._AwsXRayRemoteSampler__polling_interval, 300)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__xray_client)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__resource)
+        self.assertEqual(
+            self.rs._root._root._AwsXRayRemoteSampler__resource.attributes["service.name"], "test-service-name"
+        )
+        self.assertEqual(
+            self.rs._root._root._AwsXRayRemoteSampler__resource.attributes["cloud.platform"], "test-cloud-platform"
+        )
+
+    def test_create_remote_sampler_with_all_fields_populated(self):
+        self.rs = AwsXRayRemoteSampler(
+            resource=Resource.create({"service.name": "test-service-name", "cloud.platform": "test-cloud-platform"}),
+            endpoint="http://abc.com",
+            polling_interval=120,
+            log_level=DEBUG,
+        )
+        self.assertIsNotNone(self.rs._root._root._rules_timer)
+        self.assertEqual(self.rs._root._root._AwsXRayRemoteSampler__polling_interval, 120)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__xray_client)
+        self.assertIsNotNone(self.rs._root._root._AwsXRayRemoteSampler__resource)
+        self.assertEqual(
+            self.rs._root._root._AwsXRayRemoteSampler__xray_client._AwsXRaySamplingClient__get_sampling_rules_endpoint,
+            "http://abc.com/GetSamplingRules",
+        )
+        self.assertEqual(
+            self.rs._root._root._AwsXRayRemoteSampler__resource.attributes["service.name"], "test-service-name"
+        )
+        self.assertEqual(
+            self.rs._root._root._AwsXRayRemoteSampler__resource.attributes["cloud.platform"], "test-cloud-platform"
+        )
+
+    def test_get_description(self) -> str:
+        self.rs: AwsXRayRemoteSampler = AwsXRayRemoteSampler(resource=Resource.create({"service.name": "dummy_name"}))
+        self.assertEqual(
+            self.rs.get_description(),
+            "AwsXRayRemoteSampler{root:ParentBased{root:_AwsXRayRemoteSampler{remote sampling with AWS X-Ray},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}}",  # noqa: E501
+        )

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_aws_xray_sampling_client.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_aws_xray_sampling_client.py
@@ -1,0 +1,150 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from logging import getLogger
+from unittest import TestCase
+from unittest.mock import patch
+
+from opentelemetry.samplers.aws._aws_xray_sampling_client import _AwsXRaySamplingClient
+
+SAMPLING_CLIENT_LOGGER_NAME = "opentelemetry.samplers.aws._aws_xray_sampling_client"
+_sampling_client_logger = getLogger(SAMPLING_CLIENT_LOGGER_NAME)
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+
+class TestAwsXRaySamplingClient(TestCase):
+    @patch("requests.Session.post")
+    def test_get_no_sampling_rules(self, mock_post=None):
+        mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": []}})
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        sampling_rules = client.get_sampling_rules()
+        self.assertTrue(len(sampling_rules) == 0)
+
+    @patch("requests.Session.post")
+    def test_get_invalid_responses(self, mock_post=None):
+        mock_post.return_value.configure_mock(**{"json.return_value": {}})
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        with self.assertLogs(_sampling_client_logger, level="ERROR"):
+            sampling_rules = client.get_sampling_rules()
+            self.assertTrue(len(sampling_rules) == 0)
+
+    @patch("requests.Session.post")
+    def test_get_sampling_rule_missing_in_records(self, mock_post=None):
+        mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": [{}]}})
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        with self.assertLogs(_sampling_client_logger, level="ERROR"):
+            sampling_rules = client.get_sampling_rules()
+            self.assertTrue(len(sampling_rules) == 0)
+
+    @patch("requests.Session.post")
+    def test_default_values_used_when_missing_properties_in_sampling_rule(self, mock_post=None):
+        mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": [{"SamplingRule": {}}]}})
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        sampling_rules = client.get_sampling_rules()
+        self.assertTrue(len(sampling_rules) == 1)
+
+        sampling_rule = sampling_rules[0]
+        self.assertEqual(sampling_rule.Attributes, {})
+        self.assertEqual(sampling_rule.FixedRate, 0.0)
+        self.assertEqual(sampling_rule.HTTPMethod, "")
+        self.assertEqual(sampling_rule.Host, "")
+        self.assertEqual(sampling_rule.Priority, 10001)
+        self.assertEqual(sampling_rule.ReservoirSize, 0)
+        self.assertEqual(sampling_rule.ResourceARN, "")
+        self.assertEqual(sampling_rule.RuleARN, "")
+        self.assertEqual(sampling_rule.RuleName, "")
+        self.assertEqual(sampling_rule.ServiceName, "")
+        self.assertEqual(sampling_rule.ServiceType, "")
+        self.assertEqual(sampling_rule.URLPath, "")
+        self.assertEqual(sampling_rule.Version, 0)
+
+    @patch("requests.Session.post")
+    def test_get_correct_number_of_sampling_rules(self, mock_post=None):
+        sampling_records = []
+        with open(f"{DATA_DIR}/get-sampling-rules-response-sample.json", encoding="UTF-8") as file:
+            sample_response = json.load(file)
+            sampling_records = sample_response["SamplingRuleRecords"]
+            mock_post.return_value.configure_mock(**{"json.return_value": sample_response})
+            file.close()
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        sampling_rules = client.get_sampling_rules()
+        self.assertEqual(len(sampling_rules), 3)
+        self.assertEqual(len(sampling_rules), len(sampling_records))
+        self.validate_match_sampling_rules_properties_with_records(sampling_rules, sampling_records)
+
+    def validate_match_sampling_rules_properties_with_records(self, sampling_rules, sampling_records):
+        for _, (sampling_rule, sampling_record) in enumerate(zip(sampling_rules, sampling_records)):
+            self.assertIsNotNone(sampling_rule.Attributes)
+            self.assertEqual(sampling_rule.Attributes, sampling_record["SamplingRule"]["Attributes"])
+            self.assertIsNotNone(sampling_rule.FixedRate)
+            self.assertEqual(sampling_rule.FixedRate, sampling_record["SamplingRule"]["FixedRate"])
+            self.assertIsNotNone(sampling_rule.HTTPMethod)
+            self.assertEqual(sampling_rule.HTTPMethod, sampling_record["SamplingRule"]["HTTPMethod"])
+            self.assertIsNotNone(sampling_rule.Host)
+            self.assertEqual(sampling_rule.Host, sampling_record["SamplingRule"]["Host"])
+            self.assertIsNotNone(sampling_rule.Priority)
+            self.assertEqual(sampling_rule.Priority, sampling_record["SamplingRule"]["Priority"])
+            self.assertIsNotNone(sampling_rule.ReservoirSize)
+            self.assertEqual(sampling_rule.ReservoirSize, sampling_record["SamplingRule"]["ReservoirSize"])
+            self.assertIsNotNone(sampling_rule.ResourceARN)
+            self.assertEqual(sampling_rule.ResourceARN, sampling_record["SamplingRule"]["ResourceARN"])
+            self.assertIsNotNone(sampling_rule.RuleARN)
+            self.assertEqual(sampling_rule.RuleARN, sampling_record["SamplingRule"]["RuleARN"])
+            self.assertIsNotNone(sampling_rule.RuleName)
+            self.assertEqual(sampling_rule.RuleName, sampling_record["SamplingRule"]["RuleName"])
+            self.assertIsNotNone(sampling_rule.ServiceName)
+            self.assertEqual(sampling_rule.ServiceName, sampling_record["SamplingRule"]["ServiceName"])
+            self.assertIsNotNone(sampling_rule.ServiceType)
+            self.assertEqual(sampling_rule.ServiceType, sampling_record["SamplingRule"]["ServiceType"])
+            self.assertIsNotNone(sampling_rule.URLPath)
+            self.assertEqual(sampling_rule.URLPath, sampling_record["SamplingRule"]["URLPath"])
+            self.assertIsNotNone(sampling_rule.Version)
+            self.assertEqual(sampling_rule.Version, sampling_record["SamplingRule"]["Version"])
+
+    @patch("requests.Session.post")
+    def test_get_sampling_targets(self, mock_post=None):
+        with open(f"{DATA_DIR}/get-sampling-targets-response-sample.json", encoding="UTF-8") as file:
+            sample_response = json.load(file)
+            mock_post.return_value.configure_mock(**{"json.return_value": sample_response})
+            file.close()
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        sampling_targets_response = client.get_sampling_targets(statistics=[])
+        self.assertEqual(len(sampling_targets_response.SamplingTargetDocuments), 2)
+        self.assertEqual(len(sampling_targets_response.UnprocessedStatistics), 0)
+        self.assertEqual(sampling_targets_response.LastRuleModification, 1707551387.0)
+
+    @patch("requests.Session.post")
+    def test_get_invalid_sampling_targets(self, mock_post=None):
+        mock_post.return_value.configure_mock(
+            **{
+                "json.return_value": {
+                    "LastRuleModification": None,
+                    "SamplingTargetDocuments": None,
+                    "UnprocessedStatistics": None,
+                }
+            }
+        )
+        client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
+        sampling_targets_response = client.get_sampling_targets(statistics=[])
+        self.assertEqual(sampling_targets_response.SamplingTargetDocuments, [])
+        self.assertEqual(sampling_targets_response.UnprocessedStatistics, [])
+        self.assertEqual(sampling_targets_response.LastRuleModification, 0.0)

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_clock.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_clock.py
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from opentelemetry.samplers.aws._clock import _Clock
+
+
+class TestClock(TestCase):
+    def test_from_timestamp(self):
+        pass
+
+    def test_time_delta(self):
+        clock = _Clock()
+        dt = clock.from_timestamp(1707551387.0)
+        delta = clock.time_delta(3600)
+        new_dt = dt + delta
+        self.assertTrue(new_dt.timestamp() - dt.timestamp() == 3600)

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_rule.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_rule.py
@@ -1,0 +1,103 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from opentelemetry.samplers.aws._sampling_rule import _SamplingRule
+
+
+class TestSamplingRule(TestCase):
+    def test_sampling_rule_ordering(self):
+        rule1 = _SamplingRule(Priority=1, RuleName="abcdef", Version=1)
+        rule2 = _SamplingRule(Priority=100, RuleName="A", Version=1)
+        rule3 = _SamplingRule(Priority=100, RuleName="Abc", Version=1)
+        rule4 = _SamplingRule(Priority=100, RuleName="ab", Version=1)
+        rule5 = _SamplingRule(Priority=100, RuleName="abc", Version=1)
+        rule6 = _SamplingRule(Priority=200, RuleName="abcdef", Version=1)
+
+        self.assertTrue(rule1 < rule2 < rule3 < rule4 < rule5 < rule6)
+
+    def test_sampling_rule_equality(self):
+        sampling_rule = _SamplingRule(
+            Attributes={"abc": "123", "def": "4?6", "ghi": "*89"},
+            FixedRate=0.11,
+            HTTPMethod="GET",
+            Host="localhost",
+            Priority=20,
+            ReservoirSize=1,
+            ResourceARN="*",
+            RuleARN="arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+            RuleName="test",
+            ServiceName="myServiceName",
+            ServiceType="AWS::EKS::Container",
+            URLPath="/helloworld",
+            Version=1,
+        )
+
+        sampling_rule_attr_unordered = _SamplingRule(
+            Attributes={"ghi": "*89", "abc": "123", "def": "4?6"},
+            FixedRate=0.11,
+            HTTPMethod="GET",
+            Host="localhost",
+            Priority=20,
+            ReservoirSize=1,
+            ResourceARN="*",
+            RuleARN="arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+            RuleName="test",
+            ServiceName="myServiceName",
+            ServiceType="AWS::EKS::Container",
+            URLPath="/helloworld",
+            Version=1,
+        )
+
+        self.assertTrue(sampling_rule == sampling_rule_attr_unordered)
+
+        sampling_rule_updated = _SamplingRule(
+            Attributes={"ghi": "*89", "abc": "123", "def": "4?6"},
+            FixedRate=0.11,
+            HTTPMethod="GET",
+            Host="localhost",
+            Priority=20,
+            ReservoirSize=1,
+            ResourceARN="*",
+            RuleARN="arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+            RuleName="test",
+            ServiceName="myServiceName",
+            ServiceType="AWS::EKS::Container",
+            URLPath="/helloworld_new",
+            Version=1,
+        )
+
+        sampling_rule_updated_2 = _SamplingRule(
+            Attributes={"abc": "128", "def": "4?6", "ghi": "*89"},
+            FixedRate=0.11,
+            HTTPMethod="GET",
+            Host="localhost",
+            Priority=20,
+            ReservoirSize=1,
+            ResourceARN="*",
+            RuleARN="arn:aws:xray:us-east-1:999999999999:sampling-rule/test",
+            RuleName="test",
+            ServiceName="myServiceName",
+            ServiceType="AWS::EKS::Container",
+            URLPath="/helloworld",
+            Version=1,
+        )
+
+        self.assertFalse(sampling_rule == sampling_rule_updated)
+        self.assertFalse(sampling_rule == sampling_rule_updated_2)

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_rule_applier.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_rule_applier.py
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from opentelemetry.samplers.aws._mock_clock import MockClock
+
+from opentelemetry.samplers.aws._clock import _Clock
+from opentelemetry.samplers.aws._sampling_rule import _SamplingRule
+from opentelemetry.samplers.aws._sampling_rule_applier import _SamplingRuleApplier
+from opentelemetry.samplers.aws._sampling_target import _SamplingTarget
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.sampling import Decision, SamplingResult, TraceIdRatioBased
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.util.types import Attributes
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+CLIENT_ID = "12345678901234567890abcd"
+
+
+# pylint: disable=no-member
+class TestSamplingRuleApplier(TestCase):
+    pass

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_statistics_document.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_statistics_document.py
@@ -1,0 +1,50 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+from unittest import TestCase
+
+from opentelemetry.samplers.aws._mock_clock import MockClock
+
+from opentelemetry.samplers.aws._sampling_statistics_document import _SamplingStatisticsDocument
+
+
+class TestSamplingStatisticsDocument(TestCase):
+    def test_sampling_statistics_document_inputs(self):
+        statistics = _SamplingStatisticsDocument("", "")
+        self.assertEqual(statistics.ClientID, "")
+        self.assertEqual(statistics.RuleName, "")
+        self.assertEqual(statistics.BorrowCount, 0)
+        self.assertEqual(statistics.SampleCount, 0)
+        self.assertEqual(statistics.RequestCount, 0)
+
+        statistics = _SamplingStatisticsDocument("client_id", "rule_name", 1, 2, 3)
+        self.assertEqual(statistics.ClientID, "client_id")
+        self.assertEqual(statistics.RuleName, "rule_name")
+        self.assertEqual(statistics.RequestCount, 1)
+        self.assertEqual(statistics.BorrowCount, 2)
+        self.assertEqual(statistics.SampleCount, 3)
+
+        clock = MockClock(datetime.datetime.fromtimestamp(1707551387.0))
+        snapshot = statistics.snapshot(clock)
+        self.assertEqual(snapshot.get("ClientID"), "client_id")
+        self.assertEqual(snapshot.get("RuleName"), "rule_name")
+        self.assertEqual(snapshot.get("Timestamp"), 1707551387.0)
+        self.assertEqual(snapshot.get("RequestCount"), 1)
+        self.assertEqual(snapshot.get("BorrowCount"), 2)
+        self.assertEqual(snapshot.get("SampleCount"), 3)

--- a/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_target.py
+++ b/sampler/opentelemetry-sampler-aws-xray/tests/test_sampling_target.py
@@ -1,0 +1,48 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes work from:
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from opentelemetry.samplers.aws._sampling_target import _SamplingTargetResponse
+
+
+class TestSamplingTarget(TestCase):
+    def test_sampling_target_response_with_none_inputs(self):
+        target_response = _SamplingTargetResponse(None, None, None)
+        self.assertEqual(target_response.LastRuleModification, 0.0)
+        self.assertEqual(target_response.SamplingTargetDocuments, [])
+        self.assertEqual(target_response.UnprocessedStatistics, [])
+
+    def test_sampling_target_response_with_invalid_inputs(self):
+        target_response = _SamplingTargetResponse(1.0, [{}], [{}])
+        self.assertEqual(target_response.LastRuleModification, 1.0)
+        self.assertEqual(len(target_response.SamplingTargetDocuments), 1)
+        self.assertEqual(target_response.SamplingTargetDocuments[0].FixedRate, 0)
+        self.assertEqual(target_response.SamplingTargetDocuments[0].Interval, None)
+        self.assertEqual(target_response.SamplingTargetDocuments[0].ReservoirQuota, None)
+        self.assertEqual(target_response.SamplingTargetDocuments[0].ReservoirQuotaTTL, None)
+        self.assertEqual(target_response.SamplingTargetDocuments[0].RuleName, "")
+
+        self.assertEqual(len(target_response.UnprocessedStatistics), 1)
+        self.assertEqual(target_response.UnprocessedStatistics[0].ErrorCode, "")
+        self.assertEqual(target_response.UnprocessedStatistics[0].Message, "")
+        self.assertEqual(target_response.UnprocessedStatistics[0].RuleName, "")
+
+        target_response = _SamplingTargetResponse(1.0, [{"foo": "bar"}], [{"dog": "cat"}])
+        self.assertEqual(len(target_response.SamplingTargetDocuments), 0)
+        self.assertEqual(len(target_response.UnprocessedStatistics), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -361,6 +361,11 @@ envlist =
     pypy3-test-propagator-ot-trace
     lint-propagator-ot-trace
 
+    ; opentelemetry-sampler-aws-xray
+    py3{8,9,10,11,12,13}-test-sampler-aws-xray-{0,1}
+    pypy3-test-sampler-aws-xray-{0,1}
+    lint-sampler-aws-xray
+
     ; opentelemetry-instrumentation-sio-pika
     ; The numbers at the end of the environment names
     ; below mean these dependencies are being used:
@@ -700,6 +705,14 @@ deps =
   lint-propagator-aws-xray: -r {toxinidir}/propagator/opentelemetry-propagator-aws-xray/test-requirements-0.txt
   benchmark-propagator-aws-xray: -r {toxinidir}/propagator/opentelemetry-propagator-aws-xray/benchmark-requirements.txt
 
+  # packages that are released individually should provide a test-requirements.txt with the lowest version of OTel API
+  # and SDK supported to test we are honoring it
+  sampler-aws-xray-0: -r {toxinidir}/sampler/opentelemetry-sampler-aws-xray/test-requirements-0.txt
+  # and the latest version of OTel API and SDK
+  sampler-aws-xray-1: {[testenv]test_deps}
+  sampler-aws-xray-1: -r {toxinidir}/sampler/opentelemetry-sampler-aws-xray/test-requirements-1.txt
+  lint-sampler-aws-xray: -r {toxinidir}/sampler/opentelemetry-sampler-aws-xray/test-requirements-0.txt
+
   processor-baggage: {[testenv]test_deps}
   processor-baggage: -r {toxinidir}/processor/opentelemetry-processor-baggage/test-requirements.txt
 
@@ -916,6 +929,9 @@ commands =
 
   test-propagator-ot-trace: pytest {toxinidir}/propagator/opentelemetry-propagator-ot-trace/tests {posargs}
   lint-propagator-ot-trace: sh -c "cd propagator && pylint --rcfile ../.pylintrc opentelemetry-propagator-ot-trace"
+
+  test-sampler-aws-xray: pytest {toxinidir}/sampler/opentelemetry-sampler-aws-xray/tests {posargs}
+  lint-sampler-aws-xray: sh -c "cd sampler && pylint --rcfile ../.pylintrc opentelemetry-sampler-aws-xray"
 
   test-exporter-richconsole: pytest {toxinidir}/exporter/opentelemetry-exporter-richconsole/tests {posargs}
   lint-exporter-richconsole: sh -c "cd exporter && pylint --rcfile ../.pylintrc opentelemetry-exporter-richconsole"


### PR DESCRIPTION
# Description

This is an initial PR to address https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3305 in order for OTel Python to support X-Ray Remote Sampling. A series of PRs to fully implement this feature will follow.

Changes:
- Add new package directory `sampler/opentelemetry-sampler-aws-xray/` (since all AWS components in this repository have been split into their own packages)
- Updated the OTel Contrib mono-repo with this new Sampler package in order to automatically run tests for this component
- Code changes:
  - Add Sampling Client class to communicate with X-Ray Service for Sampling Rules/Targets
  - Add X-Ray Sampling Rules/Targets/Statistics class to help represent the Sampling related data from X-Ray
  - Added the AwsXRayRemoteSampler skeleton class
    - Ensure AwsXRayRemoteSampler is a ParentBased Sampler, with internal logic inside _AWSXRayRemoteSampler
    - Run poller upon instantiation to regularly obtain X-Ray Sampling Rules from X-Ray


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR is not a full implementation of the sampler, so it cannot be tested for correct functionality.
Right now, it currently always return a Parent Based decision or a DROP decision as a placeholder.

- [x] Unit Tests

A couple more PRs will follow-up to complete the implementation, which should look like [this Sampler code from the AWS ADOT repo](https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler). At that point in the future, a full E2E integration test will be run.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
