### PR TITLE
refactor(richconsole): replaces SpanAttributes by semconv attributes

### DIFF
--- a/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
+++ b/exporter/opentelemetry-exporter-richconsole/src/opentelemetry/exporter/richconsole/__init__.py
@@ -64,7 +64,9 @@ from rich.tree import Tree
 import opentelemetry.trace
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.db_attributes import (
+    DB_STATEMENT,
+)
 
 
 def _ns_to_time(nanoseconds):
@@ -120,7 +122,7 @@ def _child_add_optional_attributes(child: Tree, span: ReadableSpan):
             label=Text.from_markup("[bold cyan]Attributes :[/bold cyan] ")
         )
         for attribute in span.attributes:
-            if attribute == SpanAttributes.DB_STATEMENT:
+            if attribute == DB_STATEMENT:
                 attributes.add(
                     Text.from_markup(f"[bold cyan]{attribute} :[/bold cyan] ")
                 )


### PR DESCRIPTION
# Description

Replaces usage of SpanAttributes with `opentelemetry.semconv._incubating.attributes` .

Refs: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3475

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
