### PR TITLE
OpenAI v2 onboard onto new semantic conventions: chat history and other breaking changes

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/manual/main.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/manual/main.py
@@ -4,9 +4,12 @@ import os
 from openai import OpenAI
 
 # NOTE: OpenTelemetry Python Logs and Events APIs are in beta
-from opentelemetry import _events, _logs, trace
+from opentelemetry import _events, _logs, metrics, trace
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
+)
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter,
 )
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
@@ -15,6 +18,8 @@ from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -31,22 +36,42 @@ _logs.get_logger_provider().add_log_record_processor(
 )
 _events.set_event_logger_provider(EventLoggerProvider())
 
+# configure metrics
+metrics.set_meter_provider(
+    MeterProvider(
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(),
+            ),
+        ]
+    )
+)
+
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+HTTPXClientInstrumentor().instrument()
+
 # instrument OpenAI
 OpenAIInstrumentor().instrument()
+
+tracer = trace.get_tracer(__name__)
 
 
 def main():
     client = OpenAI()
-    chat_completion = client.chat.completions.create(
-        model=os.getenv("CHAT_MODEL", "gpt-4o-mini"),
-        messages=[
-            {
-                "role": "user",
-                "content": "Write a short poem on OpenTelemetry.",
-            },
-        ],
-    )
-    print(chat_completion.choices[0].message.content)
+
+    for u in range(10):
+        with tracer.start_as_current_span("main"):
+            chat_completion = client.chat.completions.create(
+                model=os.getenv("CHAT_MODEL", "gpt-4o-mini"),
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Write a haiku on OpenTelemetry.",
+                    },
+                ],
+            )
+            print(chat_completion.choices[0].message.content)
 
 
 if __name__ == "__main__":

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/manual/main.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/manual/main.py
@@ -4,12 +4,9 @@ import os
 from openai import OpenAI
 
 # NOTE: OpenTelemetry Python Logs and Events APIs are in beta
-from opentelemetry import _events, _logs, metrics, trace
+from opentelemetry import _events, _logs, trace
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
-)
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
-    OTLPMetricExporter,
 )
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
@@ -18,8 +15,6 @@ from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -36,42 +31,22 @@ _logs.get_logger_provider().add_log_record_processor(
 )
 _events.set_event_logger_provider(EventLoggerProvider())
 
-# configure metrics
-metrics.set_meter_provider(
-    MeterProvider(
-        metric_readers=[
-            PeriodicExportingMetricReader(
-                OTLPMetricExporter(),
-            ),
-        ]
-    )
-)
-
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-
-HTTPXClientInstrumentor().instrument()
-
 # instrument OpenAI
 OpenAIInstrumentor().instrument()
-
-tracer = trace.get_tracer(__name__)
 
 
 def main():
     client = OpenAI()
-
-    for u in range(10):
-        with tracer.start_as_current_span("main"):
-            chat_completion = client.chat.completions.create(
-                model=os.getenv("CHAT_MODEL", "gpt-4o-mini"),
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "Write a haiku on OpenTelemetry.",
-                    },
-                ],
-            )
-            print(chat_completion.choices[0].message.content)
+    chat_completion = client.chat.completions.create(
+        model=os.getenv("CHAT_MODEL", "gpt-4o-mini"),
+        messages=[
+            {
+                "role": "user",
+                "content": "Write a short poem on OpenTelemetry.",
+            },
+        ],
+    )
+    print(chat_completion.choices[0].message.content)
 
 
 if __name__ == "__main__":

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -47,7 +47,10 @@ from wrapt import wrap_function_wrapper
 from opentelemetry._events import get_event_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.openai_v2.package import _instruments
-from opentelemetry.instrumentation.openai_v2.utils import is_content_enabled
+from opentelemetry.instrumentation.openai_v2.utils import (
+    is_content_enabled,
+    is_latest_experimental_enabled,
+)
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.metrics import get_meter
 from opentelemetry.semconv.schemas import Schemas
@@ -94,7 +97,11 @@ class OpenAIInstrumentor(BaseInstrumentor):
             module="openai.resources.chat.completions",
             name="Completions.create",
             wrapper=chat_completions_create(
-                tracer, event_logger, instruments, is_content_enabled()
+                tracer,
+                event_logger,
+                instruments,
+                is_content_enabled(),
+                is_latest_experimental_enabled(),
             ),
         )
 
@@ -102,7 +109,11 @@ class OpenAIInstrumentor(BaseInstrumentor):
             module="openai.resources.chat.completions",
             name="AsyncCompletions.create",
             wrapper=async_chat_completions_create(
-                tracer, event_logger, instruments, is_content_enabled()
+                tracer,
+                event_logger,
+                instruments,
+                is_content_enabled(),
+                is_latest_experimental_enabled(),
             ),
         )
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -48,7 +48,7 @@ from opentelemetry._events import get_event_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.openai_v2.package import _instruments
 from opentelemetry.instrumentation.openai_v2.utils import (
-    is_content_enabled,
+    get_content_mode,
     is_latest_experimental_enabled,
 )
 from opentelemetry.instrumentation.utils import unwrap
@@ -93,6 +93,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
 
         instruments = Instruments(self._meter)
 
+        latest_experimental_enabled = is_latest_experimental_enabled()
         wrap_function_wrapper(
             module="openai.resources.chat.completions",
             name="Completions.create",
@@ -100,8 +101,8 @@ class OpenAIInstrumentor(BaseInstrumentor):
                 tracer,
                 event_logger,
                 instruments,
-                is_content_enabled(),
-                is_latest_experimental_enabled(),
+                get_content_mode(latest_experimental_enabled),
+                latest_experimental_enabled,
             ),
         )
 
@@ -112,8 +113,8 @@ class OpenAIInstrumentor(BaseInstrumentor):
                 tracer,
                 event_logger,
                 instruments,
-                is_content_enabled(),
-                is_latest_experimental_enabled(),
+                get_content_mode(latest_experimental_enabled),
+                latest_experimental_enabled,
             ),
         )
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import json
 from timeit import default_timer
 from typing import Optional
 
@@ -29,11 +30,15 @@ from opentelemetry.trace import Span, SpanKind, Tracer
 
 from .instruments import Instruments
 from .utils import (
-    choice_to_event,
+    DataclassEncoder,
+    OutputMessage,
+    TextPart,
+    ToolCallRequestPart,
     get_llm_request_attributes,
     handle_span_exception,
     is_streaming,
-    message_to_event,
+    record_input_messages,
+    record_output_messages,
     set_span_attribute,
 )
 
@@ -43,11 +48,19 @@ def chat_completions_create(
     event_logger: EventLogger,
     instruments: Instruments,
     capture_content: bool,
+    latest_experimental_enabled: bool,
 ):
     """Wrap the `create` method of the `ChatCompletion` class to trace it."""
 
     def traced_method(wrapped, instance, args, kwargs):
