### PR TITLE
requests: support explicit_bucket_boundaries_advisory in duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `opentelemetry-instrumentation-requests` Support explicit_bucket_boundaries_advisory in duration metrics
+  ([#3464](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3464))
+
 ### Fixed
 
 - `opentelemetry-instrumentation` Catch `ModuleNotFoundError` when the library is not installed

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -87,6 +87,7 @@ from requests.sessions import Session
 from requests.structures import CaseInsensitiveDict
 
 from opentelemetry.instrumentation._semconv import (
+    _DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS,
     _client_duration_attrs_new,
     _client_duration_attrs_old,
     _filter_semconv_duration_attrs,
@@ -445,6 +446,7 @@ class RequestsInstrumentor(BaseInstrumentor):
                 name=HTTP_CLIENT_REQUEST_DURATION,
                 unit="s",
                 description="Duration of HTTP client requests.",
+                explicit_bucket_boundaries_advisory=_DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS,
             )
         _instrument(
             tracer,

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -103,8 +103,8 @@ from requests.sessions import Session
 from requests.structures import CaseInsensitiveDict
 
 from opentelemetry.instrumentation._semconv import (
-    DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW,
-    DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD,
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
+    HTTP_DURATION_HISTOGRAM_BUCKETS_OLD,
     _client_duration_attrs_new,
     _client_duration_attrs_old,
     _filter_semconv_duration_attrs,
@@ -460,7 +460,7 @@ class RequestsInstrumentor(BaseInstrumentor):
                 unit="ms",
                 description="measures the duration of the outbound HTTP request",
                 explicit_bucket_boundaries_advisory=duration_histogram_boundaries
-                or DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD,
+                or HTTP_DURATION_HISTOGRAM_BUCKETS_OLD,
             )
         duration_histogram_new = None
         if _report_new(semconv_opt_in_mode):
@@ -469,7 +469,7 @@ class RequestsInstrumentor(BaseInstrumentor):
                 unit="s",
                 description="Duration of HTTP client requests.",
                 explicit_bucket_boundaries_advisory=duration_histogram_boundaries
-                or DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW,
+                or HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
             )
         _instrument(
             tracer,

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -67,7 +67,7 @@ you can provide a list of values when instrumenting:
     import requests
     from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
-    custom_boundaries = [0, 5, 10, 25, 50, 100, 250, 500, 1000]
+    custom_boundaries = [0.0, 5.0, 10.0, 25.0, 50.0, 100.0]
 
     RequestsInstrumentor().instrument(
         duration_histogram_boundaries=custom_boundaries

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -847,7 +847,7 @@ class TestRequestsIntergrationMetric(TestBase):
 
     def test_custom_histogram_boundaries(self):
         RequestsInstrumentor().uninstrument()
-        custom_boundaries = (0, 1, 2, 5, 10, 20, 50, 100)
+        custom_boundaries = (0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0)
         meter_provider, memory_reader = self.create_meter_provider()
         RequestsInstrumentor().instrument(
             meter_provider=meter_provider,
@@ -863,7 +863,7 @@ class TestRequestsIntergrationMetric(TestBase):
 
     def test_custom_histogram_boundaries_new_semconv(self):
         RequestsInstrumentor().uninstrument()
-        custom_boundaries = (0, 5, 10, 25, 50, 100, 250, 500, 1000)
+        custom_boundaries = (0.0, 5.0, 10.0, 25.0, 50.0, 100.0)
         meter_provider, memory_reader = self.create_meter_provider()
         RequestsInstrumentor().instrument(
             meter_provider=meter_provider,

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -23,8 +23,8 @@ from requests.models import Response
 import opentelemetry.instrumentation.requests
 from opentelemetry import trace
 from opentelemetry.instrumentation._semconv import (
-    DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW,
-    DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD,
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
+    HTTP_DURATION_HISTOGRAM_BUCKETS_OLD,
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
@@ -768,7 +768,7 @@ class TestRequestsIntergrationMetric(TestBase):
                     for data_point in metric.data.data_points:
                         self.assertEqual(
                             data_point.explicit_bounds,
-                            DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD,
+                            HTTP_DURATION_HISTOGRAM_BUCKETS_OLD,
                         )
                         self.assertDictEqual(
                             expected_attributes, dict(data_point.attributes)
@@ -798,7 +798,7 @@ class TestRequestsIntergrationMetric(TestBase):
                     for data_point in metric.data.data_points:
                         self.assertEqual(
                             data_point.explicit_bounds,
-                            DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW,
+                            HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                         )
                         self.assertDictEqual(
                             expected_attributes, dict(data_point.attributes)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -23,6 +23,8 @@ from requests.models import Response
 import opentelemetry.instrumentation.requests
 from opentelemetry import trace
 from opentelemetry.instrumentation._semconv import (
+    _DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS,
+    _DURATION_HISTOGRAM_OLD_EXPLICIT_BOUNDS,
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
@@ -762,6 +764,10 @@ class TestRequestsIntergrationMetric(TestBase):
                         "measures the duration of the outbound HTTP request",
                     )
                     for data_point in metric.data.data_points:
+                        self.assertEqual(
+                            data_point.explicit_bounds,
+                            _DURATION_HISTOGRAM_OLD_EXPLICIT_BOUNDS,
+                        )
                         self.assertDictEqual(
                             expected_attributes, dict(data_point.attributes)
                         )
@@ -788,6 +794,10 @@ class TestRequestsIntergrationMetric(TestBase):
                         metric.description, "Duration of HTTP client requests."
                     )
                     for data_point in metric.data.data_points:
+                        self.assertEqual(
+                            data_point.explicit_bounds,
+                            _DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS,
+                        )
                         self.assertDictEqual(
                             expected_attributes, dict(data_point.attributes)
                         )

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -47,6 +47,43 @@ from opentelemetry.semconv.attributes.user_agent_attributes import (
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
 
+# Values defined in milliseconds
+_DURATION_HISTOGRAM_OLD_EXPLICIT_BOUNDS = (
+    0.0,
+    5.0,
+    10.0,
+    25.0,
+    50.0,
+    75.0,
+    100.0,
+    250.0,
+    500.0,
+    750.0,
+    1000.0,
+    2500.0,
+    5000.0,
+    7500.0,
+    10000.0,
+)
+
+# Values defined in seconds
+_DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1,
+    2.5,
+    5,
+    7.5,
+    10,
+)
+
 # These lists represent attributes for metrics that are currently supported
 
 _client_duration_attrs_old = [

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -48,7 +48,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
 
 # Values defined in milliseconds
-_DURATION_HISTOGRAM_OLD_EXPLICIT_BOUNDS = (
+DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD = (
     0.0,
     5.0,
     10.0,
@@ -67,7 +67,7 @@ _DURATION_HISTOGRAM_OLD_EXPLICIT_BOUNDS = (
 )
 
 # Values defined in seconds
-_DURATION_HISTOGRAM_NEW_EXPLICIT_BOUNDS = (
+DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW = (
     0.005,
     0.01,
     0.025,

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -48,7 +48,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
 
 # Values defined in milliseconds
-DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD = (
+HTTP_DURATION_HISTOGRAM_BUCKETS_OLD = (
     0.0,
     5.0,
     10.0,
@@ -67,7 +67,7 @@ DURATION_HISTOGRAM_EXPLICIT_BOUNDS_OLD = (
 )
 
 # Values defined in seconds
-DURATION_HISTOGRAM_EXPLICIT_BOUNDS_NEW = (
+HTTP_DURATION_HISTOGRAM_BUCKETS_NEW = (
     0.005,
     0.01,
     0.025,


### PR DESCRIPTION
# Description

Refs https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3220
