### PR TITLE
AWS Lambda Instrumentation slash based handler fix

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -463,7 +463,7 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
         (
             self._wrapped_module_name,
             self._wrapped_function_name,
-        ) = lambda_handler.rsplit(".", 1)
+        ) = lambda_handler.replace("/",".").rsplit(".", 1)
 
         flush_timeout_env = os.environ.get(
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT, None

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -754,3 +754,36 @@ class TestAwsLambdaInstrumentorMocks(TestAwsLambdaInstrumentorBase):
         self.assertEqual(event.name, "exception")
 
         exc_env_patch.stop()
+
+    def test_handler_slash_notation(self):
+        test_env_patch = mock.patch.dict(
+            "os.environ",
+            {
+                **os.environ,
+                _HANDLER: "tests/mocks/subdir/slash_handler.slash_notation_handler",
+                "AWS_LAMBDA_FUNCTION_NAME": "mylambda",
+                _X_AMZN_TRACE_ID: MOCK_XRAY_TRACE_CONTEXT_NOT_SAMPLED,
+                OTEL_PROPAGATORS: "tracecontext",
+            },
+        )
+        test_env_patch.start()
+        reload(propagate)
+
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda()
+
+        spans = self.memory_exporter.get_finished_spans()
+
+        assert spans
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "tests/mocks/subdir/slash_handler.slash_notation_handler")
+        self.assertEqual(span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+        test_env_patch.stop()
+


### PR DESCRIPTION
# Description

The AWS Lambda instrumentation module is not compatible with slash based handlers, the instrumentation relies on import_lib without sanitizing the handler path which could include slashes. This causes the lambda to fail. 

Fixes # (issue)

#3733 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added test_handler_slash_notation in test_aws_lambda_instrumentation_manual.py that checks thats slash based handlers do not cause AwsLambdaInstrumentor to error.


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