-        span_attributes = {**get_llm_request_attributes(kwargs, instance)}
+        span_attributes = {
+            **get_llm_request_attributes(
+                kwargs,
+                instance,
+                GenAIAttributes.GenAiOperationNameValues.CHAT.value,
+                latest_experimental_enabled,
+            )
+        }
 
         span_name = f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
         with tracer.start_as_current_span(
@@ -56,8 +69,13 @@ def chat_completions_create(
             attributes=span_attributes,
             end_on_exit=False,
         ) as span:
-            for message in kwargs.get("messages", []):
-                event_logger.emit(message_to_event(message, capture_content))
+            record_input_messages(
+                kwargs.get("messages", []),
+                capture_content,
+                latest_experimental_enabled,
+                span,
+                event_logger,
+            )
 
             start = default_timer()
             result = None
@@ -66,15 +84,24 @@ def chat_completions_create(
                 result = wrapped(*args, **kwargs)
                 if is_streaming(kwargs):
                     return StreamWrapper(
-                        result, span, event_logger, capture_content
+                        result,
+                        span,
+                        event_logger,
+                        capture_content,
+                        latest_experimental_enabled,
                     )
 
                 if span.is_recording():
                     _set_response_attributes(
-                        span, result, event_logger, capture_content
+                        span, result, latest_experimental_enabled
                     )
-                for choice in getattr(result, "choices", []):
-                    event_logger.emit(choice_to_event(choice, capture_content))
+                record_output_messages(
+                    getattr(result, "choices", []),
+                    capture_content,
+                    latest_experimental_enabled,
+                    span,
+                    event_logger,
+                )
 
                 span.end()
                 return result
@@ -91,6 +118,7 @@ def chat_completions_create(
                     result,
                     span_attributes,
                     error_type,
+                    latest_experimental_enabled,
                 )
 
     return traced_method
@@ -101,11 +129,19 @@ def async_chat_completions_create(
     event_logger: EventLogger,
     instruments: Instruments,
     capture_content: bool,
+    latest_experimental_enabled: bool,
 ):
     """Wrap the `create` method of the `AsyncChatCompletion` class to trace it."""
 
     async def traced_method(wrapped, instance, args, kwargs):
-        span_attributes = {**get_llm_request_attributes(kwargs, instance)}
+        span_attributes = {
+            **get_llm_request_attributes(
+                kwargs,
+                instance,
+                GenAIAttributes.GenAiOperationNameValues.CHAT.value,
+                latest_experimental_enabled,
+            )
+        }
 
         span_name = f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
         with tracer.start_as_current_span(
@@ -114,8 +150,13 @@ def async_chat_completions_create(
             attributes=span_attributes,
             end_on_exit=False,
         ) as span:
-            for message in kwargs.get("messages", []):
-                event_logger.emit(message_to_event(message, capture_content))
+            record_input_messages(
+                kwargs.get("messages", []),
+                capture_content,
+                latest_experimental_enabled,
+                span,
+                event_logger,
+            )
 
             start = default_timer()
             result = None
@@ -124,15 +165,24 @@ def async_chat_completions_create(
                 result = await wrapped(*args, **kwargs)
                 if is_streaming(kwargs):
                     return StreamWrapper(
-                        result, span, event_logger, capture_content
+                        result,
+                        span,
+                        event_logger,
+                        capture_content,
+                        latest_experimental_enabled,
                     )
 
                 if span.is_recording():
                     _set_response_attributes(
-                        span, result, event_logger, capture_content
+                        span, result, latest_experimental_enabled
                     )
-                for choice in getattr(result, "choices", []):
-                    event_logger.emit(choice_to_event(choice, capture_content))
+                record_output_messages(
+                    getattr(result, "choices", []),
+                    capture_content,
+                    latest_experimental_enabled,
+                    span,
+                    event_logger,
+                )
 
                 span.end()
                 return result
@@ -149,6 +199,7 @@ def async_chat_completions_create(
                     result,
                     span_attributes,
                     error_type,
+                    latest_experimental_enabled,
                 )
 
     return traced_method
@@ -160,10 +211,16 @@ def _record_metrics(
     result,
     span_attributes: dict,
     error_type: Optional[str],
+    latest_experimental_enabled: bool,
 ):
+    provider_name_attr_name = (
+        "gen_ai.provider.name"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_SYSTEM
+    )
     common_attributes = {
         GenAIAttributes.GEN_AI_OPERATION_NAME: GenAIAttributes.GenAiOperationNameValues.CHAT.value,
-        GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value,
+        provider_name_attr_name: GenAIAttributes.GenAiSystemValues.OPENAI.value,
         GenAIAttributes.GEN_AI_REQUEST_MODEL: span_attributes[
             GenAIAttributes.GEN_AI_REQUEST_MODEL
         ],
@@ -175,13 +232,21 @@ def _record_metrics(
     if result and getattr(result, "model", None):
         common_attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL] = result.model
 
+    service_tier_attr_key = (
+        "openai.response.service_tier"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
+    )
     if result and getattr(result, "service_tier", None):
-        common_attributes[
-            GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
-        ] = result.service_tier
+        common_attributes[service_tier_attr_key] = result.service_tier
 
+    system_fingerprint_attr_key = (
+        "openai.response.system_fingerprint"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SYSTEM_FINGERPRINT
+    )
     if result and getattr(result, "system_fingerprint", None):
-        common_attributes["gen_ai.openai.response.system_fingerprint"] = (
+        common_attributes[system_fingerprint_attr_key] = (
             result.system_fingerprint
         )
 
@@ -220,9 +285,7 @@ def _record_metrics(
         )
 
 
-def _set_response_attributes(
-    span, result, event_logger: EventLogger, capture_content: bool
-):
+def _set_response_attributes(span, result, latest_experimental_enabled: bool):
     set_span_attribute(
         span, GenAIAttributes.GEN_AI_RESPONSE_MODEL, result.model
     )
@@ -241,10 +304,15 @@ def _set_response_attributes(
     if getattr(result, "id", None):
         set_span_attribute(span, GenAIAttributes.GEN_AI_RESPONSE_ID, result.id)
 
+    service_tier_attr_key = (
+        "openai.response.service_tier"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
+    )
     if getattr(result, "service_tier", None):
         set_span_attribute(
             span,
-            GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER,
+            service_tier_attr_key,
             result.service_tier,
         )
 
@@ -313,12 +381,14 @@ class StreamWrapper:
         span: Span,
         event_logger: EventLogger,
         capture_content: bool,
+        latest_experimental_enabled: bool,
     ):
         self.stream = stream
         self.span = span
         self.choice_buffers = []
         self._span_started = False
         self.capture_content = capture_content
+        self.latest_experimental_enabled = latest_experimental_enabled
 
         self.event_logger = event_logger
         self.setup()
@@ -355,9 +425,14 @@ class StreamWrapper:
                     self.completion_tokens,
                 )
 
+                service_tier_attr_key = (
+                    "openai.response.service_tier"
+                    if self.latest_experimental_enabled
+                    else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
+                )
                 set_span_attribute(
                     self.span,
-                    GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER,
+                    service_tier_attr_key,
                     self.service_tier,
                 )
 
@@ -367,48 +442,90 @@ class StreamWrapper:
                     self.finish_reasons,
                 )
 
-            for idx, choice in enumerate(self.choice_buffers):
-                message = {"role": "assistant"}
-                if self.capture_content and choice.text_content:
-                    message["content"] = "".join(choice.text_content)
-                if choice.tool_calls_buffers:
-                    tool_calls = []
-                    for tool_call in choice.tool_calls_buffers:
-                        function = {"name": tool_call.function_name}
-                        if self.capture_content:
-                            function["arguments"] = "".join(
-                                tool_call.arguments
+            if self.latest_experimental_enabled:
+                if not self.capture_content:
+                    pass
+                else:
+                    output_messages = []
+                    for choice in self.choice_buffers:
+                        message = OutputMessage(
+                            finish_reason=choice.finish_reason or "error",
+                            role="assistant",
+                        )
+                        output_messages.append(message)
+
+                        if self.capture_content and choice.text_content:
+                            message.parts.append(
+                                TextPart(content="".join(choice.text_content))
                             )
-                        tool_call_dict = {
-                            "id": tool_call.tool_call_id,
-                            "type": "function",
-                            "function": function,
-                        }
-                        tool_calls.append(tool_call_dict)
-                    message["tool_calls"] = tool_calls
+                        if choice.tool_calls_buffers:
+                            for tool_call in choice.tool_calls_buffers:
+                                part = ToolCallRequestPart(
+                                    name=tool_call.function_name,
+                                    id=tool_call.tool_call_id,
+                                )
+                                arguments = "".join(tool_call.arguments)
+                                if arguments:
+                                    try:
+                                        part.arguments = json.loads(arguments)
+                                    except json.JSONDecodeError:
+                                        part.arguments = arguments
 
-                body = {
-                    "index": idx,
-                    "finish_reason": choice.finish_reason or "error",
-                    "message": message,
-                }
+                                message.parts.append(part)
+                    # TODO: config between spans and events
+                    # also if spans and span is not recording, let's not do it all
+                    if self.span.is_recording():
+                        self.span.set_attribute(
+                            "gen_ai.output.messages",
+                            json.dumps(
+                                output_messages,
+                                ensure_ascii=False,
+                                cls=DataclassEncoder,
+                            ),
+                        )
+            else:
+                for idx, choice in enumerate(self.choice_buffers):
+                    message = {"role": "assistant"}
+                    if self.capture_content and choice.text_content:
+                        message["content"] = "".join(choice.text_content)
+                    if choice.tool_calls_buffers:
+                        tool_calls = []
+                        for tool_call in choice.tool_calls_buffers:
+                            function = {"name": tool_call.function_name}
+                            if self.capture_content:
+                                function["arguments"] = "".join(
+                                    tool_call.arguments
+                                )
+                            tool_call_dict = {
+                                "id": tool_call.tool_call_id,
+                                "type": "function",
+                                "function": function,
+                            }
+                            tool_calls.append(tool_call_dict)
+                        message["tool_calls"] = tool_calls
 
-                event_attributes = {
-                    GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
-                }
+                    body = {
+                        "index": idx,
+                        "finish_reason": choice.finish_reason or "error",
+                        "message": message,
+                    }
 
-                # this span is not current, so we need to manually set the context on event
-                span_ctx = self.span.get_span_context()
-                self.event_logger.emit(
-                    Event(
-                        name="gen_ai.choice",
-                        attributes=event_attributes,
-                        body=body,
-                        trace_id=span_ctx.trace_id,
-                        span_id=span_ctx.span_id,
-                        trace_flags=span_ctx.trace_flags,
+                    event_attributes = {
+                        GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
+                    }
+
+                    # this span is not current, so we need to manually set the context on event
+                    span_ctx = self.span.get_span_context()
+                    self.event_logger.emit(
+                        Event(
+                            name="gen_ai.choice",
+                            attributes=event_attributes,
+                            body=body,
+                            trace_id=span_ctx.trace_id,
+                            span_id=span_ctx.span_id,
+                            trace_flags=span_ctx.trace_flags,
+                        )
                     )
-                )
 
             self.span.end()
             self._span_started = False

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
@@ -31,6 +31,7 @@ from opentelemetry.trace import Span, SpanKind, Tracer
 from .instruments import Instruments
 from .utils import (
     DataclassEncoder,
+    ContentCapturingMode,
     OutputMessage,
     TextPart,
     ToolCallRequestPart,
@@ -47,7 +48,7 @@ def chat_completions_create(
     tracer: Tracer,
     event_logger: EventLogger,
     instruments: Instruments,
-    capture_content: bool,
+    content_mode: ContentCapturingMode,
     latest_experimental_enabled: bool,
 ):
     """Wrap the `create` method of the `ChatCompletion` class to trace it."""
@@ -71,7 +72,7 @@ def chat_completions_create(
         ) as span:
             record_input_messages(
                 kwargs.get("messages", []),
-                capture_content,
+                content_mode,
                 latest_experimental_enabled,
                 span,
                 event_logger,
@@ -87,7 +88,7 @@ def chat_completions_create(
                         result,
                         span,
                         event_logger,
-                        capture_content,
+                        content_mode,
                         latest_experimental_enabled,
                     )
 
@@ -97,7 +98,7 @@ def chat_completions_create(
                     )
                 record_output_messages(
                     getattr(result, "choices", []),
-                    capture_content,
+                    content_mode,
                     latest_experimental_enabled,
                     span,
                     event_logger,
@@ -128,7 +129,7 @@ def async_chat_completions_create(
     tracer: Tracer,
     event_logger: EventLogger,
     instruments: Instruments,
-    capture_content: bool,
+    content_mode: ContentCapturingMode,
     latest_experimental_enabled: bool,
 ):
     """Wrap the `create` method of the `AsyncChatCompletion` class to trace it."""
@@ -152,7 +153,7 @@ def async_chat_completions_create(
         ) as span:
             record_input_messages(
                 kwargs.get("messages", []),
-                capture_content,
+                content_mode,
                 latest_experimental_enabled,
                 span,
                 event_logger,
@@ -168,7 +169,7 @@ def async_chat_completions_create(
                         result,
                         span,
                         event_logger,
-                        capture_content,
+                        content_mode,
                         latest_experimental_enabled,
                     )
 
@@ -178,7 +179,7 @@ def async_chat_completions_create(
                     )
                 record_output_messages(
                     getattr(result, "choices", []),
-                    capture_content,
+                    content_mode,
                     latest_experimental_enabled,
                     span,
                     event_logger,
@@ -380,14 +381,14 @@ class StreamWrapper:
         stream: Stream,
         span: Span,
         event_logger: EventLogger,
-        capture_content: bool,
+        content_mode: ContentCapturingMode,
         latest_experimental_enabled: bool,
     ):
         self.stream = stream
         self.span = span
         self.choice_buffers = []
         self._span_started = False
-        self.capture_content = capture_content
+        self.content_mode = content_mode
         self.latest_experimental_enabled = latest_experimental_enabled
 
         self.event_logger = event_logger
@@ -443,7 +444,8 @@ class StreamWrapper:
                 )
 
             if self.latest_experimental_enabled:
-                if not self.capture_content:
+                if (self.content_mode == ContentCapturingMode.NONE or 
+                    (self.content_mode == ContentCapturingMode.SPAN and not self.span.is_recording())):
                     pass
                 else:
                     output_messages = []
@@ -454,7 +456,7 @@ class StreamWrapper:
                         )
                         output_messages.append(message)
 
-                        if self.capture_content and choice.text_content:
+                        if choice.text_content:
                             message.parts.append(
                                 TextPart(content="".join(choice.text_content))
                             )
@@ -472,9 +474,8 @@ class StreamWrapper:
                                         part.arguments = arguments
 
                                 message.parts.append(part)
-                    # TODO: config between spans and events
-                    # also if spans and span is not recording, let's not do it all
-                    if self.span.is_recording():
+                   
+                    if self.span.is_recording() and self.content_mode == ContentCapturingMode.SPAN:
                         self.span.set_attribute(
                             "gen_ai.output.messages",
                             json.dumps(
@@ -483,16 +484,17 @@ class StreamWrapper:
                                 cls=DataclassEncoder,
                             ),
                         )
+                    # TODO: event
             else:
                 for idx, choice in enumerate(self.choice_buffers):
                     message = {"role": "assistant"}
-                    if self.capture_content and choice.text_content:
+                    if self.content_mode == ContentCapturingMode.EVENT and choice.text_content:
                         message["content"] = "".join(choice.text_content)
                     if choice.tool_calls_buffers:
                         tool_calls = []
                         for tool_call in choice.tool_calls_buffers:
                             function = {"name": tool_call.function_name}
-                            if self.capture_content:
+                            if self.content_mode == ContentCapturingMode.EVENT:
                                 function["arguments"] = "".join(
                                     tool_call.arguments
                                 )

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -17,6 +17,7 @@ import json
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
+import logging
 from os import environ
 from typing import Any, List, Mapping, Optional, Union
 from urllib.parse import urlparse
@@ -43,13 +44,28 @@ OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = (
 # TODO: reuse common code
 OTEL_SEMCONV_STABILITY_OPT_IN = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
+logger = logging.getLogger(__name__)
 
-def is_content_enabled() -> bool:
+class ContentCapturingMode(str, Enum):
+    SPAN = "span"
+    EVENT = "event"
+    NONE = "none"
+    
+def get_content_mode(latest_experimental_enabled: bool) -> ContentCapturingMode:
     capture_content = environ.get(
-        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "false"
-    )
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "none"
+    ).lower()
 
-    return capture_content.lower() == "true"
+    if latest_experimental_enabled:
+        try:
+            return ContentCapturingMode(capture_content)
+        except ValueError as ex:
+            logger.warning("Error when parsing `%s` environment variable: {%s}", OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, str(ex))
+            return ContentCapturingMode.NONE
+     
+    else:
+        # back-compat
+        return ContentCapturingMode.EVENT if capture_content == "true" else ContentCapturingMode.NONE
 
 
 def is_latest_experimental_enabled() -> bool:
@@ -61,7 +77,7 @@ def is_latest_experimental_enabled() -> bool:
     )
 
 
-def extract_tool_calls_old(item, capture_content):
+def extract_tool_calls_old(item, content_mode: ContentCapturingMode):
     tool_calls = get_property_value(item, "tool_calls")
     if tool_calls is None:
         return None
@@ -86,7 +102,7 @@ def extract_tool_calls_old(item, capture_content):
                 tool_call_dict["function"]["name"] = name
 
             arguments = get_property_value(func, "arguments")
-            if capture_content and arguments:
+            if content_mode == ContentCapturingMode.EVENT and arguments:
                 if isinstance(arguments, str):
                     arguments = arguments.replace("\n", "")
                 tool_call_dict["function"]["arguments"] = arguments
@@ -150,13 +166,14 @@ def get_property_value(obj, property_name):
 
 def record_input_messages(
     messages,
-    capture_content: bool,
+    content_mode: ContentCapturingMode,
     latest_experimental_enabled: bool,
     span: Span,
     event_logger: EventLogger,
 ):
     if latest_experimental_enabled:
-        if not capture_content:
+        if (content_mode == ContentCapturingMode.NONE or 
+            (content_mode == ContentCapturingMode.SPAN and not span.is_recording())):
             return
 
         chat_messages = []
@@ -186,19 +203,17 @@ def record_input_messages(
                     chat_message.parts.append(TextPart(content=content))
                     # continue?
 
-        # TODO: config between spans and events
-        # also if spans and span is not recording, let's not do it all
-        if span.is_recording():
+        if span.is_recording() and content_mode == ContentCapturingMode.SPAN:
             span.set_attribute(
                 "gen_ai.input.messages",
                 json.dumps(
                     chat_messages, ensure_ascii=False, cls=DataclassEncoder
                 ),
             )
-
+        # TODO: events
     else:
         for message in messages:
-            event_logger.emit(_message_to_event(message, capture_content))
+            event_logger.emit(_message_to_event(message, content_mode))
 
 
 def _is_text_part(content: Any) -> bool:
@@ -210,13 +225,14 @@ def _is_text_part(content: Any) -> bool:
 
 def record_output_messages(
     choices,
-    capture_content: bool,
+    content_mode: ContentCapturingMode,
     latest_experimental_enabled: bool,
     span: Span,
     event_logger: EventLogger,
 ):
     if latest_experimental_enabled:
-        if not capture_content:
+        if (content_mode == ContentCapturingMode.NONE or 
+           (content_mode == ContentCapturingMode.SPAN and not span.is_recording())):
             return
 
         output_messages = []
@@ -239,22 +255,21 @@ def record_output_messages(
                 if _is_text_part(content):
                     message.parts.append(TextPart(content=content))
 
-        # TODO: config between spans and events
-        # also if spans and span is not recording, let's not do it all
-        if span.is_recording():
+
+        if span.is_recording() and content_mode == ContentCapturingMode.SPAN:
             span.set_attribute(
                 "gen_ai.output.messages",
                 json.dumps(
                     output_messages, ensure_ascii=False, cls=DataclassEncoder
                 ),
             )
-
+        # TODO: events
     else:
         for choice in choices:
-            event_logger.emit(_choice_to_event(choice, capture_content))
+            event_logger.emit(_choice_to_event(choice, content_mode))
 
 
-def _message_to_event(message, capture_content):
+def _message_to_event(message, content_mode: ContentCapturingMode):
     attributes = {
         GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
     }
@@ -262,10 +277,10 @@ def _message_to_event(message, capture_content):
     content = get_property_value(message, "content")
 
     body = {}
-    if capture_content and content:
+    if content_mode == ContentCapturingMode.EVENT and content:
         body["content"] = content
     if role == "assistant":
-        tool_calls = extract_tool_calls_old(message, capture_content)
+        tool_calls = extract_tool_calls_old(message, content_mode)
         if tool_calls:
             body = {"tool_calls": tool_calls}
     elif role == "tool":
@@ -280,7 +295,7 @@ def _message_to_event(message, capture_content):
     )
 
 
-def _choice_to_event(choice, capture_content):
+def _choice_to_event(choice, content_mode: ContentCapturingMode):
     attributes = {
         GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
     }
@@ -298,11 +313,11 @@ def _choice_to_event(choice, capture_content):
                 else None
             )
         }
-        tool_calls = extract_tool_calls_old(choice.message, capture_content)
+        tool_calls = extract_tool_calls_old(choice.message, content_mode)
         if tool_calls:
             message["tool_calls"] = tool_calls
         content = get_property_value(choice.message, "content")
-        if capture_content and content:
+        if content_mode == ContentCapturingMode.EVENT and content:
             message["content"] = content
         body["message"] = message
 
@@ -376,7 +391,7 @@ def get_llm_request_attributes(
             ) is not None:
                 if response_format_type == "text":
                     attributes[output_type_attr_key] = (
-                        "text"  # TODO there should be an enum
+                        "text"  # TODO there should be an enum in semconv package
                     )
                 elif (
                     response_format_type == "json_schema"
@@ -385,7 +400,6 @@ def get_llm_request_attributes(
                     attributes[output_type_attr_key] = "json"
                 else:
                     # should never happen with chat completion API
-                    # TODO: internal log
                     pass
         else:
             # should never happen with chat completion API

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from enum import Enum
 from os import environ
-from typing import Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union
 from urllib.parse import urlparse
 
 from httpx import URL
 from openai import NOT_GIVEN
 
-from opentelemetry._events import Event
+from opentelemetry._events import Event, EventLogger
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -29,11 +34,14 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv.attributes import (
     error_attributes as ErrorAttributes,
 )
+from opentelemetry.trace import Span
 from opentelemetry.trace.status import Status, StatusCode
 
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = (
     "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 )
+# TODO: reuse common code
+OTEL_SEMCONV_STABILITY_OPT_IN = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 
 def is_content_enabled() -> bool:
@@ -44,7 +52,16 @@ def is_content_enabled() -> bool:
     return capture_content.lower() == "true"
 
 
-def extract_tool_calls(item, capture_content):
+def is_latest_experimental_enabled() -> bool:
+    stability_opt_in = environ.get(OTEL_SEMCONV_STABILITY_OPT_IN, None)
+
+    return (
+        stability_opt_in is not None
+        and stability_opt_in.lower() == "gen_ai_latest_experimental"
+    )
+
+
+def extract_tool_calls_old(item, capture_content):
     tool_calls = get_property_value(item, "tool_calls")
     if tool_calls is None:
         return None
@@ -78,6 +95,33 @@ def extract_tool_calls(item, capture_content):
     return calls
 
 
+def extract_tool_calls_new(tool_calls) -> list["ToolCallRequestPart"]:
+    parts = []
+    for tool_call in tool_calls:
+        tool_call_part = ToolCallRequestPart()
+        call_id = get_property_value(tool_call, "id")
+        if call_id:
+            tool_call_part.id = call_id
+
+        func = get_property_value(tool_call, "function")
+        if func:
+            tool_call_part.function = {}
+            name = get_property_value(func, "name")
+            if name:
+                tool_call_part.name = name
+
+            arguments = get_property_value(func, "arguments")
+            if arguments:
+                try:
+                    tool_call_part.arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    tool_call_part.arguments = arguments
+
+        # TODO: support custom
+        parts.append(tool_call_part)
+    return parts
+
+
 def set_server_address_and_port(client_instance, attributes):
     base_client = getattr(client_instance, "_client", None)
     base_url = getattr(base_client, "base_url", None)
@@ -104,7 +148,113 @@ def get_property_value(obj, property_name):
     return getattr(obj, property_name, None)
 
 
-def message_to_event(message, capture_content):
+def record_input_messages(
+    messages,
+    capture_content: bool,
+    latest_experimental_enabled: bool,
+    span: Span,
+    event_logger: EventLogger,
+):
+    if latest_experimental_enabled:
+        if not capture_content:
+            return
+
+        chat_messages = []
+        for message in messages:
+            role = get_property_value(message, "role")
+            chat_message = ChatMessage(role=role, parts=[])
+            chat_messages.append(chat_message)
+
+            content = get_property_value(message, "content")
+
+            if role == "assistant":
+                tool_calls = get_property_value(message, "tool_calls")
+                if tool_calls:
+                    chat_message.parts += extract_tool_calls_new(tool_calls)
+                if _is_text_part(content):
+                    chat_message.parts.append(TextPart(content=content))
+
+            elif role == "tool":
+                tool_call_id = get_property_value(message, "tool_call_id")
+                chat_message.parts.append(
+                    ToolCallResponsePart(id=tool_call_id, response=content)
+                )
+
+            else:
+                # system, developer, user, fallback
+                if _is_text_part(content):
+                    chat_message.parts.append(TextPart(content=content))
+                    # continue?
+
+        # TODO: config between spans and events
+        # also if spans and span is not recording, let's not do it all
+        if span.is_recording():
+            span.set_attribute(
+                "gen_ai.input.messages",
+                json.dumps(
+                    chat_messages, ensure_ascii=False, cls=DataclassEncoder
+                ),
+            )
+
+    else:
+        for message in messages:
+            event_logger.emit(_message_to_event(message, capture_content))
+
+
+def _is_text_part(content: Any) -> bool:
+    return isinstance(content, str) or (
+        isinstance(content, Iterable)
+        and all(isinstance(part, str) for part in content)
+    )
+
+
+def record_output_messages(
+    choices,
+    capture_content: bool,
+    latest_experimental_enabled: bool,
+    span: Span,
+    event_logger: EventLogger,
+):
+    if latest_experimental_enabled:
+        if not capture_content:
+            return
+
+        output_messages = []
+        for choice in choices:
+            message = OutputMessage(
+                finish_reason=choice.finish_reason or "error",
+                role=(
+                    choice.message.role
+                    if choice.message and choice.message.role
+                    else None
+                ),
+            )
+            output_messages.append(message)
+
+            if choice.message:
+                tool_calls = get_property_value(choice.message, "tool_calls")
+                if tool_calls:
+                    message.parts += extract_tool_calls_new(tool_calls)
+                content = get_property_value(choice.message, "content")
+                if _is_text_part(content):
+                    message.parts.append(TextPart(content=content))
+
+        # TODO: config between spans and events
+        # also if spans and span is not recording, let's not do it all
+        if span.is_recording():
+            span.set_attribute(
+                "gen_ai.output.messages",
+                json.dumps(
+                    output_messages, ensure_ascii=False, cls=DataclassEncoder
+                ),
+            )
+
+    else:
+        for choice in choices:
+            event_logger.emit(_choice_to_event(choice, capture_content))
+
+
+def _message_to_event(message, capture_content):
     attributes = {
         GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
     }
@@ -115,7 +265,7 @@ def message_to_event(message, capture_content):
     if capture_content and content:
         body["content"] = content
     if role == "assistant":
-        tool_calls = extract_tool_calls(message, capture_content)
+        tool_calls = extract_tool_calls_old(message, capture_content)
         if tool_calls:
             body = {"tool_calls": tool_calls}
     elif role == "tool":
@@ -130,7 +280,7 @@ def message_to_event(message, capture_content):
     )
 
 
-def choice_to_event(choice, capture_content):
+def _choice_to_event(choice, capture_content):
     attributes = {
         GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value
     }
@@ -148,7 +298,7 @@ def choice_to_event(choice, capture_content):
                 else None
             )
         }
-        tool_calls = extract_tool_calls(choice.message, capture_content)
+        tool_calls = extract_tool_calls_old(choice.message, capture_content)
         if tool_calls:
             message["tool_calls"] = tool_calls
         content = get_property_value(choice.message, "content")
@@ -184,13 +334,21 @@ def non_numerical_value_is_set(value: Optional[Union[bool, str]]):
 
 
 def get_llm_request_attributes(
-    kwargs,
-    client_instance,
-    operation_name=GenAIAttributes.GenAiOperationNameValues.CHAT.value,
+    kwargs, client_instance, operation_name, latest_experimental_enabled
 ):
+    provider_name_attr_key = (
+        "gen_ai.provider.name"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_SYSTEM
+    )
+    request_seed_attr_key = (
+        "gen_ai.request.seed"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED
+    )
     attributes = {
         GenAIAttributes.GEN_AI_OPERATION_NAME: operation_name,
-        GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.OPENAI.value,
+        provider_name_attr_key: GenAIAttributes.GenAiSystemValues.OPENAI.value,
         GenAIAttributes.GEN_AI_REQUEST_MODEL: kwargs.get("model"),
         GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE: kwargs.get("temperature"),
         GenAIAttributes.GEN_AI_REQUEST_TOP_P: kwargs.get("p")
@@ -202,26 +360,52 @@ def get_llm_request_attributes(
         GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY: kwargs.get(
             "frequency_penalty"
         ),
-        GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED: kwargs.get("seed"),
+        request_seed_attr_key: kwargs.get("seed"),
     }
 
+    output_type_attr_key = (
+        "gen_ai.output.type"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
     if (response_format := kwargs.get("response_format")) is not None:
         # response_format may be string or object with a string in the `type` key
         if isinstance(response_format, Mapping):
             if (
                 response_format_type := response_format.get("type")
             ) is not None:
-                attributes[
-                    GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
-                ] = response_format_type
+                if response_format_type == "text":
+                    attributes[output_type_attr_key] = (
+                        "text"  # TODO there should be an enum
+                    )
+                elif (
+                    response_format_type == "json_schema"
+                    or response_format_type == "json_object"
+                ):
+                    attributes[output_type_attr_key] = "json"
+                else:
+                    # should never happen with chat completion API
+                    # TODO: internal log
+                    pass
         else:
-            attributes[
-                GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
-            ] = response_format
+            # should never happen with chat completion API
+            attributes[output_type_attr_key] = response_format
 
     set_server_address_and_port(client_instance, attributes)
-    service_tier = kwargs.get("service_tier")
-    attributes[GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER] = (
+
+    service_tier_attribute_key = (
+        "openai.request.service_tier"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER
+    )
+
+    extra_body = kwargs.get("extra_body", None)
+    if extra_body and isinstance(extra_body, dict):
+        service_tier = extra_body.get("service_tier", None)
+    else:
+        service_tier = kwargs.get("service_tier", None)
+
+    attributes[service_tier_attribute_key] = (
         service_tier if service_tier != "auto" else None
     )
 
@@ -236,3 +420,81 @@ def handle_span_exception(span, error):
             ErrorAttributes.ERROR_TYPE, type(error).__qualname__
         )
     span.end()
+
+
+@dataclass
+class TextPart:
+    type: str = "text"
+    content: str = None
+
+
+@dataclass
+class ToolCallRequestPart:
+    type: str = "tool_call"
+    id: Optional[str] = None
+    name: str = ""
+    arguments: Any = None
+
+
+@dataclass
+class ToolCallResponsePart:
+    type: str = "tool_call_response"
+    id: Optional[str] = None
+    response: Any = None
+
+
+@dataclass
+class GenericPart:
+    type: str = ""
+
+
+MessagePart = Union[
+    TextPart,
+    ToolCallRequestPart,
+    ToolCallResponsePart,
+    GenericPart,
+]
+
+
+class Role(str, Enum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+@dataclass
+class ChatMessage:
+    role: Union[Role, str]
+    parts: List[MessagePart] = field(default_factory=list)
+
+
+@dataclass
+class InputMessages:
+    messages: List[ChatMessage] = field(default_factory=list)
+
+
+class FinishReason(str, Enum):
+    STOP = "stop"
+    LENGTH = "length"
+    CONTENT_FILTER = "content_filter"
+    TOOL_CALL = "tool_call"
+    ERROR = "error"
+
+
+@dataclass
+class OutputMessage(ChatMessage):
+    finish_reason: Union[FinishReason, str] = ""
+
+
+@dataclass
+class OutputMessages:
+    messages: List[OutputMessage] = field(default_factory=list)
+
+
+class DataclassEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if dataclasses.is_dataclass(obj):
+            return dataclasses.asdict(obj)
+        else:
+            return super(DataclassEncoder, self).default(obj)

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
@@ -10,6 +10,7 @@ from openai import AsyncOpenAI, OpenAI
 from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 from opentelemetry.instrumentation.openai_v2.utils import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+    OTEL_SEMCONV_STABILITY_OPT_IN,
 )
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider
@@ -104,14 +105,30 @@ def vcr_config():
     }
 
 
+@pytest.fixture(scope="function", params=[True, False])
+def latest_experimental_enabled(request):
+    return request.param
+
+
 @pytest.fixture(scope="function")
 def instrument_no_content(
-    tracer_provider, event_logger_provider, meter_provider
+    tracer_provider,
+    event_logger_provider,
+    meter_provider,
+    latest_experimental_enabled,
 ):
     os.environ.update(
         {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "False"}
     )
 
+    os.environ.update(
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental"
+            if latest_experimental_enabled
+            else ""
+        }
+    )
+
     instrumentor = OpenAIInstrumentor()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
@@ -121,15 +138,27 @@ def instrument_no_content(
 
     yield instrumentor
     os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
+    os.environ.pop(OTEL_SEMCONV_STABILITY_OPT_IN, None)
     instrumentor.uninstrument()
 
 
 @pytest.fixture(scope="function")
 def instrument_with_content(
-    tracer_provider, event_logger_provider, meter_provider
+    tracer_provider,
+    event_logger_provider,
+    meter_provider,
+    latest_experimental_enabled,
 ):
     os.environ.update(
         {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+    )
+
+    os.environ.update(
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental"
+            if latest_experimental_enabled
+            else ""
+        }
     )
     instrumentor = OpenAIInstrumentor()
     instrumentor.instrument(
@@ -140,15 +169,27 @@ def instrument_with_content(
 
     yield instrumentor
     os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
+    os.environ.pop(OTEL_SEMCONV_STABILITY_OPT_IN, None)
     instrumentor.uninstrument()
 
 
 @pytest.fixture(scope="function")
 def instrument_with_content_unsampled(
-    span_exporter, event_logger_provider, meter_provider
+    span_exporter,
+    event_logger_provider,
+    meter_provider,
+    latest_experimental_enabled,
 ):
     os.environ.update(
         {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+    )
+
+    os.environ.update(
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental"
+            if latest_experimental_enabled
+            else ""
+        }
     )
 
     tracer_provider = TracerProvider(sampler=ALWAYS_OFF)
@@ -163,6 +204,7 @@ def instrument_with_content_unsampled(
 
     yield instrumentor
     os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
+    os.environ.pop(OTEL_SEMCONV_STABILITY_OPT_IN, None)
     instrumentor.uninstrument()
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/conftest.py
@@ -118,7 +118,7 @@ def instrument_no_content(
     latest_experimental_enabled,
 ):
     os.environ.update(
-        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "False"}
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "none"}
     )
 
     os.environ.update(
@@ -150,7 +150,7 @@ def instrument_with_content(
     latest_experimental_enabled,
 ):
     os.environ.update(
-        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "span" if latest_experimental_enabled else "True"}
     )
 
     os.environ.update(
@@ -181,7 +181,7 @@ def instrument_with_content_unsampled(
     latest_experimental_enabled,
 ):
     os.environ.update(
-        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "True"}
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "span" if latest_experimental_enabled else "True"}
     )
 
     os.environ.update(

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_chat_completions.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 # pylint: disable=too-many-locals
 
-from typing import Optional
 
 import pytest
 from openai import APIConnectionError, AsyncOpenAI, NotFoundError
-from openai.resources.chat.completions import ChatCompletion
 
-from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.instrumentation.openai_v2.utils import (
+    is_latest_experimental_enabled,
+)
 from opentelemetry.semconv._incubating.attributes import (
     error_attributes as ErrorAttributes,
 )
@@ -32,222 +32,388 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv._incubating.attributes import (
     server_attributes as ServerAttributes,
 )
+from tests.test_utils import (
+    assert_all_attributes,
+    assert_completion_attributes,
+    assert_log_parent,
+    assert_messages_attribute,
+    get_current_weather_tool_definition,
+    remove_none_values,
+)
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_with_content(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_with_content.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = await async_openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        response = await async_openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[0].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    user_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
+            user_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content,
-        },
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[0].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_no_content(
-    span_exporter, log_exporter, async_openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_no_content.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = await async_openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        response = await async_openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        logs = log_exporter.get_finished_logs()
+        if latest_experimental_enabled:
+            assert len(logs) == 0
+            assert "gen_ai.input.messages" not in spans[0].attributes
+            assert "gen_ai.output.messages" not in spans[0].attributes
+        else:
+            assert len(logs) == 2
 
-    assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", None, spans[0]
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {"role": "assistant"},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant"},
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.asyncio()
 async def test_async_chat_completion_bad_endpoint(
-    span_exporter, instrument_no_content
+    span_exporter,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_bad_endpoint.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    client = AsyncOpenAI(base_url="http://localhost:4242")
+        client = AsyncOpenAI(base_url="http://localhost:4242")
 
-    with pytest.raises(APIConnectionError):
-        await client.chat.completions.create(
-            messages=messages_value,
-            model=llm_model_value,
-            timeout=0.1,
+        with pytest.raises(APIConnectionError):
+            await client.chat.completions.create(
+                messages=messages_value,
+                model=llm_model_value,
+                timeout=0.1,
+            )
+
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            server_address="localhost",
         )
-
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0], llm_model_value, server_address="localhost"
-    )
-    assert 4242 == spans[0].attributes[ServerAttributes.SERVER_PORT]
-    assert (
-        "APIConnectionError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
-    )
+        assert 4242 == spans[0].attributes[ServerAttributes.SERVER_PORT]
+        assert (
+            "APIConnectionError"
+            == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
+        )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_404(
-    span_exporter, async_openai_client, instrument_no_content
+    span_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "this-model-does-not-exist"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_404.yaml"):
+        llm_model_value = "this-model-does-not-exist"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    with pytest.raises(NotFoundError):
-        await async_openai_client.chat.completions.create(
-            messages=messages_value,
-            model=llm_model_value,
+        with pytest.raises(NotFoundError):
+            await async_openai_client.chat.completions.create(
+                messages=messages_value,
+                model=llm_model_value,
+            )
+
+        spans = span_exporter.get_finished_spans()
+
+        assert_all_attributes(
+            spans[0], llm_model_value, is_latest_experimental_enabled()
         )
-
-    spans = span_exporter.get_finished_spans()
-
-    assert_all_attributes(spans[0], llm_model_value)
-    assert "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
+        assert (
+            "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
+        )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_extra_params(
-    span_exporter, async_openai_client, instrument_no_content
+    span_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_extra_params.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = await async_openai_client.chat.completions.create(
-        messages=messages_value,
-        model=llm_model_value,
-        seed=42,
-        temperature=0.5,
-        max_tokens=50,
-        stream=False,
-        extra_body={"service_tier": "default"},
-        response_format={"type": "text"},
-    )
+        response = await async_openai_client.chat.completions.create(
+            messages=messages_value,
+            model=llm_model_value,
+            seed=42,
+            temperature=0.5,
+            max_tokens=50,
+            stream=False,
+            extra_body={"service_tier": "default"},
+            response_format={"type": "text"},
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED] == 42
-    )
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.5
-    )
-    assert spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER]
-        == "default"
-    )
-    assert (
-        spans[0].attributes[
-            GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
-        ]
-        == "text"
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
+
+        request_seed_attr_key = (
+            "gen_ai.request.seed"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED
+        )
+        assert spans[0].attributes[request_seed_attr_key] == 42
+        assert (
+            spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE]
+            == 0.5
+        )
+        assert (
+            spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS]
+            == 50
+        )
+
+        service_tier_attr_key = (
+            "openai.request.service_tier"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER
+        )
+        assert spans[0].attributes[service_tier_attr_key] == "default"
+
+        output_type_attr_key = (
+            "gen_ai.output.type"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+        )
+        assert spans[0].attributes[output_type_attr_key] == "text"
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_multiple_choices(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_multiple_choices.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = await async_openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, n=2, stream=False
-    )
+        response = await async_openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, n=2, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 3  # 1 user message + 2 choice messages
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[0].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[1].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 3  # 1 user message + 2 choice messages
 
-    user_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
+            user_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    choice_event_0 = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content,
-        },
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event_0, spans[0])
+            choice_event_0 = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[0].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event_0, spans[0]
+            )
 
-    choice_event_1 = {
-        "index": 1,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[1].message.content,
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event_1, spans[0])
+            choice_event_1 = {
+                "index": 1,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[1].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[2], "gen_ai.choice", choice_event_1, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_tool_calls_with_content(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    await chat_completion_tool_call(
-        span_exporter, log_exporter, async_openai_client, True
-    )
+    with vcr.use_cassette(
+        "test_async_chat_completion_tool_calls_with_content.yaml"
+    ):
+        await chat_completion_tool_call(
+            span_exporter,
+            log_exporter,
+            async_openai_client,
+            True,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_tool_calls_no_content(
-    span_exporter, log_exporter, async_openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    await chat_completion_tool_call(
-        span_exporter, log_exporter, async_openai_client, False
-    )
+    with vcr.use_cassette(
+        "test_async_chat_completion_tool_calls_no_content.yaml"
+    ):
+        await chat_completion_tool_call(
+            span_exporter,
+            log_exporter,
+            async_openai_client,
+            False,
+            is_latest_experimental_enabled(),
+        )
 
 
 async def chat_completion_tool_call(
-    span_exporter, log_exporter, async_openai_client, expect_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    expect_content,
+    latest_experimental_enabled,
 ):
     llm_model_value = "gpt-4o-mini"
     messages_value = [
@@ -302,335 +468,636 @@ async def chat_completion_tool_call(
     # validate both calls
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 2
-    assert_completion_attributes(spans[0], llm_model_value, response_0)
-    assert_completion_attributes(spans[1], llm_model_value, response_1)
-
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 9  # 3 logs for first completion, 6 for second
-
-    # call one
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
+    assert_completion_attributes(
+        spans[0], llm_model_value, response_0, latest_experimental_enabled
     )
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
+    assert_completion_attributes(
+        spans[1], llm_model_value, response_1, latest_experimental_enabled
     )
 
-    user_message = (
-        {"content": messages_value[1]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
+    if latest_experimental_enabled:
+        if not expect_content:
+            pass
+        else:
+            # first call
+            first_input = [
+                {
+                    "role": "system",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[0]["content"],
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[1]["content"],
+                        }
+                    ],
+                },
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"], first_input
+            )
 
-    function_call_0 = {"name": "get_current_weather"}
-    function_call_1 = {"name": "get_current_weather"}
-    if expect_content:
-        function_call_0["arguments"] = (
-            response_0.choices[0]
-            .message.tool_calls[0]
-            .function.arguments.replace("\n", "")
+            first_output = [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[0]
+                            .id,
+                            "name": "get_current_weather",
+                            "arguments": {"location": "Seattle, WA"},
+                        },
+                        {
+                            "type": "tool_call",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[1]
+                            .id,
+                            "name": "get_current_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                        },
+                    ],
+                    "finish_reason": "tool_calls",
+                }
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+
+            # second call
+            del first_output[0]["finish_reason"]
+            second_input = []
+            second_input += first_input
+            second_input += first_output
+            second_input += [
+                {
+                    "role": "tool",
+                    "parts": [
+                        {
+                            "type": "tool_call_response",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[0]
+                            .id,
+                            "response": tool_call_result_0["content"],
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "parts": [
+                        {
+                            "type": "tool_call_response",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[1]
+                            .id,
+                            "response": tool_call_result_1["content"],
+                        }
+                    ],
+                },
+            ]
+
+            assert_messages_attribute(
+                spans[1].attributes["gen_ai.input.messages"], second_input
+            )
+
+            assert_messages_attribute(
+                spans[1].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response_1.choices[
+                                    0
+                                ].message.content,
+                            },
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 9  # 3 logs for first completion, 6 for second
+
+        # call one
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
         )
-        function_call_1["arguments"] = (
-            response_0.choices[0]
-            .message.tool_calls[1]
-            .function.arguments.replace("\n", "")
+        assert_message_in_logs(
+            logs[0], "gen_ai.system.message", system_message, spans[0]
         )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "tool_calls",
-        "message": {
+        user_message = (
+            {"content": messages_value[1]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[1], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        function_call_0 = {"name": "get_current_weather"}
+        function_call_1 = {"name": "get_current_weather"}
+        if expect_content:
+            function_call_0["arguments"] = (
+                response_0.choices[0]
+                .message.tool_calls[0]
+                .function.arguments.replace("\n", "")
+            )
+            function_call_1["arguments"] = (
+                response_0.choices[0]
+                .message.tool_calls[1]
+                .function.arguments.replace("\n", "")
+            )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": response_0.choices[0].message.tool_calls[0].id,
+                        "type": "function",
+                        "function": function_call_0,
+                    },
+                    {
+                        "id": response_0.choices[0].message.tool_calls[1].id,
+                        "type": "function",
+                        "function": function_call_1,
+                    },
+                ],
+            },
+        }
+        assert_message_in_logs(
+            logs[2], "gen_ai.choice", choice_event, spans[0]
+        )
+
+        # call two
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[3], "gen_ai.system.message", system_message, spans[1]
+        )
+
+        user_message = (
+            {"content": messages_value[1]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[4], "gen_ai.user.message", user_message, spans[1]
+        )
+
+        assistant_tool_call = {"tool_calls": messages_value[2]["tool_calls"]}
+        if not expect_content:
+            assistant_tool_call["tool_calls"][0]["function"]["arguments"] = (
+                None
+            )
+            assistant_tool_call["tool_calls"][1]["function"]["arguments"] = (
+                None
+            )
+
+        assert_message_in_logs(
+            logs[5], "gen_ai.assistant.message", assistant_tool_call, spans[1]
+        )
+
+        tool_message_0 = {
+            "id": tool_call_result_0["tool_call_id"],
+            "content": tool_call_result_0["content"]
+            if expect_content
+            else None,
+        }
+
+        assert_message_in_logs(
+            logs[6], "gen_ai.tool.message", tool_message_0, spans[1]
+        )
+
+        tool_message_1 = {
+            "id": tool_call_result_1["tool_call_id"],
+            "content": tool_call_result_1["content"]
+            if expect_content
+            else None,
+        }
+
+        assert_message_in_logs(
+            logs[7], "gen_ai.tool.message", tool_message_1, spans[1]
+        )
+
+        message = {
             "role": "assistant",
-            "tool_calls": [
-                {
-                    "id": response_0.choices[0].message.tool_calls[0].id,
-                    "type": "function",
-                    "function": function_call_0,
-                },
-                {
-                    "id": response_0.choices[0].message.tool_calls[1].id,
-                    "type": "function",
-                    "function": function_call_1,
-                },
-            ],
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event, spans[0])
-
-    # call two
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[3], "gen_ai.system.message", system_message, spans[1]
-    )
-
-    user_message = (
-        {"content": messages_value[1]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[4], "gen_ai.user.message", user_message, spans[1]
-    )
-
-    assistant_tool_call = {"tool_calls": messages_value[2]["tool_calls"]}
-    if not expect_content:
-        assistant_tool_call["tool_calls"][0]["function"]["arguments"] = None
-        assistant_tool_call["tool_calls"][1]["function"]["arguments"] = None
-
-    assert_message_in_logs(
-        logs[5], "gen_ai.assistant.message", assistant_tool_call, spans[1]
-    )
-
-    tool_message_0 = {
-        "id": tool_call_result_0["tool_call_id"],
-        "content": tool_call_result_0["content"] if expect_content else None,
-    }
-
-    assert_message_in_logs(
-        logs[6], "gen_ai.tool.message", tool_message_0, spans[1]
-    )
-
-    tool_message_1 = {
-        "id": tool_call_result_1["tool_call_id"],
-        "content": tool_call_result_1["content"] if expect_content else None,
-    }
-
-    assert_message_in_logs(
-        logs[7], "gen_ai.tool.message", tool_message_1, spans[1]
-    )
-
-    message = {
-        "role": "assistant",
-        "content": response_1.choices[0].message.content
-        if expect_content
-        else None,
-    }
-    choice = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": message,
-    }
-    assert_message_in_logs(logs[8], "gen_ai.choice", choice, spans[1])
+            "content": response_1.choices[0].message.content
+            if expect_content
+            else None,
+        }
+        choice = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": message,
+        }
+        assert_message_in_logs(logs[8], "gen_ai.choice", choice, spans[1])
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_streaming(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_streaming.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    kwargs = {
-        "model": llm_model_value,
-        "messages": messages_value,
-        "stream": True,
-        "stream_options": {"include_usage": True},
-    }
+        kwargs = {
+            "model": llm_model_value,
+            "messages": messages_value,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
 
-    response_stream_usage = None
-    response_stream_model = None
-    response_stream_id = None
-    response_stream_result = ""
-    response = await async_openai_client.chat.completions.create(**kwargs)
-    async for chunk in response:
-        if chunk.choices:
-            response_stream_result += chunk.choices[0].delta.content or ""
+        response_stream_usage = None
+        response_stream_model = None
+        response_stream_id = None
+        response_stream_result = ""
+        response = await async_openai_client.chat.completions.create(**kwargs)
+        async for chunk in response:
+            if chunk.choices:
+                response_stream_result += chunk.choices[0].delta.content or ""
 
-        # get the last chunk
-        if getattr(chunk, "usage", None):
-            response_stream_usage = chunk.usage
-            response_stream_model = chunk.model
-            response_stream_id = chunk.id
+            # get the last chunk
+            if getattr(chunk, "usage", None):
+                response_stream_usage = chunk.usage
+                response_stream_model = chunk.model
+                response_stream_id = chunk.id
 
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0],
-        llm_model_value,
-        response_stream_id,
-        response_stream_model,
-        response_stream_usage.prompt_tokens,
-        response_stream_usage.completion_tokens,
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+            response_stream_usage.prompt_tokens,
+            response_stream_usage.completion_tokens,
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {"type": "text", "content": response_stream_result}
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+            user_message = {"content": "Say this is a test"}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {"content": "Say this is a test"}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {"role": "assistant", "content": response_stream_result},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response_stream_result,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_streaming_not_complete(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette(
+        "test_async_chat_completion_streaming_not_complete.yaml"
+    ):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    kwargs = {
-        "model": llm_model_value,
-        "messages": messages_value,
-        "stream": True,
-    }
+        kwargs = {
+            "model": llm_model_value,
+            "messages": messages_value,
+            "stream": True,
+        }
 
-    response_stream_model = None
-    response_stream_id = None
-    response_stream_result = ""
-    response = await async_openai_client.chat.completions.create(**kwargs)
-    idx = 0
-    async for chunk in response:
-        if chunk.choices:
-            response_stream_result += chunk.choices[0].delta.content or ""
-        if idx == 1:
-            # fake a stop
-            break
+        response_stream_model = None
+        response_stream_id = None
+        response_stream_result = ""
+        response = await async_openai_client.chat.completions.create(**kwargs)
+        idx = 0
+        async for chunk in response:
+            if chunk.choices:
+                response_stream_result += chunk.choices[0].delta.content or ""
+            if idx == 1:
+                # fake a stop
+                break
 
-        if chunk.model:
-            response_stream_model = chunk.model
-        if chunk.id:
-            response_stream_id = chunk.id
-        idx += 1
+            if chunk.model:
+                response_stream_model = chunk.model
+            if chunk.id:
+                response_stream_id = chunk.id
+            idx += 1
 
-    response.close()
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0], llm_model_value, response_stream_id, response_stream_model
-    )
+        response.close()
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {"type": "text", "content": response_stream_result}
+                        ],
+                        "finish_reason": "error",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+            user_message = {"content": "Say this is a test"}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {"content": "Say this is a test"}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "error",
-        "message": {"role": "assistant", "content": response_stream_result},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "error",
+                "message": {
+                    "role": "assistant",
+                    "content": response_stream_result,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_multiple_choices_streaming(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [
-        {"role": "system", "content": "You're a helpful assistant."},
-        {
-            "role": "user",
-            "content": "What's the weather in Seattle and San Francisco today?",
-        },
-    ]
+    with vcr.use_cassette(
+        "test_async_chat_completion_multiple_choices_streaming.yaml"
+    ):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [
+            {"role": "system", "content": "You're a helpful assistant."},
+            {
+                "role": "user",
+                "content": "What's the weather in Seattle and San Francisco today?",
+            },
+        ]
 
-    response_0 = await async_openai_client.chat.completions.create(
-        messages=messages_value,
-        model=llm_model_value,
-        n=2,
-        stream=True,
-        stream_options={"include_usage": True},
-    )
+        response_0 = await async_openai_client.chat.completions.create(
+            messages=messages_value,
+            model=llm_model_value,
+            n=2,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
 
-    # two strings for each choice
-    response_stream_result = ["", ""]
-    finish_reasons = ["", ""]
-    async for chunk in response_0:
-        if chunk.choices:
-            for choice in chunk.choices:
-                response_stream_result[choice.index] += (
-                    choice.delta.content or ""
-                )
-                if choice.finish_reason:
-                    finish_reasons[choice.index] = choice.finish_reason
+        # two strings for each choice
+        response_stream_result = ["", ""]
+        finish_reasons = ["", ""]
+        async for chunk in response_0:
+            if chunk.choices:
+                for choice in chunk.choices:
+                    response_stream_result[choice.index] += (
+                        choice.delta.content or ""
+                    )
+                    if choice.finish_reason:
+                        finish_reasons[choice.index] = choice.finish_reason
 
-        # get the last chunk
-        if getattr(chunk, "usage", None):
-            response_stream_usage = chunk.usage
-            response_stream_model = chunk.model
-            response_stream_id = chunk.id
+            # get the last chunk
+            if getattr(chunk, "usage", None):
+                response_stream_usage = chunk.usage
+                response_stream_model = chunk.model
+                response_stream_id = chunk.id
 
-    # sanity check
-    assert "stop" == finish_reasons[0]
+        # sanity check
+        assert "stop" == finish_reasons[0]
 
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0],
-        llm_model_value,
-        response_stream_id,
-        response_stream_model,
-        response_stream_usage.prompt_tokens,
-        response_stream_usage.completion_tokens,
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+            response_stream_usage.prompt_tokens,
+            response_stream_usage.completion_tokens,
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 4
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "system",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[1]["content"],
+                            }
+                        ],
+                    },
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": "".join(response_stream_result[0]),
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": "".join(response_stream_result[1]),
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 4
 
-    system_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
-    )
+            system_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.system.message", system_message, spans[0]
+            )
 
-    user_message = {
-        "content": "What's the weather in Seattle and San Francisco today?"
-    }
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
+            user_message = {
+                "content": "What's the weather in Seattle and San Francisco today?"
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    choice_event_0 = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": "".join(response_stream_result[0]),
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event_0, spans[0])
+            choice_event_0 = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "".join(response_stream_result[0]),
+                },
+            }
+            assert_message_in_logs(
+                logs[2], "gen_ai.choice", choice_event_0, spans[0]
+            )
 
-    choice_event_1 = {
-        "index": 1,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": "".join(response_stream_result[1]),
-        },
-    }
-    assert_message_in_logs(logs[3], "gen_ai.choice", choice_event_1, spans[0])
+            choice_event_1 = {
+                "index": 1,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "".join(response_stream_result[1]),
+                },
+            }
+            assert_message_in_logs(
+                logs[3], "gen_ai.choice", choice_event_1, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_multiple_tools_streaming_with_content(
-    span_exporter, log_exporter, async_openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    await async_chat_completion_multiple_tools_streaming(
-        span_exporter, log_exporter, async_openai_client, True
-    )
+    with vcr.use_cassette(
+        "test_async_chat_completion_multiple_tools_streaming_with_content.yaml"
+    ):
+        await async_chat_completion_multiple_tools_streaming(
+            span_exporter,
+            log_exporter,
+            async_openai_client,
+            True,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_multiple_tools_streaming_no_content(
-    span_exporter, log_exporter, async_openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    await async_chat_completion_multiple_tools_streaming(
-        span_exporter, log_exporter, async_openai_client, False
-    )
+    with vcr.use_cassette(
+        "test_async_chat_completion_multiple_tools_streaming_no_content.yaml"
+    ):
+        await async_chat_completion_multiple_tools_streaming(
+            span_exporter,
+            log_exporter,
+            async_openai_client,
+            False,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
@@ -640,50 +1107,73 @@ async def test_async_chat_completion_streaming_unsampled(
     log_exporter,
     async_openai_client,
     instrument_with_content_unsampled,
+    vcr,
 ):
-    llm_model_value = "gpt-4"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette(
+        "test_async_chat_completion_streaming_unsampled.yaml"
+    ):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    kwargs = {
-        "model": llm_model_value,
-        "messages": messages_value,
-        "stream": True,
-        "stream_options": {"include_usage": True},
-    }
+        kwargs = {
+            "model": llm_model_value,
+            "messages": messages_value,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
 
-    response_stream_result = ""
-    response = await async_openai_client.chat.completions.create(**kwargs)
-    async for chunk in response:
-        if chunk.choices:
-            response_stream_result += chunk.choices[0].delta.content or ""
+        response_stream_result = ""
+        response = await async_openai_client.chat.completions.create(**kwargs)
+        async for chunk in response:
+            if chunk.choices:
+                response_stream_result += chunk.choices[0].delta.content or ""
 
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 0
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 0
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        logs = log_exporter.get_finished_logs()
+        if latest_experimental_enabled:
+            assert len(logs) == 0
+            # TODO: new event
+        else:
+            assert len(logs) == 2
 
-    user_message = {"content": "Say this is a test"}
-    assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, None)
+            user_message = {"content": "Say this is a test"}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, None
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {"role": "assistant", "content": response_stream_result},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, None)
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response_stream_result,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, None
+            )
 
-    assert logs[0].log_record.trace_id is not None
-    assert logs[0].log_record.span_id is not None
-    assert logs[0].log_record.trace_flags == 0
+            assert logs[0].log_record.trace_id is not None
+            assert logs[0].log_record.span_id is not None
+            assert logs[0].log_record.trace_flags == 0
 
-    assert logs[0].log_record.trace_id == logs[1].log_record.trace_id
-    assert logs[0].log_record.span_id == logs[1].log_record.span_id
-    assert logs[0].log_record.trace_flags == logs[1].log_record.trace_flags
+            assert logs[0].log_record.trace_id == logs[1].log_record.trace_id
+            assert logs[0].log_record.span_id == logs[1].log_record.span_id
+            assert (
+                logs[0].log_record.trace_flags
+                == logs[1].log_record.trace_flags
+            )
 
 
 async def async_chat_completion_multiple_tools_streaming(
-    span_exporter, log_exporter, async_openai_client, expect_content
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    expect_content,
+    latest_experimental_enabled,
 ):
     llm_model_value = "gpt-4o-mini"
     messages_value = [
@@ -735,68 +1225,127 @@ async def async_chat_completion_multiple_tools_streaming(
     assert_all_attributes(
         spans[0],
         llm_model_value,
+        latest_experimental_enabled,
         response_stream_id,
         response_stream_model,
         response_stream_usage.prompt_tokens,
         response_stream_usage.completion_tokens,
     )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 3
-
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
-    )
-
-    user_message = (
-        {"content": "What's the weather in Seattle and San Francisco today?"}
-        if expect_content
-        else None
-    )
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "tool_calls",
-        "message": {
-            "role": "assistant",
-            "tool_calls": [
+    if latest_experimental_enabled:
+        if expect_content:
+            # first call
+            first_input = [
                 {
-                    "id": tool_call_ids[0],
-                    "type": "function",
-                    "function": {
-                        "name": tool_names[0],
-                        "arguments": (
-                            tool_args[0].replace("\n", "")
-                            if expect_content
-                            else None
-                        ),
-                    },
+                    "role": "system",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[0]["content"],
+                        }
+                    ],
                 },
                 {
-                    "id": tool_call_ids[1],
-                    "type": "function",
-                    "function": {
-                        "name": tool_names[1],
-                        "arguments": (
-                            tool_args[1].replace("\n", "")
-                            if expect_content
-                            else None
-                        ),
-                    },
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[1]["content"],
+                        }
+                    ],
                 },
-            ],
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event, spans[0])
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"], first_input
+            )
+
+            first_output = [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": tool_call_ids[0],
+                            "name": "get_current_weather",
+                            "arguments": {"location": "Seattle, WA"},
+                        },
+                        {
+                            "type": "tool_call",
+                            "id": tool_call_ids[1],
+                            "name": "get_current_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                        },
+                    ],
+                    "finish_reason": "tool_calls",
+                }
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 3
+
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[0], "gen_ai.system.message", system_message, spans[0]
+        )
+
+        user_message = (
+            {
+                "content": "What's the weather in Seattle and San Francisco today?"
+            }
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[1], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": tool_call_ids[0],
+                        "type": "function",
+                        "function": {
+                            "name": tool_names[0],
+                            "arguments": (
+                                tool_args[0].replace("\n", "")
+                                if expect_content
+                                else None
+                            ),
+                        },
+                    },
+                    {
+                        "id": tool_call_ids[1],
+                        "type": "function",
+                        "function": {
+                            "name": tool_names[1],
+                            "arguments": (
+                                tool_args[1].replace("\n", "")
+                                if expect_content
+                                else None
+                            ),
+                        },
+                    },
+                ],
+            },
+        }
+        assert_message_in_logs(
+            logs[2], "gen_ai.choice", choice_event, spans[0]
+        )
 
 
 def assert_message_in_logs(log, event_name, expected_content, parent_span):
