### PR TITLE
Improve grpc instrumentation examples

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/__init__.py
@@ -149,7 +149,7 @@ Usage Aio Client
     grpc_client_instrumentor.instrument()
 
     async def run():
-        with grpc.aio.insecure_channel("localhost:50051") as channel:
+        async with grpc.aio.insecure_channel("localhost:50051") as channel:
 
             stub = helloworld_pb2_grpc.GreeterStub(channel)
             response = await stub.SayHello(helloworld_pb2.HelloRequest(name="YOU"))
@@ -168,7 +168,7 @@ You can also add the interceptor manually, rather than using
 
     from opentelemetry.instrumentation.grpc import aio_client_interceptors
 
-    channel = grpc.aio.insecure_channel("localhost:12345", interceptors=aio_client_interceptors())
+    async with grpc.aio.insecure_channel("localhost:50051", interceptors=aio_client_interceptors()) as channel:
 
 
 Usage Aio Server
@@ -252,6 +252,11 @@ You can write a global server instrumentor as follows:
 You can also use the filters directly on the provided interceptors:
 
 .. code-block::
+
+    import grpc
+    from concurrent import futures
+    from opentelemetry.instrumentation.grpc import filters
+    from opentelemetry.instrumentation.grpc import server_interceptor
 
     my_interceptor = server_interceptor(
         filter_ = filters.negate(filters.method_name("TestMethod"))


### PR DESCRIPTION
# Description

Some instrumentation examples inside `grpc` don't run. This PR fixes the examples, so they run.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone contrib repo: `git clone https://github.com/open-telemetry/opentelemetry-python-contrib`
2. Clone OTel Python repo: `git clone https://github.com/open-telemetry/opentelemetry-python`
3. Access the contrib repo: `cd opentelemetry-python-contrib`
4. Create a virtual env: `python3 -m venv otelvenv`
5. Activate the virtual env: `source otelvenv/bin/activate`
6. Install common dependencies:
```
pip install opentelemetry-distro/ opentelemetry-instrumentation/ \
 ../opentelemetry-python/opentelemetry-semantic-conventions/ \
 ../opentelemetry-python/opentelemetry-api/ \
 ../opentelemetry-python/opentelemetry-sdk/ \
 ../opentelemetry-python/opentelemetry-proto/ \
 ../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-common
```
7. Install `grpc` specific requirements:
```
pip install -r instrumentation/opentelemetry-instrumentation-grpc/test-requirements.txt
```
8. Copy the instrumentation examples inside the instrumentation main `__init__.py` file into different Python files and try to run them.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
