### PR TITLE
Fix typecheck in langchain instrumentation

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/span_manager.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/span_manager.py
@@ -31,7 +31,7 @@ __all__ = ["_SpanManager"]
 @dataclass
 class _SpanState:
     span: Span
-    children: List[UUID] = field(default_factory=list)
+    children: List[UUID] = field(default_factory=list) # type: ignore [reportUnknownVariableType]
 
 
 class _SpanManager:


### PR DESCRIPTION
# Description

Fixes 
opentelemetry-python-contrib/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/span_manager.py:34:5 - error: Type of "children" is partially unknown
    Type of "children" is "list[Unknown]" (reportUnknownVariableType)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