+    # TODO: switch to top-level eventName under latest-experimental flag
     assert log.log_record.attributes[EventAttributes.EVENT_NAME] == event_name
     assert (
         log.log_record.attributes[GenAIAttributes.GEN_AI_SYSTEM]
@@ -811,124 +1360,3 @@ def assert_message_in_logs(log, event_name, expected_content, parent_span):
             expected_content
         )
     assert_log_parent(log, parent_span)
-
-
-def remove_none_values(body):
-    result = {}
-    for key, value in body.items():
-        if value is None:
-            continue
-        if isinstance(value, dict):
-            result[key] = remove_none_values(value)
-        elif isinstance(value, list):
-            result[key] = [remove_none_values(i) for i in value]
-        else:
-            result[key] = value
-    return result
-
-
-def assert_completion_attributes(
-    span: ReadableSpan,
-    request_model: str,
-    response: ChatCompletion,
-    operation_name: str = "chat",
-    server_address: str = "api.openai.com",
-):
-    return assert_all_attributes(
-        span,
-        request_model,
-        response.id,
-        response.model,
-        response.usage.prompt_tokens,
-        response.usage.completion_tokens,
-        operation_name,
-        server_address,
-    )
-
-
-def assert_all_attributes(
-    span: ReadableSpan,
-    request_model: str,
-    response_id: str = None,
-    response_model: str = None,
-    input_tokens: Optional[int] = None,
-    output_tokens: Optional[int] = None,
-    operation_name: str = "chat",
-    server_address: str = "api.openai.com",
-):
-    assert span.name == f"{operation_name} {request_model}"
-    assert (
-        operation_name
-        == span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
-    )
-    assert (
-        GenAIAttributes.GenAiSystemValues.OPENAI.value
-        == span.attributes[GenAIAttributes.GEN_AI_SYSTEM]
-    )
-    assert (
-        request_model == span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
-    )
-    if response_model:
-        assert (
-            response_model
-            == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_RESPONSE_MODEL not in span.attributes
-
-    if response_id:
-        assert (
-            response_id == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_ID]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_RESPONSE_ID not in span.attributes
-
-    if input_tokens:
-        assert (
-            input_tokens
-            == span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS not in span.attributes
-
-    if output_tokens:
-        assert (
-            output_tokens
-            == span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
-        )
-    else:
-        assert (
-            GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS not in span.attributes
-        )
-
-    assert server_address == span.attributes[ServerAttributes.SERVER_ADDRESS]
-
-
-def assert_log_parent(log, span):
-    if span:
-        assert log.log_record.trace_id == span.get_span_context().trace_id
-        assert log.log_record.span_id == span.get_span_context().span_id
-        assert (
-            log.log_record.trace_flags == span.get_span_context().trace_flags
-        )
-
-
-def get_current_weather_tool_definition():
-    return {
-        "type": "function",
-        "function": {
-            "name": "get_current_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. Boston, MA",
-                    },
-                },
-                "required": ["location"],
-                "additionalProperties": False,
-            },
-        },
-    }

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 # pylint: disable=too-many-locals
 
