### PR TITLE
autoinstrumentation: catch `ModuleNotFoundError` when the library is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `opentelemetry-instrumentation` Catch `ModuleNotFoundError` when the library is not installed
-  and prevent exception from bubbling up
+  and log as debug instead of exception
   ([#3423](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3423))
 
 ## Version 1.32.0/0.53b0 (2025-04-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+### Fixed
+
+- `opentelemetry-instrumentation` Catch `ModuleNotFoundError` when the library is not installed
+  and prevent exception from bubbling up
+  ([#3423](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3423))
+
 ## Version 1.32.0/0.53b0 (2025-04-10)
 
 ### Added

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import getLogger
+from logging import DEBUG, basicConfig, getLogger
 from os import environ
 
 from opentelemetry.instrumentation.dependencies import DependencyConflictError
@@ -25,6 +25,7 @@ from opentelemetry.instrumentation.environment_variables import (
 from opentelemetry.instrumentation.version import __version__
 from opentelemetry.util._importlib_metadata import entry_points
 
+basicConfig(level=DEBUG)
 _logger = getLogger(__name__)
 
 
@@ -80,6 +81,14 @@ def _load_instrumentors(distro):
                 "Skipping instrumentation %s: %s",
                 entry_point.name,
                 exc.conflict,
+            )
+            continue
+        except ModuleNotFoundError as exc:
+            # ModuleNotFoundError is raised when the library is not installed
+            # and the instrumentation is not required to be loaded.
+            # See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3421
+            _logger.debug(
+                "Skipping instrumentation %s: %s", entry_point.name, exc.msg
             )
             continue
         except ImportError:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import DEBUG, basicConfig, getLogger
+from logging import getLogger
 from os import environ
 
 from opentelemetry.instrumentation.dependencies import DependencyConflictError
@@ -25,7 +25,6 @@ from opentelemetry.instrumentation.environment_variables import (
 from opentelemetry.instrumentation.version import __version__
 from opentelemetry.util._importlib_metadata import entry_points
 
-basicConfig(level=DEBUG)
 _logger = getLogger(__name__)
 
 

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -326,11 +326,12 @@ class TestLoad(TestCase):
             ]
         )
 
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
     @patch(
         "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
     def test_load_instrumentors_import_error_does_not_stop_everything(
-        self, iter_mock
+        self, iter_mock, mock_logger
     ):
         ep_mock1 = Mock(name="instr1")
         ep_mock2 = Mock(name="instr2")
@@ -354,6 +355,12 @@ class TestLoad(TestCase):
             ]
         )
         self.assertEqual(distro_mock.load_instrumentor.call_count, 2)
+        mock_logger.exception.assert_any_call(
+            "Importing of %s failed, skipping it",
+            ep_mock1.name,
+        )
+
+        mock_logger.debug.assert_any_call("Instrumented %s", ep_mock2.name)
 
     @patch(
         "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
@@ -418,39 +425,6 @@ class TestLoad(TestCase):
             "Skipping instrumentation %s: %s",
             "instr1",
             "No module named 'fake_module'",
-        )
-
-        mock_logger.debug.assert_any_call("Instrumented %s", ep_mock2.name)
-
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch(
-        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
-    )
-    def test_load_instrumentors_import_error(self, iter_mock, mock_logger):
-        ep_mock1 = Mock()
-        ep_mock1.name = "instr1"
-
-        ep_mock2 = Mock()
-        ep_mock2.name = "instr2"
-
-        distro_mock = Mock()
-        distro_mock.load_instrumentor.side_effect = [ImportError, None]
-
-        iter_mock.side_effect = [(), (ep_mock1, ep_mock2), ()]
-
-        _load._load_instrumentors(distro_mock)
-
-        distro_mock.load_instrumentor.assert_has_calls(
-            [
-                call(ep_mock1, raise_exception_on_conflict=True),
-                call(ep_mock2, raise_exception_on_conflict=True),
-            ]
-        )
-        self.assertEqual(distro_mock.load_instrumentor.call_count, 2)
-
-        mock_logger.exception.assert_any_call(
-            "Importing of %s failed, skipping it",
-            ep_mock1.name,
         )
 
         mock_logger.debug.assert_any_call("Instrumented %s", ep_mock2.name)


### PR DESCRIPTION
# Description

Fixes #3421 
Altough ModuleNotFoundError is a subclass of ImportError, we are catching `ModuleNotFoundError` and logging a debug message instead of an exception to keep the behaviour before #3202