### PR TITLE
infra(ci): configure concurrency to cancel stale runs and set timeouts

### DIFF
--- a/.github/workflows/core_contrib_test_0.yml
+++ b/.github/workflows/core_contrib_test_0.yml
@@ -12,6 +12,11 @@ on:
       CONTRIB_REPO_SHA:
         required: true
         type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: ${{ inputs.CORE_REPO_SHA }}
   CONTRIB_REPO_SHA: ${{ inputs.CONTRIB_REPO_SHA }}
@@ -22,6 +27,7 @@ jobs:
   py38-test-instrumentation-openai-v2-oldest:
     name: instrumentation-openai-v2-oldest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -44,6 +50,7 @@ jobs:
   py38-test-instrumentation-openai-v2-latest:
     name: instrumentation-openai-v2-latest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -66,6 +73,7 @@ jobs:
   py38-test-instrumentation-vertexai-oldest:
     name: instrumentation-vertexai-oldest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -88,6 +96,7 @@ jobs:
   py38-test-instrumentation-vertexai-latest:
     name: instrumentation-vertexai-latest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -110,6 +119,7 @@ jobs:
   py38-test-resource-detector-container:
     name: resource-detector-container 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -132,6 +142,7 @@ jobs:
   py38-test-resource-detector-azure-0:
     name: resource-detector-azure-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -154,6 +165,7 @@ jobs:
   py38-test-resource-detector-azure-1:
     name: resource-detector-azure-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -176,6 +188,7 @@ jobs:
   py38-test-sdk-extension-aws-0:
     name: sdk-extension-aws-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -198,6 +211,7 @@ jobs:
   py38-test-sdk-extension-aws-1:
     name: sdk-extension-aws-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -220,6 +234,7 @@ jobs:
   py38-test-distro:
     name: distro 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -242,6 +257,7 @@ jobs:
   py38-test-opentelemetry-instrumentation:
     name: opentelemetry-instrumentation 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -264,6 +280,7 @@ jobs:
   py38-test-instrumentation-aiohttp-client:
     name: instrumentation-aiohttp-client 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -286,6 +303,7 @@ jobs:
   py38-test-instrumentation-aiohttp-server:
     name: instrumentation-aiohttp-server 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -308,6 +326,7 @@ jobs:
   py38-test-instrumentation-aiopg:
     name: instrumentation-aiopg 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -330,6 +349,7 @@ jobs:
   py38-test-instrumentation-aws-lambda:
     name: instrumentation-aws-lambda 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -352,6 +372,7 @@ jobs:
   py38-test-instrumentation-botocore-0:
     name: instrumentation-botocore-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -374,6 +395,7 @@ jobs:
   py38-test-instrumentation-botocore-1:
     name: instrumentation-botocore-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -396,6 +418,7 @@ jobs:
   py38-test-instrumentation-boto3sqs:
     name: instrumentation-boto3sqs 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -418,6 +441,7 @@ jobs:
   py38-test-instrumentation-django-0:
     name: instrumentation-django-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -440,6 +464,7 @@ jobs:
   py38-test-instrumentation-django-1:
     name: instrumentation-django-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -462,6 +487,7 @@ jobs:
   py38-test-instrumentation-django-2:
     name: instrumentation-django-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -484,6 +510,7 @@ jobs:
   py38-test-instrumentation-dbapi:
     name: instrumentation-dbapi 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -506,6 +533,7 @@ jobs:
   py38-test-instrumentation-boto:
     name: instrumentation-boto 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -528,6 +556,7 @@ jobs:
   py38-test-instrumentation-asyncclick:
     name: instrumentation-asyncclick 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -550,6 +579,7 @@ jobs:
   py38-test-instrumentation-click:
     name: instrumentation-click 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -572,6 +602,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-0:
     name: instrumentation-elasticsearch-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -594,6 +625,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-1:
     name: instrumentation-elasticsearch-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -616,6 +648,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-2:
     name: instrumentation-elasticsearch-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -638,6 +671,7 @@ jobs:
   py38-test-instrumentation-falcon-0:
     name: instrumentation-falcon-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -660,6 +694,7 @@ jobs:
   py38-test-instrumentation-falcon-1:
     name: instrumentation-falcon-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -682,6 +717,7 @@ jobs:
   py38-test-instrumentation-falcon-2:
     name: instrumentation-falcon-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -704,6 +740,7 @@ jobs:
   py38-test-instrumentation-falcon-3:
     name: instrumentation-falcon-3 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -726,6 +763,7 @@ jobs:
   py38-test-instrumentation-fastapi:
     name: instrumentation-fastapi 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -748,6 +786,7 @@ jobs:
   py38-test-instrumentation-flask-0:
     name: instrumentation-flask-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -770,6 +809,7 @@ jobs:
   py38-test-instrumentation-flask-1:
     name: instrumentation-flask-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -792,6 +832,7 @@ jobs:
   py38-test-instrumentation-flask-2:
     name: instrumentation-flask-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -814,6 +855,7 @@ jobs:
   py38-test-instrumentation-urllib:
     name: instrumentation-urllib 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -836,6 +878,7 @@ jobs:
   py38-test-instrumentation-urllib3-0:
     name: instrumentation-urllib3-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -858,6 +901,7 @@ jobs:
   py38-test-instrumentation-urllib3-1:
     name: instrumentation-urllib3-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -880,6 +924,7 @@ jobs:
   py38-test-instrumentation-requests:
     name: instrumentation-requests 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -902,6 +947,7 @@ jobs:
   py38-test-instrumentation-starlette-oldest:
     name: instrumentation-starlette-oldest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -924,6 +970,7 @@ jobs:
   py38-test-instrumentation-starlette-latest:
     name: instrumentation-starlette-latest 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -946,6 +993,7 @@ jobs:
   py38-test-instrumentation-jinja2:
     name: instrumentation-jinja2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -968,6 +1016,7 @@ jobs:
   py38-test-instrumentation-logging:
     name: instrumentation-logging 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -990,6 +1039,7 @@ jobs:
   py38-test-exporter-richconsole:
     name: exporter-richconsole 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1012,6 +1062,7 @@ jobs:
   py38-test-exporter-prometheus-remote-write:
     name: exporter-prometheus-remote-write 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1034,6 +1085,7 @@ jobs:
   py38-test-instrumentation-mysql-0:
     name: instrumentation-mysql-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1056,6 +1108,7 @@ jobs:
   py38-test-instrumentation-mysql-1:
     name: instrumentation-mysql-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1078,6 +1131,7 @@ jobs:
   py38-test-instrumentation-mysqlclient:
     name: instrumentation-mysqlclient 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1100,6 +1154,7 @@ jobs:
   py38-test-instrumentation-psycopg2:
     name: instrumentation-psycopg2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1122,6 +1177,7 @@ jobs:
   py38-test-instrumentation-psycopg2-binary:
     name: instrumentation-psycopg2-binary 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1144,6 +1200,7 @@ jobs:
   py38-test-instrumentation-psycopg:
     name: instrumentation-psycopg 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1166,6 +1223,7 @@ jobs:
   py38-test-instrumentation-pymemcache-0:
     name: instrumentation-pymemcache-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1188,6 +1246,7 @@ jobs:
   py38-test-instrumentation-pymemcache-1:
     name: instrumentation-pymemcache-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1210,6 +1269,7 @@ jobs:
   py38-test-instrumentation-pymemcache-2:
     name: instrumentation-pymemcache-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1232,6 +1292,7 @@ jobs:
   py38-test-instrumentation-pymemcache-3:
     name: instrumentation-pymemcache-3 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1254,6 +1315,7 @@ jobs:
   py38-test-instrumentation-pymemcache-4:
     name: instrumentation-pymemcache-4 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1276,6 +1338,7 @@ jobs:
   py38-test-instrumentation-pymongo:
     name: instrumentation-pymongo 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1298,6 +1361,7 @@ jobs:
   py38-test-instrumentation-pymysql:
     name: instrumentation-pymysql 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1320,6 +1384,7 @@ jobs:
   py38-test-instrumentation-pymssql:
     name: instrumentation-pymssql 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1342,6 +1407,7 @@ jobs:
   py38-test-instrumentation-pyramid:
     name: instrumentation-pyramid 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1364,6 +1430,7 @@ jobs:
   py38-test-instrumentation-asgi:
     name: instrumentation-asgi 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1386,6 +1453,7 @@ jobs:
   py38-test-instrumentation-asyncpg:
     name: instrumentation-asyncpg 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1408,6 +1476,7 @@ jobs:
   py38-test-instrumentation-sqlite3:
     name: instrumentation-sqlite3 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1430,6 +1499,7 @@ jobs:
   py38-test-instrumentation-wsgi:
     name: instrumentation-wsgi 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1452,6 +1522,7 @@ jobs:
   py38-test-instrumentation-grpc-0:
     name: instrumentation-grpc-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1474,6 +1545,7 @@ jobs:
   py38-test-instrumentation-grpc-1:
     name: instrumentation-grpc-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1496,6 +1568,7 @@ jobs:
   py38-test-instrumentation-sqlalchemy-1:
     name: instrumentation-sqlalchemy-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1518,6 +1591,7 @@ jobs:
   py38-test-instrumentation-sqlalchemy-2:
     name: instrumentation-sqlalchemy-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1540,6 +1614,7 @@ jobs:
   py38-test-instrumentation-redis:
     name: instrumentation-redis 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1562,6 +1637,7 @@ jobs:
   py38-test-instrumentation-remoulade:
     name: instrumentation-remoulade 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1584,6 +1660,7 @@ jobs:
   py38-test-instrumentation-celery:
     name: instrumentation-celery 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1606,6 +1683,7 @@ jobs:
   py38-test-instrumentation-system-metrics:
     name: instrumentation-system-metrics 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1628,6 +1706,7 @@ jobs:
   py38-test-instrumentation-threading:
     name: instrumentation-threading 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1650,6 +1729,7 @@ jobs:
   py38-test-instrumentation-tornado:
     name: instrumentation-tornado 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1672,6 +1752,7 @@ jobs:
   py38-test-instrumentation-tortoiseorm:
     name: instrumentation-tortoiseorm 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1694,6 +1775,7 @@ jobs:
   py38-test-instrumentation-httpx-0:
     name: instrumentation-httpx-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1716,6 +1798,7 @@ jobs:
   py38-test-instrumentation-httpx-1:
     name: instrumentation-httpx-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1738,6 +1821,7 @@ jobs:
   py38-test-util-http:
     name: util-http 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1760,6 +1844,7 @@ jobs:
   py38-test-propagator-aws-xray-0:
     name: propagator-aws-xray-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1782,6 +1867,7 @@ jobs:
   py38-test-propagator-aws-xray-1:
     name: propagator-aws-xray-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1804,6 +1890,7 @@ jobs:
   py38-test-propagator-ot-trace:
     name: propagator-ot-trace 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1826,6 +1913,7 @@ jobs:
   py38-test-instrumentation-sio-pika-0:
     name: instrumentation-sio-pika-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1848,6 +1936,7 @@ jobs:
   py38-test-instrumentation-sio-pika-1:
     name: instrumentation-sio-pika-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1870,6 +1959,7 @@ jobs:
   py38-test-instrumentation-aio-pika-0:
     name: instrumentation-aio-pika-0 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1892,6 +1982,7 @@ jobs:
   py38-test-instrumentation-aio-pika-1:
     name: instrumentation-aio-pika-1 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1914,6 +2005,7 @@ jobs:
   py38-test-instrumentation-aio-pika-2:
     name: instrumentation-aio-pika-2 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1936,6 +2028,7 @@ jobs:
   py38-test-instrumentation-aio-pika-3:
     name: instrumentation-aio-pika-3 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1958,6 +2051,7 @@ jobs:
   py38-test-instrumentation-aiokafka:
     name: instrumentation-aiokafka 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -1980,6 +2074,7 @@ jobs:
   py38-test-instrumentation-kafka-python:
     name: instrumentation-kafka-python 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -2002,6 +2097,7 @@ jobs:
   py38-test-instrumentation-kafka-pythonng:
     name: instrumentation-kafka-pythonng 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -2024,6 +2120,7 @@ jobs:
   py38-test-instrumentation-confluent-kafka:
     name: instrumentation-confluent-kafka 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -2046,6 +2143,7 @@ jobs:
   py38-test-instrumentation-asyncio:
     name: instrumentation-asyncio 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -2068,6 +2166,7 @@ jobs:
   py38-test-instrumentation-cassandra:
     name: instrumentation-cassandra 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4
