### PR TITLE
opentelemetry-instrumentation-urllib: add explicit http duration buckets for stable semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
+- `opentelemetry-instrumentation-urllib` Proper bucket boundaries in stable semconv http duration metrics
+  ([#3519](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3519))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
-- `opentelemetry-instrumentation-urllib` Proper bucket boundaries in stable semconv http duration metrics
+- `opentelemetry-instrumentation-urllib`: proper bucket boundaries in stable semconv http duration metrics
   ([#3519](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3519))
 
 ### Breaking changes

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -95,6 +95,7 @@ from urllib.request import (  # pylint: disable=no-name-in-module,import-error
 )
 
 from opentelemetry.instrumentation._semconv import (
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     _client_duration_attrs_new,
     _client_duration_attrs_old,
     _filter_semconv_duration_attrs,
@@ -434,6 +435,7 @@ def _create_client_histograms(
             name=HTTP_CLIENT_REQUEST_DURATION,
             unit="s",
             description="Duration of HTTP client requests.",
+            explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
         )
         histograms[HTTP_CLIENT_REQUEST_BODY_SIZE] = (
             create_http_client_request_body_size(meter)

--- a/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/tests/test_metrics_instrumentation.py
@@ -23,6 +23,7 @@ import httpretty
 from pytest import mark
 
 from opentelemetry.instrumentation._semconv import (
+    HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
@@ -76,10 +77,17 @@ class TestUrllibMetricsInstrumentation(TestBase):
         httpretty.disable()
 
     # Return Sequence with one histogram
-    def create_histogram_data_points(self, sum_data_point, attributes):
+    def create_histogram_data_points(
+        self, sum_data_point, attributes, explicit_bounds=None
+    ):
         return [
             self.create_histogram_data_point(
-                sum_data_point, 1, sum_data_point, sum_data_point, attributes
+                sum_data_point,
+                1,
+                sum_data_point,
+                sum_data_point,
+                attributes,
+                explicit_bounds=explicit_bounds,
             )
         ]
 
@@ -176,6 +184,7 @@ class TestUrllibMetricsInstrumentation(TestBase):
                         "http.request.method": "GET",
                         "network.protocol.version": "1.1",
                     },
+                    explicit_bounds=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                 ),
                 est_value_delta=40,
             )
@@ -295,6 +304,7 @@ class TestUrllibMetricsInstrumentation(TestBase):
                         "http.request.method": "GET",
                         "network.protocol.version": "1.1",
                     },
+                    explicit_bounds=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
                 ),
                 est_value_delta=40,
             )


### PR DESCRIPTION
# Description

Refs #3220 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python/pull/4595
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
