### PR TITLE
requests: migrate from SpanAttributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -51,7 +51,19 @@ from opentelemetry.semconv.attributes.server_attributes import (
     SERVER_PORT,
 )
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_FLAVOR,
+    HTTP_HOST,
+    HTTP_METHOD,
+    HTTP_SCHEME,
+    HTTP_STATUS_CODE,
+    HTTP_URL,
+)
+from opentelemetry.semconv.schemas import Schemas
+from opentelemetry.semconv._incubating.attributes.net_attributes import (
+    NET_PEER_NAME,
+    NET_PEER_PORT,
+)
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import StatusCode
@@ -161,9 +173,9 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: self.URL,
-                SpanAttributes.HTTP_STATUS_CODE: 200,
+                HTTP_METHOD: "GET",
+                HTTP_URL: self.URL,
+                HTTP_STATUS_CODE: 200,
             },
         )
 
@@ -187,7 +199,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            SpanAttributes.SCHEMA_URL,
+            "https://opentelemetry.io/schemas/1.21.0",
         )
         self.assertEqual(
             span.attributes,
@@ -223,22 +235,22 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            SpanAttributes.SCHEMA_URL,
+            "https://opentelemetry.io/schemas/1.21.0",       
         )
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
+                HTTP_METHOD: "GET",
                 HTTP_REQUEST_METHOD: "GET",
-                SpanAttributes.HTTP_URL: url_with_port,
+                HTTP_URL: url_with_port,
                 URL_FULL: url_with_port,
-                SpanAttributes.HTTP_HOST: "mock",
+                HTTP_HOST: "mock",
                 SERVER_ADDRESS: "mock",
                 NETWORK_PEER_ADDRESS: "mock",
-                SpanAttributes.NET_PEER_PORT: 80,
-                SpanAttributes.HTTP_STATUS_CODE: 200,
+                NET_PEER_PORT: 80,
+                HTTP_STATUS_CODE: 200,
                 HTTP_RESPONSE_STATUS_CODE: 200,
-                SpanAttributes.HTTP_FLAVOR: "1.1",
+                HTTP_FLAVOR: "1.1",
                 NETWORK_PROTOCOL_VERSION: "1.1",
                 SERVER_PORT: 80,
                 NETWORK_PEER_PORT: 80,
@@ -262,9 +274,9 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "_OTHER",
-                SpanAttributes.HTTP_URL: self.URL,
-                SpanAttributes.HTTP_STATUS_CODE: 405,
+                HTTP_METHOD: "_OTHER",
+                HTTP_URL: self.URL,
+                HTTP_STATUS_CODE: 405,
             },
         )
 
@@ -366,7 +378,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         span = self.assert_span()
 
         self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 404
+            span.attributes.get(HTTP_STATUS_CODE), 404
         )
 
         self.assertIs(
@@ -407,7 +419,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         span = self.assert_span()
 
         self.assertEqual(
-            span.attributes.get(SpanAttributes.HTTP_STATUS_CODE), 404
+            span.attributes.get(HTTP_STATUS_CODE), 404
         )
         self.assertEqual(span.attributes.get(HTTP_RESPONSE_STATUS_CODE), 404)
         self.assertEqual(span.attributes.get(ERROR_TYPE), "404")
@@ -523,9 +535,9 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: self.URL,
-                SpanAttributes.HTTP_STATUS_CODE: 200,
+                HTTP_METHOD: "GET",
+                HTTP_URL: self.URL,
+                HTTP_STATUS_CODE: 200,
                 "http.response.body": "Hello!",
             },
         )
@@ -555,8 +567,8 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: self.URL,
+                HTTP_METHOD: "GET",
+                HTTP_URL: self.URL,
             },
         )
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
@@ -604,8 +616,8 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: self.URL,
+                HTTP_METHOD: "GET",
+                HTTP_URL: self.URL,
             },
         )
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
@@ -626,9 +638,9 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assertEqual(
             span.attributes,
             {
-                SpanAttributes.HTTP_METHOD: "GET",
-                SpanAttributes.HTTP_URL: self.URL,
-                SpanAttributes.HTTP_STATUS_CODE: 500,
+                HTTP_METHOD: "GET",
+                HTTP_URL: self.URL,
+                HTTP_STATUS_CODE: 500,
             },
         )
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
@@ -684,7 +696,7 @@ class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
         self.perform_request(new_url)
         span = self.assert_span()
 
-        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
+        self.assertEqual(span.attributes[HTTP_URL], self.URL)
 
     def test_if_headers_equals_none(self):
         result = requests.get(self.URL, headers=None, timeout=5)