-from typing import Optional
 
 import pytest
 from openai import APIConnectionError, NotFoundError, OpenAI
-from openai.resources.chat.completions import ChatCompletion
 
-from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.instrumentation.openai_v2.utils import (
+    is_latest_experimental_enabled,
+)
 from opentelemetry.semconv._incubating.attributes import (
     error_attributes as ErrorAttributes,
 )
@@ -33,254 +33,419 @@ from opentelemetry.semconv._incubating.attributes import (
     server_attributes as ServerAttributes,
 )
 from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
+from tests.test_utils import (
+    assert_all_attributes,
+    assert_completion_attributes,
+    assert_log_parent,
+    assert_messages_attribute,
+    get_current_weather_tool_definition,
+)
 
 
 @pytest.mark.vcr()
 def test_chat_completion_with_content(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_with_content.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        response = openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[0].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    user_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
+            user_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content,
-        },
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[0].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_no_content(
-    span_exporter, log_exporter, openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_no_content.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        response = openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        logs = log_exporter.get_finished_logs()
+        if latest_experimental_enabled:
+            assert len(logs) == 0
+            assert "gen_ai.input.messages" not in spans[0].attributes
+            assert "gen_ai.output.messages" not in spans[0].attributes
+        else:
+            assert len(logs) == 2
 
-    assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", None, spans[0]
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {"role": "assistant"},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant"},
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 def test_chat_completion_bad_endpoint(
-    span_exporter, metric_reader, instrument_no_content
+    span_exporter,
+    metric_reader,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_bad_endpoint.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    client = OpenAI(base_url="http://localhost:4242")
+        client = OpenAI(base_url="http://localhost:4242")
 
-    with pytest.raises(APIConnectionError):
-        client.chat.completions.create(
-            messages=messages_value,
-            model=llm_model_value,
-            timeout=0.1,
+        with pytest.raises(APIConnectionError):
+            client.chat.completions.create(
+                messages=messages_value,
+                model=llm_model_value,
+                timeout=0.1,
+            )
+
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            server_address="localhost",
+        )
+        assert 4242 == spans[0].attributes[ServerAttributes.SERVER_PORT]
+        assert (
+            "APIConnectionError"
+            == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
         )
 
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0], llm_model_value, server_address="localhost"
-    )
-    assert 4242 == spans[0].attributes[ServerAttributes.SERVER_PORT]
-    assert (
-        "APIConnectionError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
-    )
+        metrics = metric_reader.get_metrics_data().resource_metrics
+        assert len(metrics) == 1
 
