### PR TITLE
RELEASING: update after label automation in workflows

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,8 @@
       (otherwise the workflow will pick up the version from `main` and just remove the `.dev` suffix).
   * Review the two pull requests that it creates.
     (one is targeted to the release branch and one is targeted to `main`).
-    * The builds will fail for both the `main` and release pr because of validation rules. Follow the [release workflow](https://github.com/open-telemetry/opentelemetry-python/blob/main/RELEASING.md) for the core repo up until this same point. Change the SHAs of each PR to point at each other to get the `main` and release builds to pass.
+    * The builds will fail for the release PR because of validation rules. Follow the [release workflow](https://github.com/open-telemetry/opentelemetry-python/blob/main/RELEASING.md) for the core repo up until this same point.
+    * Close and reopen the PR so that the workflow will take into account the label automation we have in place
   * Merge the release PR.
   * Merge the PR to main (this can be done separately from [making the release](#making-the-release))
 


### PR DESCRIPTION
# Description

Updated RELEASING.md to match the current state of affairs. We have a race condition on kicking CI jobs vs adding labels to the PR that requires to close and reopen the PR. Not great but better than change the branches 2 times per repo.