### PR TITLE
Add `gen_ai_latest_experimental` to the Sem Conv stability flag. Add `ContentCapturingMode` enum

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -162,9 +162,10 @@ _server_active_requests_count_attrs_new = [
 OTEL_SEMCONV_STABILITY_OPT_IN = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 
-class _OpenTelemetryStabilitySignalType:
+class _OpenTelemetryStabilitySignalType(Enum):
     HTTP = "http"
     DATABASE = "database"
+    GEN_AI = "gen_ai"
 
 
 class _StabilityMode(Enum):
@@ -173,6 +174,7 @@ class _StabilityMode(Enum):
     HTTP_DUP = "http/dup"
     DATABASE = "database"
     DATABASE_DUP = "database/dup"
+    GEN_AI_LATEST = "gen_ai_latest_experimental"
 
 
 def _report_new(mode: _StabilityMode):
@@ -195,7 +197,7 @@ class _OpenTelemetrySemanticConventionStability:
                 return
 
             # Users can pass in comma delimited string for opt-in options
-            # Only values for http and database stability are supported for now
+            # Only values for http, gen ai, and database stability are supported for now
             opt_in = os.environ.get(OTEL_SEMCONV_STABILITY_OPT_IN)
 
             if not opt_in:
@@ -203,6 +205,7 @@ class _OpenTelemetrySemanticConventionStability:
                 cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = {
                     _OpenTelemetryStabilitySignalType.HTTP: _StabilityMode.DEFAULT,
                     _OpenTelemetryStabilitySignalType.DATABASE: _StabilityMode.DEFAULT,
+                    _OpenTelemetryStabilitySignalType.GEN_AI: _StabilityMode.DEFAULT,
                 }
                 cls._initialized = True
                 return
@@ -210,9 +213,11 @@ class _OpenTelemetrySemanticConventionStability:
             opt_in_list = [s.strip() for s in opt_in.split(",")]
 
             cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING[
-                _OpenTelemetryStabilitySignalType.HTTP
+                _OpenTelemetryStabilitySignalType.GEN_AI
             ] = cls._filter_mode(
-                opt_in_list, _StabilityMode.HTTP, _StabilityMode.HTTP_DUP
+                opt_in_list,
+                _StabilityMode.DEFAULT,
+                _StabilityMode.GEN_AI_LATEST,
             )
 
             cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING[

--- a/opentelemetry-instrumentation/tests/test_semconv.py
+++ b/opentelemetry-instrumentation/tests/test_semconv.py
@@ -54,6 +54,12 @@ class TestOpenTelemetrySemConvStability(TestCase):
             ),
             _StabilityMode.DEFAULT,
         )
+        self.assertEqual(
+            _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+                _OpenTelemetryStabilitySignalType.GEN_AI
+            ),
+            _StabilityMode.DEFAULT,
+        )
 
     @stability_mode("http")
     def test_http_stable_mode(self):
@@ -89,6 +95,15 @@ class TestOpenTelemetrySemConvStability(TestCase):
                 _OpenTelemetryStabilitySignalType.DATABASE
             ),
             _StabilityMode.DATABASE_DUP,
+        )
+
+    @stability_mode("gen_ai_latest_experimental")
+    def test_genai_latest_experimental(self):
+        self.assertEqual(
+            _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+                _OpenTelemetryStabilitySignalType.GEN_AI
+            ),
+            _StabilityMode.GEN_AI_LATEST,
         )
 
     @stability_mode("database,http")

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
@@ -1,0 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = (
+    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class ContentCapturingMode(Enum):
+    # Do not capture content (default).
+    NO_CONTENT = 0
+    # Only capture content in spans.
+    SPAN_ONLY = 1
+    # Only capture content in events.
+    EVENT_ONLY = 2
+    # Capture content in both spans and events.
+    SPAN_AND_EVENT = 3

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -1,0 +1,48 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from opentelemetry.instrumentation._semconv import (
+    _OpenTelemetrySemanticConventionStability,
+    _OpenTelemetryStabilitySignalType,
+    _StabilityMode,
+)
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
+from opentelemetry.util.genai.types import ContentCapturingMode
+
+
+def get_content_capturing_mode() -> ContentCapturingMode:
+    envvar = os.environ.get(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT)
+    if (
+        _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+            _OpenTelemetryStabilitySignalType.GEN_AI,
+        )
+        == _StabilityMode.DEFAULT
+    ):
+        raise RuntimeError(
+            "This function should never be called when StabilityMode is default.."
+        )
+    if not envvar:
+        return ContentCapturingMode.NO_CONTENT
+    try:
+        return ContentCapturingMode[envvar.upper()]
+    except KeyError:
+        raise RuntimeError(
+            "{} is not a valid option for `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable. Must be one of {}".format(
+                envvar, ", ".join([e.name for e in ContentCapturingMode])
+            )
+        )

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -42,7 +42,5 @@ def get_content_capturing_mode() -> ContentCapturingMode:
         return ContentCapturingMode[envvar.upper()]
     except KeyError:
         raise RuntimeError(
-            "{} is not a valid option for `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable. Must be one of {}".format(
-                envvar, ", ".join([e.name for e in ContentCapturingMode])
-            )
+            f"{envvar} is not a valid option for `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable. Must be one of {', '.join(e.name for e in ContentCapturingMode)}"
         )

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -1,0 +1,74 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
+from opentelemetry.util.genai.types import ContentCapturingMode
+from opentelemetry.util.genai.utils import get_content_capturing_mode
+
+
+def patch_env_vars(stability_mode, content_capturing):
+    def decorator(test_case):
+        @patch.dict(
+            os.environ,
+            {
+                OTEL_SEMCONV_STABILITY_OPT_IN: stability_mode,
+                OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: content_capturing,
+            },
+        )
+        def wrapper(*args, **kwargs):
+            # Reset state.
+            _OpenTelemetrySemanticConventionStability._initialized = False
+            _OpenTelemetrySemanticConventionStability._initialize()
+            return test_case(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class TestVersion(unittest.TestCase):
+    @patch_env_vars("gen_ai_latest_experimental", "SPAN_ONLY")
+    def test_get_content_caputring_mode_parses_valid_envvar(self):  # pylint: disable=no-self-use
+        _OpenTelemetrySemanticConventionStability._initialized = False
+        assert get_content_capturing_mode() == ContentCapturingMode.SPAN_ONLY
+
+    @patch_env_vars("gen_ai_latest_experimental", "")
+    def test_empty_content_capturing_envvar(self):  # pylint: disable=no-self-use
+        _OpenTelemetrySemanticConventionStability._initialized = False
+        assert get_content_capturing_mode() == ContentCapturingMode.NO_CONTENT
+
+    @patch_env_vars("default", "True")
+    def test_get_content_caputring_mode_raises_exception_when_semconv_stability_default(
+        self,
+    ):  # pylint: disable=no-self-use
+        _OpenTelemetrySemanticConventionStability._initialized = False
+        with self.assertRaises(RuntimeError):
+            get_content_capturing_mode()
+
+    @patch_env_vars("gen_ai_latest_experimental", "INVALID_VALUE")
+    def test_get_content_caputring_mode_raises_exception_on_invalid_envvar(
+        self,
+    ):  # pylint: disable=no-self-use
+        with self.assertRaises(RuntimeError):
+            get_content_capturing_mode()


### PR DESCRIPTION
# Description

Add `gen_ai_latest_experimental` to the Sem Conv stability env var. 

Add `ContentCapturingMode` enum which will get it's value from the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env var

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ x] Followed the style guidelines of this project
- [ x] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
