### PR TITLE
Improve pika instrumentation examples

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/__init__.py
@@ -51,7 +51,6 @@ Usage
     pika_instrumentation = PikaInstrumentor()
     pika_instrumentation.instrument_channel(channel=channel)
 
-
     channel.basic_publish(exchange='', routing_key='hello', body=b'Hello World!')
 
     pika_instrumentation.uninstrument_channel(channel=channel)
@@ -60,7 +59,21 @@ Usage
 
 .. code-block:: python
 
+    import pika
+    from opentelemetry.instrumentation.pika import PikaInstrumentor
+    from opentelemetry.trace import get_tracer_provider
+
+    connection = pika.BlockingConnection(pika.URLParameters('amqp://localhost'))
+    channel = connection.channel()
+    tracer_provider = get_tracer_provider()
+
+    channel.queue_declare(queue='hello')
+
     PikaInstrumentor.instrument_channel(channel, tracer_provider=tracer_provider)
+
+    channel.basic_publish(exchange='', routing_key='hello', body=b'Hello World!')
+
+    PikaInstrumentor.uninstrument_channel(channel)
 
 * PikaInstrumentor also supports instrumenting with hooks that will be called when producing or consuming a message.
   The hooks should be of type "Callable[[Span, bytes, BasicProperties], None]"
@@ -69,13 +82,26 @@ Usage
 
 .. code-block:: python
 
+    import pika
+    from opentelemetry.instrumentation.pika import PikaInstrumentor
+    from opentelemetry.trace import Span
+    from pika import BasicProperties
+
     def publish_hook(span: Span, body: bytes, properties: BasicProperties):
         span.set_attribute("messaging.payload", body.decode())
 
     def consume_hook(span: Span, body: bytes, properties: BasicProperties):
         span.set_attribute("messaging.id", properties.message_id)
 
+    connection = pika.BlockingConnection(pika.URLParameters('amqp://localhost'))
+    channel = connection.channel()
+    channel.queue_declare(queue='hello')
+
     PikaInstrumentor.instrument_channel(channel, publish_hook=publish_hook, consume_hook=consume_hook)
+
+    channel.basic_publish(exchange='', routing_key='hello', body=b'Hello World!')
+
+    PikaInstrumentor.uninstrument_channel(channel)
 
 Consumer Instrumentation
 ------------------------


### PR DESCRIPTION
# Description

Some instrumentation examples inside `pika` don't run. This PR fixes the examples, so they run.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6. Install common dependencies:
```
pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
 ../opentelemetry-python/opentelemetry-semantic-conventions/ \
 ../opentelemetry-python/opentelemetry-api/ \
 ../opentelemetry-python/opentelemetry-sdk/ \
 ../opentelemetry-python/opentelemetry-proto/ \
 ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
```
7. Install `pika` specific requirements:
```
pip install -r instrumentation/opentelemetry-instrumentation-pika/test-requirements.txt
```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
