### PR TITLE
feat(pymongo): aggregate and getMore capture statements support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-util-http` Added support for redacting specific url query string values and url credentials in instrumentations
   ([#3508](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3508))
-  
+- `opentelemetry-instrumentation-pymongo` `aggregate` and `getMore` capture statements support
+  ([#3601](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3601))
+
 ## Version 1.34.0/0.55b0 (2025-06-04)
 
 ### Fixed

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/utils.py
@@ -17,4 +17,6 @@ COMMAND_TO_ATTRIBUTE_MAPPING = {
     "delete": "deletes",
     "update": "updates",
     "find": "filter",
+    "getMore": "collection",
+    "aggregate": "pipeline",
 }

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -62,9 +62,7 @@ class TestPymongo(TestBase):
         self.assertEqual(
             span.attributes[SpanAttributes.DB_NAME], "database_name"
         )
-        self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], "find"
-        )
+        self.assertEqual(span.attributes[SpanAttributes.DB_STATEMENT], "find")
         self.assertEqual(
             span.attributes[SpanAttributes.NET_PEER_NAME], "test.com"
         )
@@ -201,9 +199,7 @@ class TestPymongo(TestBase):
         }
         mock_event = MockEvent(command_attrs)
 
-        command_tracer = CommandTracer(
-            self.tracer, capture_statement=True
-        )
+        command_tracer = CommandTracer(self.tracer, capture_statement=True)
         command_tracer.started(event=mock_event)
         command_tracer.succeeded(event=mock_event)
 
@@ -214,18 +210,19 @@ class TestPymongo(TestBase):
 
         self.assertEqual(
             span.attributes[SpanAttributes.DB_STATEMENT],
-            "getMore test_collection"
+            "getMore test_collection",
         )
 
     def test_capture_statement_aggregate(self):
-        pipeline = [{"$match": {"status": "active"}}, {"$group": {"_id": "$category", "count": {"$sum": 1}}}]
+        pipeline = [
+            {"$match": {"status": "active"}},
+            {"$group": {"_id": "$category", "count": {"$sum": 1}}},
+        ]
         command_attrs = {
             "command_name": "aggregate",
             "pipeline": pipeline,
         }
-        command_tracer = CommandTracer(
-            self.tracer, capture_statement=True
-        )
+        command_tracer = CommandTracer(self.tracer, capture_statement=True)
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
         command_tracer.succeeded(event=mock_event)
@@ -237,8 +234,7 @@ class TestPymongo(TestBase):
 
         expected_statement = f"aggregate {pipeline}"
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT],
-            expected_statement
+            span.attributes[SpanAttributes.DB_STATEMENT], expected_statement
         )
 
     def test_capture_statement_disabled_getmore(self):
@@ -246,9 +242,7 @@ class TestPymongo(TestBase):
             "command_name": "getMore",
             "collection": "test_collection",
         }
-        command_tracer = CommandTracer(
-            self.tracer, capture_statement=False
-        )
+        command_tracer = CommandTracer(self.tracer, capture_statement=False)
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
         command_tracer.succeeded(event=mock_event)
@@ -259,8 +253,7 @@ class TestPymongo(TestBase):
         span = spans_list[0]
 
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT],
-            "getMore"
+            span.attributes[SpanAttributes.DB_STATEMENT], "getMore"
         )
 
     def test_capture_statement_disabled_aggregate(self):
@@ -269,9 +262,7 @@ class TestPymongo(TestBase):
             "command_name": "aggregate",
             "pipeline": pipeline,
         }
-        command_tracer = CommandTracer(
-            self.tracer, capture_statement=False
-        )
+        command_tracer = CommandTracer(self.tracer, capture_statement=False)
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
         command_tracer.succeeded(event=mock_event)
@@ -282,8 +273,7 @@ class TestPymongo(TestBase):
         span = spans_list[0]
 
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT],
-            "aggregate"
+            span.attributes[SpanAttributes.DB_STATEMENT], "aggregate"
         )
 
 

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -204,10 +204,15 @@ class TestPymongo(TestBase):
         )
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
-        # pylint: disable=protected-access
-        span = command_tracer._pop_span(mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], 
+            span.attributes[SpanAttributes.DB_STATEMENT],
             "getMore test_collection"
         )
 
@@ -222,11 +227,16 @@ class TestPymongo(TestBase):
         )
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
-        # pylint: disable=protected-access
-        span = command_tracer._pop_span(mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
         expected_statement = f"aggregate {pipeline}"
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], 
+            span.attributes[SpanAttributes.DB_STATEMENT],
             expected_statement
         )
 
@@ -240,10 +250,15 @@ class TestPymongo(TestBase):
         )
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
-        # pylint: disable=protected-access
-        span = command_tracer._pop_span(mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], 
+            span.attributes[SpanAttributes.DB_STATEMENT],
             "getMore"
         )
 
@@ -258,10 +273,15 @@ class TestPymongo(TestBase):
         )
         mock_event = MockEvent(command_attrs)
         command_tracer.started(event=mock_event)
-        # pylint: disable=protected-access
-        span = command_tracer._pop_span(mock_event)
+        command_tracer.succeeded(event=mock_event)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], 
+            span.attributes[SpanAttributes.DB_STATEMENT],
             "aggregate"
         )
 


### PR DESCRIPTION
# Description

This PR enhances the PyMongo instrumentation to capture statement details for `getMore` and `aggregate` operations when `capture_statement = True`. Previously, only `insert`, `delete`, `update`, and `find` operations had their statements captured.

Changes Made:
- Added `getMore` and `aggregate` command mappings to `COMMAND_TO_ATTRIBUTE_MAPPING`
- When `capture_statement=True`, traces now show:
  - `getMore <collection_name>` for cursor continuation operations
  - `aggregate <pipeline>` for aggregation operations
- When `capture_statement=False`, only command names are captured (preserving existing behavior)

This enhancement provides better observability for MongoDB operations, especially for complex aggregation pipelines and large result set iterations.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The changes have been tested with comprehensive unit tests and a practical demo:

## Unit Tests:
- [x] `test_capture_statement_getmore()` - Verifies getMore statement capture when enabled
- [x] `test_capture_statement_aggregate()` - Verifies aggregate statement capture when enabled
- [x] `test_capture_statement_disabled_getmore()` - Verifies behavior when capture disabled
- [x] `test_capture_statement_disabled_aggregate()` - Verifies behavior when capture disabled

## Demo Application:

docker-compose.yml
```yml
version: '3.8'

services:
  mongodb:
    image: mongo:7.0
    container_name: pymongo-demo-mongo
    restart: unless-stopped
    ports:
      - "27017:27017"
    environment:
      MONGO_INITDB_ROOT_USERNAME: admin
      MONGO_INITDB_ROOT_PASSWORD: admin123
      MONGO_INITDB_DATABASE: demo_db
    volumes:
      - mongodb_data:/data/db
      - ./init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro

volumes:
  mongodb_data:
```

init-mongo.js
```js
db = db.getSiblingDB('demo_db');

db.createUser({
  user: 'demo_user',
  pwd: 'demo_pass',
  roles: [
    {
      role: 'readWrite',
      db: 'demo_db'
    }
  ]
});

db.products.insertMany([
  { name: "Laptop", category: "electronics", price: 999, status: "active" },
  { name: "Phone", category: "electronics", price: 599, status: "active" },
  { name: "Tablet", category: "electronics", price: 399, status: "inactive" },
  { name: "Chair", category: "furniture", price: 199, status: "active" },
  { name: "Desk", category: "furniture", price: 299, status: "active" },
  { name: "Book", category: "books", price: 19, status: "active" },
  { name: "Magazine", category: "books", price: 9, status: "inactive" }
]);
```

requirements.txt
```
pymongo>=4.0.0
opentelemetry-api
opentelemetry-sdk
-e ../../opentelemetry-instrumentation-pymongo
```

demo.py
```python
#!/usr/bin/env python3
"""
Demo script showing PyMongo instrumentation with getMore and aggregate statement capture.

This script demonstrates how the updated PyMongo instrumentation captures
both getMore and aggregate statements when capture_statement=True.
"""