-    metrics = metric_reader.get_metrics_data().resource_metrics
-    assert len(metrics) == 1
-
-    metric_data = metrics[0].scope_metrics[0].metrics
-    duration_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
-        ),
-        None,
-    )
-    assert duration_metric is not None
-    assert duration_metric.data.data_points[0].sum > 0
-    assert (
-        duration_metric.data.data_points[0].attributes[
-            ErrorAttributes.ERROR_TYPE
-        ]
-        == "APIConnectionError"
-    )
+        metric_data = metrics[0].scope_metrics[0].metrics
+        duration_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
+            ),
+            None,
+        )
+        assert duration_metric is not None
+        assert duration_metric.data.data_points[0].sum > 0
+        assert (
+            duration_metric.data.data_points[0].attributes[
+                ErrorAttributes.ERROR_TYPE
+            ]
+            == "APIConnectionError"
+        )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_404(
-    span_exporter, openai_client, metric_reader, instrument_no_content
+    span_exporter,
+    openai_client,
+    metric_reader,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "this-model-does-not-exist"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_404.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "this-model-does-not-exist"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    with pytest.raises(NotFoundError):
-        openai_client.chat.completions.create(
-            messages=messages_value,
-            model=llm_model_value,
+        with pytest.raises(NotFoundError):
+            openai_client.chat.completions.create(
+                messages=messages_value,
+                model=llm_model_value,
+            )
+
+        spans = span_exporter.get_finished_spans()
+
+        assert_all_attributes(
+            spans[0], llm_model_value, latest_experimental_enabled
+        )
+        assert (
+            "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
         )
 
-    spans = span_exporter.get_finished_spans()
+        metrics = metric_reader.get_metrics_data().resource_metrics
+        assert len(metrics) == 1
 
-    assert_all_attributes(spans[0], llm_model_value)
-    assert "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]
-
-    metrics = metric_reader.get_metrics_data().resource_metrics
-    assert len(metrics) == 1
-
-    metric_data = metrics[0].scope_metrics[0].metrics
-    duration_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
-        ),
-        None,
-    )
-    assert duration_metric is not None
-    assert duration_metric.data.data_points[0].sum > 0
-    assert (
-        duration_metric.data.data_points[0].attributes[
-            ErrorAttributes.ERROR_TYPE
-        ]
-        == "NotFoundError"
-    )
+        metric_data = metrics[0].scope_metrics[0].metrics
+        duration_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
+            ),
+            None,
+        )
+        assert duration_metric is not None
+        assert duration_metric.data.data_points[0].sum > 0
+        assert (
+            duration_metric.data.data_points[0].attributes[
+                ErrorAttributes.ERROR_TYPE
+            ]
+            == "NotFoundError"
+        )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_extra_params(
-    span_exporter, openai_client, instrument_no_content
+    span_exporter,
+    openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_extra_params.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = openai_client.chat.completions.create(
-        messages=messages_value,
-        model=llm_model_value,
-        seed=42,
-        temperature=0.5,
-        max_tokens=50,
-        stream=False,
-        extra_body={"service_tier": "default"},
-        response_format={"type": "text"},
-    )
+        response = openai_client.chat.completions.create(
+            messages=messages_value,
+            model=llm_model_value,
+            seed=42,
+            temperature=0.5,
+            max_tokens=50,
+            stream=False,
+            extra_body={"service_tier": "default"},
+            response_format={"type": "text"},
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED] == 42
-    )
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.5
-    )
-    assert spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    assert (
-        spans[0].attributes[GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER]
-        == "default"
-    )
-    assert (
-        spans[0].attributes[
-            GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
-        ]
-        == "text"
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
+
+        request_seed_attr_key = (
+            "gen_ai.request.seed"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SEED
+        )
+        assert spans[0].attributes[request_seed_attr_key] == 42
+        assert (
+            spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE]
+            == 0.5
+        )
+        assert (
+            spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS]
+            == 50
+        )
+
+        service_tier_attr_key = (
+            "openai.request.service_tier"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER
+        )
+        assert spans[0].attributes[service_tier_attr_key] == "default"
+
+        output_type_attr_key = (
+            "gen_ai.output.type"
+            if latest_experimental_enabled
+            else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+        )
+        assert spans[0].attributes[output_type_attr_key] == "text"
 
 
 @pytest.mark.vcr()
 def test_chat_completion_multiple_choices(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_multiple_choices.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, n=2, stream=False
-    )
+        response = openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, n=2, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert_completion_attributes(spans[0], llm_model_value, response)
+        spans = span_exporter.get_finished_spans()
+        assert_completion_attributes(
+            spans[0], llm_model_value, response, latest_experimental_enabled
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[0].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response.choices[1].message.content,
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 3  # 1 user message + 2 choice messages
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 3  # 1 user message + 2 choice messages
+            user_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
+            choice_event_0 = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[0].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event_0, spans[0]
+            )
 
