### PR TITLE
botocore: upgrade moto package from 5.0.9 to 5.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3366](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3366))
 - `opentelemetry-instrumentation`: add support for  `OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH` to inform opentelemetry-instrument about gevent monkeypatching
   ([#3699](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3699))
+- `opentelemetry-instrumentation`: botocore: upgrade moto package from 5.0.9 to 5.1.11
+  ([#3736](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3736))
 
 ## Version 1.36.0/0.57b0 (2025-07-29)
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-0.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-0.txt
@@ -13,7 +13,7 @@ iniconfig==2.0.0
 Jinja2==3.1.6
 jmespath==1.0.1
 MarkupSafe==2.1.5
-moto==5.0.9
+moto==5.1.11
 packaging==24.0
 pluggy==1.5.0
 py-cpuinfo==9.0.0

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-1.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-1.txt
@@ -13,7 +13,7 @@ iniconfig==2.0.0
 Jinja2==3.1.6
 jmespath==1.0.1
 MarkupSafe==2.1.5
-moto==5.0.9
+moto==5.1.11
 packaging==24.0
 pluggy==1.5.0
 py-cpuinfo==9.0.0

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_dynamodb.py
@@ -439,7 +439,7 @@ class TestDynamoDbExtension(TestBase):
             Limit=42,
             Select="ALL_ATTRIBUTES",
             TotalSegments=17,
-            Segment=21,
+            Segment=16,
             ProjectionExpression="PE",
             ConsistentRead=True,
             ReturnConsumedCapacity="TOTAL",
@@ -448,14 +448,14 @@ class TestDynamoDbExtension(TestBase):
         span = self.assert_span("Scan")
         self.assert_table_names(span, self.default_table_name)
         self.assertEqual(
-            21, span.attributes[SpanAttributes.AWS_DYNAMODB_SEGMENT]
+            16, span.attributes[SpanAttributes.AWS_DYNAMODB_SEGMENT]
         )
         self.assertEqual(
             17, span.attributes[SpanAttributes.AWS_DYNAMODB_TOTAL_SEGMENTS]
         )
-        self.assertEqual(1, span.attributes[SpanAttributes.AWS_DYNAMODB_COUNT])
+        self.assertEqual(0, span.attributes[SpanAttributes.AWS_DYNAMODB_COUNT])
         self.assertEqual(
-            1, span.attributes[SpanAttributes.AWS_DYNAMODB_SCANNED_COUNT]
+            0, span.attributes[SpanAttributes.AWS_DYNAMODB_SCANNED_COUNT]
         )
         self.assert_attributes_to_get(span, "id", "idl")
         self.assert_consistent_read(span, True)


### PR DESCRIPTION
# Description
Moto 5.0.9, released in May 2024, lacks support for certain AWS resources such as Step Functions APIs (describeActivity). This PR upgrades moto to the latest release (5.1.11) to add these capabilities.

After the upgrade, one DynamoDB unit test failed. This PR also addresses that failure.

The unit test failures after upgrading moto from 5.0.9 to 5.1.11 happened due to two key improvements in moto's DynamoDB implementation:

1. Enhanced Parameter Validation Before (moto 5.0.9): Moto had lenient validation and allowed invalid parameter combinations like Segment=21 with TotalSegments=17, even though this violates AWS DynamoDB's actual behavior.

After (moto 5.1.11): Moto added stricter validation that matches AWS DynamoDB's real behavior:

Segment parameter must be zero-based (0 to TotalSegments-1)

Segment=21 with TotalSegments=17 now correctly throws ValidationException

2. More Accurate Parallel Scan Simulation Before (moto 5.0.9): Moto's parallel scan implementation was simplified and might have returned items regardless of which segment was being scanned, leading to predictable but incorrect behavior.

After (moto 5.1.11): Moto improved its parallel scan simulation to more accurately reflect how AWS DynamoDB distributes items across segments:

Items are distributed based on hash values of partition keys

Different segments contain different subsets of data

Segment 16 (out of 17 total) might legitimately contain 0 items if the hash distribution doesn't place any items there

Why This Matters
These changes make moto behave more like the actual AWS DynamoDB service, which is beneficial for testing because:

Tests catch invalid parameter usage that would fail in production

Tests reflect realistic data distribution patterns

Code is validated against more accurate AWS behavior

The test failures weren't bugs in the OpenTelemetry instrumentation code - they were issues with the test setup that became visible when moto started enforcing AWS's actual constraints and behavior patterns.



Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.



### Test
Verified with:
tox -e py312-test-instrumentation-botocore
tox -e spellcheck
tox -e lint-instrumentation-botocore
tox -e ruff

Skip Changelog
as this PR only impacts unit tests.