import logging
import time
from pymongo import MongoClient

from opentelemetry import trace
from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
from opentelemetry.sdk.resources import Resource, SERVICE_NAME

# Configure logging
logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)

def setup_tracing():
    """Set up OpenTelemetry tracing with console exporter."""
    # Create a resource
    resource = Resource(attributes={
        SERVICE_NAME: "pymongo-demo"
    })
    
    # Set up the tracer provider
    trace.set_tracer_provider(TracerProvider(resource=resource))
    tracer = trace.get_tracer(__name__)
    
    # Add console exporter for traces
    console_exporter = ConsoleSpanExporter()
    span_processor = BatchSpanProcessor(console_exporter)
    trace.get_tracer_provider().add_span_processor(span_processor)
    
    return tracer

def main():
    """Main demo function."""
    # Setup tracing
    tracer = setup_tracing()
    
    # Instrument PyMongo with statement capture enabled
    PymongoInstrumentor().instrument(capture_statement=True)
    
    # Connect to MongoDB
    client = MongoClient("mongodb://admin:admin123@localhost:27017/demo_db?authSource=admin")
    db = client.demo_db
    collection = db.products
    
    logger.info("Starting PyMongo instrumentation demo...")
    
    with tracer.start_as_current_span("demo-operations"):
        # 1. Simple find operation (existing functionality)
        logger.info("\n=== 1. Simple find operation ===")
        result = collection.find_one({"category": "electronics"})
        logger.info(f"Found product: {result['name'] if result else 'None'}")
        
        # 2. Find with cursor (will generate getMore operations)
        logger.info("\n=== 2. Find with cursor (getMore operations) ===")
        cursor = collection.find({"status": "active"}).batch_size(2)
        for i, doc in enumerate(cursor):
            logger.info(f"Product {i+1}: {doc['name']}")
            if i >= 3:  # Limit to avoid too much output
                break
        
        # 3. Aggregate operation (new functionality)
        logger.info("\n=== 3. Aggregate operation ===")
        pipeline = [
            {"$match": {"status": "active"}},
            {"$group": {
                "_id": "$category",
                "count": {"$sum": 1},
                "avg_price": {"$avg": "$price"}
            }},
            {"$sort": {"count": -1}}
        ]
        
        agg_result = list(collection.aggregate(pipeline))
        for category_info in agg_result:
            logger.info(f"Category: {category_info['_id']}, Count: {category_info['count']}, Avg Price: ${category_info['avg_price']:.2f}")
        
        # 4. Large aggregate with cursor (may generate getMore)
        logger.info("\n=== 4. Large aggregate with cursor ===")
        large_pipeline = [
            {"$match": {"price": {"$gt": 50}}},
            {"$project": {
                "name": 1,
                "price": 1,
                "category": 1,
                "price_tier": {
                    "$switch": {
                        "branches": [
                            {"case": {"$lt": ["$price", 100]}, "then": "budget"},
                            {"case": {"$lt": ["$price", 500]}, "then": "mid-range"},
                            {"case": {"$gte": ["$price", 500]}, "then": "premium"}
                        ]
                    }
                }
            }}
        ]
        
        cursor = collection.aggregate(large_pipeline)
        for doc in cursor:
            logger.info(f"Product: {doc['name']} (${doc['price']}) - {doc['price_tier']}")
    
    # Close the client
    client.close()
    
    logger.info("\nDemo completed! Check the console output above for traced operations.")
    logger.info("Notice how 'getMore' and 'aggregate' statements are now captured when capture_statement=True")
    
    # Give some time for spans to be exported
    time.sleep(2)

if __name__ == "__main__":
    main()
```


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