@@ -745,13 +757,13 @@ class TestRequestsIntergrationMetric(TestBase):
         self.perform_request(self.URL)
 
         expected_attributes = {
-            SpanAttributes.HTTP_STATUS_CODE: 200,
-            SpanAttributes.HTTP_HOST: "examplehost",
-            SpanAttributes.NET_PEER_PORT: 8000,
-            SpanAttributes.NET_PEER_NAME: "examplehost",
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            HTTP_STATUS_CODE: 200,
+            HTTP_HOST: "examplehost",
+            NET_PEER_PORT: 8000,
+            NET_PEER_NAME: "examplehost",
+            HTTP_METHOD: "GET",
+            HTTP_FLAVOR: "1.1",
+            HTTP_SCHEME: "http",
         }
 
         for (
@@ -809,13 +821,13 @@ class TestRequestsIntergrationMetric(TestBase):
         self.perform_request(self.URL)
 
         expected_attributes_old = {
-            SpanAttributes.HTTP_STATUS_CODE: 200,
-            SpanAttributes.HTTP_HOST: "examplehost",
-            SpanAttributes.NET_PEER_PORT: 8000,
-            SpanAttributes.NET_PEER_NAME: "examplehost",
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            HTTP_STATUS_CODE: 200,
+            HTTP_HOST: "examplehost",
+            NET_PEER_PORT: 8000,
+            NET_PEER_NAME: "examplehost",
+            HTTP_METHOD: "GET",
+            HTTP_FLAVOR: "1.1",
+            HTTP_SCHEME: "http",
         }
 
         expected_attributes_new = {
@@ -879,13 +891,13 @@ class TestRequestsIntergrationMetric(TestBase):
 
     def test_basic_metric_non_recording_span(self):
         expected_attributes = {
-            SpanAttributes.HTTP_STATUS_CODE: 200,
-            SpanAttributes.HTTP_HOST: "examplehost",
-            SpanAttributes.NET_PEER_PORT: 8000,
-            SpanAttributes.NET_PEER_NAME: "examplehost",
-            SpanAttributes.HTTP_METHOD: "GET",
-            SpanAttributes.HTTP_FLAVOR: "1.1",
-            SpanAttributes.HTTP_SCHEME: "http",
+            HTTP_STATUS_CODE: 200,
+            HTTP_HOST: "examplehost",
+            NET_PEER_PORT: 8000,
+            NET_PEER_NAME: "examplehost",
+            HTTP_METHOD: "GET",
+            HTTP_FLAVOR: "1.1",
+            HTTP_SCHEME: "http",
         }
 
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -35,6 +35,18 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.sdk import resources
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_FLAVOR,
+    HTTP_HOST,
+    HTTP_METHOD,
+    HTTP_SCHEME,
+    HTTP_STATUS_CODE,
+    HTTP_URL,
+)
+from opentelemetry.semconv._incubating.attributes.net_attributes import (
+    NET_PEER_NAME,
+    NET_PEER_PORT,
+)
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.attributes.http_attributes import (
     HTTP_REQUEST_METHOD,
@@ -51,18 +63,6 @@ from opentelemetry.semconv.attributes.server_attributes import (
     SERVER_PORT,
 )
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
-from opentelemetry.semconv._incubating.attributes.http_attributes import (
-    HTTP_FLAVOR,
-    HTTP_HOST,
-    HTTP_METHOD,
-    HTTP_SCHEME,
-    HTTP_STATUS_CODE,
-    HTTP_URL,
-)
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
-)
 from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import StatusCode

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -51,6 +51,7 @@ from opentelemetry.semconv.attributes.server_attributes import (
     SERVER_PORT,
 )
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
+from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_FLAVOR,
     HTTP_HOST,
@@ -59,7 +60,6 @@ from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_STATUS_CODE,
     HTTP_URL,
 )
-from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
@@ -167,7 +167,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            "https://opentelemetry.io/schemas/1.11.0",
+            SpanAttributes.SCHEMA_URL,
         )
 
         self.assertEqual(
@@ -199,7 +199,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            "https://opentelemetry.io/schemas/1.21.0",
+            SpanAttributes.SCHEMA_URL,
         )
         self.assertEqual(
             span.attributes,

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -51,7 +51,6 @@ from opentelemetry.semconv.attributes.server_attributes import (
     SERVER_PORT,
 )
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_FLAVOR,
     HTTP_HOST,
@@ -167,7 +166,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            SpanAttributes.SCHEMA_URL,
+            "https://opentelemetry.io/schemas/1.11.0",
         )
 
         self.assertEqual(
@@ -199,7 +198,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            SpanAttributes.SCHEMA_URL,
+            "https://opentelemetry.io/schemas/1.21.0",
         )
         self.assertEqual(
             span.attributes,
@@ -235,7 +234,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assertEqual(
             span.instrumentation_scope.schema_url,
-            "https://opentelemetry.io/schemas/1.21.0",       
+            "https://opentelemetry.io/schemas/1.21.0",
         )
         self.assertEqual(
             span.attributes,


### PR DESCRIPTION
# Description


Replaces usage of `SpanAttributes` with `opentelemetry.semconv.attributes.http_attributes` and `opentelemetry.semconv._incubating.attributes` .

Refs #3475

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated