### PR TITLE
adds NoOpTracerProvider test case for falcon instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/test_falcon.py
@@ -426,6 +426,20 @@ class TestFalconInstrumentation(TestFalconBase, WsgiTestBase):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 0)
 
+    def test_no_op_tracer_provider(self):
+        FalconInstrumentor().uninstrument()
+
+        FalconInstrumentor().instrument(
+            tracer_provider=trace.NoOpTracerProvider()
+        )
+
+        self.memory_exporter.clear()
+
+        self.client().simulate_get(path="/hello")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
     def test_exclude_lists(self):
         self.client().simulate_get(path="/ping")
         span_list = self.memory_exporter.get_finished_spans()


### PR DESCRIPTION
# Description

Adds NoOpTracerProvider test cases for falcon instrumentation.

Fixes [#983](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/983)


# How Has This Been Tested?
tox -e test-instrumentation-botocore
pytest instrumentation/opentelemetry-instrumentation-falcon/tests


# Does This PR Require a Core Repo Change?

- [ ] Yes. 
- [x] No.
