### PR TITLE
VertexAI support for async calling

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement uninstrument for `opentelemetry-instrumentation-vertexai`
   ([#3328](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3328))
+- VertexAI support for async calling
+  ([#3386](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3386))
 
 ## Version 2.0b0 (2025-02-24)
 

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
@@ -39,42 +39,66 @@ API
 ---
 """
 
+from __future__ import annotations
+
 from typing import Any, Collection
 
 from wrapt import (
-    wrap_function_wrapper,  # type: ignore[reportUnknownVariableType]
+    wrap_function_wrapper,  # pyright: ignore[reportUnknownVariableType]
 )
 
 from opentelemetry._events import get_event_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.instrumentation.vertexai.package import _instruments
-from opentelemetry.instrumentation.vertexai.patch import (
-    generate_content_create,
-)
+from opentelemetry.instrumentation.vertexai.patch import MethodWrappers
 from opentelemetry.instrumentation.vertexai.utils import is_content_enabled
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import get_tracer
 
 
-def _client_classes():
+def _methods_to_wrap(
+    method_wrappers: MethodWrappers,
+):
     # This import is very slow, do it lazily in case instrument() is not called
-
     # pylint: disable=import-outside-toplevel
     from google.cloud.aiplatform_v1.services.prediction_service import (
+        async_client,
         client,
+    )
+    from google.cloud.aiplatform_v1beta1.services.prediction_service import (
+        async_client as async_client_v1beta1,
     )
     from google.cloud.aiplatform_v1beta1.services.prediction_service import (
         client as client_v1beta1,
     )
 
-    return (
+    for client_class in (
         client.PredictionServiceClient,
         client_v1beta1.PredictionServiceClient,
-    )
+    ):
+        yield (
+            client_class,
+            client_class.generate_content.__name__,  # pyright: ignore[reportUnknownMemberType]
+            method_wrappers.generate_content,
+        )
+
+    for client_class in (
+        async_client.PredictionServiceAsyncClient,
+        async_client_v1beta1.PredictionServiceAsyncClient,
+    ):
+        yield (
+            client_class,
+            client_class.generate_content.__name__,  # pyright: ignore[reportUnknownMemberType]
+            method_wrappers.agenerate_content,
+        )
 
 
 class VertexAIInstrumentor(BaseInstrumentor):
+    def __init__(self) -> None:
+        super().__init__()
+        self._methods_to_unwrap: list[tuple[Any, str]] = []
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
@@ -95,15 +119,19 @@ class VertexAIInstrumentor(BaseInstrumentor):
             event_logger_provider=event_logger_provider,
         )
 
-        for client_class in _client_classes():
+        method_wrappers = MethodWrappers(
+            tracer, event_logger, is_content_enabled()
+        )
+        for client_class, method_name, wrapper in _methods_to_wrap(
+            method_wrappers
+        ):
             wrap_function_wrapper(
                 client_class,
-                name="generate_content",
-                wrapper=generate_content_create(
-                    tracer, event_logger, is_content_enabled()
-                ),
+                name=method_name,
+                wrapper=wrapper,
             )
+            self._methods_to_unwrap.append((client_class, method_name))
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        for client_class in _client_classes():
-            unwrap(client_class, "generate_content")
+        for client_class, method_name in self._methods_to_unwrap:
+            unwrap(client_class, method_name)

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/__init__.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 from typing import Any, Collection
 
 from wrapt import (
-    wrap_function_wrapper,  # pyright: ignore[reportUnknownVariableType]
+    wrap_function_wrapper,  # type: ignore[reportUnknownVariableType]
 )
 
 from opentelemetry._events import get_event_logger

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.latest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.latest.txt
@@ -44,8 +44,8 @@ charset-normalizer==3.4.0
 Deprecated==1.2.15
 docstring_parser==0.16
 exceptiongroup==1.2.2
-google-api-core==2.23.0
-google-auth==2.36.0
+google-api-core[grpc, async_rest]==2.23.0
+google-auth[aiohttp]==2.36.0
 google-cloud-aiplatform==1.79.0
 google-cloud-bigquery==3.27.0
 google-cloud-core==2.4.1

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
@@ -22,8 +22,8 @@ charset-normalizer==3.4.0
 Deprecated==1.2.14
 docstring_parser==0.16
 exceptiongroup==1.2.2
-google-api-core==2.23.0
-google-auth==2.36.0
+google-api-core[grpc, async_rest]==2.23.0
+google-auth[aiohttp]==2.36.0
 google-cloud-aiplatform==1.79.0
 google-cloud-bigquery==3.27.0
 google-cloud-core==2.4.1

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
@@ -470,19 +470,20 @@ def generate_content_all_input_events(
     }
 
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _copy_signature(
+    func_type: Callable[_P, _R],
+) -> Callable[
+    [Callable[..., Any]], Callable[Concatenate[GenerativeModel, _P], _R]
+]:
+    return lambda func: func
+
+
 # Type annotation for fixture to make LSP work properly
 class GenerateContentFixture(Protocol):
-    _P = ParamSpec("_P")
-    _R = TypeVar("_R")
-
-    @staticmethod
-    def _copy_signature(
-        func_type: Callable[_P, _R],
-    ) -> Callable[
-        [Callable[..., Any]], Callable[Concatenate[GenerativeModel, _P], _R]
-    ]:
-        return lambda func: func
-
     @_copy_signature(GenerativeModel.generate_content)
     def __call__(self): ...
 

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
@@ -17,7 +17,6 @@ from google.auth.aio.credentials import (
 from google.cloud.aiplatform.initializer import _set_async_rest_credentials
 from typing_extensions import Concatenate, ParamSpec
 from vcr import VCR
-from vcr.record_mode import RecordMode
 from vertexai.generative_models import (
     Content,
     GenerationConfig,

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
@@ -504,11 +504,6 @@ def fixture_generate_content(
     """
     is_async: bool = request.param
 
-    if is_async and vcr.record_mode != RecordMode.NONE:
-        pytest.skip(
-            "Skip async tests when VCR is recording so that fixtures are only recorded once"
-        )
-
     if is_async:
         # See
         # https://github.com/googleapis/python-aiplatform/blob/cb0e5fedbf45cb0531c0b8611fb7fabdd1f57e56/google/cloud/aiplatform/initializer.py#L717-L729

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/test_chat_completions.py
@@ -498,10 +498,15 @@ def fixture_generate_content(
     request: pytest.FixtureRequest,
     vcr: VCR,
 ) -> Generator[GenerateContentFixture, None, None]:
+    """This fixture parameterizes tests that use it to test calling both
+    GenerativeModel.generate_content() and GenerativeModel.generate_content_async().
+    """
     is_async: bool = request.param
 
     if is_async and vcr.record_mode != RecordMode.NONE:
-        pytest.skip("Do not run async tests when VCR is recording")
+        pytest.skip(
+            "Skip async tests when VCR is recording so that fixtures are only recorded once"
+        )
 
     if is_async:
         # See


### PR DESCRIPTION
# Description

This makes `opentelemetry-instrumentation-vertexai` work with async calls through the Vertex SDK.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Parameterized all tests in `test_chat_completions.py` to call with sync and async

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
