### PR TITLE
Improve aiopg instrumentation examples

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
@@ -23,40 +23,53 @@ Usage
 
 .. code-block:: python
 
+    import asyncio
     import aiopg
     from opentelemetry.instrumentation.aiopg import AiopgInstrumentor
     # Call instrument() to wrap all database connections
     AiopgInstrumentor().instrument()
 
-    cnx = await aiopg.connect(database='Database')
-    cursor = await cnx.cursor()
-    await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
-    await cursor.execute("INSERT INTO test (testField) VALUES (123)")
-    cursor.close()
-    cnx.close()
+    dsn = 'user=user password=password host=127.0.0.1'
 
-    pool = await aiopg.create_pool(database='Database')
+    async def connect():
+        cnx = await aiopg.connect(dsn)
+        cursor = await cnx.cursor()
+        await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
+        await cursor.execute("INSERT INTO test (testField) VALUES (123)")
+        cursor.close()
+        cnx.close()
 
-    cnx = await pool.acquire()
-    cursor = await cnx.cursor()
-    await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
-    await cursor.execute("INSERT INTO test (testField) VALUES (123)")
-    cursor.close()
-    cnx.close()
+    async def create_pool():
+        pool = await aiopg.create_pool(dsn)
+        cnx = await pool.acquire()
+        cursor = await cnx.cursor()
+        await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
+        await cursor.execute("INSERT INTO test (testField) VALUES (123)")
+        cursor.close()
+        cnx.close()
+
+    asyncio.run(connect())
+    asyncio.run(create_pool())
 
 .. code-block:: python
 
+    import asyncio
     import aiopg
     from opentelemetry.instrumentation.aiopg import AiopgInstrumentor
 
+    dsn = 'user=user password=password host=127.0.0.1'
+
     # Alternatively, use instrument_connection for an individual connection
-    cnx = await aiopg.connect(database='Database')
-    instrumented_cnx = AiopgInstrumentor().instrument_connection(cnx)
-    cursor = await instrumented_cnx.cursor()
-    await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
-    await cursor.execute("INSERT INTO test (testField) VALUES (123)")
-    cursor.close()
-    instrumented_cnx.close()
+    async def go():
+        cnx = await aiopg.connect(dsn)
+        instrumented_cnx = AiopgInstrumentor().instrument_connection(cnx)
+        cursor = await instrumented_cnx.cursor()
+        await cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
+        await cursor.execute("INSERT INTO test (testField) VALUES (123)")
+        cursor.close()
+        instrumented_cnx.close()
+
+    asyncio.run(go())
 
 API
 ---


### PR DESCRIPTION
# Description

Some instrumentation examples inside `aiopg` don't run. This PR fixes the examples, so they run.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6. Install common dependencies:
```
pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
 ../opentelemetry-python/opentelemetry-semantic-conventions/ \
 ../opentelemetry-python/opentelemetry-api/ \
 ../opentelemetry-python/opentelemetry-sdk/ \
 ../opentelemetry-python/opentelemetry-proto/ \
 ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
```
7. Install `aiopg` specific requirements:
```
pip install -r instrumentation/opentelemetry-instrumentation-aiopg/test-requirements.txt
```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
