### PR TITLE
celery: allow using links instead of child spans for task execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-
-- `opentelemetry-instrumentation-celery`: Add `use_links` parameter to allow creating span links instead of parent-child relationships between task creation and execution spans.
-  ([#3002](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3002))
-
 ### Fixed
 
 - `opentelemetry-instrumentation-botocore`: migrate off the deprecated events API to use the logs API
@@ -37,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3676](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3676))
 - `opentelemetry-instrumentation-dbapi`: Adds sqlcommenter to documentation.
   ([#3720](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3720))
+- `opentelemetry-instrumentation-celery`: Add `use_span_links` parameter to allow creating span links instead of parent-child relationships between task creation and execution spans.
+  ([#3002](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3002))
 
 ## Version 1.37.0/0.58b0 (2025-09-11)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -52,7 +52,7 @@ Configuration
 
 The ``CeleryInstrumentor().instrument()`` method accepts the following arguments:
 
-* ``use_links`` (bool): When ``True``, Celery task execution spans will be linked to the
+* ``use_span_links`` (bool): When ``True``, Celery task execution spans will be linked to the
   task creation spans instead of being created as child spans. This provides a looser
   coupling between spans in distributed systems. Defaults to ``False`` to maintain
   backward compatibility.
@@ -132,7 +132,7 @@ class CeleryInstrumentor(BaseInstrumentor):
 
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")
-        use_links = kwargs.get("use_links", False)
+        use_span_links = kwargs.get("use_span_links", False)
 
         # pylint: disable=attribute-defined-outside-init
         self._tracer = trace.get_tracer(
@@ -142,7 +142,7 @@ class CeleryInstrumentor(BaseInstrumentor):
             schema_url="https://opentelemetry.io/schemas/1.11.0",
         )
         # pylint: disable=attribute-defined-outside-init
-        self._use_links = use_links
+        self._use_span_links = use_span_links
 
         meter_provider = kwargs.get("meter_provider")
         meter = get_meter(
@@ -188,7 +188,7 @@ class CeleryInstrumentor(BaseInstrumentor):
 
         operation_name = f"{_TASK_RUN}/{task.name}"
 
-        if self._use_links and tracectx is not None:
+        if self._use_span_links and tracectx is not None:
             parent_span_context = trace.get_current_span(
                 tracectx
             ).get_span_context()

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -222,8 +222,8 @@ class TestCeleryInstrumentation(TestBase):
 
         unwrap(utils, "retrieve_context")
 
-    def test_task_use_links(self):
-        CeleryInstrumentor().instrument(use_links=True)
+    def test_task_use_span_links(self):
+        CeleryInstrumentor().instrument(use_span_links=True)
 
         result = task_add.delay(1, 2)
 


### PR DESCRIPTION
# Description

As described in #3002, the current default behaviour results in all celery tasks that execute are child spans of the code that pushed it on to the broker, which [conflicts with the semantic conventions](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3002#issuecomment-3211249453). 

This PR **doesn't change the default behaviour** since this may be undesirable for consumers expecting the behaviour to be consistent.

Fixes #3002 by providing an optional parameter to the `.instrument()` method to allow for optionally using span links, e.g. 
```python
CeleryInstrumentor().instrument(use_links=True)
```

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unit test added
- Tested E2E locally with jaeger with `use_links=False` and also `use_links=True` and observed the expected behaviour: when the flag is `False` (default) all task executions of a fan-out job are child spans of the code that enqueued it and when `True` they appeared as linked spans. 

# Does This PR Require a Core Repo Change?
- No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
