### PR TITLE
refactor: don't use deprecated `SpanAttributes` in confluent  kafka

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from opentelemetry import context, propagate
 from opentelemetry.propagators import textmap
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
-    MESSAGING_DESTINATION_NAME,
     MESSAGING_DESTINATION_TEMPORARY,
     MESSAGING_KAFKA_DESTINATION_PARTITION,
     MESSAGING_MESSAGE_ID,
@@ -128,7 +127,7 @@ def _enrich_span(
         return
 
     span.set_attribute(MESSAGING_SYSTEM, "kafka")
-    span.set_attribute(MESSAGING_DESTINATION_NAME, topic)
+    span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
     if partition is not None:
         span.set_attribute(MESSAGING_KAFKA_DESTINATION_PARTITION, partition)
     span.set_attribute(

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
@@ -26,7 +26,6 @@ from opentelemetry.instrumentation.confluent_kafka.utils import (
     KafkaContextSetter,
 )
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
-    MESSAGING_DESTINATION_NAME,
     MESSAGING_KAFKA_DESTINATION_PARTITION,
     MESSAGING_MESSAGE_ID,
     MESSAGING_OPERATION,
@@ -132,7 +131,7 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_OPERATION: "process",
                     MESSAGING_KAFKA_DESTINATION_PARTITION: 0,
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-10",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-10",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-10.0.0",
                 },
@@ -144,7 +143,7 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_OPERATION: "process",
                     MESSAGING_KAFKA_DESTINATION_PARTITION: 2,
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-20",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-20",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-20.2.4",
                 },
@@ -156,7 +155,7 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_OPERATION: "process",
                     MESSAGING_KAFKA_DESTINATION_PARTITION: 1,
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-30",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-30",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-30.1.3",
                 },
@@ -199,7 +198,7 @@ class TestConfluentKafka(TestBase):
                 "attributes": {
                     MESSAGING_OPERATION: "process",
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-1",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-1",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -209,7 +208,7 @@ class TestConfluentKafka(TestBase):
                 "attributes": {
                     MESSAGING_OPERATION: "process",
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-2",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-2",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -219,7 +218,7 @@ class TestConfluentKafka(TestBase):
                 "attributes": {
                     MESSAGING_OPERATION: "process",
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-3",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-3",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -257,7 +256,7 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_OPERATION: "process",
                     MESSAGING_KAFKA_DESTINATION_PARTITION: 0,
                     MESSAGING_SYSTEM: "kafka",
-                    MESSAGING_DESTINATION_NAME: "topic-a",
+                    SpanAttributes.MESSAGING_DESTINATION: "topic-a",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-a.0.0",
                 },
@@ -293,7 +292,7 @@ class TestConfluentKafka(TestBase):
 
     def _assert_topic(self, span, expected_topic: str) -> None:
         self.assertEqual(
-            span.attributes[MESSAGING_DESTINATION_NAME],
+            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
             expected_topic,
         )
 

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
@@ -25,6 +25,13 @@ from opentelemetry.instrumentation.confluent_kafka.utils import (
     KafkaContextGetter,
     KafkaContextSetter,
 )
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_KAFKA_DESTINATION_PARTITION,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION,
+    MESSAGING_SYSTEM,
+)
 from opentelemetry.semconv.trace import (
     MessagingDestinationKindValues,
     SpanAttributes,
@@ -122,36 +129,36 @@ class TestConfluentKafka(TestBase):
             {
                 "name": "topic-10 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 0,
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-10",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_KAFKA_DESTINATION_PARTITION: 0,
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-10",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: "topic-10.0.0",
+                    MESSAGING_MESSAGE_ID: "topic-10.0.0",
                 },
             },
             {"name": "recv", "attributes": {}},
             {
                 "name": "topic-20 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 2,
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-20",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_KAFKA_DESTINATION_PARTITION: 2,
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-20",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: "topic-20.2.4",
+                    MESSAGING_MESSAGE_ID: "topic-20.2.4",
                 },
             },
             {"name": "recv", "attributes": {}},
             {
                 "name": "topic-30 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 1,
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-30",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_KAFKA_DESTINATION_PARTITION: 1,
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-30",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: "topic-30.1.3",
+                    MESSAGING_MESSAGE_ID: "topic-30.1.3",
                 },
             },
             {"name": "recv", "attributes": {}},
@@ -190,9 +197,9 @@ class TestConfluentKafka(TestBase):
             {
                 "name": "topic-1 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-1",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-1",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -200,9 +207,9 @@ class TestConfluentKafka(TestBase):
             {
                 "name": "topic-2 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-2",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-2",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -210,9 +217,9 @@ class TestConfluentKafka(TestBase):
             {
                 "name": "topic-3 process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-3",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-3",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                 },
             },
@@ -247,12 +254,12 @@ class TestConfluentKafka(TestBase):
             {
                 "name": "topic-a process",
                 "attributes": {
-                    SpanAttributes.MESSAGING_OPERATION: "process",
-                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 0,
-                    SpanAttributes.MESSAGING_SYSTEM: "kafka",
-                    SpanAttributes.MESSAGING_DESTINATION: "topic-a",
+                    MESSAGING_OPERATION: "process",
+                    MESSAGING_KAFKA_DESTINATION_PARTITION: 0,
+                    MESSAGING_SYSTEM: "kafka",
+                    MESSAGING_DESTINATION_NAME: "topic-a",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: "topic-a.0.0",
+                    MESSAGING_MESSAGE_ID: "topic-a.0.0",
                 },
             },
         ]
@@ -286,7 +293,7 @@ class TestConfluentKafka(TestBase):
 
     def _assert_topic(self, span, expected_topic: str) -> None:
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+            span.attributes[MESSAGING_DESTINATION_NAME],
             expected_topic,
         )
 


### PR DESCRIPTION
# Description

Stop using `SpanAttributes` in kafka.
Part of  #3475 

## Type of change

Please delete options that are not relevant.

# How Has This Been Tested?

Exist test

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
