### PR TITLE
autoinstrumentation: don't print duplicated conflict log error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3423](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3423))
 - `opentelemetry-instrumentation-asyncio` Fix duplicate instrumentation
   ([#3383](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3383))
-
 - `opentelemetry-instrumentation-botocore` Add GenAI instrumentation for additional Bedrock models for InvokeModel API
   ([#3419](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3419))
+- `opentelemetry-instrumentation` don't print duplicated conflict log error message
+  ([#3432](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3432))
 
 ## Version 1.32.0/0.53b0 (2025-04-10)
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -111,8 +111,11 @@ class BaseInstrumentor(ABC):
         if not skip_dep_check:
             conflict = self._check_dependency_conflicts()
             if conflict:
+                # auto-instrumentation path: don't log conflict as error, instead
+                # let _load_instrumentors handle the exception
                 if raise_exception_on_conflict:
                     raise DependencyConflictError(conflict)
+                # manual instrumentation path: log the conflict as error
                 _LOG.error(conflict)
                 return None
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -111,9 +111,9 @@ class BaseInstrumentor(ABC):
         if not skip_dep_check:
             conflict = self._check_dependency_conflicts()
             if conflict:
-                _LOG.error(conflict)
                 if raise_exception_on_conflict:
                     raise DependencyConflictError(conflict)
+                _LOG.error(conflict)
                 return None
 
         # initialize semantic conventions opt-in if needed

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -82,9 +82,7 @@ class TestInstrumentor(TestCase):
         self, mock__check_dependency_conflicts, mock_logger
     ):
         instrumentor = self.Instrumentor()
-        conflict = DependencyConflict(
-            "missing", "missing"
-        )
+        conflict = DependencyConflict("missing", "missing")
         mock__check_dependency_conflicts.return_value = conflict
         self.assertIsNone(
             instrumentor.instrument(raise_exception_on_conflict=False)


### PR DESCRIPTION
# Description
When testing the new version in the otel-operator, I'm getting errors:
```
DependencyConflict: requested: "starlette >= 0.13, <0.15" but found: "starlette 0.46.2"
```
The same message is also logged as debug:
```
ERROR:opentelemetry.instrumentation.instrumentor:DependencyConflict: requested: "starlette >= 0.13, <0.15" but found: "starlette 0.46.2"
DEBUG:opentelemetry.instrumentation.auto_instrumentation._load:Skipping instrumentation starlette: DependencyConflict: requested: "starlette >= 0.13, <0.15" but found: "starlette 0.46.2"
```

MRE:
```python
# /// script
# requires-python = ">=3.13"
# dependencies = [
#     "opentelemetry-distro==0.53b1",
#     "opentelemetry-exporter-otlp-proto-http==1.32.0",
#     "opentelemetry-exporter-prometheus==0.53b1",
#     "opentelemetry-instrumentation==0.53b1",
#     "opentelemetry-instrumentation-aio-pika==0.53b1",
#     "opentelemetry-instrumentation-aiohttp-client==0.53b1",
#     "opentelemetry-instrumentation-aiohttp-server==0.53b1",
#     "opentelemetry-instrumentation-aiokafka==0.53b1",
#     "opentelemetry-instrumentation-aiopg==0.53b1",
#     "opentelemetry-instrumentation-asgi==0.53b1",
#     "opentelemetry-instrumentation-asyncio==0.53b1",
#     "opentelemetry-instrumentation-asyncpg==0.53b1",
#     "opentelemetry-instrumentation-aws-lambda==0.53b1",
#     "opentelemetry-instrumentation-boto==0.53b1",
#     "opentelemetry-instrumentation-boto3sqs==0.53b1",
#     "opentelemetry-instrumentation-botocore==0.53b1",
#     "opentelemetry-instrumentation-cassandra==0.53b1",
#     "opentelemetry-instrumentation-celery==0.53b1",
#     "opentelemetry-instrumentation-click==0.53b1",
#     "opentelemetry-instrumentation-confluent-kafka==0.53b1",
#     "opentelemetry-instrumentation-dbapi==0.53b1",
#     "opentelemetry-instrumentation-django==0.53b1",
#     "opentelemetry-instrumentation-elasticsearch==0.53b1",
#     "opentelemetry-instrumentation-falcon==0.53b1",
#     "opentelemetry-instrumentation-fastapi==0.53b1",
#     "opentelemetry-instrumentation-flask==0.53b1",
#     "opentelemetry-instrumentation-grpc==0.53b1",
#     "opentelemetry-instrumentation-httpx==0.53b1",
#     "opentelemetry-instrumentation-jinja2==0.53b1",
#     "opentelemetry-instrumentation-kafka-python==0.53b1",
#     "opentelemetry-instrumentation-logging==0.53b1",
#     "opentelemetry-instrumentation-mysql==0.53b1",
#     "opentelemetry-instrumentation-mysqlclient==0.53b1",
#     "opentelemetry-instrumentation-pika==0.53b1",
#     "opentelemetry-instrumentation-psycopg==0.53b1",
#     "opentelemetry-instrumentation-psycopg2==0.53b1",
#     "opentelemetry-instrumentation-pymemcache==0.53b1",
#     "opentelemetry-instrumentation-pymongo==0.53b1",
#     "opentelemetry-instrumentation-pymysql==0.53b1",
#     "opentelemetry-instrumentation-pyramid==0.53b1",
#     "opentelemetry-instrumentation-redis==0.53b1",
#     "opentelemetry-instrumentation-remoulade==0.53b1",
#     "opentelemetry-instrumentation-requests==0.53b1",
#     "opentelemetry-instrumentation-sqlalchemy==0.53b1",
#     "opentelemetry-instrumentation-sqlite3==0.53b1",
#     "opentelemetry-instrumentation-starlette==0.53b1",
#     "opentelemetry-instrumentation-system-metrics==0.53b1",
#     "opentelemetry-instrumentation-threading==0.53b1",
#     "opentelemetry-instrumentation-tornado==0.53b1",
#     "opentelemetry-instrumentation-tortoiseorm==0.53b1",
#     "opentelemetry-instrumentation-urllib==0.53b1",
#     "opentelemetry-instrumentation-urllib3==0.53b1",
#     "opentelemetry-instrumentation-wsgi==0.53b1",
#     "opentelemetry-propagator-aws-xray==1.0.2",
#     "opentelemetry-propagator-b3==1.30.0",
#     "opentelemetry-propagator-jaeger==1.30.0",
#     "opentelemetry-propagator-ot-trace==0.53b1",
#     "urllib3<2.3.0",
# ]
# ///


from opentelemetry.instrumentation.auto_instrumentation import initialize
from os import environ
#import logging
#logging.basicConfig(level=0)

environ["OTEL_LOGS_EXPORTER"] = "console"
environ["OTEL_TRACES_EXPORTER"] = "console"
environ["OTEL_METRICS_EXPORTER"] = "console"

initialize()
```

`uv run repro.py`
