### PR TITLE
Exclude opentelemetry-util-genai from release upload

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,7 @@ DISTDIR=dist
    cd $DISTDIR
    for x in * ; do
     # FIXME: Remove this once opentelemetry-resource-detector-azure package goes 1.X
-    if echo "$x" | grep -Eq "^opentelemetry_resource_detector_azure.*(\.tar\.gz|\.whl)$"; then
+    if echo "$x" | grep -Eq "^opentelemetry_(resource_detector_azure|util_genai).*(\.tar\.gz|\.whl)$"; then
       echo "Skipping $x because of manual upload by Azure maintainers."
       rm $x
     # NOTE: We filter beta vs 1.0 package at this point because we can read the

--- a/util/opentelemetry-util-genai/README.rst
+++ b/util/opentelemetry-util-genai/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Util for GenAI
-=======================
+============================
 
 
 The GenAI Utils package will include boilerplate and helpers to standardize instrumentation for Generative AI. 


### PR DESCRIPTION
Because it should be released on its own.
While at it fix its README.rst formatting.