### PR TITLE
Update garbage collection metrics to use get_stats to align with semconv

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -905,10 +905,10 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
         self, options: CallbackOptions
     ) -> Iterable[Observation]:
         """Observer callback for garbage collection"""
-        for index, count in enumerate(gc.get_count()):
+        for index, stat in enumerate(gc.get_stats()):
             self._runtime_gc_collections_labels["generation"] = str(index)
             yield Observation(
-                count, self._runtime_gc_collections_labels.copy()
+                stat["collections"], self._runtime_gc_collections_labels.copy()
             )
 
     def _get_runtime_thread_count(

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -959,16 +959,24 @@ class TestSystemMetrics(TestBase):
             expected_gc_count,
         )
 
-    @mock.patch("gc.get_count")
+    @mock.patch("gc.get_stats")
     @skipIf(
         python_implementation().lower() == "pypy", "not supported for pypy"
     )
-    def test_runtime_get_gc_collections(self, mock_gc_get_count):
-        mock_gc_get_count.configure_mock(**{"return_value": (1, 2, 3)})
+    def test_runtime_get_gc_collections(self, mock_gc_get_stats):
+        mock_gc_get_stats.configure_mock(
+            **{
+                "return_value": [
+                    {"collections": 10, "collected": 100, "uncollectable": 1},
+                    {"collections": 20, "collected": 200, "uncollectable": 2},
+                    {"collections": 30, "collected": 300, "uncollectable": 3},
+                ]
+            }
+        )
         expected_gc_collections = [
-            _SystemMetricsResult({"generation": "0"}, 1),
-            _SystemMetricsResult({"generation": "1"}, 2),
-            _SystemMetricsResult({"generation": "2"}, 3),
+            _SystemMetricsResult({"generation": "0"}, 10),
+            _SystemMetricsResult({"generation": "1"}, 20),
+            _SystemMetricsResult({"generation": "2"}, 30),
         ]
         self._test_metrics(
             "cpython.gc.collections",


### PR DESCRIPTION
# Description

This is a continuation of: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3617#discussion_r2241932611
We want to align with the semantic conventions. As specified there the data should be taken from get_stats

## Type of change

# How Has This Been Tested?

Changed the unit tests to mock get_stats

# Does This PR Require a Core Repo Change?
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ V] Followed the style guidelines of this project
- [ ] Changelogs have been updated - not relevant
- [ ] Unit tests have been added - not relevant
- [ ] Documentation has been updated - not relevant
