### PR TITLE
fix(grpc): Allow non-list interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
+- `opentelemetry-instrumentation-grpc`: support non-list interceptors
+  ([#3520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3520))
 
 ### Breaking changes
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -334,7 +334,8 @@ class GrpcInstrumentorServer(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
 
         def server(*args, **kwargs):
-            if "interceptors" in kwargs:
+            if "interceptors" in kwargs and kwargs["interceptors"]:
+                kwargs["interceptors"] = list(kwargs["interceptors"])
                 # add our interceptor as the first
                 kwargs["interceptors"].insert(
                     0,
@@ -348,6 +349,7 @@ class GrpcInstrumentorServer(BaseInstrumentor):
                         tracer_provider=tracer_provider, filter_=self._filter
                     )
                 ]
+
             return self._original_func(*args, **kwargs)
 
         grpc.server = server
@@ -386,7 +388,8 @@ class GrpcAioInstrumentorServer(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
 
         def server(*args, **kwargs):
-            if "interceptors" in kwargs:
+            if "interceptors" in kwargs and kwargs["interceptors"]:
+                kwargs["interceptors"] = list(kwargs["interceptors"])
                 # add our interceptor as the first
                 kwargs["interceptors"].insert(
                     0,
@@ -516,6 +519,7 @@ class GrpcAioInstrumentorClient(BaseInstrumentor):
 
     def _add_interceptors(self, tracer_provider, kwargs):
         if "interceptors" in kwargs and kwargs["interceptors"]:
+            kwargs["interceptors"] = list(kwargs["interceptors"])
             kwargs["interceptors"] = (
                 aio_client_interceptors(
                     tracer_provider=tracer_provider,

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
@@ -60,10 +60,7 @@ class Servicer(GRPCTestServerServicer):
 async def run_with_test_server(
     runnable, servicer=Servicer(), interceptors=None
 ):
-    if interceptors is not None:
-        server = grpc.aio.server(interceptors=interceptors)
-    else:
-        server = grpc.aio.server()
+    server = grpc.aio.server(interceptors=interceptors)
 
     add_GRPCTestServerServicer_to_server(servicer, server)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py
@@ -153,7 +153,9 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             msg = request.SerializeToString()
             return await channel.unary_unary(rpc_call)(msg)
 
-        await run_with_test_server(request, interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request, interceptors=[aio_server_interceptor()]
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
@@ -205,7 +207,11 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             msg = request.SerializeToString()
             return await channel.unary_unary(rpc_call)(msg)
 
-        await run_with_test_server(request, servicer=TwoSpanServicer(), interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request,
+            servicer=TwoSpanServicer(),
+            interceptors=[aio_server_interceptor()],
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 2)
@@ -252,7 +258,9 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             async for response in channel.unary_stream(rpc_call)(msg):
                 print(response)
 
-        await run_with_test_server(request, interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request, interceptors=[aio_server_interceptor()]
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
@@ -306,7 +314,11 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             async for response in channel.unary_stream(rpc_call)(msg):
                 print(response)
 
-        await run_with_test_server(request, servicer=TwoSpanServicer(), interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request,
+            servicer=TwoSpanServicer(),
+            interceptors=[aio_server_interceptor()],
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 2)
@@ -366,7 +378,11 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
         lifetime_servicer = SpanLifetimeServicer()
         active_span_before_call = trace.get_current_span()
 
-        await run_with_test_server(request, servicer=lifetime_servicer, interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request,
+            servicer=lifetime_servicer,
+            interceptors=[aio_server_interceptor()],
+        )
 
         active_span_in_handler = lifetime_servicer.span
         active_span_after_call = trace.get_current_span()
@@ -389,7 +405,9 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             await request(channel)
             await request(channel)
 
-        await run_with_test_server(sequential_requests, interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            sequential_requests, interceptors=[aio_server_interceptor()]
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 2)
@@ -449,7 +467,9 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             await asyncio.gather(request(channel), request(channel))
 
         await run_with_test_server(
-            concurrent_requests, servicer=LatchedServicer(), interceptors=[aio_server_interceptor()]
+            concurrent_requests,
+            servicer=LatchedServicer(),
+            interceptors=[aio_server_interceptor()],
         )
 
         spans_list = self.memory_exporter.get_finished_spans()
@@ -503,7 +523,11 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             self.assertEqual(cm.exception.code(), grpc.StatusCode.INTERNAL)
             self.assertEqual(cm.exception.details(), failure_message)
 
-        await run_with_test_server(request, servicer=AbortServicer(), interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request,
+            servicer=AbortServicer(),
+            interceptors=[aio_server_interceptor()],
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
@@ -568,7 +592,11 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
             )
             self.assertEqual(cm.exception.details(), failure_message)
 
-        await run_with_test_server(request, servicer=AbortServicer(), interceptors=[aio_server_interceptor()])
+        await run_with_test_server(
+            request,
+            servicer=AbortServicer(),
+            interceptors=[aio_server_interceptor()],
+        )
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
@@ -616,10 +644,14 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
                 return await channel.unary_unary(rpc_call)(msg)
 
             class MockInterceptor(grpc.aio.ServerInterceptor):
-                async def intercept_service(self, continuation, handler_call_details):
+                async def intercept_service(
+                    self, continuation, handler_call_details
+                ):
                     return await continuation(handler_call_details)
 
-            await run_with_test_server(request, interceptors=(MockInterceptor(),))
+            await run_with_test_server(
+                request, interceptors=(MockInterceptor(),)
+            )
 
         finally:
             grpc_server_instrumentor.uninstrument()
@@ -650,6 +682,7 @@ class TestOpenTelemetryAioServerInterceptor(TestBase, IsolatedAsyncioTestCase):
                 ],
             },
         )
+
 
 def get_latch(num):
     """Get a countdown latch function for use in n threads."""

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -19,6 +19,7 @@ import contextlib
 import tempfile
 import threading
 from concurrent import futures
+from unittest import mock
 
 import grpc
 
@@ -104,41 +105,44 @@ class TestOpenTelemetryServerInterceptor(TestBase):
 
         grpc_server_instrumentor = GrpcInstrumentorServer()
         grpc_server_instrumentor.instrument()
-        with self.server(max_workers=1) as (server, channel):
-            server.add_generic_rpc_handlers((UnaryUnaryRpcHandler(handler),))
-            rpc_call = "TestServicer/handler"
-            try:
-                server.start()
-                channel.unary_unary(rpc_call)(b"test")
-            finally:
-                server.stop(None)
 
-            spans_list = self.memory_exporter.get_finished_spans()
-            self.assertEqual(len(spans_list), 1)
-            span = spans_list[0]
-            self.assertEqual(span.name, rpc_call)
-            self.assertIs(span.kind, trace.SpanKind.SERVER)
+        try:
+            with self.server(max_workers=1) as (server, channel):
+                server.add_generic_rpc_handlers((UnaryUnaryRpcHandler(handler),))
+                rpc_call = "TestServicer/handler"
+                try:
+                    server.start()
+                    channel.unary_unary(rpc_call)(b"test")
+                finally:
+                    server.stop(None)
 
-            # Check version and name in span's instrumentation info
-            self.assertEqualSpanInstrumentationScope(
-                span, opentelemetry.instrumentation.grpc
-            )
-
-            # Check attributes
-            self.assertSpanHasAttributes(
-                span,
-                {
-                    **self.net_peer_span_attributes,
-                    SpanAttributes.RPC_METHOD: "handler",
-                    SpanAttributes.RPC_SERVICE: "TestServicer",
-                    SpanAttributes.RPC_SYSTEM: "grpc",
-                    SpanAttributes.RPC_GRPC_STATUS_CODE: grpc.StatusCode.OK.value[
-                        0
-                    ],
-                },
-            )
-
+        finally:
             grpc_server_instrumentor.uninstrument()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, rpc_call)
+        self.assertIs(span.kind, trace.SpanKind.SERVER)
+
+        # Check version and name in span's instrumentation info
+        self.assertEqualSpanInstrumentationScope(
+            span, opentelemetry.instrumentation.grpc
+        )
+
+        # Check attributes
+        self.assertSpanHasAttributes(
+            span,
+            {
+                **self.net_peer_span_attributes,
+                SpanAttributes.RPC_METHOD: "handler",
+                SpanAttributes.RPC_SERVICE: "TestServicer",
+                SpanAttributes.RPC_SYSTEM: "grpc",
+                SpanAttributes.RPC_GRPC_STATUS_CODE: grpc.StatusCode.OK.value[
+                    0
+                ],
+            },
+        )
 
     def test_uninstrument(self):
         def handler(request, context):
@@ -642,6 +646,55 @@ class TestOpenTelemetryServerInterceptor(TestBase):
                 SpanAttributes.RPC_SERVICE: "TestServicer",
                 SpanAttributes.RPC_SYSTEM: "grpc",
                 SpanAttributes.RPC_GRPC_STATUS_CODE: grpc.StatusCode.FAILED_PRECONDITION.value[
+                    0
+                ],
+            },
+        )
+
+    def test_non_list_interceptors(self):
+        """Check that we handle non-list interceptors correctly."""
+        grpc_server_instrumentor = GrpcInstrumentorServer()
+        grpc_server_instrumentor.instrument()
+
+        try:
+            with self.server(
+                max_workers=1,
+                interceptors=(mock.MagicMock(),),
+            ) as (server, channel):
+                add_GRPCTestServerServicer_to_server(Servicer(), server)
+
+                rpc_call = "/GRPCTestServer/SimpleMethod"
+                request = Request(client_id=1, request_data="test")
+                msg = request.SerializeToString()
+                try:
+                    server.start()
+                    channel.unary_unary(rpc_call)(msg)
+                finally:
+                    server.stop(None)
+        finally:
+            grpc_server_instrumentor.uninstrument()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        self.assertEqual(span.name, rpc_call)
+        self.assertIs(span.kind, trace.SpanKind.SERVER)
+
+        # Check version and name in span's instrumentation info
+        self.assertEqualSpanInstrumentationScope(
+            span, opentelemetry.instrumentation.grpc
+        )
+
+        # Check attributes
+        self.assertSpanHasAttributes(
+            span,
+            {
+                **self.net_peer_span_attributes,
+                SpanAttributes.RPC_METHOD: "SimpleMethod",
+                SpanAttributes.RPC_SERVICE: "GRPCTestServer",
+                SpanAttributes.RPC_SYSTEM: "grpc",
+                SpanAttributes.RPC_GRPC_STATUS_CODE: grpc.StatusCode.OK.value[
                     0
                 ],
             },

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -108,7 +108,9 @@ class TestOpenTelemetryServerInterceptor(TestBase):
 
         try:
             with self.server(max_workers=1) as (server, channel):
-                server.add_generic_rpc_handlers((UnaryUnaryRpcHandler(handler),))
+                server.add_generic_rpc_handlers(
+                    (UnaryUnaryRpcHandler(handler),)
+                )
                 rpc_call = "TestServicer/handler"
                 try:
                     server.start()


### PR DESCRIPTION
# Description

The OpenTelemetry GRPC instrumentation assumes that server interceptors will be provided as a list -- it's using the `.insert()` method both in the [sync](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/38f741383694561a53e377a661da4bbe6b4c8357/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py#L339-L344) and [async](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/38f741383694561a53e377a661da4bbe6b4c8357/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py#L391-L396) server wrapper to add an interceptor of its own.

GRPC however states `interceptors` is just a `Sequence`([sync](https://github.com/grpc/grpc/blob/f71fac77473e06142bcc6805e471ceaca1671869/src/python/grpcio/grpc/_server.py#L1428), [async](https://github.com/grpc/grpc/blob/f71fac77473e06142bcc6805e471ceaca1671869/src/python/grpcio/grpc/aio/_server.py#L43)) and not necessarily a `list`, so we shouldn't assume that whatever gets passed in has an `insert()` method.

This originally surfaced in https://github.com/getsentry/sentry-python/issues/4389. In case both Sentry and OTel are instrumenting GRPC, Sentry makes `interceptors` a `tuple`, which then throws an exception in OTel since tuples don't have an `insert()` method.

For good measure, I also applied this fix to channel interceptors (in the `_add_interceptors` wrapper).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added two test cases:

- [x] test_non_list_interceptors in `instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_server_interceptor.py` (async server interceptors)
- [x] test_non_list_interceptors in `instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py` (sync server interceptors)

Undoing the changes in `instrumentation/grpc/__init__.py` and running the tests makes the new test cases fail.

The `secure_channel` and `insecure_channel` fix doesn't have a corresponding test case. I can add one if needed.

I also changed some of the existing tests to call `uninstrument()` in a `finally` if they call `instrument()` at the start. Not all of them would uninstrument if there was an exception, which was causing weird issues for me when sometimes things in other tests wouldn't be patched correctly.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
