### PR TITLE
opentelemetry-instrumentation-system-metrics: fix running on Google Cloud Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-system-metrics`: fix loading on Google Cloud Run
+  ([#3533](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3533))
 - `opentelemetry-instrumentation-fastapi`: fix wrapping of middlewares
   ([#3012](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3012))
 

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-many-lines
 
 import sys
 from collections import namedtuple
@@ -235,13 +235,27 @@ class TestSystemMetrics(TestBase):
                                 assertions += 1
         self.assertEqual(len(expected), assertions)
 
-    def _test_metrics(self, observer_name, expected):
+    @staticmethod
+    def _setup_instrumentor() -> InMemoryMetricReader:
         reader = InMemoryMetricReader()
         meter_provider = MeterProvider(metric_readers=[reader])
 
         system_metrics = SystemMetricsInstrumentor()
         system_metrics.instrument(meter_provider=meter_provider)
+        return reader
+
+    def _test_metrics(self, observer_name, expected):
+        reader = self._setup_instrumentor()
         self._assert_metrics(observer_name, reader, expected)
+
+    def _assert_metrics_not_found(self, observer_name):
+        reader = self._setup_instrumentor()
+        seen_metrics = set()
+        for resource_metrics in reader.get_metrics_data().resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    seen_metrics.add(metric.name)
+        self.assertNotIn(observer_name, seen_metrics)
 
     # This patch is added here to stop psutil from raising an exception
     # because we're patching cpu_times
@@ -861,17 +875,7 @@ class TestSystemMetrics(TestBase):
     ):
         mock_process_num_ctx_switches.side_effect = NotImplementedError
 
-        reader = InMemoryMetricReader()
-        meter_provider = MeterProvider(metric_readers=[reader])
-        system_metrics = SystemMetricsInstrumentor()
-        system_metrics.instrument(meter_provider=meter_provider)
-
-        seen_metrics = set()
-        for resource_metrics in reader.get_metrics_data().resource_metrics:
-            for scope_metrics in resource_metrics.scope_metrics:
-                for metric in scope_metrics.metrics:
-                    seen_metrics.add(metric.name)
-        self.assertNotIn("process.context_switches", seen_metrics)
+        self._assert_metrics_not_found("process.context_switches")
 
     @mock.patch("psutil.Process.num_threads")
     def test_thread_count(self, mock_process_thread_num):
@@ -971,19 +975,8 @@ class TestSystemMetrics(TestBase):
     ):
         mock_process_num_ctx_switches.side_effect = NotImplementedError
 
-        reader = InMemoryMetricReader()
-        meter_provider = MeterProvider(metric_readers=[reader])
-        system_metrics = SystemMetricsInstrumentor()
-        system_metrics.instrument(meter_provider=meter_provider)
-
-        seen_metrics = set()
-        for resource_metrics in reader.get_metrics_data().resource_metrics:
-            for scope_metrics in resource_metrics.scope_metrics:
-                for metric in scope_metrics.metrics:
-                    seen_metrics.add(metric.name)
-        self.assertNotIn(
+        self._assert_metrics_not_found(
             f"process.runtime.{self.implementation}.context_switches",
-            seen_metrics,
         )
 
     @mock.patch("psutil.Process.num_threads")


### PR DESCRIPTION
# Description

psutil fails reading context switches on Google Cloud Run, so before setting up the observable counter trying to read the values check we are actually being able to do so.

Fixes #3531

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py312-test-instrumentation-system-metrics

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
