### PR TITLE
Redact specific url query string values and url credentials in instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `opentelemetry-instrumentation-aiohttp-client` Add support for HTTP metrics
   ([#3517](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3517))
+- `opentelemetry-util-http` Added support for redacting specific url query string values and url credentials in instrumentations
+  ([#3508](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3508))
 
 ### Deprecated
 

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -135,7 +135,7 @@ from opentelemetry.semconv.metrics.http_metrics import (
 )
 from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.util.http import remove_url_credentials, sanitize_method
+from opentelemetry.util.http import redact_url, sanitize_method
 
 _UrlFilterT = typing.Optional[typing.Callable[[yarl.URL], str]]
 _RequestHookT = typing.Optional[
@@ -311,9 +311,9 @@ def create_trace_config(
         method = params.method
         request_span_name = _get_span_name(method)
         request_url = (
-            remove_url_credentials(trace_config_ctx.url_filter(params.url))
+            redact_url(trace_config_ctx.url_filter(params.url))
             if callable(trace_config_ctx.url_filter)
-            else remove_url_credentials(str(params.url))
+            else redact_url(str(params.url))
         )
 
         span_attributes = {}

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -762,16 +762,16 @@ class TestAioHttpIntegration(TestBase):
         )
         self.memory_exporter.clear()
 
-    def test_credential_removal(self):
+    def test_remove_sensitive_params(self):
         trace_configs = [aiohttp_client.create_trace_config()]
 
-        app = HttpServerMock("test_credential_removal")
+        app = HttpServerMock("test_remove_sensitive_params")
 
         @app.route("/status/200")
         def index():
             return "hello"
 
-        url = "http://username:password@localhost:5000/status/200"
+        url = "http://username:password@localhost:5000/status/200?Signature=secret"
 
         with app.run("localhost", 5000):
             with self.subTest(url=url):
@@ -793,7 +793,7 @@ class TestAioHttpIntegration(TestBase):
                     (StatusCode.UNSET, None),
                     {
                         HTTP_METHOD: "GET",
-                        HTTP_URL: ("http://localhost:5000/status/200"),
+                        HTTP_URL: ("http://REDACTED:REDACTED@localhost:5000/status/200?Signature=REDACTED"),
                         HTTP_STATUS_CODE: int(HTTPStatus.OK),
                     },
                 )

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
@@ -72,7 +72,7 @@ from opentelemetry.semconv._incubating.attributes.net_attributes import (
 )
 from opentelemetry.semconv.metrics import MetricInstruments
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.util.http import get_excluded_urls, remove_url_credentials
+from opentelemetry.util.http import get_excluded_urls, redact_url
 
 _duration_attrs = [
     HTTP_METHOD,
@@ -148,6 +148,17 @@ def collect_request_attributes(request: web.Request) -> Dict:
         request.url.port,
         str(request.url),
     )
+
+    user_info = request.headers.get("Authorization")
+    if user_info and http_url and "@" not in http_url:
+        # If there are credentials in Authorization header but not in URL
+        # Add dummy credentials that will be redacted
+        parsed = urllib.parse.urlparse(http_url)
+        netloc_with_auth = f"username:password@{parsed.netloc}"
+        http_url = urllib.parse.urlunparse(
+            (parsed.scheme, netloc_with_auth, parsed.path, parsed.params, parsed.query, parsed.fragment)
+        )
+        
     query_string = request.query_string
     if query_string and http_url:
         if isinstance(query_string, bytes):
@@ -161,7 +172,7 @@ def collect_request_attributes(request: web.Request) -> Dict:
         HTTP_ROUTE: _get_view_func(request),
         HTTP_FLAVOR: f"{request.version.major}.{request.version.minor}",
         HTTP_TARGET: request.path,
-        HTTP_URL: remove_url_credentials(http_url),
+        HTTP_URL: redact_url(http_url),
     }
 
     http_method = request.method

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
@@ -152,3 +152,41 @@ async def test_suppress_instrumentation(
     await client.get("/test-path")
 
     assert len(memory_exporter.get_finished_spans()) == 0
+
+@pytest.mark.asyncio
+async def test_remove_sensitive_params(tracer, aiohttp_server):
+    """Test that sensitive information in URLs is properly redacted."""
+    _, memory_exporter = tracer
+    
+    # Set up instrumentation
+    AioHttpServerInstrumentor().instrument()
+    
+    # Create app with test route
+    app = aiohttp.web.Application()
+    async def handler(request):
+        return aiohttp.web.Response(text="hello")
+    
+    app.router.add_get('/status/200', handler)
+    
+    # Start the server
+    server = await aiohttp_server(app)
+    
+    # Make request with sensitive data in URL
+    url = f"http://username:password@{server.host}:{server.port}/status/200?Signature=secret"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            assert response.status == 200
+            assert await response.text() == "hello"
+    
+    # Verify redaction in span attributes
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    
+    span = spans[0]
+    assert span.attributes[HTTP_METHOD] == "GET"
+    assert span.attributes[HTTP_STATUS_CODE] == 200
+    assert span.attributes[HTTP_URL] == f"http://REDACTED:REDACTED@{server.host}:{server.port}/status/200?Signature=REDACTED"
+    
+    # Clean up
+    AioHttpServerInstrumentor().uninstrument()
+    memory_exporter.clear()

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -259,7 +259,7 @@ from opentelemetry.util.http import (
     get_custom_headers,
     normalise_request_header_name,
     normalise_response_header_name,
-    remove_url_credentials,
+    redact_url,
     sanitize_method,
 )
 
@@ -356,7 +356,7 @@ def collect_request_attributes(
         if _report_old(sem_conv_opt_in_mode):
             _set_http_url(
                 result,
-                remove_url_credentials(http_url),
+                redact_url(http_url),
                 _StabilityMode.DEFAULT,
             )
     http_method = scope.get("method", "")

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -1809,12 +1809,13 @@ class TestAsgiAttributes(unittest.TestCase):
         otel_asgi.set_status_code(self.span, "Invalid Status Code")
         self.assertEqual(self.span.set_status.call_count, 1)
 
-    def test_credential_removal(self):
+    def test_remove_sensitive_params(self):
         self.scope["server"] = ("username:password@mock", 80)
         self.scope["path"] = "/status/200"
+        self.scope["query_string"] = b"X-Goog-Signature=1234567890"
         attrs = otel_asgi.collect_request_attributes(self.scope)
         self.assertEqual(
-            attrs[SpanAttributes.HTTP_URL], "http://mock/status/200"
+            attrs[SpanAttributes.HTTP_URL], "http://REDACTED:REDACTED@mock/status/200?X-Goog-Signature=REDACTED"
         )
 
     def test_collect_target_attribute_missing(self):

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -244,7 +244,7 @@ from opentelemetry.semconv.attributes.network_attributes import (
 from opentelemetry.trace import SpanKind, Tracer, TracerProvider, get_tracer
 from opentelemetry.trace.span import Span
 from opentelemetry.trace.status import StatusCode
-from opentelemetry.util.http import remove_url_credentials, sanitize_method
+from opentelemetry.util.http import redact_url, sanitize_method
 
 _logger = logging.getLogger(__name__)
 
@@ -298,7 +298,7 @@ def _extract_parameters(
         # In httpx >= 0.20.0, handle_request receives a Request object
         request: httpx.Request = args[0]
         method = request.method.encode()
-        url = httpx.URL(remove_url_credentials(str(request.url)))
+        url = httpx.URL(redact_url(str(request.url)))
         headers = request.headers
         stream = request.stream
         extensions = request.extensions

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -1127,12 +1127,12 @@ class TestSyncIntegration(BaseTestCases.BaseManualTest):
             return self.client.request(method, url, headers=headers)
         return client.request(method, url, headers=headers)
 
-    def test_credential_removal(self):
-        new_url = "http://username:password@mock/status/200"
+    def test_remove_sensitive_params(self):
+        new_url = "http://username:password@mock/status/200?sig=secret"
         self.perform_request(new_url)
         span = self.assert_span()
 
-        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
+        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], "http://REDACTED:REDACTED@mock/status/200?sig=REDACTED")
 
 
 class TestAsyncIntegration(BaseTestCases.BaseManualTest):
@@ -1196,12 +1196,12 @@ class TestAsyncIntegration(BaseTestCases.BaseManualTest):
         )
         self.assert_span(num_spans=2)
 
-    def test_credential_removal(self):
-        new_url = "http://username:password@mock/status/200"
+    def test_remove_sensitive_params(self):
+        new_url = "http://username:password@mock/status/200?Signature=secret"
         self.perform_request(new_url)
         span = self.assert_span()
 
-        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
+        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], "http://REDACTED:REDACTED@mock/status/200?Signature=REDACTED")
 
 
 class TestSyncInstrumentationIntegration(BaseTestCases.BaseInstrumentorTest):

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -147,7 +147,7 @@ from opentelemetry.util.http import (
     ExcludeList,
     get_excluded_urls,
     parse_excluded_urls,
-    remove_url_credentials,
+    redact_url,
     sanitize_method,
 )
 from opentelemetry.util.http.httplib import set_ip_on_next_http_connection
@@ -232,7 +232,7 @@ def _instrument(
         method = request.method
         span_name = get_default_span_name(method)
 
-        url = remove_url_credentials(request.url)
+        url = redact_url(request.url)
 
         span_attributes = {}
         _set_http_method(

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -686,12 +686,12 @@ class TestRequestsIntegration(RequestsIntegrationTestBase, TestBase):
             return requests.get(url, timeout=5)
         return session.get(url)
 
-    def test_credential_removal(self):
-        new_url = "http://username:password@mock/status/200"
+    def test_remove_sensitive_params(self):
+        new_url = "http://username:password@mock/status/200?AWSAccessKeyId=secret"
         self.perform_request(new_url)
         span = self.assert_span()
 
-        self.assertEqual(span.attributes[HTTP_URL], self.URL)
+        self.assertEqual(span.attributes[HTTP_URL], "http://REDACTED:REDACTED@mock/status/200?AWSAccessKeyId=REDACTED")
 
     def test_if_headers_equals_none(self):
         result = requests.get(self.URL, headers=None, timeout=5)

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
@@ -22,7 +22,7 @@ from opentelemetry.instrumentation.utils import http_status_to_status_code
 from opentelemetry.propagate import inject
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.util.http import remove_url_credentials
+from opentelemetry.util.http import redact_url
 
 
 def _normalize_request(args, kwargs):
@@ -75,7 +75,7 @@ def fetch_async(
 
     if span.is_recording():
         attributes = {
-            SpanAttributes.HTTP_URL: remove_url_credentials(request.url),
+            SpanAttributes.HTTP_URL: redact_url(request.url),
             SpanAttributes.HTTP_METHOD: request.method,
         }
         for key, value in attributes.items():
@@ -161,7 +161,7 @@ def _finish_tracing_callback(
 def _create_metric_attributes(response):
     metric_attributes = {
         SpanAttributes.HTTP_STATUS_CODE: response.code,
-        SpanAttributes.HTTP_URL: remove_url_credentials(response.request.url),
+        SpanAttributes.HTTP_URL: redact_url(response.request.url),
         SpanAttributes.HTTP_METHOD: response.request.method,
     }
 

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -496,8 +496,8 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
 
         set_global_response_propagator(orig)
 
-    def test_credential_removal(self):
-        app = HttpServerMock("test_credential_removal")
+    def test_remove_sensitive_params(self):
+        app = HttpServerMock("test_remove_sensitive_params")
 
         @app.route("/status/200")
         def index():
@@ -505,7 +505,7 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
 
         with app.run("localhost", 5000):
             response = self.fetch(
-                "http://username:password@localhost:5000/status/200"
+                "http://username:password@localhost:5000/status/200?Signature=secret"
             )
         self.assertEqual(response.code, 200)
 
@@ -518,7 +518,7 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
         self.assertSpanHasAttributes(
             client,
             {
-                SpanAttributes.HTTP_URL: "http://localhost:5000/status/200",
+                SpanAttributes.HTTP_URL: "http://REDACTED:REDACTED@localhost:5000/status/200?Signature=REDACTED",
                 SpanAttributes.HTTP_METHOD: "GET",
                 SpanAttributes.HTTP_STATUS_CODE: 200,
             },

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -136,7 +136,7 @@ from opentelemetry.util.http import (
     ExcludeList,
     get_excluded_urls,
     parse_excluded_urls,
-    remove_url_credentials,
+    redact_url,
     sanitize_method,
 )
 from opentelemetry.util.types import Attributes
@@ -258,7 +258,7 @@ def _instrument(
 
         span_name = _get_span_name(method)
 
-        url = remove_url_credentials(url)
+        url = redact_url(url)
 
         data = getattr(request, "data", None)
         request_size = 0 if data is None else len(data)

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_urllib_integration.py
@@ -512,14 +512,14 @@ class URLLibIntegrationTestBase(abc.ABC):
         span = self.assert_span()
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
-    def test_credential_removal(self):
+    def test_remove_sensitive_params(self):
         url = "http://username:password@mock/status/200"
 
         with self.assertRaises(Exception):
             self.perform_request(url)
 
         span = self.assert_span()
-        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], self.URL)
+        self.assertEqual(span.attributes[SpanAttributes.HTTP_URL], "http://REDACTED:REDACTED@mock/status/200")
 
     def test_hooks(self):
         def request_hook(span, request_obj):

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -273,7 +273,7 @@ from opentelemetry.util.http import (
     get_custom_headers,
     normalise_request_header_name,
     normalise_response_header_name,
-    remove_url_credentials,
+    redact_url,
     sanitize_method,
 )
 
@@ -370,7 +370,7 @@ def collect_request_attributes(
     else:
         # old semconv v1.20.0
         if _report_old(sem_conv_opt_in_mode):
-            result[HTTP_URL] = remove_url_credentials(
+            result[HTTP_URL] = redact_url(
                 wsgiref_util.request_uri(environ)
             )
 

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -818,11 +818,12 @@ class TestWsgiAttributes(unittest.TestCase):
         self.assertEqual(mock_span.is_recording.call_count, 2)
         self.assertEqual(attrs[HTTP_STATUS_CODE], 404)
 
-    def test_credential_removal(self):
+    def test_remove_sensitive_params(self):
         self.environ["HTTP_HOST"] = "username:password@mock"
         self.environ["PATH_INFO"] = "/status/200"
+        self.environ["QUERY_STRING"] = "sig=secret"
         expected = {
-            HTTP_URL: "http://mock/status/200",
+            HTTP_URL: "http://REDACTED:REDACTED@mock/status/200?sig=REDACTED",
             NET_HOST_PORT: 80,
         }
         self.assertGreaterEqual(

--- a/util/opentelemetry-util-http/tests/test_redact_query_parameters.py
+++ b/util/opentelemetry-util-http/tests/test_redact_query_parameters.py
@@ -1,0 +1,51 @@
+import unittest
+from opentelemetry.util.http import redact_query_parameters
+
+class TestRedactSensitiveInfo(unittest.TestCase):
+    def test_redact_goog_signature(self):
+        url = "https://www.example.com/path?color=blue&X-Goog-Signature=secret"
+        self.assertEqual(redact_query_parameters(url), "https://www.example.com/path?color=blue&X-Goog-Signature=REDACTED")
+    
+    def test_no_redaction_needed(self):
+        url = "https://www.example.com/path?color=blue&query=secret"
+        self.assertEqual(redact_query_parameters(url), "https://www.example.com/path?color=blue&query=secret")
+    
+    def test_no_query_parameters(self):
+        url = "https://www.example.com/path"
+        self.assertEqual(redact_query_parameters(url), "https://www.example.com/path")
+    
+    def test_empty_query_string(self):
+        url = "https://www.example.com/path?"
+        self.assertEqual(redact_query_parameters(url), "https://www.example.com/path?")
+    
+    def test_empty_url(self):
+        url = ""
+        self.assertEqual(redact_query_parameters(url), "")
+    
+    def test_redact_aws_access_key_id(self):
+        url = "https://www.example.com/path?color=blue&AWSAccessKeyId=secrets" 
+        self.assertEqual(redact_query_parameters(url), "https://www.example.com/path?color=blue&AWSAccessKeyId=REDACTED")
+    
+    def test_api_key_not_in_redact_list(self):
+        url = "https://www.example.com/path?api_key=secret%20key&user=john"
+        self.assertNotEqual(redact_query_parameters(url), "https://www.example.com/path?api_key=REDACTED&user=john")
+    
+    def test_password_key_not_in_redact_list(self):
+        url = "https://api.example.com?key=abc&password=123&user=admin"
+        self.assertNotEqual(redact_query_parameters(url), "https://api.example.com?key=REDACTED&password=REDACTED&user=admin")
+    
+    def test_url_with_at_symbol_in_path_and_query(self):
+        url = "https://github.com/p@th?foo=b@r"
+        self.assertEqual(redact_query_parameters(url), "https://github.com/p@th?foo=b@r")
+    
+    def test_aws_access_key_with_real_format(self):
+        url = "https://microsoft.com?AWSAccessKeyId=AKIAIOSFODNN7" 
+        self.assertEqual(redact_query_parameters(url), "https://microsoft.com?AWSAccessKeyId=REDACTED")
+    
+    def test_signature_parameter(self):
+        url = "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0" 
+        self.assertEqual(redact_query_parameters(url), "https://service.com?sig=REDACTED")
+    
+    def test_signature_with_url_encoding(self):
+        url = "https://service.com?Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377" 
+        self.assertEqual(redact_query_parameters(url), "https://service.com?Signature=REDACTED")

--- a/util/opentelemetry-util-http/tests/test_redact_url.py
+++ b/util/opentelemetry-util-http/tests/test_redact_url.py
@@ -1,0 +1,39 @@
+import unittest
+from opentelemetry.util.http import redact_url, PARAMS_TO_REDACT
+
+class TestRedactUrl(unittest.TestCase):
+    def test_redact_both_credentials_and_query_params(self):
+        """Test URL with both credentials and sensitive query parameters."""
+        url = "https://user:password@api.example.com/data?AWSAccessKeyId=AKIAIOSFODNN7&color=blue"
+        expected = "https://REDACTED:REDACTED@api.example.com/data?AWSAccessKeyId=REDACTED&color=blue"
+        self.assertEqual(redact_url(url), expected)
+    
+    def test_multiple_sensitive_query_params(self):
+        """Test URL with multiple sensitive query parameters."""
+        url = "https://admin:1234@example.com/secure?Signature=abc123&X-Goog-Signature=xyz789&sig=def456"
+        expected = "https://REDACTED:REDACTED@example.com/secure?Signature=REDACTED&X-Goog-Signature=REDACTED&sig=REDACTED"
+        self.assertEqual(redact_url(url), expected)
+    
+    def test_url_with_special_characters(self):
+        """Test URL with special characters in both credentials and query parameters."""
+        url = "https://user@domain:p@ss!word@api.example.com/path?Signature=s%40me+special%20chars&normal=fine"
+        expected = "https://REDACTED:REDACTED@api.example.com/path?Signature=REDACTED&normal=fine"
+        self.assertEqual(redact_url(url), expected)
+    
+    def test_edge_cases(self):
+        """Test unusual URL formats and corner cases."""
+        # URL with fragment
+        url1 = "https://user:pass@api.example.com/data?Signature=secret#section"
+        self.assertEqual(redact_url(url1), "https://REDACTED:REDACTED@api.example.com/data?Signature=REDACTED#section")
+        
+        # URL with port number
+        url2 = "https://user:pass@api.example.com:8443/data?AWSAccessKeyId=secret"
+        self.assertEqual(redact_url(url2), "https://REDACTED:REDACTED@api.example.com:8443/data?AWSAccessKeyId=REDACTED")
+        
+        # URL with IP address instead of domain
+        url3 = "https://user:pass@192.168.1.1/path?X-Goog-Signature=xyz"
+        self.assertEqual(redact_url(url3), "https://REDACTED:REDACTED@192.168.1.1/path?X-Goog-Signature=REDACTED")
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/util/opentelemetry-util-http/tests/test_remove_credentials.py
+++ b/util/opentelemetry-util-http/tests/test_remove_credentials.py
@@ -10,22 +10,28 @@ class TestRemoveUrlCredentials(unittest.TestCase):
         self.assertEqual(cleaned_url, url)
 
     def test_remove_credentials(self):
-        url = "http://someuser:somepass@opentelemetry.io:8080/test/path?query=value"
+        url = "http://someuser:somepass@opentelemetry.io:8080/test/path?sig=value"
         cleaned_url = remove_url_credentials(url)
         self.assertEqual(
-            cleaned_url, "http://opentelemetry.io:8080/test/path?query=value"
+            cleaned_url, "http://REDACTED:REDACTED@opentelemetry.io:8080/test/path?sig=value"
         )
 
     def test_remove_credentials_ipv4_literal(self):
         url = "http://someuser:somepass@127.0.0.1:8080/test/path?query=value"
         cleaned_url = remove_url_credentials(url)
         self.assertEqual(
-            cleaned_url, "http://127.0.0.1:8080/test/path?query=value"
+            cleaned_url, "http://REDACTED:REDACTED@127.0.0.1:8080/test/path?query=value"
         )
 
     def test_remove_credentials_ipv6_literal(self):
         url = "http://someuser:somepass@[::1]:8080/test/path?query=value"
         cleaned_url = remove_url_credentials(url)
         self.assertEqual(
-            cleaned_url, "http://[::1]:8080/test/path?query=value"
+            cleaned_url, "http://REDACTED:REDACTED@[::1]:8080/test/path?query=value"
         )
+
+    def test_empty_url(self):
+        url = ""
+        cleaned_url = remove_url_credentials(url)
+        self.assertEqual(cleaned_url, url)
+    


### PR DESCRIPTION
# Description

This pull request provides an implementation for issue #2992 which points to a specification which states that specific URL query string values should now be redacted by default. This PR also aligns with the semantic conventions for HTTP spans which states that sensitive content provided in url.full SHOULD be scrubbed when instrumentations can identify it, in such case username and password SHOULD be redacted (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md). 

The existing method `remove_url_credentials` (PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/538), which previously removed the `username:password` portion from a URL if present, has been updated to replace the credentials with the string REDACTED.

The new method `redact_query_parameters` removes the values of query string parameters for the following keys by default:

      - AWSAccessKeyId

      - Signature

      - sig

      - X-Goog-Signature

Note: This is not an exhaustive list and is subject to change over time.

These methods have been absorbed in the following instrumentations - httpx, requests, urllib, urllib3, aiohttp, tornado, asgi, wsgi.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests have been added to validate the functionality of both `remove_url_credentials` and `redact_query_parameters` methods.
- [x] Integration tests for the instrumentations have been updated. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
