### PR TITLE
feat: change semcov util/opentelemetry-util-http

### DIFF
--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -22,7 +22,18 @@ from re import search
 from typing import Callable, Iterable, overload
 from urllib.parse import urlparse, urlunparse
 
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_FLAVOR,
+    HTTP_HOST,
+    HTTP_METHOD,
+    HTTP_SCHEME,
+    HTTP_SERVER_NAME,
+    HTTP_STATUS_CODE,
+)
+from opentelemetry.semconv._incubating.attributes.net_attributes import (
+    NET_HOST_NAME,
+    NET_HOST_PORT,
+)
 
 OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS = (
     "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS"
@@ -40,22 +51,22 @@ OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS = (
 
 # List of recommended metrics attributes
 _duration_attrs = {
-    SpanAttributes.HTTP_METHOD,
-    SpanAttributes.HTTP_HOST,
-    SpanAttributes.HTTP_SCHEME,
-    SpanAttributes.HTTP_STATUS_CODE,
-    SpanAttributes.HTTP_FLAVOR,
-    SpanAttributes.HTTP_SERVER_NAME,
-    SpanAttributes.NET_HOST_NAME,
-    SpanAttributes.NET_HOST_PORT,
+    HTTP_METHOD,
+    HTTP_HOST,
+    HTTP_SCHEME,
+    HTTP_STATUS_CODE,
+    HTTP_FLAVOR,
+    HTTP_SERVER_NAME,
+    NET_HOST_NAME,
+    NET_HOST_PORT,
 }
 
 _active_requests_count_attrs = {
-    SpanAttributes.HTTP_METHOD,
-    SpanAttributes.HTTP_HOST,
-    SpanAttributes.HTTP_SCHEME,
-    SpanAttributes.HTTP_FLAVOR,
-    SpanAttributes.HTTP_SERVER_NAME,
+    HTTP_METHOD,
+    HTTP_HOST,
+    HTTP_SCHEME,
+    HTTP_FLAVOR,
+    HTTP_SERVER_NAME,
 }
 
 

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/httplib.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/httplib.py
@@ -31,7 +31,9 @@ import wrapt
 from opentelemetry import context
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes.net_attributes import (
+    NET_PEER_IP,
+)
 from opentelemetry.trace.span import Span
 
 _STATE_KEY = "httpbase_instrumentation_state"
@@ -111,7 +113,7 @@ def trysetip(
         )
     else:
         for span in spanlist:
-            span.set_attribute(SpanAttributes.NET_PEER_IP, ip)
+            span.set_attribute(NET_PEER_IP, ip)
     return True
 
 


### PR DESCRIPTION
# Description

This pull request updates the OpenTelemetry utility for HTTP instrumentation by transitioning from the deprecated `SpanAttributes` to the new `_incubating.attributes` module for attribute definitions. The changes ensure compatibility with the latest OpenTelemetry conventions and improve maintainability by using the updated attribute module.

### Transition to `_incubating.attributes` module:

* [`util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py`](diffhunk://#diff-9f93b3514e50dc2c60507d1deb1ad7bd80b8dcca02a5d1cb4bcec412b5cdcbaeL25-R36): Replaced imports of `SpanAttributes` with imports from `_incubating.attributes.http_attributes` and `_incubating.attributes.net_attributes`. Updated `_duration_attrs` and `_active_requests_count_attrs` to use the new attributes. [[1]](diffhunk://#diff-9f93b3514e50dc2c60507d1deb1ad7bd80b8dcca02a5d1cb4bcec412b5cdcbaeL25-R36) [[2]](diffhunk://#diff-9f93b3514e50dc2c60507d1deb1ad7bd80b8dcca02a5d1cb4bcec412b5cdcbaeL43-R69)
* [`util/opentelemetry-util-http/src/opentelemetry/util/http/httplib.py`](diffhunk://#diff-639fa196bdbc5da7d4b9ece26957d90c970df3822c5352f24ab8092fdb254c3dL34-R36): Replaced `SpanAttributes.NET_PEER_IP` with `NET_PEER_IP` from `_incubating.attributes.net_attributes`. Updated the `trysetip` function to use the new attribute. [[1]](diffhunk://#diff-639fa196bdbc5da7d4b9ece26957d90c970df3822c5352f24ab8092fdb254c3dL34-R36) [[2]](diffhunk://#diff-639fa196bdbc5da7d4b9ece26957d90c970df3822c5352f24ab8092fdb254c3dL114-R116)

Fixes #3475 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
