### PR TITLE
support InvokeModel GenAi instrumentation for additional Bedrock models

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import math
 from timeit import default_timer
 from typing import Any
 
@@ -514,11 +515,11 @@ class _BedrockRuntimeExtension(_AwsSdkExtension):
                     span, response_body, instrumentor_context, capture_content
                 )
             elif "cohere.command-r" in model_id:
-                self._handle_command_r_response(
+                self._handle_cohere_command_r_response(
                     span, response_body, instrumentor_context, capture_content
                 )
             elif "cohere.command" in model_id:
-                self._handle_command_response(
+                self._handle_cohere_command_response(
                     span, response_body, instrumentor_context, capture_content
                 )
             elif "meta.llama" in model_id:

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
@@ -519,6 +519,48 @@ class _Choice:
             message["content"] = response["content"]
         return cls(message, response["stop_reason"], index=0)
 
+    @classmethod
+    def from_invoke_cohere_command_r(
+        cls, response: dict[str, Any], capture_content: bool
+    ) -> _Choice:
+        if capture_content:
+            message = {"content": response["text"]}
+        else:
+            message = {}
+        return cls(message, response["finish_reason"], index=0)
+    
+    @classmethod
+    def from_invoke_cohere_command(
+        cls, response: dict[str, Any], capture_content: bool
+    ) -> _Choice:
+        result = response["generations"][0]
+        if capture_content:
+            message = {"content": result["text"]}
+        else:
+            message = {}
+        return cls(message, result["finish_reason"], index=0)
+
+    @classmethod
+    def from_invoke_meta_llama(
+        cls, response: dict[str, Any], capture_content: bool
+    ) -> _Choice:
+        if capture_content:
+            message = {"content": response["generation"]}
+        else:
+            message = {}
+        return cls(message, response["stop_reason"], index=0)
+    
+    @classmethod
+    def from_invoke_mistral_mistral(
+        cls, response: dict[str, Any], capture_content: bool
+    ) -> _Choice:
+        result = response["outputs"][0]
+        if capture_content:
+            message = {"content": result["text"]}
+        else:
+            message = {}
+        return cls(message, result["stop_reason"], index=0)
+
     def _to_body_dict(self) -> dict[str, Any]:
         return {
             "finish_reason": self.finish_reason,

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/bedrock_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/bedrock_utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import math
 from typing import Any
 
 from botocore.response import StreamingBody
@@ -54,6 +55,7 @@ def assert_completion_attributes_from_streaming_body(
     input_tokens = None
     output_tokens = None
     finish_reason = None
+    request_prompt = "Say this is a test"
     if response is not None:
         original_body = response["body"]
         body_content = original_body.read()
@@ -89,6 +91,33 @@ def assert_completion_attributes_from_streaming_body(
                 finish_reason = (response["stop_reason"],)
             else:
                 finish_reason = None
+        elif "cohere.command-r" in request_model:
+            input_tokens = math.ceil(len(request_prompt) / 6)
+            text = response.get("text")
+            if text:
+                output_tokens = math.ceil(len(text) / 6)
+            finish_reason = (response["finish_reason"],)
+        elif "cohere.command" in request_model:
+            input_tokens = math.ceil(len(request_prompt) / 6)
+            generations = response.get("generations")
+            if generations:
+                first_generation = generations[0]
+                output_tokens = math.ceil(len(first_generation["text"]) / 6)
+                finish_reason = (first_generation["finish_reason"],)
+        elif "meta.llama" in request_model:
+            if "prompt_token_count" in response:
+                input_tokens = response.get("prompt_token_count")
+            if "generation_token_count" in response:
+                output_tokens = response.get("generation_token_count")
+            if "stop_reason" in response:
+                finish_reason = (response["stop_reason"],)
+        elif "mistral.mistral" in request_model:
+            input_tokens = math.ceil(len(request_prompt) / 6)
+            outputs = response.get("outputs")
+            if outputs:
+                first_output = outputs[0]
+                output_tokens = math.ceil(len(first_output["text"]) / 6)
+                finish_reason = (first_output["stop_reason"],)
 
     return assert_all_attributes(
         span,

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[cohere.command-r].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[cohere.command-r].yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: |-
+      {
+        "message": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "p": 0.9,
+        "stop_sequences": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '106'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T165615Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-d11162cc-5e3ef3bd07c5f9eb3ad25214;Parent=0a40817ca75eead7;Sampled=1
+      amz-sdk-invocation-id:
+      - 54acc108-181d-4437-a0a2-8293496f892d
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-r-v1%3A0/invoke
+  response:
+    body:
+      string: |-
+        {
+          "response_id": "379ed018/64bcb4c2-902c-4646-9e54-3e5e90c3b11e",
+          "text": "This is a test.<",
+          "generation_id": "dcf7f3e3-a611-4fb5-85fe-ae09e6b2eaea",
+          "chat_history": [
+            {
+              "role": "USER",
+              "message": "Say this is a test"
+            },
+            {
+              "role": "CHATBOT",
+              "message": "This is a test.<"
+            }
+          ],
+          "finish_reason": "STOP_SEQUENCE"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 16:56:15 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '141'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '5'
+      x-amzn-RequestId:
+      - 4d1ce10c-03d3-4579-8bab-a0e4eb14a8d0
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[cohere.command].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[cohere.command].yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "p": 1,
+        "stop_sequences": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '103'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T183021Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-668b3eaf-1927d32dd30fc4f0fedf3a02;Parent=6b49f910f73172c6;Sampled=1
+      amz-sdk-invocation-id:
+      - 98cb0162-a3bb-4d4e-bcbf-290664700ecf
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-light-text-v14/invoke
+  response:
+    body:
+      string: |-
+        {
+          "id": "b68fba0b-67f6-46dd-a659-dab9a99ee354",
+          "generations": [
+            {
+              "id": "195692c2-6457-4ae0-9e5e-f0472a429cdc",
+              "text": " I would be more than happy to assist you with",
+              "finish_reason": "MAX_TOKENS"
+            }
+          ],
+          "prompt": "Say this is a test"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 18:30:21 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '309'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - b68fba0b-67f6-46dd-a659-dab9a99ee354
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[meta.llama].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[meta.llama].yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_gen_len": 10,
+        "temperature": 0.8,
+        "top_p": 1
+      }
+    headers:
+      Content-Length:
+      - '83'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T192408Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-db2cb3ce-1a9a7362f6f0e5eb7dc0ce56;Parent=a301dca505171c7f;Sampled=1
+      amz-sdk-invocation-id:
+      - 87acada6-b95b-4280-b002-50ef98edf99d
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/meta.llama3-1-70b-instruct-v1%3A0/invoke
+  response:
+    body:
+      string: |-
+        {
+          "generation": " and you are a test subject. You are not",
+          "prompt_token_count": 5,
+          "generation_token_count": 10,
+          "stop_reason": "length"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 19:24:09 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '617'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - 51b421ef-fd84-4c69-b933-8c928b735d17
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[mistral.mistral].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_no_content[mistral.mistral].yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "top_p": 1,
+        "stop": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T183022Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-e325095b-1fab9945412a3dcac8474715;Parent=ae78dbba36fcf5b0;Sampled=1
+      amz-sdk-invocation-id:
+      - cbfbbad5-adc8-4a71-82f0-0777f6c78f83
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/mistral.mistral-7b-instruct-v0%3A2/invoke
+  response:
+    body:
+      string: |-
+        {
+          "outputs": [
+            {
+              "text": " to find out whether you think an animal is cute",
+              "stop_reason": "length"
+            }
+          ]
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 18:30:22 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '6'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '219'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - 97084131-1cef-4927-9bab-53a36390153e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[cohere.command-r].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[cohere.command-r].yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: |-
+      {
+        "message": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "p": 0.99,
+        "stop_sequences": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '107'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T224018Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-51673f20-3dd018601b078c785c032a50;Parent=c05b84f54e2c35ee;Sampled=1
+      amz-sdk-invocation-id:
+      - c81a224e-d8b3-4416-aaca-858b478b7db4
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-r-v1%3A0/invoke
+  response:
+    body:
+      string: |-
+        {
+          "response_id": "379ed018/aa2df2bf-edc8-483f-8cd0-d22d04ba34ba",
+          "text": "This is a test. How are you doing today",
+          "generation_id": "2d74c447-266d-4286-8425-a92ad7fc0cbc",
+          "chat_history": [
+            {
+              "role": "USER",
+              "message": "Say this is a test"
+            },
+            {
+              "role": "CHATBOT",
+              "message": "This is a test. How are you doing today"
+            }
+          ],
+          "finish_reason": "MAX_TOKENS"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 22:40:18 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '196'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - c1fd38df-b669-4464-9f4b-4cf32c32fde8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[cohere.command].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[cohere.command].yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "p": 1,
+        "stop_sequences": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '103'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T223753Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-461bf523-e7a0388221ce8a1d7a31fc5b;Parent=a55a9398f0f3d364;Sampled=1
+      amz-sdk-invocation-id:
+      - 17fbe175-373f-4c10-8047-8bba2fd8e22c
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-light-text-v14/invoke
+  response:
+    body:
+      string: |-
+        {
+          "id": "a09c1c60-6608-482a-b98d-764e4d87fcd1",
+          "generations": [
+            {
+              "id": "8b38ce59-5f77-4b79-82c3-58eb72d4b1a2",
+              "text": " Let it be a test of knowledge, skills,",
+              "finish_reason": "MAX_TOKENS"
+            }
+          ],
+          "prompt": "Say this is a test"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 22:37:53 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '248'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - a09c1c60-6608-482a-b98d-764e4d87fcd1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[meta.llama].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[meta.llama].yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_gen_len": 10,
+        "temperature": 0.8,
+        "top_p": 1
+      }
+    headers:
+      Content-Length:
+      - '83'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T224059Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-9930be15-db431eb0bf3c21be1ed23dde;Parent=0c4e46fcf0474877;Sampled=1
+      amz-sdk-invocation-id:
+      - c3afc5f6-9912-4892-b48e-dff457911e1c
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/meta.llama3-1-70b-instruct-v1%3A0/invoke
+  response:
+    body:
+      string: |-
+        {
+          "generation": " post. This is a test post. This is",
+          "prompt_token_count": 5,
+          "generation_token_count": 10,
+          "stop_reason": "length"
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 22:40:59 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '5'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '604'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - 4b8da626-00b1-4535-b75b-a7e985e9877e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[mistral.mistral].yaml
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/cassettes/test_invoke_model_with_content[mistral.mistral].yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: |-
+      {
+        "prompt": "Say this is a test",
+        "max_tokens": 10,
+        "temperature": 0.8,
+        "top_p": 1,
+        "stop": [
+          "|"
+        ]
+      }
+    headers:
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Boto3/1.35.56 md/Botocore#1.35.56 ua/2.0 os/macos#24.3.0 md/arch#arm64 lang/python#3.10.16
+        md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.35.56
+      X-Amz-Date:
+      - 20250410T224059Z
+      X-Amz-Security-Token:
+      - test_aws_security_token
+      X-Amzn-Trace-Id:
+      - Root=1-332feae9-215a9553da54b4789bf12414;Parent=f3899b50f888d5d7;Sampled=1
+      amz-sdk-invocation-id:
+      - 2d410cd2-ef68-48af-9cad-b7ddf3b1d844
+      amz-sdk-request:
+      - attempt=1
+      authorization:
+      - Bearer test_aws_authorization
+    method: POST
+    uri: https://bedrock-runtime.us-west-2.amazonaws.com/model/mistral.mistral-7b-instruct-v0%3A2/invoke
+  response:
+    body:
+      string: |-
+        {
+          "outputs": [
+            {
+              "text": "\n\nA man stands before a crowd of people",
+              "stop_reason": "length"
+            }
+          ]
+        }
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 10 Apr 2025 22:41:00 GMT
+      Set-Cookie: test_set_cookie
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '6'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '174'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - 68547039-f30c-4aff-b368-31bb6d9b9d07
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
# Description

This adds gen_ai instrumentation for the following Bedrock model providers:
Cohere Command and Command R, Meta Llama, Mistral AI

refs #3210 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] tox -e py310-test-instrumentation-botocore-1

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
