### PR TITLE
optimization of remove_url_credentials __init__.py

### DIFF
--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -175,16 +175,15 @@ def remove_url_credentials(url: str) -> str:
     try:
         parsed = urlparse(url)
         if all([parsed.scheme, parsed.netloc]):  # checks for valid url
-            parsed_url = urlparse(url)
             _, _, netloc = parsed.netloc.rpartition("@")
             return urlunparse(
                 (
-                    parsed_url.scheme,
+                    parsed.scheme,
                     netloc,
-                    parsed_url.path,
-                    parsed_url.params,
-                    parsed_url.query,
-                    parsed_url.fragment,
+                    parsed.path,
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment,
                 )
             )
     except ValueError:  # an unparsable url was passed


### PR DESCRIPTION
Removed second call of urlparse in remove_url_credentials

# Description

There was a second call of urlparse thad did apparently nothing new compared to first urlparse. The call is removed

Fixes # (issue)

## Type of change

# How Has This Been Tested?

pytest

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
