### PR TITLE
opentelemetry-instrumentation-urllib3: add explicit http duration buckets for stable semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
+- `opentelemetry-instrumentation-urllib3` Proper bucket boundaries in stable semconv http duration metrics
+  ([#3518](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3518))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
-- `opentelemetry-instrumentation-urllib3` Proper bucket boundaries in stable semconv http duration metrics
+- `opentelemetry-instrumentation-urllib3`: proper bucket boundaries in stable semconv http duration metrics
   ([#3518](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3518))
 
 ### Breaking changes

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -103,6 +103,7 @@ import urllib3.connectionpool
 import wrapt
 
 from opentelemetry.instrumentation._semconv import (
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     _client_duration_attrs_new,
     _client_duration_attrs_old,
     _filter_semconv_duration_attrs,
@@ -267,6 +268,7 @@ class URLLib3Instrumentor(BaseInstrumentor):
                 name=HTTP_CLIENT_REQUEST_DURATION,
                 unit="s",
                 description="Duration of HTTP client requests.",
+                explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
             )
             # http.client.request.body.size histogram
             request_size_histogram_new = create_http_client_request_body_size(

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_metrics.py
@@ -22,6 +22,7 @@ import urllib3.exceptions
 from urllib3 import encode_multipart_formdata
 
 from opentelemetry.instrumentation._semconv import (
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
@@ -169,6 +170,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     max_data_point=duration_s,
                     min_data_point=duration_s,
                     attributes=attrs_new,
+                    explicit_bounds=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                 )
             ],
             est_value_delta=40 / 1000,
@@ -258,6 +260,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     max_data_point=duration_s,
                     min_data_point=duration_s,
                     attributes=attrs_new,
+                    explicit_bounds=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                 )
             ],
             est_value_delta=40 / 1000,
@@ -451,6 +454,7 @@ class TestURLLib3InstrumentorMetric(HttpTestBase, TestBase):
                     max_data_point=duration_s,
                     min_data_point=duration_s,
                     attributes=attrs_new,
+                    explicit_bounds=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                 )
             ],
             est_value_delta=40 / 1000,


### PR DESCRIPTION
# Description

Refs #3220

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/4595
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
