### PR TITLE
refactor(elasticsearch) Replace SpanAttributes by semconv attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/src/opentelemetry/instrumentation/elasticsearch/__init__.py
@@ -106,7 +106,10 @@ from opentelemetry.instrumentation.elasticsearch.package import _instruments
 from opentelemetry.instrumentation.elasticsearch.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.db_attributes import (
+    DB_STATEMENT,
+    DB_SYSTEM,
+)
 from opentelemetry.trace import SpanKind, Status, StatusCode, get_tracer
 
 from .utils import sanitize_body
@@ -288,7 +291,7 @@ def _wrap_perform_request(
 
             if span.is_recording():
                 attributes = {
-                    SpanAttributes.DB_SYSTEM: "elasticsearch",
+                    DB_SYSTEM: "elasticsearch",
                 }
                 if url:
                     attributes["elasticsearch.url"] = url
@@ -297,9 +300,7 @@ def _wrap_perform_request(
                 if body:
                     # Don't set db.statement for bulk requests, as it can be very large
                     if isinstance(body, dict):
-                        attributes[SpanAttributes.DB_STATEMENT] = (
-                            sanitize_body(body)
-                        )
+                        attributes[DB_STATEMENT] = sanitize_body(body)
                 if params:
                     attributes["elasticsearch.params"] = str(params)
                 if doc_id:


### PR DESCRIPTION
# Description

Replaces usage of SpanAttributes with `opentelemetry.semconv._incubating.attributes` .

Refs: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3475

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
