### PR TITLE
Adding new optional `post_injection_hook` to `RequestsInstrumentor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610))
 - `opentelemetry-instrumentation-kafka-python` Utilize instruments-any functionality.
   ([#3610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610))
+- `opentelemetry-instrumentation-requests` Add support for post-injection-hook.
+  ([#3610](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610))
 
 ## Version 1.35.0/0.56b0 (2025-07-11)
 


### PR DESCRIPTION
# Description
The `tracestate` and `baggage` headers may contain sensitive information that is valuable to propagate to trusted systems but could pose concerns when sent to untrusted systems. Currently there is no way to support instrumenting these spans while ensuring these, or other, headers are conditionally propagated. This new option allows callers to define a callable to mutate the post-injection headers based on each request.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`tox -e py312-test-instrumentation-requests`

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
