### PR TITLE
Fix package release workflows version.py finding

### DIFF
--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -49,7 +49,7 @@ jobs:
 
           version=$(./scripts/eachdist.py version --package ${{ inputs.package }})
 
-          version_file=$(find $path -type f -path "*version*.py")
+          version_file=$(find $path -type f -path "**/version.py")
           file_count=$(echo "$version_file" | wc -l)
 
           if [ "$file_count" -ne 1 ]; then

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -61,7 +61,7 @@ jobs:
 
           version=${version_dev%.dev}
 
-          version_file=$(find $path -type f -path "*version*.py")
+          version_file=$(find $path -type f -path "**/version.py")
           file_count=$(echo "$version_file" | wc -l)
 
           if [ "$file_count" -ne 1 ]; then


### PR DESCRIPTION
Fixes failing run https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/17988593058/job/51172963011. Looking at the files in this repo, the version file is always called version.py (and it should be). Tested the find command locally.

```shell
$ for f in $(git ls-files '*version*.py'); do basename $f; done | sort -u
test_version.py
version.py

$ find util/opentelemetry-util-genai/ -type f -path "**/version.py"
util/opentelemetry-util-genai/src/opentelemetry/util/genai/version.py
```
