### PR TITLE
Refactor: replace use of SpanAttributes in test-instrumentation-aiohttp-server

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
@@ -24,7 +24,11 @@ from opentelemetry.instrumentation.aiohttp_server import (
     AioHttpServerInstrumentor,
 )
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_METHOD,
+    HTTP_STATUS_CODE,
+    HTTP_URL,
+)
 from opentelemetry.test.globals_test import reset_trace_globals
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.util._importlib_metadata import entry_points
@@ -127,15 +131,11 @@ async def test_status_code_instrumentation(
 
     [span] = memory_exporter.get_finished_spans()
 
-    assert expected_method.value == span.attributes[SpanAttributes.HTTP_METHOD]
-    assert (
-        expected_status_code
-        == span.attributes[SpanAttributes.HTTP_STATUS_CODE]
-    )
+    assert expected_method.value == span.attributes[HTTP_METHOD]
+    assert expected_status_code == span.attributes[HTTP_STATUS_CODE]
 
     assert (
-        f"http://{server.host}:{server.port}{url}"
-        == span.attributes[SpanAttributes.HTTP_URL]
+        f"http://{server.host}:{server.port}{url}" == span.attributes[HTTP_URL]
     )
 
 


### PR DESCRIPTION
# Description

Replaces usage of SpanAttributes with `opentelemetry.semconv._incubating.attributes` in `instrumentation/opentelemetry-instrumentation-aiohttp-server`

Refs: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3475



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
