### PR TITLE
[WIP]add commenter_options in trace_integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3734](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3734))
 - `opentelemetry-instrumentation`: botocore: upgrade moto package from 5.0.9 to 5.1.11
   ([#3736](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3736))
+- `opentelemetry-instrumentation-dbapi`: Add support for `commenter_options` in `trace_integration` to control SQLCommenter behavior
+  ([#3743](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3743))
 
 ## Version 1.36.0/0.57b0 (2025-07-29)
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -78,6 +78,7 @@ def trace_integration(
     capture_parameters: bool = False,
     enable_commenter: bool = False,
     db_api_integration_factory: type[DatabaseApiIntegration] | None = None,
+    commenter_options: dict[str, Any] | None = None,
     enable_attribute_commenter: bool = False,
 ):
     """Integrate with DB API library.
@@ -96,6 +97,7 @@ def trace_integration(
         enable_commenter: Flag to enable/disable sqlcommenter.
         db_api_integration_factory: The `DatabaseApiIntegration` to use. If none is passed the
             default one is used.
+        commenter_options: Configurations for tags to be appended at the sql query.
         enable_attribute_commenter: Flag to enable/disable sqlcomment inclusion in `db.statement` span attribute. Only available if enable_commenter=True.
     """
     wrap_connect(
@@ -109,6 +111,7 @@ def trace_integration(
         capture_parameters=capture_parameters,
         enable_commenter=enable_commenter,
         db_api_integration_factory=db_api_integration_factory,
+        commenter_options=commenter_options,
         enable_attribute_commenter=enable_attribute_commenter,
     )
 


### PR DESCRIPTION
# Description

This PR adds support for passing `commenter_options` to the `trace_integration` function and `DatabaseApiIntegration` in the `opentelemetry-instrumentation-dbapi` package. This allows users to customize SQLCommenter behavior (for example, disabling `opentelemetry_values`) when instrumenting DB-API drivers.

Fixes #3726 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added a new unit test `test_commenter_options_propagation`.
- `tox -e lint` and  `pytest`.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