@@ -2090,6 +2189,7 @@ jobs:
   py38-test-processor-baggage:
     name: processor-baggage 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v4

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/core_contrib_test.yml.j2
@@ -12,6 +12,11 @@ on:
       CONTRIB_REPO_SHA:
         required: true
         type: string
+
+concurrency:
+  group: ${% raw %}{{ github.workflow }}-${{ github.head_ref || github.run_id }}{% endraw %}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: ${% raw %}{{ inputs.CORE_REPO_SHA }}{% endraw %}
   CONTRIB_REPO_SHA: ${% raw %}{{ inputs.CONTRIB_REPO_SHA }}{% endraw %}
@@ -23,6 +28,7 @@ jobs:
   {{ job_data.tox_env }}:
     name: {{ job_data.ui_name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout contrib repo @ SHA - ${% raw %}{{ env.CONTRIB_REPO_SHA }}{% endraw %}
         uses: actions/checkout@v4

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${% raw %}{{ github.workflow }}-${{ github.head_ref || github.run_id }}{% endraw %}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -20,6 +24,7 @@ jobs:
   {{ job_data.name }}:
     name: {{ job_data.ui_name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
         uses: actions/checkout@v4

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${% raw %}{{ github.workflow }}-${{ github.head_ref || github.run_id }}{% endraw %}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -20,6 +24,7 @@ jobs:
   {{ job_data }}:
     name: {{ job_data }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     {%- if job_data == "generate-workflows" %}
     if: |
       !contains(github.event.pull_request.labels.*.name, 'Skip generate-workflows')

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${% raw %}{{ github.workflow }}-${{ github.head_ref || github.run_id }}{% endraw %}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -20,6 +24,7 @@ jobs:
   {{ job_data.name }}:
     name: {{ job_data.ui_name }}
     runs-on: {{ job_data.os }}
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
         uses: actions/checkout@v4

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -19,6 +23,7 @@ jobs:
   lint-instrumentation-openai-v2:
     name: instrumentation-openai-v2
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -37,6 +42,7 @@ jobs:
   lint-instrumentation-vertexai:
     name: instrumentation-vertexai
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -55,6 +61,7 @@ jobs:
   lint-instrumentation-google-genai:
     name: instrumentation-google-genai
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -73,6 +80,7 @@ jobs:
   lint-resource-detector-container:
     name: resource-detector-container
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -91,6 +99,7 @@ jobs:
   lint-resource-detector-azure:
     name: resource-detector-azure
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -109,6 +118,7 @@ jobs:
   lint-sdk-extension-aws:
     name: sdk-extension-aws
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -127,6 +137,7 @@ jobs:
   lint-distro:
     name: distro
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -145,6 +156,7 @@ jobs:
   lint-opentelemetry-instrumentation:
     name: opentelemetry-instrumentation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -163,6 +175,7 @@ jobs:
   lint-instrumentation-aiohttp-client:
     name: instrumentation-aiohttp-client
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -181,6 +194,7 @@ jobs:
   lint-instrumentation-aiohttp-server:
     name: instrumentation-aiohttp-server
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -199,6 +213,7 @@ jobs:
   lint-instrumentation-aiopg:
     name: instrumentation-aiopg
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -217,6 +232,7 @@ jobs:
   lint-instrumentation-aws-lambda:
     name: instrumentation-aws-lambda
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -235,6 +251,7 @@ jobs:
   lint-instrumentation-botocore:
     name: instrumentation-botocore
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -253,6 +270,7 @@ jobs:
   lint-instrumentation-boto3sqs:
     name: instrumentation-boto3sqs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -271,6 +289,7 @@ jobs:
   lint-instrumentation-django:
     name: instrumentation-django
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -289,6 +308,7 @@ jobs:
   lint-instrumentation-dbapi:
     name: instrumentation-dbapi
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -307,6 +327,7 @@ jobs:
   lint-instrumentation-boto:
     name: instrumentation-boto
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -325,6 +346,7 @@ jobs:
   lint-instrumentation-asyncclick:
     name: instrumentation-asyncclick
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -343,6 +365,7 @@ jobs:
   lint-instrumentation-click:
     name: instrumentation-click
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -361,6 +384,7 @@ jobs:
   lint-instrumentation-elasticsearch:
     name: instrumentation-elasticsearch
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -379,6 +403,7 @@ jobs:
   lint-instrumentation-falcon:
     name: instrumentation-falcon
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -397,6 +422,7 @@ jobs:
   lint-instrumentation-fastapi:
     name: instrumentation-fastapi
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -415,6 +441,7 @@ jobs:
   lint-instrumentation-flask:
     name: instrumentation-flask
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -433,6 +460,7 @@ jobs:
   lint-instrumentation-urllib:
     name: instrumentation-urllib
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -451,6 +479,7 @@ jobs:
   lint-instrumentation-urllib3:
     name: instrumentation-urllib3
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -469,6 +498,7 @@ jobs:
   lint-instrumentation-requests:
     name: instrumentation-requests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -487,6 +517,7 @@ jobs:
   lint-instrumentation-starlette:
     name: instrumentation-starlette
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -505,6 +536,7 @@ jobs:
   lint-instrumentation-jinja2:
     name: instrumentation-jinja2
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -523,6 +555,7 @@ jobs:
   lint-instrumentation-logging:
     name: instrumentation-logging
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -541,6 +574,7 @@ jobs:
   lint-exporter-richconsole:
     name: exporter-richconsole
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -559,6 +593,7 @@ jobs:
   lint-exporter-prometheus-remote-write:
     name: exporter-prometheus-remote-write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -577,6 +612,7 @@ jobs:
   lint-instrumentation-mysql:
     name: instrumentation-mysql
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -595,6 +631,7 @@ jobs:
   lint-instrumentation-mysqlclient:
     name: instrumentation-mysqlclient
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -613,6 +650,7 @@ jobs:
   lint-instrumentation-psycopg2:
     name: instrumentation-psycopg2
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -631,6 +669,7 @@ jobs:
   lint-instrumentation-psycopg:
     name: instrumentation-psycopg
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -649,6 +688,7 @@ jobs:
   lint-instrumentation-pymemcache:
     name: instrumentation-pymemcache
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -667,6 +707,7 @@ jobs:
   lint-instrumentation-pymongo:
     name: instrumentation-pymongo
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -685,6 +726,7 @@ jobs:
   lint-instrumentation-pymysql:
     name: instrumentation-pymysql
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -703,6 +745,7 @@ jobs:
   lint-instrumentation-pymssql:
     name: instrumentation-pymssql
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -721,6 +764,7 @@ jobs:
   lint-instrumentation-pyramid:
     name: instrumentation-pyramid
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -739,6 +783,7 @@ jobs:
   lint-instrumentation-asgi:
     name: instrumentation-asgi
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -757,6 +802,7 @@ jobs:
   lint-instrumentation-asyncpg:
     name: instrumentation-asyncpg
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -775,6 +821,7 @@ jobs:
   lint-instrumentation-sqlite3:
     name: instrumentation-sqlite3
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -793,6 +840,7 @@ jobs:
   lint-instrumentation-wsgi:
     name: instrumentation-wsgi
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -811,6 +859,7 @@ jobs:
   lint-instrumentation-grpc:
     name: instrumentation-grpc
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -829,6 +878,7 @@ jobs:
   lint-instrumentation-sqlalchemy:
     name: instrumentation-sqlalchemy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -847,6 +897,7 @@ jobs:
   lint-instrumentation-redis:
     name: instrumentation-redis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -865,6 +916,7 @@ jobs:
   lint-instrumentation-remoulade:
     name: instrumentation-remoulade
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -883,6 +935,7 @@ jobs:
   lint-instrumentation-celery:
     name: instrumentation-celery
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -901,6 +954,7 @@ jobs:
   lint-instrumentation-system-metrics:
     name: instrumentation-system-metrics
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -919,6 +973,7 @@ jobs:
   lint-instrumentation-threading:
     name: instrumentation-threading
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -937,6 +992,7 @@ jobs:
   lint-instrumentation-tornado:
     name: instrumentation-tornado
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -955,6 +1011,7 @@ jobs:
   lint-instrumentation-tortoiseorm:
     name: instrumentation-tortoiseorm
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -973,6 +1030,7 @@ jobs:
   lint-instrumentation-httpx:
     name: instrumentation-httpx
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -991,6 +1049,7 @@ jobs:
   lint-util-http:
     name: util-http
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1009,6 +1068,7 @@ jobs:
   lint-propagator-aws-xray:
     name: propagator-aws-xray
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1027,6 +1087,7 @@ jobs:
   lint-propagator-ot-trace:
     name: propagator-ot-trace
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1045,6 +1106,7 @@ jobs:
   lint-instrumentation-sio-pika:
     name: instrumentation-sio-pika
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1063,6 +1125,7 @@ jobs:
   lint-instrumentation-aio-pika:
     name: instrumentation-aio-pika
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1081,6 +1144,7 @@ jobs:
   lint-instrumentation-aiokafka:
     name: instrumentation-aiokafka
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1099,6 +1163,7 @@ jobs:
   lint-instrumentation-kafka-python:
     name: instrumentation-kafka-python
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1117,6 +1182,7 @@ jobs:
   lint-instrumentation-confluent-kafka:
     name: instrumentation-confluent-kafka
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1135,6 +1201,7 @@ jobs:
   lint-instrumentation-asyncio:
     name: instrumentation-asyncio
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1153,6 +1220,7 @@ jobs:
   lint-instrumentation-cassandra:
     name: instrumentation-cassandra
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1171,6 +1239,7 @@ jobs:
   lint-processor-baggage:
     name: processor-baggage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -19,6 +23,7 @@ jobs:
   spellcheck:
     name: spellcheck
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -37,6 +42,7 @@ jobs:
   docker-tests:
     name: docker-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -55,6 +61,7 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       github.event.pull_request.user.login != 'opentelemetrybot' && github.event_name == 'pull_request'
     steps:
@@ -75,6 +82,7 @@ jobs:
   generate:
     name: generate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -96,6 +104,7 @@ jobs:
   generate-workflows:
     name: generate-workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       !contains(github.event.pull_request.labels.*.name, 'Skip generate-workflows')
       && github.event.pull_request.user.login != 'opentelemetrybot' && github.event_name == 'pull_request'
@@ -120,6 +129,7 @@ jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -138,6 +148,7 @@ jobs:
   ruff:
     name: ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -156,6 +167,7 @@ jobs:
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -19,6 +23,7 @@ jobs:
   py38-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -37,6 +42,7 @@ jobs:
   py38-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -55,6 +61,7 @@ jobs:
   py39-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -73,6 +80,7 @@ jobs:
   py39-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -91,6 +99,7 @@ jobs:
   py310-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -109,6 +118,7 @@ jobs:
   py310-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -127,6 +137,7 @@ jobs:
   py311-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -145,6 +156,7 @@ jobs:
   py311-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -163,6 +175,7 @@ jobs:
   py312-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -181,6 +194,7 @@ jobs:
   py312-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -199,6 +213,7 @@ jobs:
   py313-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -217,6 +232,7 @@ jobs:
   py313-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -235,6 +251,7 @@ jobs:
   pypy3-test-instrumentation-openai-v2-oldest_ubuntu-latest:
     name: instrumentation-openai-v2-oldest pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -253,6 +270,7 @@ jobs:
   pypy3-test-instrumentation-openai-v2-latest_ubuntu-latest:
     name: instrumentation-openai-v2-latest pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -271,6 +289,7 @@ jobs:
   py38-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -289,6 +308,7 @@ jobs:
   py38-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -307,6 +327,7 @@ jobs:
   py39-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -325,6 +346,7 @@ jobs:
   py39-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -343,6 +365,7 @@ jobs:
   py310-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -361,6 +384,7 @@ jobs:
   py310-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -379,6 +403,7 @@ jobs:
   py311-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -397,6 +422,7 @@ jobs:
   py311-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -415,6 +441,7 @@ jobs:
   py312-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -433,6 +460,7 @@ jobs:
   py312-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -451,6 +479,7 @@ jobs:
   py313-test-instrumentation-vertexai-oldest_ubuntu-latest:
     name: instrumentation-vertexai-oldest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -469,6 +498,7 @@ jobs:
   py313-test-instrumentation-vertexai-latest_ubuntu-latest:
     name: instrumentation-vertexai-latest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -487,6 +517,7 @@ jobs:
   py39-test-instrumentation-google-genai-oldest_ubuntu-latest:
     name: instrumentation-google-genai-oldest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -505,6 +536,7 @@ jobs:
   py39-test-instrumentation-google-genai-latest_ubuntu-latest:
     name: instrumentation-google-genai-latest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -523,6 +555,7 @@ jobs:
   py310-test-instrumentation-google-genai-oldest_ubuntu-latest:
     name: instrumentation-google-genai-oldest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -541,6 +574,7 @@ jobs:
   py310-test-instrumentation-google-genai-latest_ubuntu-latest:
     name: instrumentation-google-genai-latest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -559,6 +593,7 @@ jobs:
   py311-test-instrumentation-google-genai-oldest_ubuntu-latest:
     name: instrumentation-google-genai-oldest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -577,6 +612,7 @@ jobs:
   py311-test-instrumentation-google-genai-latest_ubuntu-latest:
     name: instrumentation-google-genai-latest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -595,6 +631,7 @@ jobs:
   py312-test-instrumentation-google-genai-oldest_ubuntu-latest:
     name: instrumentation-google-genai-oldest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -613,6 +650,7 @@ jobs:
   py312-test-instrumentation-google-genai-latest_ubuntu-latest:
     name: instrumentation-google-genai-latest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -631,6 +669,7 @@ jobs:
   py313-test-instrumentation-google-genai-oldest_ubuntu-latest:
     name: instrumentation-google-genai-oldest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -649,6 +688,7 @@ jobs:
   py313-test-instrumentation-google-genai-latest_ubuntu-latest:
     name: instrumentation-google-genai-latest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -667,6 +707,7 @@ jobs:
   py38-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -685,6 +726,7 @@ jobs:
   py39-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -703,6 +745,7 @@ jobs:
   py310-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -721,6 +764,7 @@ jobs:
   py311-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -739,6 +783,7 @@ jobs:
   py312-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -757,6 +802,7 @@ jobs:
   py313-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -775,6 +821,7 @@ jobs:
   pypy3-test-resource-detector-container_ubuntu-latest:
     name: resource-detector-container pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -793,6 +840,7 @@ jobs:
   py38-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -811,6 +859,7 @@ jobs:
   py38-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -829,6 +878,7 @@ jobs:
   py39-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -847,6 +897,7 @@ jobs:
   py39-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -865,6 +916,7 @@ jobs:
   py310-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -883,6 +935,7 @@ jobs:
   py310-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -901,6 +954,7 @@ jobs:
   py311-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -919,6 +973,7 @@ jobs:
   py311-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -937,6 +992,7 @@ jobs:
   py312-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -955,6 +1011,7 @@ jobs:
   py312-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -973,6 +1030,7 @@ jobs:
   py313-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -991,6 +1049,7 @@ jobs:
   py313-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1009,6 +1068,7 @@ jobs:
   pypy3-test-resource-detector-azure-0_ubuntu-latest:
     name: resource-detector-azure-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1027,6 +1087,7 @@ jobs:
   pypy3-test-resource-detector-azure-1_ubuntu-latest:
     name: resource-detector-azure-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1045,6 +1106,7 @@ jobs:
   py38-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1063,6 +1125,7 @@ jobs:
   py38-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1081,6 +1144,7 @@ jobs:
   py39-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1099,6 +1163,7 @@ jobs:
   py39-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1117,6 +1182,7 @@ jobs:
   py310-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1135,6 +1201,7 @@ jobs:
   py310-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1153,6 +1220,7 @@ jobs:
   py311-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1171,6 +1239,7 @@ jobs:
   py311-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1189,6 +1258,7 @@ jobs:
   py312-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1207,6 +1277,7 @@ jobs:
   py312-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1225,6 +1296,7 @@ jobs:
   py313-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1243,6 +1315,7 @@ jobs:
   py313-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1261,6 +1334,7 @@ jobs:
   pypy3-test-sdk-extension-aws-0_ubuntu-latest:
     name: sdk-extension-aws-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1279,6 +1353,7 @@ jobs:
   pypy3-test-sdk-extension-aws-1_ubuntu-latest:
     name: sdk-extension-aws-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1297,6 +1372,7 @@ jobs:
   py38-test-distro_ubuntu-latest:
     name: distro 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1315,6 +1391,7 @@ jobs:
   py39-test-distro_ubuntu-latest:
     name: distro 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1333,6 +1410,7 @@ jobs:
   py310-test-distro_ubuntu-latest:
     name: distro 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1351,6 +1429,7 @@ jobs:
   py311-test-distro_ubuntu-latest:
     name: distro 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1369,6 +1448,7 @@ jobs:
   py312-test-distro_ubuntu-latest:
     name: distro 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1387,6 +1467,7 @@ jobs:
   py313-test-distro_ubuntu-latest:
     name: distro 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1405,6 +1486,7 @@ jobs:
   pypy3-test-distro_ubuntu-latest:
     name: distro pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1423,6 +1505,7 @@ jobs:
   py38-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1441,6 +1524,7 @@ jobs:
   py39-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1459,6 +1543,7 @@ jobs:
   py310-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1477,6 +1562,7 @@ jobs:
   py311-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1495,6 +1581,7 @@ jobs:
   py312-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1513,6 +1600,7 @@ jobs:
   py313-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1531,6 +1619,7 @@ jobs:
   pypy3-test-opentelemetry-instrumentation_ubuntu-latest:
     name: opentelemetry-instrumentation pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1549,6 +1638,7 @@ jobs:
   py38-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1567,6 +1657,7 @@ jobs:
   py39-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1585,6 +1676,7 @@ jobs:
   py310-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1603,6 +1695,7 @@ jobs:
   py311-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1621,6 +1714,7 @@ jobs:
   py312-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1639,6 +1733,7 @@ jobs:
   py313-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1657,6 +1752,7 @@ jobs:
   pypy3-test-instrumentation-aiohttp-client_ubuntu-latest:
     name: instrumentation-aiohttp-client pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1675,6 +1771,7 @@ jobs:
   py38-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1693,6 +1790,7 @@ jobs:
   py39-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1711,6 +1809,7 @@ jobs:
   py310-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1729,6 +1828,7 @@ jobs:
   py311-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1747,6 +1847,7 @@ jobs:
   py312-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1765,6 +1866,7 @@ jobs:
   py313-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1783,6 +1885,7 @@ jobs:
   pypy3-test-instrumentation-aiohttp-server_ubuntu-latest:
     name: instrumentation-aiohttp-server pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1801,6 +1904,7 @@ jobs:
   py38-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1819,6 +1923,7 @@ jobs:
   py39-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1837,6 +1942,7 @@ jobs:
   py310-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1855,6 +1961,7 @@ jobs:
   py311-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1873,6 +1980,7 @@ jobs:
   py312-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1891,6 +1999,7 @@ jobs:
   py313-test-instrumentation-aiopg_ubuntu-latest:
     name: instrumentation-aiopg 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1909,6 +2018,7 @@ jobs:
   py38-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1927,6 +2037,7 @@ jobs:
   py39-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1945,6 +2056,7 @@ jobs:
   py310-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1963,6 +2075,7 @@ jobs:
   py311-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1981,6 +2094,7 @@ jobs:
   py312-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1999,6 +2113,7 @@ jobs:
   py313-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2017,6 +2132,7 @@ jobs:
   pypy3-test-instrumentation-aws-lambda_ubuntu-latest:
     name: instrumentation-aws-lambda pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2035,6 +2151,7 @@ jobs:
   py38-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2053,6 +2170,7 @@ jobs:
   py38-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2071,6 +2189,7 @@ jobs:
   py39-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2089,6 +2208,7 @@ jobs:
   py39-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2107,6 +2227,7 @@ jobs:
   py310-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2125,6 +2246,7 @@ jobs:
   py310-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2143,6 +2265,7 @@ jobs:
   py311-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2161,6 +2284,7 @@ jobs:
   py311-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2179,6 +2303,7 @@ jobs:
   py312-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2197,6 +2322,7 @@ jobs:
   py312-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2215,6 +2341,7 @@ jobs:
   py313-test-instrumentation-botocore-0_ubuntu-latest:
     name: instrumentation-botocore-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2233,6 +2360,7 @@ jobs:
   py313-test-instrumentation-botocore-1_ubuntu-latest:
     name: instrumentation-botocore-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2251,6 +2379,7 @@ jobs:
   py38-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2269,6 +2398,7 @@ jobs:
   py39-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2287,6 +2417,7 @@ jobs:
   py310-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2305,6 +2436,7 @@ jobs:
   py311-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2323,6 +2455,7 @@ jobs:
   py312-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2341,6 +2474,7 @@ jobs:
   py313-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2359,6 +2493,7 @@ jobs:
   pypy3-test-instrumentation-boto3sqs_ubuntu-latest:
     name: instrumentation-boto3sqs pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2377,6 +2512,7 @@ jobs:
   py38-test-instrumentation-django-0_ubuntu-latest:
     name: instrumentation-django-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2395,6 +2531,7 @@ jobs:
   py38-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2413,6 +2550,7 @@ jobs:
   py38-test-instrumentation-django-2_ubuntu-latest:
     name: instrumentation-django-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2431,6 +2569,7 @@ jobs:
   py39-test-instrumentation-django-0_ubuntu-latest:
     name: instrumentation-django-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2449,6 +2588,7 @@ jobs:
   py39-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2467,6 +2607,7 @@ jobs:
   py39-test-instrumentation-django-2_ubuntu-latest:
     name: instrumentation-django-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2485,6 +2626,7 @@ jobs:
   py310-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2503,6 +2645,7 @@ jobs:
   py310-test-instrumentation-django-3_ubuntu-latest:
     name: instrumentation-django-3 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2521,6 +2664,7 @@ jobs:
   py311-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2539,6 +2683,7 @@ jobs:
   py311-test-instrumentation-django-3_ubuntu-latest:
     name: instrumentation-django-3 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2557,6 +2702,7 @@ jobs:
   py312-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2575,6 +2721,7 @@ jobs:
   py312-test-instrumentation-django-3_ubuntu-latest:
     name: instrumentation-django-3 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2593,6 +2740,7 @@ jobs:
   py313-test-instrumentation-django-3_ubuntu-latest:
     name: instrumentation-django-3 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2611,6 +2759,7 @@ jobs:
   pypy3-test-instrumentation-django-0_ubuntu-latest:
     name: instrumentation-django-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2629,6 +2778,7 @@ jobs:
   pypy3-test-instrumentation-django-1_ubuntu-latest:
     name: instrumentation-django-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2647,6 +2797,7 @@ jobs:
   py38-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2665,6 +2816,7 @@ jobs:
   py39-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2683,6 +2835,7 @@ jobs:
   py310-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2701,6 +2854,7 @@ jobs:
   py311-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2719,6 +2873,7 @@ jobs:
   py312-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2737,6 +2892,7 @@ jobs:
   py313-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2755,6 +2911,7 @@ jobs:
   pypy3-test-instrumentation-dbapi_ubuntu-latest:
     name: instrumentation-dbapi pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2773,6 +2930,7 @@ jobs:
   py38-test-instrumentation-boto_ubuntu-latest:
     name: instrumentation-boto 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2791,6 +2949,7 @@ jobs:
   py39-test-instrumentation-boto_ubuntu-latest:
     name: instrumentation-boto 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2809,6 +2968,7 @@ jobs:
   py310-test-instrumentation-boto_ubuntu-latest:
     name: instrumentation-boto 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2827,6 +2987,7 @@ jobs:
   py311-test-instrumentation-boto_ubuntu-latest:
     name: instrumentation-boto 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2845,6 +3006,7 @@ jobs:
   py38-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2863,6 +3025,7 @@ jobs:
   py39-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2881,6 +3044,7 @@ jobs:
   py310-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2899,6 +3063,7 @@ jobs:
   py311-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2917,6 +3082,7 @@ jobs:
   py312-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2935,6 +3101,7 @@ jobs:
   py313-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2953,6 +3120,7 @@ jobs:
   pypy3-test-instrumentation-asyncclick_ubuntu-latest:
     name: instrumentation-asyncclick pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2971,6 +3139,7 @@ jobs:
   py38-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2989,6 +3158,7 @@ jobs:
   py39-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3007,6 +3177,7 @@ jobs:
   py310-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3025,6 +3196,7 @@ jobs:
   py311-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3043,6 +3215,7 @@ jobs:
   py312-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3061,6 +3234,7 @@ jobs:
   py313-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3079,6 +3253,7 @@ jobs:
   pypy3-test-instrumentation-click_ubuntu-latest:
     name: instrumentation-click pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3097,6 +3272,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3115,6 +3291,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3133,6 +3310,7 @@ jobs:
   py38-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3151,6 +3329,7 @@ jobs:
   py39-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3169,6 +3348,7 @@ jobs:
   py39-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3187,6 +3367,7 @@ jobs:
   py39-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3205,6 +3386,7 @@ jobs:
   py310-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3223,6 +3405,7 @@ jobs:
   py310-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3241,6 +3424,7 @@ jobs:
   py310-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3259,6 +3443,7 @@ jobs:
   py311-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3277,6 +3462,7 @@ jobs:
   py311-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3295,6 +3481,7 @@ jobs:
   py311-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3313,6 +3500,7 @@ jobs:
   py312-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3331,6 +3519,7 @@ jobs:
   py312-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3349,6 +3538,7 @@ jobs:
   py312-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3367,6 +3557,7 @@ jobs:
   py313-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3385,6 +3576,7 @@ jobs:
   py313-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3403,6 +3595,7 @@ jobs:
   py313-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3421,6 +3614,7 @@ jobs:
   pypy3-test-instrumentation-elasticsearch-0_ubuntu-latest:
     name: instrumentation-elasticsearch-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3439,6 +3633,7 @@ jobs:
   pypy3-test-instrumentation-elasticsearch-1_ubuntu-latest:
     name: instrumentation-elasticsearch-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3457,6 +3652,7 @@ jobs:
   pypy3-test-instrumentation-elasticsearch-2_ubuntu-latest:
     name: instrumentation-elasticsearch-2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3475,6 +3671,7 @@ jobs:
   py38-test-instrumentation-falcon-0_ubuntu-latest:
     name: instrumentation-falcon-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3493,6 +3690,7 @@ jobs:
   py38-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3511,6 +3709,7 @@ jobs:
   py38-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3529,6 +3728,7 @@ jobs:
   py38-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3547,6 +3747,7 @@ jobs:
   py39-test-instrumentation-falcon-0_ubuntu-latest:
     name: instrumentation-falcon-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3565,6 +3766,7 @@ jobs:
   py39-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3583,6 +3785,7 @@ jobs:
   py39-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3601,6 +3804,7 @@ jobs:
   py39-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3619,6 +3823,7 @@ jobs:
   py310-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3637,6 +3842,7 @@ jobs:
   py310-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3655,6 +3861,7 @@ jobs:
   py310-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3673,6 +3880,7 @@ jobs:
   py310-test-instrumentation-falcon-4_ubuntu-latest:
     name: instrumentation-falcon-4 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3691,6 +3899,7 @@ jobs:
   py311-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3709,6 +3918,7 @@ jobs:
   py311-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3727,6 +3937,7 @@ jobs:
   py311-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3745,6 +3956,7 @@ jobs:
   py311-test-instrumentation-falcon-4_ubuntu-latest:
     name: instrumentation-falcon-4 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3763,6 +3975,7 @@ jobs:
   py312-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3781,6 +3994,7 @@ jobs:
   py312-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3799,6 +4013,7 @@ jobs:
   py312-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3817,6 +4032,7 @@ jobs:
   py312-test-instrumentation-falcon-4_ubuntu-latest:
     name: instrumentation-falcon-4 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3835,6 +4051,7 @@ jobs:
   py313-test-instrumentation-falcon-4_ubuntu-latest:
     name: instrumentation-falcon-4 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3853,6 +4070,7 @@ jobs:
   pypy3-test-instrumentation-falcon-0_ubuntu-latest:
     name: instrumentation-falcon-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3871,6 +4089,7 @@ jobs:
   pypy3-test-instrumentation-falcon-1_ubuntu-latest:
     name: instrumentation-falcon-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3889,6 +4108,7 @@ jobs:
   pypy3-test-instrumentation-falcon-2_ubuntu-latest:
     name: instrumentation-falcon-2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3907,6 +4127,7 @@ jobs:
   pypy3-test-instrumentation-falcon-3_ubuntu-latest:
     name: instrumentation-falcon-3 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3925,6 +4146,7 @@ jobs:
   pypy3-test-instrumentation-falcon-4_ubuntu-latest:
     name: instrumentation-falcon-4 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3943,6 +4165,7 @@ jobs:
   py38-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3961,6 +4184,7 @@ jobs:
   py39-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3979,6 +4203,7 @@ jobs:
   py310-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3997,6 +4222,7 @@ jobs:
   py311-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4015,6 +4241,7 @@ jobs:
   py312-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4033,6 +4260,7 @@ jobs:
   py313-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4051,6 +4279,7 @@ jobs:
   pypy3-test-instrumentation-fastapi_ubuntu-latest:
     name: instrumentation-fastapi pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4069,6 +4298,7 @@ jobs:
   py38-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4087,6 +4317,7 @@ jobs:
   py38-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4105,6 +4336,7 @@ jobs:
   py38-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4123,6 +4355,7 @@ jobs:
   py39-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4141,6 +4374,7 @@ jobs:
   py39-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4159,6 +4393,7 @@ jobs:
   py39-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4177,6 +4412,7 @@ jobs:
   py310-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4195,6 +4431,7 @@ jobs:
   py310-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4213,6 +4450,7 @@ jobs:
   py310-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4231,6 +4469,7 @@ jobs:
   py311-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4249,6 +4488,7 @@ jobs:
   py311-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4267,6 +4507,7 @@ jobs:
   py311-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4285,6 +4526,7 @@ jobs:
   py312-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4303,6 +4545,7 @@ jobs:
   py312-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4321,6 +4564,7 @@ jobs:
   py312-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4339,6 +4583,7 @@ jobs:
   py313-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4357,6 +4602,7 @@ jobs:
   py313-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4375,6 +4621,7 @@ jobs:
   py313-test-instrumentation-flask-2_ubuntu-latest:
     name: instrumentation-flask-2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4393,6 +4640,7 @@ jobs:
   pypy3-test-instrumentation-flask-0_ubuntu-latest:
     name: instrumentation-flask-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4411,6 +4659,7 @@ jobs:
   pypy3-test-instrumentation-flask-1_ubuntu-latest:
     name: instrumentation-flask-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4429,6 +4678,7 @@ jobs:
   py38-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4447,6 +4697,7 @@ jobs:
   py39-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4465,6 +4716,7 @@ jobs:
   py310-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4483,6 +4735,7 @@ jobs:
   py311-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4501,6 +4754,7 @@ jobs:
   py312-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -19,6 +23,7 @@ jobs:
   py313-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -37,6 +42,7 @@ jobs:
   pypy3-test-instrumentation-urllib_ubuntu-latest:
     name: instrumentation-urllib pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -55,6 +61,7 @@ jobs:
   py38-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -73,6 +80,7 @@ jobs:
   py38-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -91,6 +99,7 @@ jobs:
   py39-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -109,6 +118,7 @@ jobs:
   py39-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -127,6 +137,7 @@ jobs:
   py310-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -145,6 +156,7 @@ jobs:
   py310-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -163,6 +175,7 @@ jobs:
   py311-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -181,6 +194,7 @@ jobs:
   py311-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -199,6 +213,7 @@ jobs:
   py312-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -217,6 +232,7 @@ jobs:
   py312-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -235,6 +251,7 @@ jobs:
   py313-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -253,6 +270,7 @@ jobs:
   py313-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -271,6 +289,7 @@ jobs:
   pypy3-test-instrumentation-urllib3-0_ubuntu-latest:
     name: instrumentation-urllib3-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -289,6 +308,7 @@ jobs:
   pypy3-test-instrumentation-urllib3-1_ubuntu-latest:
     name: instrumentation-urllib3-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -307,6 +327,7 @@ jobs:
   py38-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -325,6 +346,7 @@ jobs:
   py39-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -343,6 +365,7 @@ jobs:
   py310-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -361,6 +384,7 @@ jobs:
   py311-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -379,6 +403,7 @@ jobs:
   py312-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -397,6 +422,7 @@ jobs:
   py313-test-instrumentation-requests_ubuntu-latest:
     name: instrumentation-requests 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -415,6 +441,7 @@ jobs:
   py38-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -433,6 +460,7 @@ jobs:
   py38-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -451,6 +479,7 @@ jobs:
   py39-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -469,6 +498,7 @@ jobs:
   py39-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -487,6 +517,7 @@ jobs:
   py310-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -505,6 +536,7 @@ jobs:
   py310-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -523,6 +555,7 @@ jobs:
   py311-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -541,6 +574,7 @@ jobs:
   py311-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -559,6 +593,7 @@ jobs:
   py312-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -577,6 +612,7 @@ jobs:
   py312-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -595,6 +631,7 @@ jobs:
   py313-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -613,6 +650,7 @@ jobs:
   py313-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -631,6 +669,7 @@ jobs:
   pypy3-test-instrumentation-starlette-oldest_ubuntu-latest:
     name: instrumentation-starlette-oldest pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -649,6 +688,7 @@ jobs:
   pypy3-test-instrumentation-starlette-latest_ubuntu-latest:
     name: instrumentation-starlette-latest pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -667,6 +707,7 @@ jobs:
   py38-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -685,6 +726,7 @@ jobs:
   py39-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -703,6 +745,7 @@ jobs:
   py310-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -721,6 +764,7 @@ jobs:
   py311-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -739,6 +783,7 @@ jobs:
   py312-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -757,6 +802,7 @@ jobs:
   py313-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -775,6 +821,7 @@ jobs:
   pypy3-test-instrumentation-jinja2_ubuntu-latest:
     name: instrumentation-jinja2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -793,6 +840,7 @@ jobs:
   py38-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -811,6 +859,7 @@ jobs:
   py39-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -829,6 +878,7 @@ jobs:
   py310-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -847,6 +897,7 @@ jobs:
   py311-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -865,6 +916,7 @@ jobs:
   py312-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -883,6 +935,7 @@ jobs:
   py313-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -901,6 +954,7 @@ jobs:
   pypy3-test-instrumentation-logging_ubuntu-latest:
     name: instrumentation-logging pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -919,6 +973,7 @@ jobs:
   py38-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -937,6 +992,7 @@ jobs:
   py39-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -955,6 +1011,7 @@ jobs:
   py310-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -973,6 +1030,7 @@ jobs:
   py311-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -991,6 +1049,7 @@ jobs:
   py312-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1009,6 +1068,7 @@ jobs:
   py313-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1027,6 +1087,7 @@ jobs:
   pypy3-test-exporter-richconsole_ubuntu-latest:
     name: exporter-richconsole pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1045,6 +1106,7 @@ jobs:
   py38-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1063,6 +1125,7 @@ jobs:
   py39-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1081,6 +1144,7 @@ jobs:
   py310-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1099,6 +1163,7 @@ jobs:
   py311-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1117,6 +1182,7 @@ jobs:
   py312-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1135,6 +1201,7 @@ jobs:
   py313-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1153,6 +1220,7 @@ jobs:
   pypy3-test-exporter-prometheus-remote-write_ubuntu-latest:
     name: exporter-prometheus-remote-write pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1171,6 +1239,7 @@ jobs:
   py38-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1189,6 +1258,7 @@ jobs:
   py38-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1207,6 +1277,7 @@ jobs:
   py39-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1225,6 +1296,7 @@ jobs:
   py39-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1243,6 +1315,7 @@ jobs:
   py310-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1261,6 +1334,7 @@ jobs:
   py310-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1279,6 +1353,7 @@ jobs:
   py311-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1297,6 +1372,7 @@ jobs:
   py311-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1315,6 +1391,7 @@ jobs:
   py312-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1333,6 +1410,7 @@ jobs:
   py312-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1351,6 +1429,7 @@ jobs:
   py313-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1369,6 +1448,7 @@ jobs:
   py313-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1387,6 +1467,7 @@ jobs:
   pypy3-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1405,6 +1486,7 @@ jobs:
   pypy3-test-instrumentation-mysql-1_ubuntu-latest:
     name: instrumentation-mysql-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1423,6 +1505,7 @@ jobs:
   py38-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1441,6 +1524,7 @@ jobs:
   py39-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1459,6 +1543,7 @@ jobs:
   py310-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1477,6 +1562,7 @@ jobs:
   py311-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1495,6 +1581,7 @@ jobs:
   py312-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1513,6 +1600,7 @@ jobs:
   py313-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1531,6 +1619,7 @@ jobs:
   pypy3-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1549,6 +1638,7 @@ jobs:
   py38-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1567,6 +1657,7 @@ jobs:
   py39-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1585,6 +1676,7 @@ jobs:
   py310-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1603,6 +1695,7 @@ jobs:
   py311-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1621,6 +1714,7 @@ jobs:
   py312-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1639,6 +1733,7 @@ jobs:
   py313-test-instrumentation-psycopg2_ubuntu-latest:
     name: instrumentation-psycopg2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1657,6 +1752,7 @@ jobs:
   py38-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1675,6 +1771,7 @@ jobs:
   py39-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1693,6 +1790,7 @@ jobs:
   py310-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1711,6 +1809,7 @@ jobs:
   py311-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1729,6 +1828,7 @@ jobs:
   py312-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1747,6 +1847,7 @@ jobs:
   py313-test-instrumentation-psycopg2-binary_ubuntu-latest:
     name: instrumentation-psycopg2-binary 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1765,6 +1866,7 @@ jobs:
   py38-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1783,6 +1885,7 @@ jobs:
   py39-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1801,6 +1904,7 @@ jobs:
   py310-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1819,6 +1923,7 @@ jobs:
   py311-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1837,6 +1942,7 @@ jobs:
   py312-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1855,6 +1961,7 @@ jobs:
   py313-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1873,6 +1980,7 @@ jobs:
   pypy3-test-instrumentation-psycopg_ubuntu-latest:
     name: instrumentation-psycopg pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1891,6 +1999,7 @@ jobs:
   py38-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1909,6 +2018,7 @@ jobs:
   py38-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1927,6 +2037,7 @@ jobs:
   py38-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1945,6 +2056,7 @@ jobs:
   py38-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1963,6 +2075,7 @@ jobs:
   py38-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1981,6 +2094,7 @@ jobs:
   py39-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1999,6 +2113,7 @@ jobs:
   py39-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2017,6 +2132,7 @@ jobs:
   py39-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2035,6 +2151,7 @@ jobs:
   py39-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2053,6 +2170,7 @@ jobs:
   py39-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2071,6 +2189,7 @@ jobs:
   py310-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2089,6 +2208,7 @@ jobs:
   py310-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2107,6 +2227,7 @@ jobs:
   py310-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2125,6 +2246,7 @@ jobs:
   py310-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2143,6 +2265,7 @@ jobs:
   py310-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2161,6 +2284,7 @@ jobs:
   py311-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2179,6 +2303,7 @@ jobs:
   py311-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2197,6 +2322,7 @@ jobs:
   py311-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2215,6 +2341,7 @@ jobs:
   py311-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2233,6 +2360,7 @@ jobs:
   py311-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2251,6 +2379,7 @@ jobs:
   py312-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2269,6 +2398,7 @@ jobs:
   py312-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2287,6 +2417,7 @@ jobs:
   py312-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2305,6 +2436,7 @@ jobs:
   py312-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2323,6 +2455,7 @@ jobs:
   py312-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2341,6 +2474,7 @@ jobs:
   py313-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2359,6 +2493,7 @@ jobs:
   py313-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2377,6 +2512,7 @@ jobs:
   py313-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2395,6 +2531,7 @@ jobs:
   py313-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2413,6 +2550,7 @@ jobs:
   py313-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2431,6 +2569,7 @@ jobs:
   pypy3-test-instrumentation-pymemcache-0_ubuntu-latest:
     name: instrumentation-pymemcache-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2449,6 +2588,7 @@ jobs:
   pypy3-test-instrumentation-pymemcache-1_ubuntu-latest:
     name: instrumentation-pymemcache-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2467,6 +2607,7 @@ jobs:
   pypy3-test-instrumentation-pymemcache-2_ubuntu-latest:
     name: instrumentation-pymemcache-2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2485,6 +2626,7 @@ jobs:
   pypy3-test-instrumentation-pymemcache-3_ubuntu-latest:
     name: instrumentation-pymemcache-3 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2503,6 +2645,7 @@ jobs:
   pypy3-test-instrumentation-pymemcache-4_ubuntu-latest:
     name: instrumentation-pymemcache-4 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2521,6 +2664,7 @@ jobs:
   py38-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2539,6 +2683,7 @@ jobs:
   py39-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2557,6 +2702,7 @@ jobs:
   py310-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2575,6 +2721,7 @@ jobs:
   py311-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2593,6 +2740,7 @@ jobs:
   py312-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2611,6 +2759,7 @@ jobs:
   py313-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2629,6 +2778,7 @@ jobs:
   pypy3-test-instrumentation-pymongo_ubuntu-latest:
     name: instrumentation-pymongo pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2647,6 +2797,7 @@ jobs:
   py38-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2665,6 +2816,7 @@ jobs:
   py39-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2683,6 +2835,7 @@ jobs:
   py310-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2701,6 +2854,7 @@ jobs:
   py311-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2719,6 +2873,7 @@ jobs:
   py312-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2737,6 +2892,7 @@ jobs:
   py313-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2755,6 +2911,7 @@ jobs:
   pypy3-test-instrumentation-pymysql_ubuntu-latest:
     name: instrumentation-pymysql pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2773,6 +2930,7 @@ jobs:
   py38-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2791,6 +2949,7 @@ jobs:
   py39-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2809,6 +2968,7 @@ jobs:
   py310-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2827,6 +2987,7 @@ jobs:
   py311-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2845,6 +3006,7 @@ jobs:
   py312-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2863,6 +3025,7 @@ jobs:
   py313-test-instrumentation-pymssql_ubuntu-latest:
     name: instrumentation-pymssql 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2881,6 +3044,7 @@ jobs:
   py38-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2899,6 +3063,7 @@ jobs:
   py39-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2917,6 +3082,7 @@ jobs:
   py310-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2935,6 +3101,7 @@ jobs:
   py311-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2953,6 +3120,7 @@ jobs:
   py312-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2971,6 +3139,7 @@ jobs:
   pypy3-test-instrumentation-pyramid_ubuntu-latest:
     name: instrumentation-pyramid pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2989,6 +3158,7 @@ jobs:
   py38-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3007,6 +3177,7 @@ jobs:
   py39-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3025,6 +3196,7 @@ jobs:
   py310-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3043,6 +3215,7 @@ jobs:
   py311-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3061,6 +3234,7 @@ jobs:
   py312-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3079,6 +3253,7 @@ jobs:
   py313-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3097,6 +3272,7 @@ jobs:
   pypy3-test-instrumentation-asgi_ubuntu-latest:
     name: instrumentation-asgi pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3115,6 +3291,7 @@ jobs:
   py38-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3133,6 +3310,7 @@ jobs:
   py39-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3151,6 +3329,7 @@ jobs:
   py310-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3169,6 +3348,7 @@ jobs:
   py311-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3187,6 +3367,7 @@ jobs:
   py312-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3205,6 +3386,7 @@ jobs:
   py313-test-instrumentation-asyncpg_ubuntu-latest:
     name: instrumentation-asyncpg 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3223,6 +3405,7 @@ jobs:
   py38-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3241,6 +3424,7 @@ jobs:
   py39-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3259,6 +3443,7 @@ jobs:
   py310-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3277,6 +3462,7 @@ jobs:
   py311-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3295,6 +3481,7 @@ jobs:
   py312-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3313,6 +3500,7 @@ jobs:
   py313-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3331,6 +3519,7 @@ jobs:
   pypy3-test-instrumentation-sqlite3_ubuntu-latest:
     name: instrumentation-sqlite3 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3349,6 +3538,7 @@ jobs:
   py38-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3367,6 +3557,7 @@ jobs:
   py39-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3385,6 +3576,7 @@ jobs:
   py310-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3403,6 +3595,7 @@ jobs:
   py311-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3421,6 +3614,7 @@ jobs:
   py312-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3439,6 +3633,7 @@ jobs:
   py313-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3457,6 +3652,7 @@ jobs:
   pypy3-test-instrumentation-wsgi_ubuntu-latest:
     name: instrumentation-wsgi pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3475,6 +3671,7 @@ jobs:
   py38-test-instrumentation-grpc-0_ubuntu-latest:
     name: instrumentation-grpc-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3493,6 +3690,7 @@ jobs:
   py38-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3511,6 +3709,7 @@ jobs:
   py39-test-instrumentation-grpc-0_ubuntu-latest:
     name: instrumentation-grpc-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3529,6 +3728,7 @@ jobs:
   py39-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3547,6 +3747,7 @@ jobs:
   py310-test-instrumentation-grpc-0_ubuntu-latest:
     name: instrumentation-grpc-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3565,6 +3766,7 @@ jobs:
   py310-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3583,6 +3785,7 @@ jobs:
   py311-test-instrumentation-grpc-0_ubuntu-latest:
     name: instrumentation-grpc-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3601,6 +3804,7 @@ jobs:
   py311-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3619,6 +3823,7 @@ jobs:
   py312-test-instrumentation-grpc-0_ubuntu-latest:
     name: instrumentation-grpc-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3637,6 +3842,7 @@ jobs:
   py312-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3655,6 +3861,7 @@ jobs:
   py313-test-instrumentation-grpc-1_ubuntu-latest:
     name: instrumentation-grpc-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3673,6 +3880,7 @@ jobs:
   py38-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3691,6 +3899,7 @@ jobs:
   py38-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3709,6 +3918,7 @@ jobs:
   py39-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3727,6 +3937,7 @@ jobs:
   py39-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3745,6 +3956,7 @@ jobs:
   py310-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3763,6 +3975,7 @@ jobs:
   py310-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3781,6 +3994,7 @@ jobs:
   py311-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3799,6 +4013,7 @@ jobs:
   py311-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3817,6 +4032,7 @@ jobs:
   py312-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3835,6 +4051,7 @@ jobs:
   py312-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3853,6 +4070,7 @@ jobs:
   py313-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3871,6 +4089,7 @@ jobs:
   py313-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3889,6 +4108,7 @@ jobs:
   pypy3-test-instrumentation-sqlalchemy-0_ubuntu-latest:
     name: instrumentation-sqlalchemy-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3907,6 +4127,7 @@ jobs:
   pypy3-test-instrumentation-sqlalchemy-1_ubuntu-latest:
     name: instrumentation-sqlalchemy-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3925,6 +4146,7 @@ jobs:
   pypy3-test-instrumentation-sqlalchemy-2_ubuntu-latest:
     name: instrumentation-sqlalchemy-2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3943,6 +4165,7 @@ jobs:
   py38-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3961,6 +4184,7 @@ jobs:
   py39-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3979,6 +4203,7 @@ jobs:
   py310-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -3997,6 +4222,7 @@ jobs:
   py311-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4015,6 +4241,7 @@ jobs:
   py312-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4033,6 +4260,7 @@ jobs:
   py313-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4051,6 +4279,7 @@ jobs:
   pypy3-test-instrumentation-redis_ubuntu-latest:
     name: instrumentation-redis pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4069,6 +4298,7 @@ jobs:
   py38-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4087,6 +4317,7 @@ jobs:
   py39-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4105,6 +4336,7 @@ jobs:
   py310-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4123,6 +4355,7 @@ jobs:
   py311-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4141,6 +4374,7 @@ jobs:
   py312-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4159,6 +4393,7 @@ jobs:
   py313-test-instrumentation-remoulade_ubuntu-latest:
     name: instrumentation-remoulade 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4177,6 +4412,7 @@ jobs:
   py38-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4195,6 +4431,7 @@ jobs:
   py39-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4213,6 +4450,7 @@ jobs:
   py310-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4231,6 +4469,7 @@ jobs:
   py311-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4249,6 +4488,7 @@ jobs:
   py312-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4267,6 +4507,7 @@ jobs:
   py313-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4285,6 +4526,7 @@ jobs:
   pypy3-test-instrumentation-celery_ubuntu-latest:
     name: instrumentation-celery pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4303,6 +4545,7 @@ jobs:
   py38-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4321,6 +4564,7 @@ jobs:
   py39-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4339,6 +4583,7 @@ jobs:
   py310-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4357,6 +4602,7 @@ jobs:
   py311-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4375,6 +4621,7 @@ jobs:
   py312-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4393,6 +4640,7 @@ jobs:
   py313-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4411,6 +4659,7 @@ jobs:
   pypy3-test-instrumentation-system-metrics_ubuntu-latest:
     name: instrumentation-system-metrics pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4429,6 +4678,7 @@ jobs:
   py38-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4447,6 +4697,7 @@ jobs:
   py39-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4465,6 +4716,7 @@ jobs:
   py310-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4483,6 +4735,7 @@ jobs:
   py311-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -4501,6 +4754,7 @@ jobs:
   py312-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/.github/workflows/test_2.yml
+++ b/.github/workflows/test_2.yml
@@ -9,6 +9,10 @@ on:
     - 'release/*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CORE_REPO_SHA: main
   CONTRIB_REPO_SHA: main
@@ -19,6 +23,7 @@ jobs:
   py313-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -37,6 +42,7 @@ jobs:
   pypy3-test-instrumentation-threading_ubuntu-latest:
     name: instrumentation-threading pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -55,6 +61,7 @@ jobs:
   py38-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -73,6 +80,7 @@ jobs:
   py39-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -91,6 +99,7 @@ jobs:
   py310-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -109,6 +118,7 @@ jobs:
   py311-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -127,6 +137,7 @@ jobs:
   py312-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -145,6 +156,7 @@ jobs:
   py313-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -163,6 +175,7 @@ jobs:
   pypy3-test-instrumentation-tornado_ubuntu-latest:
     name: instrumentation-tornado pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -181,6 +194,7 @@ jobs:
   py38-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -199,6 +213,7 @@ jobs:
   py39-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -217,6 +232,7 @@ jobs:
   py310-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -235,6 +251,7 @@ jobs:
   py311-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -253,6 +270,7 @@ jobs:
   py312-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -271,6 +289,7 @@ jobs:
   py313-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -289,6 +308,7 @@ jobs:
   pypy3-test-instrumentation-tortoiseorm_ubuntu-latest:
     name: instrumentation-tortoiseorm pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -307,6 +327,7 @@ jobs:
   py38-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -325,6 +346,7 @@ jobs:
   py38-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -343,6 +365,7 @@ jobs:
   py39-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -361,6 +384,7 @@ jobs:
   py39-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -379,6 +403,7 @@ jobs:
   py310-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -397,6 +422,7 @@ jobs:
   py310-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -415,6 +441,7 @@ jobs:
   py311-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -433,6 +460,7 @@ jobs:
   py311-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -451,6 +479,7 @@ jobs:
   py312-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -469,6 +498,7 @@ jobs:
   py312-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -487,6 +517,7 @@ jobs:
   py313-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -505,6 +536,7 @@ jobs:
   pypy3-test-instrumentation-httpx-0_ubuntu-latest:
     name: instrumentation-httpx-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -523,6 +555,7 @@ jobs:
   pypy3-test-instrumentation-httpx-1_ubuntu-latest:
     name: instrumentation-httpx-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -541,6 +574,7 @@ jobs:
   py38-test-util-http_ubuntu-latest:
     name: util-http 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -559,6 +593,7 @@ jobs:
   py39-test-util-http_ubuntu-latest:
     name: util-http 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -577,6 +612,7 @@ jobs:
   py310-test-util-http_ubuntu-latest:
     name: util-http 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -595,6 +631,7 @@ jobs:
   py311-test-util-http_ubuntu-latest:
     name: util-http 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -613,6 +650,7 @@ jobs:
   py312-test-util-http_ubuntu-latest:
     name: util-http 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -631,6 +669,7 @@ jobs:
   py313-test-util-http_ubuntu-latest:
     name: util-http 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -649,6 +688,7 @@ jobs:
   pypy3-test-util-http_ubuntu-latest:
     name: util-http pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -667,6 +707,7 @@ jobs:
   py38-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -685,6 +726,7 @@ jobs:
   py38-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -703,6 +745,7 @@ jobs:
   py39-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -721,6 +764,7 @@ jobs:
   py39-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -739,6 +783,7 @@ jobs:
   py310-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -757,6 +802,7 @@ jobs:
   py310-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -775,6 +821,7 @@ jobs:
   py311-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -793,6 +840,7 @@ jobs:
   py311-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -811,6 +859,7 @@ jobs:
   py312-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -829,6 +878,7 @@ jobs:
   py312-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -847,6 +897,7 @@ jobs:
   py313-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -865,6 +916,7 @@ jobs:
   py313-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -883,6 +935,7 @@ jobs:
   pypy3-test-propagator-aws-xray-0_ubuntu-latest:
     name: propagator-aws-xray-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -901,6 +954,7 @@ jobs:
   pypy3-test-propagator-aws-xray-1_ubuntu-latest:
     name: propagator-aws-xray-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -919,6 +973,7 @@ jobs:
   py38-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -937,6 +992,7 @@ jobs:
   py39-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -955,6 +1011,7 @@ jobs:
   py310-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -973,6 +1030,7 @@ jobs:
   py311-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -991,6 +1049,7 @@ jobs:
   py312-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1009,6 +1068,7 @@ jobs:
   py313-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1027,6 +1087,7 @@ jobs:
   pypy3-test-propagator-ot-trace_ubuntu-latest:
     name: propagator-ot-trace pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1045,6 +1106,7 @@ jobs:
   py38-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1063,6 +1125,7 @@ jobs:
   py38-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1081,6 +1144,7 @@ jobs:
   py39-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1099,6 +1163,7 @@ jobs:
   py39-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1117,6 +1182,7 @@ jobs:
   py310-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1135,6 +1201,7 @@ jobs:
   py310-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1153,6 +1220,7 @@ jobs:
   py311-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1171,6 +1239,7 @@ jobs:
   py311-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1189,6 +1258,7 @@ jobs:
   py312-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1207,6 +1277,7 @@ jobs:
   py312-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1225,6 +1296,7 @@ jobs:
   py313-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1243,6 +1315,7 @@ jobs:
   py313-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1261,6 +1334,7 @@ jobs:
   pypy3-test-instrumentation-sio-pika-0_ubuntu-latest:
     name: instrumentation-sio-pika-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1279,6 +1353,7 @@ jobs:
   pypy3-test-instrumentation-sio-pika-1_ubuntu-latest:
     name: instrumentation-sio-pika-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1297,6 +1372,7 @@ jobs:
   py38-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1315,6 +1391,7 @@ jobs:
   py38-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1333,6 +1410,7 @@ jobs:
   py38-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1351,6 +1429,7 @@ jobs:
   py38-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1369,6 +1448,7 @@ jobs:
   py39-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1387,6 +1467,7 @@ jobs:
   py39-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1405,6 +1486,7 @@ jobs:
   py39-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1423,6 +1505,7 @@ jobs:
   py39-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1441,6 +1524,7 @@ jobs:
   py310-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1459,6 +1543,7 @@ jobs:
   py310-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1477,6 +1562,7 @@ jobs:
   py310-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1495,6 +1581,7 @@ jobs:
   py310-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1513,6 +1600,7 @@ jobs:
   py311-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1531,6 +1619,7 @@ jobs:
   py311-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1549,6 +1638,7 @@ jobs:
   py311-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1567,6 +1657,7 @@ jobs:
   py311-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1585,6 +1676,7 @@ jobs:
   py312-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1603,6 +1695,7 @@ jobs:
   py312-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1621,6 +1714,7 @@ jobs:
   py312-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1639,6 +1733,7 @@ jobs:
   py312-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1657,6 +1752,7 @@ jobs:
   py313-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1675,6 +1771,7 @@ jobs:
   py313-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1693,6 +1790,7 @@ jobs:
   py313-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1711,6 +1809,7 @@ jobs:
   py313-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1729,6 +1828,7 @@ jobs:
   pypy3-test-instrumentation-aio-pika-0_ubuntu-latest:
     name: instrumentation-aio-pika-0 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1747,6 +1847,7 @@ jobs:
   pypy3-test-instrumentation-aio-pika-1_ubuntu-latest:
     name: instrumentation-aio-pika-1 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1765,6 +1866,7 @@ jobs:
   pypy3-test-instrumentation-aio-pika-2_ubuntu-latest:
     name: instrumentation-aio-pika-2 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1783,6 +1885,7 @@ jobs:
   pypy3-test-instrumentation-aio-pika-3_ubuntu-latest:
     name: instrumentation-aio-pika-3 pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1801,6 +1904,7 @@ jobs:
   py38-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1819,6 +1923,7 @@ jobs:
   py39-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1837,6 +1942,7 @@ jobs:
   py310-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1855,6 +1961,7 @@ jobs:
   py311-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1873,6 +1980,7 @@ jobs:
   py312-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1891,6 +1999,7 @@ jobs:
   py313-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1909,6 +2018,7 @@ jobs:
   pypy3-test-instrumentation-aiokafka_ubuntu-latest:
     name: instrumentation-aiokafka pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1927,6 +2037,7 @@ jobs:
   py38-test-instrumentation-kafka-python_ubuntu-latest:
     name: instrumentation-kafka-python 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1945,6 +2056,7 @@ jobs:
   py39-test-instrumentation-kafka-python_ubuntu-latest:
     name: instrumentation-kafka-python 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1963,6 +2075,7 @@ jobs:
   py310-test-instrumentation-kafka-python_ubuntu-latest:
     name: instrumentation-kafka-python 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1981,6 +2094,7 @@ jobs:
   py311-test-instrumentation-kafka-python_ubuntu-latest:
     name: instrumentation-kafka-python 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -1999,6 +2113,7 @@ jobs:
   py38-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2017,6 +2132,7 @@ jobs:
   py39-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2035,6 +2151,7 @@ jobs:
   py310-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2053,6 +2170,7 @@ jobs:
   py311-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2071,6 +2189,7 @@ jobs:
   py312-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2089,6 +2208,7 @@ jobs:
   py313-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2107,6 +2227,7 @@ jobs:
   pypy3-test-instrumentation-kafka-python_ubuntu-latest:
     name: instrumentation-kafka-python pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2125,6 +2246,7 @@ jobs:
   pypy3-test-instrumentation-kafka-pythonng_ubuntu-latest:
     name: instrumentation-kafka-pythonng pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2143,6 +2265,7 @@ jobs:
   py38-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2161,6 +2284,7 @@ jobs:
   py39-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2179,6 +2303,7 @@ jobs:
   py310-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2197,6 +2322,7 @@ jobs:
   py311-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2215,6 +2341,7 @@ jobs:
   py312-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2233,6 +2360,7 @@ jobs:
   py313-test-instrumentation-confluent-kafka_ubuntu-latest:
     name: instrumentation-confluent-kafka 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2251,6 +2379,7 @@ jobs:
   py38-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2269,6 +2398,7 @@ jobs:
   py39-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2287,6 +2417,7 @@ jobs:
   py310-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2305,6 +2436,7 @@ jobs:
   py311-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2323,6 +2455,7 @@ jobs:
   py312-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2341,6 +2474,7 @@ jobs:
   py313-test-instrumentation-asyncio_ubuntu-latest:
     name: instrumentation-asyncio 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2359,6 +2493,7 @@ jobs:
   py38-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2377,6 +2512,7 @@ jobs:
   py39-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2395,6 +2531,7 @@ jobs:
   py310-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2413,6 +2550,7 @@ jobs:
   py311-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2431,6 +2569,7 @@ jobs:
   py312-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2449,6 +2588,7 @@ jobs:
   py313-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2467,6 +2607,7 @@ jobs:
   pypy3-test-instrumentation-cassandra_ubuntu-latest:
     name: instrumentation-cassandra pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2485,6 +2626,7 @@ jobs:
   py38-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2503,6 +2645,7 @@ jobs:
   py39-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.9 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2521,6 +2664,7 @@ jobs:
   py310-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.10 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2539,6 +2683,7 @@ jobs:
   py311-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.11 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2557,6 +2702,7 @@ jobs:
   py312-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.12 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2575,6 +2721,7 @@ jobs:
   py313-test-processor-baggage_ubuntu-latest:
     name: processor-baggage 3.13 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
@@ -2593,6 +2740,7 @@ jobs:
   pypy3-test-processor-baggage_ubuntu-latest:
     name: processor-baggage pypy-3.8 Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Same as https://github.com/open-telemetry/opentelemetry-python/pull/4498. The same strategy is adopted in opentelemetry-collector repo.