### PR TITLE
Fix "module 'json' has no attribute 'DecodeError'" in bedrock

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock_utils.py
@@ -117,7 +117,7 @@ class ConverseStreamWrapper(ObjectProxy):
                         self._content_block["toolUse"]["input"] = json.loads(
                             self._tool_json_input_buf
                         )
-                    except json.DecodeError:
+                    except json.JSONDecodeError:
                         self._content_block["toolUse"]["input"] = (
                             self._tool_json_input_buf
                         )


### PR DESCRIPTION
# Description

Seems like theres a bad reference to a non-existent type. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No, I have no idea how to reproduce this as it was in the middle of a complicated bug and it crashed my application with:

```
module 'json' has no attribute 'DecodeError'
module 'json' has no attribute 'DecodeError'. Did you mean: 'JSONDecodeError'
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
