### PR TITLE
missing capture_parameters in instrumentation psycopg

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
@@ -183,6 +183,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
         enable_attribute_commenter = kwargs.get(
             "enable_attribute_commenter", False
         )
+        capture_parameters = kwargs.get("capture_parameters", False)
         dbapi.wrap_connect(
             __name__,
             psycopg,
@@ -195,6 +196,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            capture_parameters=capture_parameters,
         )
 
         dbapi.wrap_connect(
@@ -209,6 +211,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            capture_parameters=capture_parameters,
         )
         dbapi.wrap_connect(
             __name__,
@@ -222,6 +225,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            capture_parameters=capture_parameters,
         )
 
     def _uninstrument(self, **kwargs: Any):


### PR DESCRIPTION
# Description

Added missing parameter `capture_parameters` for psycopg instrumentation:
```python
PsycopgInstrumentor().instrument(capture_parameters=True)
```
populates the `db.statement.parameters` attribute in spans.

Fixes # [(issue)](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3569)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested in a small script with Python 3.13.3 + jaegertracing/jaeger:2.6.0 docker image.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
