### PR TITLE
Add opentelemetry-instrumentation as a dependency for click & asyncclick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3432](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3432))
 - `opentelemetry-instrumentation-grpc` Check for None result in gRPC
   ([#3380](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3381))
+- `opentelemetry-instrumentation-[asynclick/click]` Add missing opentelemetry-instrumentation dep
+  ([#3447](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3447))
 
 ## Version 1.32.0/0.53b0 (2025-04-10)
 

--- a/instrumentation/opentelemetry-instrumentation-asyncclick/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-asyncclick/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation == 0.54b0.dev",
   "opentelemetry-semantic-conventions == 0.54b0.dev",
   "wrapt ~= 1.0",
   "typing_extensions ~= 4.12",

--- a/instrumentation/opentelemetry-instrumentation-click/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-click/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api ~= 1.12",
+  "opentelemetry-instrumentation == 0.54b0.dev",
   "opentelemetry-semantic-conventions == 0.54b0.dev",
   "wrapt >= 1.0.0, < 2.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2903,6 +2903,7 @@ name = "opentelemetry-instrumentation-asyncclick"
 source = { editable = "instrumentation/opentelemetry-instrumentation-asyncclick" }
 dependencies = [
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
     { name = "wrapt" },
@@ -2918,6 +2919,7 @@ instruments = [
 requires-dist = [
     { name = "asyncclick", marker = "extra == 'instruments'", specifier = "~=8.0" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
+    { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "typing-extensions", specifier = "~=4.12" },
     { name = "wrapt", specifier = "~=1.0" },
@@ -3111,6 +3113,7 @@ name = "opentelemetry-instrumentation-click"
 source = { editable = "instrumentation/opentelemetry-instrumentation-click" }
 dependencies = [
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
@@ -3124,6 +3127,7 @@ instruments = [
 requires-dist = [
     { name = "click", marker = "extra == 'instruments'", specifier = ">=8.1.3,<9.0.0" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
+    { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "wrapt", specifier = ">=1.0.0,<2.0.0" },
 ]


### PR DESCRIPTION
# Description

Using click / asyncclick instrumentation in a project that does not already depend on opentelemetry-instrumentation raises a module not found error.

Added opentelemetry-instrumentation as a dependency for click & asyncclick.

Fixes #3441

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested locally with tox
- [ ] Tested in project that was previously raising the error

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