-    choice_event_0 = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content,
-        },
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event_0, spans[0])
-
-    choice_event_1 = {
-        "index": 1,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[1].message.content,
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event_1, spans[0])
+            choice_event_1 = {
+                "index": 1,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[1].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[2], "gen_ai.choice", choice_event_1, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_tool_calls_with_content(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    chat_completion_tool_call(span_exporter, log_exporter, openai_client, True)
+    with vcr.use_cassette("test_chat_completion_tool_calls_with_content.yaml"):
+        chat_completion_tool_call(
+            span_exporter,
+            log_exporter,
+            openai_client,
+            True,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_tool_calls_no_content(
-    span_exporter, log_exporter, openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    chat_completion_tool_call(
-        span_exporter, log_exporter, openai_client, False
-    )
+    with vcr.use_cassette("test_chat_completion_tool_calls_no_content.yaml"):
+        chat_completion_tool_call(
+            span_exporter,
+            log_exporter,
+            openai_client,
+            False,
+            is_latest_experimental_enabled(),
+        )
 
 
 def chat_completion_tool_call(
-    span_exporter, log_exporter, openai_client, expect_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    expect_content,
+    latest_experimental_enabled,
 ):
     llm_model_value = "gpt-4o-mini"
     messages_value = [
@@ -335,328 +500,627 @@ def chat_completion_tool_call(
     # validate both calls
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 2
-    assert_completion_attributes(spans[0], llm_model_value, response_0)
-    assert_completion_attributes(spans[1], llm_model_value, response_1)
-
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 9  # 3 logs for first completion, 6 for second
-
-    # call one
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
+    assert_completion_attributes(
+        spans[0], llm_model_value, response_0, latest_experimental_enabled
     )
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
+    assert_completion_attributes(
+        spans[1], llm_model_value, response_1, latest_experimental_enabled
     )
 
-    user_message = (
-        {"content": messages_value[1]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
+    if latest_experimental_enabled:
+        if not expect_content:
+            pass
+        else:
+            # first call
+            first_input = [
+                {
+                    "role": "system",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[0]["content"],
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[1]["content"],
+                        }
+                    ],
+                },
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"], first_input
+            )
 
-    function_call_0 = {"name": "get_current_weather"}
-    function_call_1 = {"name": "get_current_weather"}
-    if expect_content:
-        function_call_0["arguments"] = (
-            response_0.choices[0]
-            .message.tool_calls[0]
-            .function.arguments.replace("\n", "")
+            first_output = [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[0]
+                            .id,
+                            "name": "get_current_weather",
+                            "arguments": {"location": "Seattle, WA"},
+                        },
+                        {
+                            "type": "tool_call",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[1]
+                            .id,
+                            "name": "get_current_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                        },
+                    ],
+                    "finish_reason": "tool_calls",
+                }
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+
+            # second call
+            del first_output[0]["finish_reason"]
+            second_input = []
+            second_input += first_input
+            second_input += first_output
+            second_input += [
+                {
+                    "role": "tool",
+                    "parts": [
+                        {
+                            "type": "tool_call_response",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[0]
+                            .id,
+                            "response": tool_call_result_0["content"],
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "parts": [
+                        {
+                            "type": "tool_call_response",
+                            "id": response_0.choices[0]
+                            .message.tool_calls[1]
+                            .id,
+                            "response": tool_call_result_1["content"],
+                        }
+                    ],
+                },
+            ]
+
+            assert_messages_attribute(
+                spans[1].attributes["gen_ai.input.messages"], second_input
+            )
+
+            assert_messages_attribute(
+                spans[1].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": response_1.choices[
+                                    0
+                                ].message.content,
+                            },
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+    else:
+        logs = log_exporter.get_finished_logs()
+
+        assert len(logs) == 9  # 3 logs for first completion, 6 for second
+
+        # call one
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
         )
-        function_call_1["arguments"] = (
-            response_0.choices[0]
-            .message.tool_calls[1]
-            .function.arguments.replace("\n", "")
+        assert_message_in_logs(
+            logs[0], "gen_ai.system.message", system_message, spans[0]
         )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "tool_calls",
-        "message": {
+        user_message = (
+            {"content": messages_value[1]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[1], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        function_call_0 = {"name": "get_current_weather"}
+        function_call_1 = {"name": "get_current_weather"}
+        if expect_content:
+            function_call_0["arguments"] = (
+                response_0.choices[0]
+                .message.tool_calls[0]
+                .function.arguments.replace("\n", "")
+            )
+            function_call_1["arguments"] = (
+                response_0.choices[0]
+                .message.tool_calls[1]
+                .function.arguments.replace("\n", "")
+            )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": response_0.choices[0].message.tool_calls[0].id,
+                        "type": "function",
+                        "function": function_call_0,
+                    },
+                    {
+                        "id": response_0.choices[0].message.tool_calls[1].id,
+                        "type": "function",
+                        "function": function_call_1,
+                    },
+                ],
+            },
+        }
+        assert_message_in_logs(
+            logs[2], "gen_ai.choice", choice_event, spans[0]
+        )
+
+        # call two
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[3], "gen_ai.system.message", system_message, spans[1]
+        )
+
+        user_message = (
+            {"content": messages_value[1]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[4], "gen_ai.user.message", user_message, spans[1]
+        )
+
+        assistant_tool_call = {"tool_calls": messages_value[2]["tool_calls"]}
+        if not expect_content:
+            assistant_tool_call["tool_calls"][0]["function"]["arguments"] = (
+                None
+            )
+            assistant_tool_call["tool_calls"][1]["function"]["arguments"] = (
+                None
+            )
+
+        assert_message_in_logs(
+            logs[5], "gen_ai.assistant.message", assistant_tool_call, spans[1]
+        )
+
+        tool_message_0 = {
+            "id": tool_call_result_0["tool_call_id"],
+            "content": tool_call_result_0["content"]
+            if expect_content
+            else None,
+        }
+
+        assert_message_in_logs(
+            logs[6], "gen_ai.tool.message", tool_message_0, spans[1]
+        )
+
+        tool_message_1 = {
+            "id": tool_call_result_1["tool_call_id"],
+            "content": tool_call_result_1["content"]
+            if expect_content
+            else None,
+        }
+
+        assert_message_in_logs(
+            logs[7], "gen_ai.tool.message", tool_message_1, spans[1]
+        )
+
+        message = {
             "role": "assistant",
-            "tool_calls": [
-                {
-                    "id": response_0.choices[0].message.tool_calls[0].id,
-                    "type": "function",
-                    "function": function_call_0,
-                },
-                {
-                    "id": response_0.choices[0].message.tool_calls[1].id,
-                    "type": "function",
-                    "function": function_call_1,
-                },
-            ],
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event, spans[0])
-
-    # call two
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[3], "gen_ai.system.message", system_message, spans[1]
-    )
-
-    user_message = (
-        {"content": messages_value[1]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[4], "gen_ai.user.message", user_message, spans[1]
-    )
-
-    assistant_tool_call = {"tool_calls": messages_value[2]["tool_calls"]}
-    if not expect_content:
-        assistant_tool_call["tool_calls"][0]["function"]["arguments"] = None
-        assistant_tool_call["tool_calls"][1]["function"]["arguments"] = None
-
-    assert_message_in_logs(
-        logs[5], "gen_ai.assistant.message", assistant_tool_call, spans[1]
-    )
-
-    tool_message_0 = {
-        "id": tool_call_result_0["tool_call_id"],
-        "content": tool_call_result_0["content"] if expect_content else None,
-    }
-
-    assert_message_in_logs(
-        logs[6], "gen_ai.tool.message", tool_message_0, spans[1]
-    )
-
-    tool_message_1 = {
-        "id": tool_call_result_1["tool_call_id"],
-        "content": tool_call_result_1["content"] if expect_content else None,
-    }
-
-    assert_message_in_logs(
-        logs[7], "gen_ai.tool.message", tool_message_1, spans[1]
-    )
-
-    message = {
-        "role": "assistant",
-        "content": response_1.choices[0].message.content
-        if expect_content
-        else None,
-    }
-    choice = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": message,
-    }
-    assert_message_in_logs(logs[8], "gen_ai.choice", choice, spans[1])
+            "content": response_1.choices[0].message.content
+            if expect_content
+            else None,
+        }
+        choice = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": message,
+        }
+        assert_message_in_logs(logs[8], "gen_ai.choice", choice, spans[1])
 
 
 @pytest.mark.vcr()
 def test_chat_completion_streaming(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_streaming.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    kwargs = {
-        "model": llm_model_value,
-        "messages": messages_value,
-        "stream": True,
-        "stream_options": {"include_usage": True},
-    }
+        kwargs = {
+            "model": llm_model_value,
+            "messages": messages_value,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
 
-    response_stream_usage = None
-    response_stream_model = None
-    response_stream_id = None
-    response_stream_result = ""
-    response = openai_client.chat.completions.create(**kwargs)
-    for chunk in response:
-        if chunk.choices:
-            response_stream_result += chunk.choices[0].delta.content or ""
+        response_stream_usage = None
+        response_stream_model = None
+        response_stream_id = None
+        response_stream_result = ""
+        response = openai_client.chat.completions.create(**kwargs)
+        for chunk in response:
+            if chunk.choices:
+                response_stream_result += chunk.choices[0].delta.content or ""
 
-        # get the last chunk
-        if getattr(chunk, "usage", None):
-            response_stream_usage = chunk.usage
-            response_stream_model = chunk.model
-            response_stream_id = chunk.id
+            # get the last chunk
+            if getattr(chunk, "usage", None):
+                response_stream_usage = chunk.usage
+                response_stream_model = chunk.model
+                response_stream_id = chunk.id
 
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0],
-        llm_model_value,
-        response_stream_id,
-        response_stream_model,
-        response_stream_usage.prompt_tokens,
-        response_stream_usage.completion_tokens,
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+            response_stream_usage.prompt_tokens,
+            response_stream_usage.completion_tokens,
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {"type": "text", "content": response_stream_result}
+                        ],
+                        "finish_reason": "stop",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+            user_message = {"content": "Say this is a test"}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {"content": "Say this is a test"}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {"role": "assistant", "content": response_stream_result},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response_stream_result,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_streaming_not_complete(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_streaming_not_complete.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    kwargs = {
-        "model": llm_model_value,
-        "messages": messages_value,
-        "stream": True,
-    }
+        kwargs = {
+            "model": llm_model_value,
+            "messages": messages_value,
+            "stream": True,
+        }
 
-    response_stream_model = None
-    response_stream_id = None
-    response_stream_result = ""
-    response = openai_client.chat.completions.create(**kwargs)
-    for idx, chunk in enumerate(response):
-        if chunk.choices:
-            response_stream_result += chunk.choices[0].delta.content or ""
-        if idx == 1:
-            # fake a stop
-            break
+        response_stream_model = None
+        response_stream_id = None
+        response_stream_result = ""
+        response = openai_client.chat.completions.create(**kwargs)
+        for idx, chunk in enumerate(response):
+            if chunk.choices:
+                response_stream_result += chunk.choices[0].delta.content or ""
+            if idx == 1:
+                # fake a stop
+                break
 
-        if chunk.model:
-            response_stream_model = chunk.model
-        if chunk.id:
-            response_stream_id = chunk.id
+            if chunk.model:
+                response_stream_model = chunk.model
+            if chunk.id:
+                response_stream_id = chunk.id
 
-    response.close()
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0], llm_model_value, response_stream_id, response_stream_model
-    )
+        response.close()
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    }
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {"type": "text", "content": response_stream_result}
+                        ],
+                        "finish_reason": "error",
+                    }
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 2
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+            user_message = {"content": "Say this is a test"}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {"content": "Say this is a test"}
-    assert_message_in_logs(
-        logs[0], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "error",
-        "message": {"role": "assistant", "content": response_stream_result},
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+            choice_event = {
+                "index": 0,
+                "finish_reason": "error",
+                "message": {
+                    "role": "assistant",
+                    "content": response_stream_result,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_multiple_choices_streaming(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [
-        {"role": "system", "content": "You're a helpful assistant."},
-        {
-            "role": "user",
-            "content": "What's the weather in Seattle and San Francisco today?",
-        },
-    ]
+    with vcr.use_cassette(
+        "test_chat_completion_multiple_choices_streaming.yaml"
+    ):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [
+            {"role": "system", "content": "You're a helpful assistant."},
+            {
+                "role": "user",
+                "content": "What's the weather in Seattle and San Francisco today?",
+            },
+        ]
 
-    response_0 = openai_client.chat.completions.create(
-        messages=messages_value,
-        model=llm_model_value,
-        n=2,
-        stream=True,
-        stream_options={"include_usage": True},
-    )
+        response_0 = openai_client.chat.completions.create(
+            messages=messages_value,
+            model=llm_model_value,
+            n=2,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
 
-    # two strings for each choice
-    response_stream_result = ["", ""]
-    finish_reasons = ["", ""]
-    for chunk in response_0:
-        if chunk.choices:
-            for choice in chunk.choices:
-                response_stream_result[choice.index] += (
-                    choice.delta.content or ""
-                )
-                if choice.finish_reason:
-                    finish_reasons[choice.index] = choice.finish_reason
+        # two strings for each choice
+        response_stream_result = ["", ""]
+        finish_reasons = ["", ""]
+        for chunk in response_0:
+            if chunk.choices:
+                for choice in chunk.choices:
+                    response_stream_result[choice.index] += (
+                        choice.delta.content or ""
+                    )
+                    if choice.finish_reason:
+                        finish_reasons[choice.index] = choice.finish_reason
 
-        # get the last chunk
-        if getattr(chunk, "usage", None):
-            response_stream_usage = chunk.usage
-            response_stream_model = chunk.model
-            response_stream_id = chunk.id
+            # get the last chunk
+            if getattr(chunk, "usage", None):
+                response_stream_usage = chunk.usage
+                response_stream_model = chunk.model
+                response_stream_id = chunk.id
 
-    # sanity check
-    assert "stop" == finish_reasons[0]
+        # sanity check
+        assert "stop" == finish_reasons[0]
 
-    spans = span_exporter.get_finished_spans()
-    assert_all_attributes(
-        spans[0],
-        llm_model_value,
-        response_stream_id,
-        response_stream_model,
-        response_stream_usage.prompt_tokens,
-        response_stream_usage.completion_tokens,
-    )
+        spans = span_exporter.get_finished_spans()
+        assert_all_attributes(
+            spans[0],
+            llm_model_value,
+            latest_experimental_enabled,
+            response_stream_id,
+            response_stream_model,
+            response_stream_usage.prompt_tokens,
+            response_stream_usage.completion_tokens,
+        )
+        if latest_experimental_enabled:
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"],
+                [
+                    {
+                        "role": "system",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[0]["content"],
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": messages_value[1]["content"],
+                            }
+                        ],
+                    },
+                ],
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"],
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": "".join(response_stream_result[0]),
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                    {
+                        "role": "assistant",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "content": "".join(response_stream_result[1]),
+                            }
+                        ],
+                        "finish_reason": "stop",
+                    },
+                ],
+            )
+        else:
+            logs = log_exporter.get_finished_logs()
+            assert len(logs) == 4
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 4
+            system_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.system.message", system_message, spans[0]
+            )
 
