### PR TITLE
Remove starlette version ceiling

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -44,7 +44,7 @@
 | [opentelemetry-instrumentation-requests](./opentelemetry-instrumentation-requests) | requests ~= 2.0 | Yes | migration
 | [opentelemetry-instrumentation-sqlalchemy](./opentelemetry-instrumentation-sqlalchemy) | sqlalchemy >= 1.0.0, < 2.1.0 | Yes | development
 | [opentelemetry-instrumentation-sqlite3](./opentelemetry-instrumentation-sqlite3) | sqlite3 | No | development
-| [opentelemetry-instrumentation-starlette](./opentelemetry-instrumentation-starlette) | starlette >= 0.13, <0.15 | Yes | development
+| [opentelemetry-instrumentation-starlette](./opentelemetry-instrumentation-starlette) | starlette >= 0.13 | Yes | development
 | [opentelemetry-instrumentation-system-metrics](./opentelemetry-instrumentation-system-metrics) | psutil >= 5 | No | development
 | [opentelemetry-instrumentation-threading](./opentelemetry-instrumentation-threading) | threading | No | development
 | [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | Yes | development

--- a/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["starlette >= 0.13, <0.15"]
+instruments = ["starlette >= 0.13"]
 
 [project.entry-points.opentelemetry_instrumentor]
 starlette = "opentelemetry.instrumentation.starlette:StarletteInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -239,7 +239,7 @@ class StarletteInstrumentor(BaseInstrumentor):
             meter_provider,
             schema_url="https://opentelemetry.io/schemas/1.11.0",
         )
-        if not getattr(app, "is_instrumented_by_opentelemetry", False):
+        if not getattr(app, "_is_instrumented_by_opentelemetry", False):
             app.add_middleware(
                 OpenTelemetryMiddleware,
                 excluded_urls=_excluded_urls,
@@ -251,7 +251,7 @@ class StarletteInstrumentor(BaseInstrumentor):
                 tracer=tracer,
                 meter=meter,
             )
-            app.is_instrumented_by_opentelemetry = True
+            app._is_instrumented_by_opentelemetry = True
 
             # adding apps to set for uninstrumenting
             if app not in _InstrumentedStarlette._instrumented_starlette_apps:
@@ -332,7 +332,7 @@ class _InstrumentedStarlette(applications.Starlette):
         _InstrumentedStarlette._instrumented_starlette_apps.add(self)
 
     def __del__(self):
-        _InstrumentedStarlette._instrumented_starlette_apps.remove(self)
+        _InstrumentedStarlette._instrumented_starlette_apps.discard(self)
 
 
 def _get_route_details(scope: dict[str, Any]) -> str | None:

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/package.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-_instruments = ("starlette >= 0.13, <0.15",)
+_instruments = ("starlette >= 0.13",)
 
 _supports_metrics = True

--- a/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.latest.txt
@@ -17,31 +17,31 @@
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-starlette
 anyio==4.5.2 ; python_full_version < '3.9'
-    # via httpx
-anyio==4.8.0 ; python_full_version >= '3.9'
-    # via httpx
+    # via
+    #   httpx
+    #   starlette
+anyio==4.9.0 ; python_full_version >= '3.9'
+    # via
+    #   httpx
+    #   starlette
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 colorama==0.4.6 ; sys_platform == 'win32'
     # via pytest
-deprecated==1.2.18
-    # via
-    #   opentelemetry-api
-    #   opentelemetry-semantic-conventions
-exceptiongroup==1.2.2 ; python_full_version < '3.11'
+exceptiongroup==1.3.0 ; python_full_version < '3.11'
     # via
     #   anyio
     #   pytest
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
@@ -52,15 +52,17 @@ idna==3.10
     #   requests
 importlib-metadata==8.5.0 ; python_full_version < '3.9'
     # via opentelemetry-api
-importlib-metadata==8.6.1 ; python_full_version >= '3.9'
+importlib-metadata==8.7.0 ; python_full_version >= '3.9'
     # via opentelemetry-api
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-packaging==24.2
+packaging==25.0
     # via
     #   opentelemetry-instrumentation
     #   pytest
-pluggy==1.5.0
+pluggy==1.5.0 ; python_full_version < '3.9'
+    # via pytest
+pluggy==1.6.0 ; python_full_version >= '3.9'
     # via pytest
 pytest==7.4.4
     # via
@@ -72,22 +74,26 @@ requests==2.32.3
     #   -r instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
 sniffio==1.3.1
     # via anyio
-starlette==0.14.2
+starlette==0.44.0 ; python_full_version < '3.9'
+    # via opentelemetry-instrumentation-starlette
+starlette==0.46.2 ; python_full_version >= '3.9'
     # via opentelemetry-instrumentation-starlette
 tomli==2.2.1 ; python_full_version < '3.11'
     # via pytest
-typing-extensions==4.12.2 ; python_full_version < '3.13'
+typing-extensions==4.13.2
     # via
     #   anyio
     #   asgiref
+    #   exceptiongroup
+    #   opentelemetry-api
+    #   opentelemetry-semantic-conventions
+    #   starlette
 urllib3==2.2.3 ; python_full_version < '3.9'
     # via requests
-urllib3==2.3.0 ; python_full_version >= '3.9'
+urllib3==2.4.0 ; python_full_version >= '3.9'
     # via requests
 wrapt==1.17.2
-    # via
-    #   deprecated
-    #   opentelemetry-instrumentation
+    # via opentelemetry-instrumentation
 zipp==3.20.2 ; python_full_version < '3.9'
     # via importlib-metadata
 zipp==3.21.0 ; python_full_version >= '3.9'

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -667,15 +667,17 @@ class TestBaseWithCustomHeaders(TestBase):
 
 
 class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
-    @patch.dict(
-        "os.environ",
-        {
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
-        },
-    )
     def setUp(self) -> None:
+        patcher = patch.dict(
+            "os.environ",
+            {
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
+            },
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
         super().setUp()
 
     def test_custom_request_headers_in_span_attributes(self):
@@ -793,15 +795,17 @@ class TestHTTPAppWithCustomHeaders(TestBaseWithCustomHeaders):
 
 
 class TestWebSocketAppWithCustomHeaders(TestBaseWithCustomHeaders):
-    @patch.dict(
-        "os.environ",
-        {
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
-            OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
-        },
-    )
     def setUp(self) -> None:
+        patcher = patch.dict(
+            "os.environ",
+            {
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS: ".*my-secret.*",
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,Regex-Test-Header-.*,Regex-Invalid-Test-Header-.*,.*my-secret.*",
+                OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: "Custom-Test-Header-1,Custom-Test-Header-2,Custom-Test-Header-3,my-custom-regex-header-.*,invalid-regex-header-.*,.*my-secret.*",
+            },
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
         super().setUp()
 
     def test_custom_request_headers_in_span_attributes(self):

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -189,7 +189,7 @@ libraries = [
         "instrumentation": "opentelemetry-instrumentation-sqlalchemy==0.55b0.dev",
     },
     {
-        "library": "starlette >= 0.13, <0.15",
+        "library": "starlette >= 0.13",
         "instrumentation": "opentelemetry-instrumentation-starlette==0.55b0.dev",
     },
     {


### PR DESCRIPTION
# Description

Removes the starlette version ceiling which is currently set to a very ancient version of starlette. I think this is fairly sane to do since the instrumentation only uses starlette's public API (`add_middleware`) and should be relatively stable.

There was test failure when bumping but it was an issue with the test code itself, not the instrumentation, so I fixed it.

Fixes #3317

## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests of latest and oldest

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
