### PR TITLE
starlette: use wrapt for patching instead of class replacement

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-starlette/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "opentelemetry-instrumentation-asgi == 0.55b0.dev",
   "opentelemetry-semantic-conventions == 0.55b0.dev",
   "opentelemetry-util-http == 0.55b0.dev",
+  "wrapt >= 1.0.0, < 2.0.0"
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -572,15 +572,15 @@ class TestAutoInstrumentationLogic(unittest.TestCase):
         removing as expected.
         """
         instrumentor = otel_starlette.StarletteInstrumentor()
-        original = applications.Starlette
+        original = applications.Starlette.__init__
         instrumentor.instrument()
         try:
-            instrumented = applications.Starlette
+            instrumented = applications.Starlette.__init__
             self.assertIsNot(original, instrumented)
         finally:
             instrumentor.uninstrument()
 
-        should_be_original = applications.Starlette
+        should_be_original = applications.Starlette.__init__
         self.assertIs(original, should_be_original)
 
 


### PR DESCRIPTION
# Description

Moving starlette instrumentation to patch `Starlette.__init__` method using `wrapt` instead of doing the class replacement to prevent potential ordering issues. 

Left the behaviour of manual instrumentation methods of `StarletteInstrumentor` to work as it did before.

The core issue where this surfaced (https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3476)  has already been closed, but this was still a relevant improvement

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been ~added~ updated
- [ ] Documentation has been updated
