### PR TITLE
Avoid Django's "ALLOWED_HOSTS" check

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -194,7 +194,7 @@ class _DjangoMiddleware(MiddlewareMixin):
         # Read more about request.META here:
         # https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.META
 
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if self._url_is_disabled(request):
             return
 
         is_asgi_request = _is_asgi_request(request)
@@ -305,7 +305,7 @@ class _DjangoMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, *args, **kwargs):
         # Process view is executed before the view function, here we get the
         # route template from request.resolver_match.  It is not set yet in process_request
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if self._url_is_disabled(request):
             return
 
         if (
@@ -330,7 +330,7 @@ class _DjangoMiddleware(MiddlewareMixin):
                         duration_attrs[HTTP_ROUTE] = route
 
     def process_exception(self, request, exception):
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if self._url_is_disabled(request):
             return
 
         if self._environ_activation_key in request.META.keys():
@@ -340,7 +340,7 @@ class _DjangoMiddleware(MiddlewareMixin):
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
     def process_response(self, request, response):
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if self._url_is_disabled(request):
             return response
 
         is_asgi_request = _is_asgi_request(request)
@@ -452,6 +452,15 @@ class _DjangoMiddleware(MiddlewareMixin):
             request.META.pop(self._environ_token)
 
         return response
+
+    def _url_is_disabled(self, request):
+        """
+        Avoid `request.get_host` to bypass Django's ALLOWED_HOST check
+        """
+        url = "{}://{}{}?".format(
+            request.scheme, request._get_raw_host(), request.path
+        )
+        return self._excluded_urls.url_disabled(url)
 
 
 def _parse_duration_attrs(

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -116,6 +116,10 @@ class TestMiddleware(WsgiTestBase):
     def setUp(self):
         super().setUp()
         setup_test_environment()
+        conf.settings.ALLOWED_HOSTS = [
+            # Django adds "testserver" within "setup_test_environment" so this check doesn't break during tests.
+            "unknown"
+        ]
         test_name = ""
         if hasattr(self, "_testMethodName"):
             test_name = self._testMethodName


### PR DESCRIPTION
# Description

Django (eventually) calls `HttpRequest.get_host` when calling `HttpRequest.build_absolute_uri`, which we use in the middleware.

In the context I'm at, we have a case for setting up a health check as early as possible in a middleware that needs to bypass that check since Kubernetes hits the containers directly via IP.

I can put the middleware after the health check one but would be good to also instrument it to collect traces if that ever fails.

These changes will bring up the implementation of `build_absolute_uri` without any of the checks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
