### PR TITLE
infra: ignore pushes on otelbot branches

### DIFF
--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:

--- a/.github/workflows/test_2.yml
+++ b/.github/workflows/test_2.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
     - 'release/*'
+    - 'otelbot/*'
   pull_request:
 
 permissions:


### PR DESCRIPTION
# Description

Avoid situations when needed to push changes to otelbot branches, which results in a deadlock in CI during releases (because of the automation with labels)