### PR TITLE
Fixes container detector for systemd & cgroupv1 with Docker

### DIFF
--- a/resource/opentelemetry-resource-detector-container/src/opentelemetry/resource/detector/container/__init__.py
+++ b/resource/opentelemetry-resource-detector-container/src/opentelemetry/resource/detector/container/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from logging import getLogger
 
 from opentelemetry.sdk.resources import Resource, ResourceDetector
@@ -31,9 +32,14 @@ def _get_container_id_v1():
         ) as container_info_file:
             for raw_line in container_info_file.readlines():
                 line = raw_line.strip()
-                if len(line) > _CONTAINER_ID_LENGTH:
-                    container_id = line[-_CONTAINER_ID_LENGTH:]
+
+                match = re.search(
+                    r"^.*/(?:.*[-:])?([0-9a-f]+)(?:\.|\s*$)", line
+                )
+                if match is not None:
+                    container_id = match.group(1)
                     break
+
     except FileNotFoundError as exception:
         logger.warning("Failed to get container id. Exception: %s", exception)
     return container_id

--- a/resource/opentelemetry-resource-detector-container/tests/test_container.py
+++ b/resource/opentelemetry-resource-detector-container/tests/test_container.py
@@ -52,6 +52,20 @@ class ContainerResourceDetectorTest(TestBase):
         )
 
     @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=f"""0::/system.slice/docker-{MockContainerResourceAttributes[ResourceAttributes.CONTAINER_ID]}.scope
+        """,
+    )
+    def test_container_id_detect_from_cgroup_file_with_suffix(
+        self, mock_cgroup_file
+    ):
+        actual = ContainerResourceDetector().detect()
+        self.assertDictEqual(
+            actual.attributes.copy(), MockContainerResourceAttributes
+        )
+
+    @patch(
         "opentelemetry.resource.detector.container._get_container_id_v1",
         return_value=None,
     )


### PR DESCRIPTION
# Description
Running the container detector on certain Docker setups returns the incorrect container.id.

For example: `08767a667f35c8505cbf40d14e931ef6db5b0210329cf193b15ba9d605.scope` where it should be `7be92808767a667f35c8505cbf40d14e931ef6db5b0210329cf193b15ba9d605`

I believe this is from some combination of Cgroups v1 and systemd cgroup driver. 

The output I have included in the test can be reproduced:
```
$ docker run --rm --cgroupns=host -it python:3 cat /proc/self/cgroup
0::/system.slice/docker-dcc3d0d5ddcfe3ce60dfe0978aa3598ee4a82f18531a276aeb4264923b16310b.scope
```

For the fix, I borrowed the regex which is used by opentelemetry-go uses for parsing the container ID from this file: https://github.com/open-telemetry/opentelemetry-go/blob/7639c93baffc820f9f19ab1f9d1c085b0b45e071/sdk/resource/container.go#L21

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Start up a container:
```
$ docker run --rm --cgroupns=host -v $(pwd):/code -it python:3 bash
root@f445652dca46:/# pip install opentelemetry-sdk
root@f445652dca46:/# cd /code/src/opentelemetry/resource/detector
root@f445652dca46:/code/src/opentelemetry/resource/detector# cat /proc/self/cgroup
0::/system.slice/docker-f445652dca462c6355cc7216a036942ae4e1dc9c2917f9e43d7003d7d23394dc.scope
```

Before change:
```
root@f445652dca46:/code/src/opentelemetry/resource/detector# python3
>>> import container
>>> container._get_container_id_v1()
'2dca462c6355cc7216a036942ae4e1dc9c2917f9e43d7003d7d23394dc.scope'
```

After change:
```
>>> import container
>>>
>>> container._get_container_id_v1()
'f445652dca462c6355cc7216a036942ae4e1dc9c2917f9e43d7003d7d23394dc'
```


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
