### PR TITLE
Add empty changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The following components are released independently and maintain individual CHANGELOG files.
 > Use [this search for a list of all CHANGELOG.md files in this repo](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib+path%3A**%2FCHANGELOG.md&type=code).
 
+## Unreleased
+
 ## Version 1.33.0/0.54b0 (2025-05-09)
 
 ### Added


### PR DESCRIPTION
Otherwise patch release workflow fails. Similar to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3377