### PR TITLE
opentelemetry-exporter-prometheus-remote-write: workaround build failure with Pypy 3.8

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.8.1
 certifi==2024.7.4
 charset-normalizer==3.3.2
 # We can drop this after bumping baseline to pypy-39
-cramjam==2.1.0; platform_python_implementation == "PyPy"
+cramjam==2.8.0; platform_python_implementation == "PyPy"
 cramjam==2.8.4; platform_python_implementation != "PyPy"
 Deprecated==1.2.14
 idna==3.7

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from platform import python_implementation
 from unittest.mock import patch
 
 import pytest
@@ -282,6 +283,10 @@ class TestValidation(unittest.TestCase):
             )
 
 
+@pytest.mark.skipif(
+    python_implementation() == "PyPy",
+    reason="Fails with pypy 3.8, bump cramjam when 3.9 is baseline",
+)
 # Ensures export is successful with valid export_records and config
 @patch("requests.post")
 def test_valid_export(mock_post, prom_rw, metric):


### PR DESCRIPTION
# Description

Find a version that has a wheel for PyPy 3.8 skipping the failing test while we bump the baseline to 3.9.

Fixes CI.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