-    system_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
-    )
+            user_message = {
+                "content": "What's the weather in Seattle and San Francisco today?"
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.user.message", user_message, spans[0]
+            )
 
-    user_message = {
-        "content": "What's the weather in Seattle and San Francisco today?"
-    }
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
+            choice_event_0 = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "".join(response_stream_result[0]),
+                },
+            }
+            assert_message_in_logs(
+                logs[2], "gen_ai.choice", choice_event_0, spans[0]
+            )
 
-    choice_event_0 = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": "".join(response_stream_result[0]),
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event_0, spans[0])
-
-    choice_event_1 = {
-        "index": 1,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": "".join(response_stream_result[1]),
-        },
-    }
-    assert_message_in_logs(logs[3], "gen_ai.choice", choice_event_1, spans[0])
+            choice_event_1 = {
+                "index": 1,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "".join(response_stream_result[1]),
+                },
+            }
+            assert_message_in_logs(
+                logs[3], "gen_ai.choice", choice_event_1, spans[0]
+            )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_multiple_tools_streaming_with_content(
-    span_exporter, log_exporter, openai_client, instrument_with_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_with_content,
+    vcr,
 ):
-    chat_completion_multiple_tools_streaming(
-        span_exporter, log_exporter, openai_client, True
-    )
+    with vcr.use_cassette(
+        "test_chat_completion_multiple_tools_streaming_with_content.yaml"
+    ):
+        chat_completion_multiple_tools_streaming(
+            span_exporter,
+            log_exporter,
+            openai_client,
+            True,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
 def test_chat_completion_multiple_tools_streaming_no_content(
-    span_exporter, log_exporter, openai_client, instrument_no_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    instrument_no_content,
+    vcr,
 ):
-    chat_completion_multiple_tools_streaming(
-        span_exporter, log_exporter, openai_client, False
-    )
+    with vcr.use_cassette(
+        "test_chat_completion_multiple_tools_streaming_no_content.yaml"
+    ):
+        chat_completion_multiple_tools_streaming(
+            span_exporter,
+            log_exporter,
+            openai_client,
+            False,
+            is_latest_experimental_enabled(),
+        )
 
 
 @pytest.mark.vcr()
@@ -665,44 +1129,64 @@ def test_chat_completion_with_content_span_unsampled(
     log_exporter,
     openai_client,
     instrument_with_content_unsampled,
+    vcr,
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette(
+        "test_chat_completion_with_content_span_unsampled.yaml"
+    ):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    response = openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        response = openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 0
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 0
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 2
+        logs = log_exporter.get_finished_logs()
+        if latest_experimental_enabled:
+            assert len(logs) == 0
+            # TODO: check event
+        else:
+            assert len(logs) == 2
 
-    user_message = {"content": messages_value[0]["content"]}
-    assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, None)
+            user_message = {"content": messages_value[0]["content"]}
+            assert_message_in_logs(
+                logs[0], "gen_ai.user.message", user_message, None
+            )
 
-    choice_event = {
-        "index": 0,
-        "finish_reason": "stop",
-        "message": {
-            "role": "assistant",
-            "content": response.choices[0].message.content,
-        },
-    }
-    assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, None)
+            choice_event = {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": response.choices[0].message.content,
+                },
+            }
+            assert_message_in_logs(
+                logs[1], "gen_ai.choice", choice_event, None
+            )
 
-    assert logs[0].log_record.trace_id is not None
-    assert logs[0].log_record.span_id is not None
-    assert logs[0].log_record.trace_flags == 0
+            assert logs[0].log_record.trace_id is not None
+            assert logs[0].log_record.span_id is not None
+            assert logs[0].log_record.trace_flags == 0
 
-    assert logs[0].log_record.trace_id == logs[1].log_record.trace_id
-    assert logs[0].log_record.span_id == logs[1].log_record.span_id
-    assert logs[0].log_record.trace_flags == logs[1].log_record.trace_flags
+            assert logs[0].log_record.trace_id == logs[1].log_record.trace_id
+            assert logs[0].log_record.span_id == logs[1].log_record.span_id
+            assert (
+                logs[0].log_record.trace_flags
+                == logs[1].log_record.trace_flags
+            )
 
 
 def chat_completion_multiple_tools_streaming(
-    span_exporter, log_exporter, openai_client, expect_content
+    span_exporter,
+    log_exporter,
+    openai_client,
+    expect_content,
+    latest_experimental_enabled,
 ):
     llm_model_value = "gpt-4o-mini"
     messages_value = [
@@ -754,61 +1238,119 @@ def chat_completion_multiple_tools_streaming(
     assert_all_attributes(
         spans[0],
         llm_model_value,
+        latest_experimental_enabled,
         response_stream_id,
         response_stream_model,
         response_stream_usage.prompt_tokens,
         response_stream_usage.completion_tokens,
     )
 
-    logs = log_exporter.get_finished_logs()
-    assert len(logs) == 3
-
-    system_message = (
-        {"content": messages_value[0]["content"]} if expect_content else None
-    )
-    assert_message_in_logs(
-        logs[0], "gen_ai.system.message", system_message, spans[0]
-    )
-
-    user_message = (
-        {"content": "What's the weather in Seattle and San Francisco today?"}
-        if expect_content
-        else None
-    )
-    assert_message_in_logs(
-        logs[1], "gen_ai.user.message", user_message, spans[0]
-    )
-
-    choice_event = {
-        "index": 0,
-        "finish_reason": "tool_calls",
-        "message": {
-            "role": "assistant",
-            "tool_calls": [
+    if latest_experimental_enabled:
+        if expect_content:
+            # first call
+            first_input = [
                 {
-                    "id": tool_call_ids[0],
-                    "type": "function",
-                    "function": {
-                        "name": tool_names[0],
-                        "arguments": tool_args[0].replace("\n", "")
-                        if expect_content
-                        else None,
-                    },
+                    "role": "system",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[0]["content"],
+                        }
+                    ],
                 },
                 {
-                    "id": tool_call_ids[1],
-                    "type": "function",
-                    "function": {
-                        "name": tool_names[1],
-                        "arguments": tool_args[1].replace("\n", "")
-                        if expect_content
-                        else None,
-                    },
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": messages_value[1]["content"],
+                        }
+                    ],
                 },
-            ],
-        },
-    }
-    assert_message_in_logs(logs[2], "gen_ai.choice", choice_event, spans[0])
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.input.messages"], first_input
+            )
+
+            first_output = [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": tool_call_ids[0],
+                            "name": "get_current_weather",
+                            "arguments": {"location": "Seattle, WA"},
+                        },
+                        {
+                            "type": "tool_call",
+                            "id": tool_call_ids[1],
+                            "name": "get_current_weather",
+                            "arguments": {"location": "San Francisco, CA"},
+                        },
+                    ],
+                    "finish_reason": "tool_calls",
+                }
+            ]
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 3
+
+        system_message = (
+            {"content": messages_value[0]["content"]}
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[0], "gen_ai.system.message", system_message, spans[0]
+        )
+
+        user_message = (
+            {
+                "content": "What's the weather in Seattle and San Francisco today?"
+            }
+            if expect_content
+            else None
+        )
+        assert_message_in_logs(
+            logs[1], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": tool_call_ids[0],
+                        "type": "function",
+                        "function": {
+                            "name": tool_names[0],
+                            "arguments": tool_args[0].replace("\n", "")
+                            if expect_content
+                            else None,
+                        },
+                    },
+                    {
+                        "id": tool_call_ids[1],
+                        "type": "function",
+                        "function": {
+                            "name": tool_names[1],
+                            "arguments": tool_args[1].replace("\n", "")
+                            if expect_content
+                            else None,
+                        },
+                    },
+                ],
+            },
+        }
+        assert_message_in_logs(
+            logs[2], "gen_ai.choice", choice_event, spans[0]
+        )
 
 
 def assert_message_in_logs(log, event_name, expected_content, parent_span):
