### PR TITLE
Update botocore instrumentation to use semantic convention attribute for cloud region

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -109,6 +109,9 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.metrics import Instrument, Meter, get_meter
 from opentelemetry.propagators.aws.aws_xray_propagator import AwsXRayPropagator
+from opentelemetry.semconv._incubating.attributes.cloud_attributes import (
+    CLOUD_REGION,
+)
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import get_tracer
 from opentelemetry.trace.span import Span
@@ -276,8 +279,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
             SpanAttributes.RPC_SYSTEM: "aws-api",
             SpanAttributes.RPC_SERVICE: call_context.service_id,
             SpanAttributes.RPC_METHOD: call_context.operation,
-            # TODO: update when semantic conventions exist
-            "aws.region": call_context.region,
+            CLOUD_REGION: call_context.region,
             **get_server_attributes(call_context.endpoint_url),
         }
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -27,6 +27,9 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.propagators.aws.aws_xray_propagator import TRACE_HEADER_KEY
+from opentelemetry.semconv._incubating.attributes.cloud_attributes import (
+    CLOUD_REGION,
+)
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
@@ -61,7 +64,7 @@ class TestBotocoreInstrumentor(TestBase):
             SpanAttributes.RPC_SYSTEM: "aws-api",
             SpanAttributes.RPC_SERVICE: service,
             SpanAttributes.RPC_METHOD: operation,
-            "aws.region": self.region,
+            CLOUD_REGION: self.region,
             "retry_attempts": 0,
             SpanAttributes.HTTP_STATUS_CODE: 200,
             # Some services like IAM or STS have a global endpoint and exclude specified region.
@@ -527,7 +530,7 @@ class TestBotocoreInstrumentor(TestBase):
             attributes={
                 SpanAttributes.SERVER_ADDRESS: "iam.amazonaws.com",
                 SpanAttributes.SERVER_PORT: 443,
-                "aws.region": "aws-global",
+                CLOUD_REGION: "aws-global",
             },
         )
 


### PR DESCRIPTION
# Description


This change is a result of the conversation on semantic conventions and the correct use of the cloud region attribute (see https://github.com/open-telemetry/semantic-conventions/issues/2142 for details). This PR depends on the semantic conventions update to expand the definition of `cloud.region` attribute ([PR](https://github.com/open-telemetry/semantic-conventions/pull/2238)).

Changes made: 
- Update botocore instrumentation to use semantic convention attribute for cloud region
  - Region will no longer be captured as `aws.region` attribute.
- Update tests to reflect this change.


## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - This change removes `aws.region` from the span attributes in favour of `cloud.region` which may affect existing functionality.

# How Has This Been Tested?

- [x] Updated unit tests that assert the span attributes.
- [x] Smoke-tested using the bedrock-runtime examples provided alongside the instrumentation library. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No, but it does require semantic conventions change: https://github.com/open-telemetry/semantic-conventions/pull/2238.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
