### PR TITLE
starlette/fastapi: fix error on host-based routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3679](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3679))
 - `opentelemetry-instrumentation`: Avoid calls to `context.detach` with `None` token.
   ([#3673](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3673))
-- `opentelemetry-instrumentation-starlette`/`opentelemetry-instrumentation-fastapi`: Fixes a crash when host-based routing is used ([#3507](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3507/))
+- `opentelemetry-instrumentation-starlette`/`opentelemetry-instrumentation-fastapi`: Fixes a crash when host-based routing is used
+  ([#3507](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3507))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3679](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3679))
 - `opentelemetry-instrumentation`: Avoid calls to `context.detach` with `None` token.
   ([#3673](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3673))
+- `opentelemetry-instrumentation-starlette`/`opentelemetry-instrumentation-fastapi`: Fixes a crash when host-based routing is used ([#3507](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3507/))
 
 ### Added
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -457,7 +457,11 @@ def _get_route_details(scope):
     for starlette_route in app.routes:
         match, _ = starlette_route.matches(scope)
         if match == Match.FULL:
-            route = starlette_route.path
+            try:
+                route = starlette_route.path
+            except AttributeError:
+                # routes added via host routing won't have a path attribute
+                route = scope.get("path")
             break
         if match == Match.PARTIAL:
             route = starlette_route.path

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -230,6 +230,7 @@ class TestBaseFastAPI(TestBase):
             raise UnhandledException("This is an unhandled exception")
 
         app.mount("/sub", app=sub_app)
+        app.host("testserver2", sub_app)
 
         return app
 
@@ -305,6 +306,26 @@ class TestBaseManualFastAPI(TestBaseFastAPI):
             "https://testserver:443/sub/home",
             span.attributes[HTTP_URL],
         )
+
+    def test_host_fastapi_call(self):
+        client = TestClient(self._app, base_url="https://testserver2")
+        client.get("/")
+        spans = self.memory_exporter.get_finished_spans()
+
+        spans_with_http_attributes = [
+            span
+            for span in spans
+            if (HTTP_URL in span.attributes or HTTP_TARGET in span.attributes)
+        ]
+
+        self.assertEqual(1, len(spans_with_http_attributes))
+
+        for span in spans_with_http_attributes:
+            self.assertEqual("/", span.attributes[HTTP_TARGET])
+            self.assertEqual(
+                "https://testserver2:443/",
+                span.attributes[HTTP_URL],
+            )
 
 
 class TestBaseAutoFastAPI(TestBaseFastAPI):

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -354,7 +354,11 @@ def _get_route_details(scope: dict[str, Any]) -> str | None:
     for starlette_route in app.routes:
         match, _ = starlette_route.matches(scope)
         if match == Match.FULL:
-            route = starlette_route.path
+            try:
+                route = starlette_route.path
+            except AttributeError:
+                # routes added via host routing won't have a path attribute
+                route = scope.get("path")
             break
         if match == Match.PARTIAL:
             route = starlette_route.path

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 from starlette import applications
 from starlette.responses import PlainTextResponse
-from starlette.routing import Mount, Route
+from starlette.routing import Host, Mount, Route
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocket
 
@@ -137,6 +137,25 @@ class TestStarletteManualInstrumentation(TestBase):
             self.assertEqual("/sub/home", span.attributes[HTTP_TARGET])
             self.assertEqual(
                 "http://testserver/sub/home",
+                span.attributes[HTTP_URL],
+            )
+
+    def test_host_starlette_call(self):
+        client = TestClient(self._app, base_url="http://testserver2")
+        client.get("/home")
+        spans = self.memory_exporter.get_finished_spans()
+
+        spans_with_http_attributes = [
+            span
+            for span in spans
+            if (HTTP_URL in span.attributes or HTTP_TARGET in span.attributes)
+        ]
+
+        for span in spans_with_http_attributes:
+            print(span.name, span.attributes)
+            self.assertEqual("/home", span.attributes[HTTP_TARGET])
+            self.assertEqual(
+                "http://testserver2/home",
                 span.attributes[HTTP_URL],
             )
 
@@ -294,6 +313,7 @@ class TestStarletteManualInstrumentation(TestBase):
                 Route("/user/{username}", home),
                 Route("/healthzz", health),
                 Mount("/sub", app=sub_app),
+                Host("testserver2", sub_app),
             ],
         )
 

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -152,7 +152,6 @@ class TestStarletteManualInstrumentation(TestBase):
         ]
 
         for span in spans_with_http_attributes:
-            print(span.name, span.attributes)
             self.assertEqual("/home", span.attributes[HTTP_TARGET])
             self.assertEqual(
                 "http://testserver2/home",


### PR DESCRIPTION
# Description

Handle case where the Starlette/FastAPI app uses a hosted-based routing. In this case, there is no `path` attribute to read from the routing class. Therefore, fallback to the path present in `scope`. The fix is inspired from what Sentry did to fix a similar bug: https://github.com/getsentry/sentry-python/blob/312f85739af27bb9665f61fedd9a589178a67000/sentry_sdk/integrations/starlette.py#L696-L700

Fixes #3506

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added basic unit tests to assess the instrument not longer crashes when a host-based route is called.

> [!NOTE]
> I've not added assertions regarding the collected spans/traces, wasn't really sure where to start. But happy to improve that with some guidance :) 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- ~[ ] Documentation has been updated~ (not relevant)
