### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
+++ b/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
@@ -68,7 +68,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 
 def _ns_to_time(nanoseconds):
-    ts = datetime.datetime.utcfromtimestamp(nanoseconds / 1e9)
+    ts = datetime.datetime.fromtimestamp(nanoseconds / 1e9, datetime.timezone.utc)
     return ts.strftime("%H:%M:%S.%f")
 
 

--- a/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
+++ b/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
@@ -68,7 +68,9 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 
 def _ns_to_time(nanoseconds):
-    ts = datetime.datetime.fromtimestamp(nanoseconds / 1e9, datetime.timezone.utc)
+    ts = datetime.datetime.fromtimestamp(
+        nanoseconds / 1e9, datetime.timezone.utc
+    )
     return ts.strftime("%H:%M:%S.%f")
 
 


### PR DESCRIPTION
# Description

This small PR resolves the deprecation warnings on `datetime` in Python3.12+. You can find them in the [CI logs](https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/14537809366/job/40789629860#step:5:39):
```python
  /home/runner/work/opentelemetry-python-contrib/opentelemetry-python-contrib/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py:71: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    ts = datetime.datetime.utcfromtimestamp(nanoseconds / 1e9)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

run tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
