### PR TITLE
Check for None result in gRPC (#3380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-grpc` Check for None result in gRPC
+  ([#3380](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3381))
 - `opentelemetry-instrumentation-redis` Add missing entry in doc string for `def _instrument`
   ([#3247](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3247))
 - `opentelemetry-instrumentation-botocore` sns-extension: Change destination name attribute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3419](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3419))
 - `opentelemetry-instrumentation` don't print duplicated conflict log error message
   ([#3432](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3432))
+- `opentelemetry-instrumentation-grpc` Check for None result in gRPC
+  ([#3380](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3381))
 
 ## Version 1.32.0/0.53b0 (2025-04-10)
 
@@ -78,8 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `opentelemetry-instrumentation-grpc` Check for None result in gRPC
-  ([#3380](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3381))
 - `opentelemetry-instrumentation-redis` Add missing entry in doc string for `def _instrument`
   ([#3247](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3247))
 - `opentelemetry-instrumentation-botocore` sns-extension: Change destination name attribute

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -165,7 +165,7 @@ class OpenTelemetryClientInterceptor(
                 span.record_exception(exc)
                 raise exc
             finally:
-                if not result:
+                if result is None:
                     span.end()
         return self._trace_result(span, rpc_info, result)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -296,7 +296,7 @@ class TestClientProto(TestBase):
                 ),
                 invoker=invoker,
             )
-            assert span_end_mock.call_count == 1
+            self.assertEqual(span_end_mock.call_count, 1)
 
     def test_client_interceptor_trace_context_propagation(
         self,

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -274,7 +274,7 @@ class TestClientProto(TestBase):
 
     def test_client_interceptor_falsy_response(
         self,
-    ):  # pylint: disable=no-self-use
+    ):
         """ensure that client interceptor closes the span only once even if the response is falsy."""
 
         with mock.patch.object(SdkSpan, "end") as span_end_mock:


### PR DESCRIPTION
# Description

This is a fix for #3380 that checks explicitly for a `None` result rather than evaluating truthiness. PubSub results with zero messages evaluate to `False`, causing `span.end()` to be called twice.

Fixes #3380 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran Tox
- [x] Ran locally against an empty PubSub queue and no longer received warning messages, but spans correctly started and ended.
- [x] Ran against queue with messages and behavior was as expected (spans correctly started and ended, as before)

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