@@ -840,110 +1382,3 @@ def remove_none_values(body):
         else:
             result[key] = value
     return result
-
-
-def assert_completion_attributes(
-    span: ReadableSpan,
-    request_model: str,
-    response: ChatCompletion,
-    operation_name: str = "chat",
-    server_address: str = "api.openai.com",
-):
-    return assert_all_attributes(
-        span,
-        request_model,
-        response.id,
-        response.model,
-        response.usage.prompt_tokens,
-        response.usage.completion_tokens,
-        operation_name,
-        server_address,
-    )
-
-
-def assert_all_attributes(
-    span: ReadableSpan,
-    request_model: str,
-    response_id: str = None,
-    response_model: str = None,
-    input_tokens: Optional[int] = None,
-    output_tokens: Optional[int] = None,
-    operation_name: str = "chat",
-    server_address: str = "api.openai.com",
-):
-    assert span.name == f"{operation_name} {request_model}"
-    assert (
-        operation_name
-        == span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
-    )
-    assert (
-        GenAIAttributes.GenAiSystemValues.OPENAI.value
-        == span.attributes[GenAIAttributes.GEN_AI_SYSTEM]
-    )
-    assert (
-        request_model == span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
-    )
-    if response_model:
-        assert (
-            response_model
-            == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_RESPONSE_MODEL not in span.attributes
-
-    if response_id:
-        assert (
-            response_id == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_ID]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_RESPONSE_ID not in span.attributes
-
-    if input_tokens:
-        assert (
-            input_tokens
-            == span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
-        )
-    else:
-        assert GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS not in span.attributes
-
-    if output_tokens:
-        assert (
-            output_tokens
-            == span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
-        )
-    else:
-        assert (
-            GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS not in span.attributes
-        )
-
-    assert server_address == span.attributes[ServerAttributes.SERVER_ADDRESS]
-
-
-def assert_log_parent(log, span):
-    if span:
-        assert log.log_record.trace_id == span.get_span_context().trace_id
-        assert log.log_record.span_id == span.get_span_context().span_id
-        assert (
-            log.log_record.trace_flags == span.get_span_context().trace_flags
-        )
-
-
-def get_current_weather_tool_definition():
-    return {
-        "type": "function",
-        "function": {
-            "name": "get_current_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. Boston, MA",
-                    },
-                },
-                "required": ["location"],
-                "additionalProperties": False,
-            },
-        },
-    }

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_metrics.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_metrics.py
@@ -1,5 +1,8 @@
 import pytest
 
+from opentelemetry.instrumentation.openai_v2.utils import (
+    is_latest_experimental_enabled,
+)
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -42,15 +45,21 @@ _TOKEN_USAGE_BUCKETS = (
 )
 
 
-def assert_all_metric_attributes(data_point):
+def assert_all_metric_attributes(data_point, latest_experimental_enabled):
     assert GenAIAttributes.GEN_AI_OPERATION_NAME in data_point.attributes
     assert (
         data_point.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
         == GenAIAttributes.GenAiOperationNameValues.CHAT.value
     )
-    assert GenAIAttributes.GEN_AI_SYSTEM in data_point.attributes
+
+    provider_name_attr_name = (
+        "gen_ai.provider.name"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_SYSTEM
+    )
+    assert provider_name_attr_name in data_point.attributes
     assert (
-        data_point.attributes[GenAIAttributes.GEN_AI_SYSTEM]
+        data_point.attributes[provider_name_attr_name]
         == GenAIAttributes.GenAiSystemValues.OPENAI.value
     )
     assert GenAIAttributes.GEN_AI_REQUEST_MODEL in data_point.attributes
@@ -63,21 +72,25 @@ def assert_all_metric_attributes(data_point):
         data_point.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
         == "gpt-4o-mini-2024-07-18"
     )
-    assert "gen_ai.openai.response.system_fingerprint" in data_point.attributes
-    assert (
-        data_point.attributes["gen_ai.openai.response.system_fingerprint"]
-        == "fp_0ba0d124f1"
+
+    system_fingerprint_attr_key = (
+        "openai.response.system_fingerprint"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SYSTEM_FINGERPRINT
     )
+    assert system_fingerprint_attr_key in data_point.attributes
     assert (
-        GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
-        in data_point.attributes
+        data_point.attributes[system_fingerprint_attr_key] == "fp_0ba0d124f1"
     )
-    assert (
-        data_point.attributes[
-            GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
-        ]
-        == "default"
+
+    service_tier_attr_key = (
+        "openai.response.service_tier"
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_RESPONSE_SERVICE_TIER
     )
+    assert service_tier_attr_key in data_point.attributes
+    assert service_tier_attr_key in data_point.attributes
+    assert data_point.attributes[service_tier_attr_key] == "default"
     assert (
         data_point.attributes[ServerAttributes.SERVER_ADDRESS]
         == "api.openai.com"
@@ -86,142 +99,158 @@ def assert_all_metric_attributes(data_point):
 
 @pytest.mark.vcr()
 def test_chat_completion_metrics(
-    metric_reader, openai_client, instrument_with_content
+    metric_reader, openai_client, instrument_with_content, vcr
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_chat_completion_metrics.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    metrics = metric_reader.get_metrics_data().resource_metrics
-    assert len(metrics) == 1
+        metrics = metric_reader.get_metrics_data().resource_metrics
+        assert len(metrics) == 1
 
-    metric_data = metrics[0].scope_metrics[0].metrics
-    assert len(metric_data) == 2
+        metric_data = metrics[0].scope_metrics[0].metrics
+        assert len(metric_data) == 2
 
-    duration_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
-        ),
-        None,
-    )
-    assert duration_metric is not None
+        duration_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
+            ),
+            None,
+        )
+        assert duration_metric is not None
 
-    duration_point = duration_metric.data.data_points[0]
-    assert duration_point.sum > 0
-    assert_all_metric_attributes(duration_point)
-    assert duration_point.explicit_bounds == _DURATION_BUCKETS
+        duration_point = duration_metric.data.data_points[0]
+        assert duration_point.sum > 0
+        assert_all_metric_attributes(
+            duration_point, latest_experimental_enabled
+        )
+        assert duration_point.explicit_bounds == _DURATION_BUCKETS
 
-    token_usage_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE
-        ),
-        None,
-    )
-    assert token_usage_metric is not None
+        token_usage_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE
+            ),
+            None,
+        )
+        assert token_usage_metric is not None
 
-    input_token_usage = next(
-        (
-            d
-            for d in token_usage_metric.data.data_points
-            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
-            == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
-        ),
-        None,
-    )
-    assert input_token_usage is not None
-    assert input_token_usage.sum == 12
+        input_token_usage = next(
+            (
+                d
+                for d in token_usage_metric.data.data_points
+                if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+                == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
+            ),
+            None,
+        )
+        assert input_token_usage is not None
+        assert input_token_usage.sum == 12
 
-    assert input_token_usage.explicit_bounds == _TOKEN_USAGE_BUCKETS
-    assert input_token_usage.bucket_counts[2] == 1
-    assert_all_metric_attributes(input_token_usage)
+        assert input_token_usage.explicit_bounds == _TOKEN_USAGE_BUCKETS
+        assert input_token_usage.bucket_counts[2] == 1
+        assert_all_metric_attributes(
+            input_token_usage, latest_experimental_enabled
+        )
 
-    output_token_usage = next(
-        (
-            d
-            for d in token_usage_metric.data.data_points
-            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
-            == GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value
-        ),
-        None,
-    )
-    assert output_token_usage is not None
-    assert output_token_usage.sum == 5
-    # assert against buckets [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864]
-    assert output_token_usage.bucket_counts[2] == 1
-    assert_all_metric_attributes(output_token_usage)
+        output_token_usage = next(
+            (
+                d
+                for d in token_usage_metric.data.data_points
+                if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+                == GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value
+            ),
+            None,
+        )
+        assert output_token_usage is not None
+        assert output_token_usage.sum == 5
+        # assert against buckets [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864]
+        assert output_token_usage.bucket_counts[2] == 1
+        assert_all_metric_attributes(
+            output_token_usage, latest_experimental_enabled
+        )
 
 
 @pytest.mark.vcr()
 @pytest.mark.asyncio()
 async def test_async_chat_completion_metrics(
-    metric_reader, async_openai_client, instrument_with_content
+    metric_reader, async_openai_client, instrument_with_content, vcr
 ):
-    llm_model_value = "gpt-4o-mini"
-    messages_value = [{"role": "user", "content": "Say this is a test"}]
+    with vcr.use_cassette("test_async_chat_completion_metrics.yaml"):
+        latest_experimental_enabled = is_latest_experimental_enabled()
+        llm_model_value = "gpt-4o-mini"
+        messages_value = [{"role": "user", "content": "Say this is a test"}]
 
-    await async_openai_client.chat.completions.create(
-        messages=messages_value, model=llm_model_value, stream=False
-    )
+        await async_openai_client.chat.completions.create(
+            messages=messages_value, model=llm_model_value, stream=False
+        )
 
-    metrics = metric_reader.get_metrics_data().resource_metrics
-    assert len(metrics) == 1
+        metrics = metric_reader.get_metrics_data().resource_metrics
+        assert len(metrics) == 1
 
-    metric_data = metrics[0].scope_metrics[0].metrics
-    assert len(metric_data) == 2
+        metric_data = metrics[0].scope_metrics[0].metrics
+        assert len(metric_data) == 2
 
-    duration_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
-        ),
-        None,
-    )
-    assert duration_metric is not None
-    assert duration_metric.data.data_points[0].sum > 0
-    assert_all_metric_attributes(duration_metric.data.data_points[0])
+        duration_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
+            ),
+            None,
+        )
+        assert duration_metric is not None
+        assert duration_metric.data.data_points[0].sum > 0
+        assert_all_metric_attributes(
+            duration_metric.data.data_points[0], latest_experimental_enabled
+        )
 
-    token_usage_metric = next(
-        (
-            m
-            for m in metric_data
-            if m.name == gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE
-        ),
-        None,
-    )
-    assert token_usage_metric is not None
+        token_usage_metric = next(
+            (
+                m
+                for m in metric_data
+                if m.name == gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE
+            ),
+            None,
+        )
+        assert token_usage_metric is not None
 
-    input_token_usage = next(
-        (
-            d
-            for d in token_usage_metric.data.data_points
-            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
-            == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
-        ),
-        None,
-    )
+        input_token_usage = next(
+            (
+                d
+                for d in token_usage_metric.data.data_points
+                if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+                == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
+            ),
+            None,
+        )
 
-    assert input_token_usage is not None
-    assert input_token_usage.sum == 12
-    assert_all_metric_attributes(input_token_usage)
+        assert input_token_usage is not None
+        assert input_token_usage.sum == 12
+        assert_all_metric_attributes(
+            input_token_usage, latest_experimental_enabled
+        )
 
-    output_token_usage = next(
-        (
-            d
-            for d in token_usage_metric.data.data_points
-            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
-            == GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value
-        ),
-        None,
-    )
+        output_token_usage = next(
+            (
+                d
+                for d in token_usage_metric.data.data_points
+                if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+                == GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value
+            ),
+            None,
+        )
 
-    assert output_token_usage is not None
-    assert output_token_usage.sum == 12
-    assert_all_metric_attributes(output_token_usage)
+        assert output_token_usage is not None
+        assert output_token_usage.sum == 12
+        assert_all_metric_attributes(
+            output_token_usage, latest_experimental_enabled
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_utils.py
@@ -1,0 +1,135 @@
+import json
+from typing import Optional
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+    server_attributes as ServerAttributes,
+)
+
+from openai.resources.chat.completions import ChatCompletion
+
+def assert_all_attributes(
+    span: ReadableSpan,
+    request_model: str,
+    latest_experimental_enabled: bool,
+    response_id: str = None,
+    response_model: str = None,
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
+    operation_name: str = "chat",
+    server_address: str = "api.openai.com",
+):
+    assert span.name == f"{operation_name} {request_model}"
+    assert (
+        operation_name
+        == span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+    )
+    provider_name_attr_name = "gen_ai.provider.name" if latest_experimental_enabled else GenAIAttributes.GEN_AI_SYSTEM    
+    assert (
+        GenAIAttributes.GenAiSystemValues.OPENAI.value
+        == span.attributes[provider_name_attr_name]
+    )
+    assert (
+        request_model == span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+    )
+    if response_model:
+        assert (
+            response_model
+            == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
+        )
+    else:
+        assert GenAIAttributes.GEN_AI_RESPONSE_MODEL not in span.attributes
+
+    if response_id:
+        assert (
+            response_id == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_ID]
+        )
+    else:
+        assert GenAIAttributes.GEN_AI_RESPONSE_ID not in span.attributes
+
+    if input_tokens:
+        assert (
+            input_tokens
+            == span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
+        )
+    else:
+        assert GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS not in span.attributes
+
+    if output_tokens:
+        assert (
+            output_tokens
+            == span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
+        )
+    else:
+        assert (
+            GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS not in span.attributes
+        )
+
+    assert server_address == span.attributes[ServerAttributes.SERVER_ADDRESS]
+
+
+def assert_log_parent(log, span):
+    if span:
+        assert log.log_record.trace_id == span.get_span_context().trace_id
+        assert log.log_record.span_id == span.get_span_context().span_id
+        assert (
+            log.log_record.trace_flags == span.get_span_context().trace_flags
+        )
+
+
+def get_current_weather_tool_definition():
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. Boston, MA",
+                    },
+                },
+                "required": ["location"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+def remove_none_values(body):
+    result = {}
+    for key, value in body.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            result[key] = remove_none_values(value)
+        elif isinstance(value, list):
+            result[key] = [remove_none_values(i) for i in value]
+        else:
+            result[key] = value
+    return result
+
+
+def assert_completion_attributes(
+    span: ReadableSpan,
+    request_model: str,
+    response: ChatCompletion,
+    latest_experimental_enabled: bool,
+    operation_name: str = "chat",
+    server_address: str = "api.openai.com",
+):
+    return assert_all_attributes(
+        span,
+        request_model,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+        operation_name,
+        server_address,
+    )
+
+def assert_messages_attribute(actual, expected):
+    assert json.loads(actual) == expected


### PR DESCRIPTION
Implements new semconv 1.37.0 behind `OTEL_SEMCONV_STABILITY_OPT_IN = gen_ai_latest_experimental` opt-in.

Depends on #3709 (common code for `OTEL_SEMCONV_STABILITY_OPT_IN`) and https://github.com/open-telemetry/opentelemetry-python/pull/4731 (new semconv package).

TODOs:
- [ ] support emitting new operation details event
- [ ] figure out common place for `ContentCapturingMode` (discussed with @DylanRussell we could potentially put it into https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation until we have common package dedicated for gen-ai)
- [ ] clean up
