### PR TITLE
Refactor (elasticsearch) to use semconv incubating attributes in tests.

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -31,7 +31,10 @@ from opentelemetry.instrumentation.elasticsearch import (
     ElasticsearchInstrumentor,
 )
 from opentelemetry.instrumentation.elasticsearch.utils import sanitize_body
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.db_attributes import (
+    DB_STATEMENT,
+    DB_SYSTEM,
+)
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import StatusCode
 
@@ -76,15 +79,15 @@ def get_elasticsearch_client(*args, **kwargs):
 )
 class TestElasticsearchIntegration(TestBase):
     search_attributes = {
-        SpanAttributes.DB_SYSTEM: "elasticsearch",
+        DB_SYSTEM: "elasticsearch",
         "elasticsearch.url": "/test-index/_search",
         "elasticsearch.method": helpers.dsl_search_method,
         "elasticsearch.target": "test-index",
-        SpanAttributes.DB_STATEMENT: str({"query": {"bool": {"filter": "?"}}}),
+        DB_STATEMENT: str({"query": {"bool": {"filter": "?"}}}),
     }
 
     create_attributes = {
-        SpanAttributes.DB_SYSTEM: "elasticsearch",
+        DB_SYSTEM: "elasticsearch",
         "elasticsearch.url": "/test-index",
         "elasticsearch.method": "HEAD",
     }
@@ -361,13 +364,13 @@ class TestElasticsearchIntegration(TestBase):
         )
 
         attributes = {
-            SpanAttributes.DB_SYSTEM: "elasticsearch",
+            DB_SYSTEM: "elasticsearch",
             "elasticsearch.url": "/test-index",
             "elasticsearch.method": "PUT",
         }
         self.assertSpanHasAttributes(span2, attributes)
         self.assertEqual(
-            literal_eval(span2.attributes[SpanAttributes.DB_STATEMENT]),
+            literal_eval(span2.attributes[DB_STATEMENT]),
             helpers.dsl_create_statement,
         )
 
@@ -408,13 +411,13 @@ class TestElasticsearchIntegration(TestBase):
         span = spans[0]
         self.assertEqual(span.name, helpers.dsl_index_span_name)
         attributes = {
-            SpanAttributes.DB_SYSTEM: "elasticsearch",
+            DB_SYSTEM: "elasticsearch",
             "elasticsearch.url": helpers.dsl_index_url,
             "elasticsearch.method": "PUT",
         }
         self.assertSpanHasAttributes(span, attributes)
         self.assertEqual(
-            literal_eval(span.attributes[SpanAttributes.DB_STATEMENT]),
+            literal_eval(span.attributes[DB_STATEMENT]),
             {
                 "body": "A few words here, a few words there",
                 "title": "About searching",


### PR DESCRIPTION
# Description

Replaced `SpanAttributes` with `opentelemetry.semconv._incubating.attributes.db_attributes` in instrumentation-elasticsearch tests.

Refs: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3475

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
