### PR TITLE
feat: Add custom span naming for dbapi and requests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -234,6 +234,8 @@ def _instrument(
 
         url = redact_url(request.url)
 
+        span_name = f"{span_name} {url}"
+
         span_attributes = {}
         _set_http_method(
             span_attributes,


### PR DESCRIPTION
### Description

This pull request contains custom modifications to the `opentelemetry-instrumentation-dbapi` and `opentelemetry-instrumentation-requests` packages. The primary goal of these changes is to enrich the default span names for database and HTTP client operations with more specific, low-cardinality information.

- **For `dbapi` instrumentation:** The span name is modified to include the table name, derived from parsing the SQL statement. For example, a span for `SELECT * FROM users` will be named `SELECT users`.
- **For `requests` instrumentation:** The span name is modified to include the URL path. For example, a span for a `GET` request to `https://example.com/api/v1/users` will be named `GET /api/v1/users`.

**Note:** This pull request is for internal use and serves as a proof of concept. The changes bypass standard extension points and would not be suitable for general use. We are using this fork to deploy our custom instrumentation packages via a git dependency in our `requirements.txt`.

**No issue is fixed in the upstream repository, as this addresses a specific configuration challenge we encountered.**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change was tested in a local Dockerized Python 3.11 environment.

- **Test 1: Psycopg2 Span Naming**
    - A simple Python script was created to connect to a PostgreSQL database via `psycopg2` and execute a DML query (e.g., `SELECT`, `INSERT`).
    - The generated traces were observed to verify that the database spans had names in the format `{OPERATION} {table_name}`.
- **Test 2: Requests Span Naming**
    - A Python script was created to make an HTTP `GET` request using the `requests` library to a specific URL (e.g., `http://example.com/users/123`).
    - The generated traces were observed to verify that the HTTP client spans had names in the format `{METHOD} {url_path}`.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated