### PR TITLE
Improve mysqlclient instrumentation examples

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -26,12 +26,12 @@ Usage
     import MySQLdb
     from opentelemetry.instrumentation.mysqlclient import MySQLClientInstrumentor
 
-
     MySQLClientInstrumentor().instrument()
 
     cnx = MySQLdb.connect(database="MySQL_Database")
     cursor = cnx.cursor()
-    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
+    cursor.execute("INSERT INTO test (testField) VALUES (123)")
     cnx.commit()
     cursor.close()
     cnx.close()
@@ -52,7 +52,7 @@ the query with contextual information.
     cnx = MySQLdb.connect(database="MySQL_Database")
     cursor = cnx.cursor()
     cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
-    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cursor.execute("INSERT INTO test (testField) VALUES (123)")
     cnx.commit()
     cursor.close()
     cnx.close()
@@ -75,7 +75,7 @@ the query with contextual information.
     )
     cursor = instrumented_cnx.cursor()
     cursor.execute("CREATE TABLE IF NOT EXISTS test (testField INTEGER)")
-    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cursor.execute("INSERT INTO test (testField) VALUES (123)")
     instrumented_cnx.commit()
     cursor.close()
     instrumented_cnx.close()


### PR DESCRIPTION
# Description

Some instrumentation examples inside `mysqlclient` don't run. This PR fixes the examples, so they run.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6. Install common dependencies:
```
pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
 ../opentelemetry-python/opentelemetry-semantic-conventions/ \
 ../opentelemetry-python/opentelemetry-api/ \
 ../opentelemetry-python/opentelemetry-sdk/ \
 ../opentelemetry-python/opentelemetry-proto/ \
 ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
```
7. Install `mysqlclient` specific requirements:
```
pip install -r instrumentation/opentelemetry-instrumentation-mysqlclient/test-requirements.txt
```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
