### PR TITLE
Add jsonlines support to fsspec uploader

### DIFF
--- a/util/opentelemetry-util-genai/CHANGELOG.md
+++ b/util/opentelemetry-util-genai/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add jsonlines support to fsspec uploader
+  ([https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3791](#3791))
+
 ## Version 0.1b0 (2025-09-24)
 
 - Add completion hook to genai utils to implement semconv v1.37.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fsspec_upload/completion_hook.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fsspec_upload/completion_hook.py
@@ -78,11 +78,9 @@ JsonEncodeable = list[dict[str, Any]]
 UploadData = dict[str, Callable[[], JsonEncodeable]]
 
 
-def fsspec_open(
-    urlpath: str, mode: Literal["w"], *args: Any, **kwargs: Any
-) -> TextIO:
+def fsspec_open(urlpath: str, mode: Literal["w"]) -> TextIO:
     """typed wrapper around `fsspec.open`"""
-    return cast(TextIO, fsspec.open(urlpath, mode, *args, **kwargs))  # pyright: ignore[reportUnknownMemberType]
+    return cast(TextIO, fsspec.open(urlpath, mode))  # pyright: ignore[reportUnknownMemberType]
 
 
 class FsspecUploadCompletionHook(CompletionHook):
@@ -181,8 +179,10 @@ class FsspecUploadCompletionHook(CompletionHook):
         self, path: str, json_encodeable: Callable[[], JsonEncodeable]
     ) -> None:
         if self._format == "json":
+            # output as a single line with the json messages array
             message_lines = [json_encodeable()]
         else:
+            # output as one line per message in the array
             message_lines = json_encodeable()
             # add an index for streaming readers of jsonl
             for message_idx, line in enumerate(message_lines):

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fsspec_upload/completion_hook.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fsspec_upload/completion_hook.py
@@ -24,6 +24,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import ExitStack
 from dataclasses import asdict, dataclass
 from functools import partial
+from os import environ
 from time import time
 from typing import Any, Callable, Final, Literal, TextIO, cast
 from uuid import uuid4
@@ -35,6 +36,9 @@ from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
 from opentelemetry.trace import Span
 from opentelemetry.util.genai import types
 from opentelemetry.util.genai.completion_hook import CompletionHook
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT,
+)
 
 GEN_AI_INPUT_MESSAGES_REF: Final = (
     gen_ai_attributes.GEN_AI_INPUT_MESSAGES + "_ref"
@@ -46,6 +50,10 @@ GEN_AI_SYSTEM_INSTRUCTIONS_REF: Final = (
     gen_ai_attributes.GEN_AI_SYSTEM_INSTRUCTIONS + "_ref"
 )
 
+_MESSAGE_INDEX_KEY = "index"
+
+Format = Literal["json", "jsonl"]
+_FORMATS: tuple[Format, ...] = ("json", "jsonl")
 
 _logger = logging.getLogger(__name__)
 
@@ -70,9 +78,11 @@ JsonEncodeable = list[dict[str, Any]]
 UploadData = dict[str, Callable[[], JsonEncodeable]]
 
 
-def fsspec_open(urlpath: str, mode: Literal["w"]) -> TextIO:
+def fsspec_open(
+    urlpath: str, mode: Literal["w"], *args: Any, **kwargs: Any
+) -> TextIO:
     """typed wrapper around `fsspec.open`"""
-    return cast(TextIO, fsspec.open(urlpath, mode))  # pyright: ignore[reportUnknownMemberType]
+    return cast(TextIO, fsspec.open(urlpath, mode, *args, **kwargs))  # pyright: ignore[reportUnknownMemberType]
 
 
 class FsspecUploadCompletionHook(CompletionHook):
@@ -94,9 +104,26 @@ class FsspecUploadCompletionHook(CompletionHook):
         *,
         base_path: str,
         max_size: int = 20,
+        upload_format: Format | None = None,
     ) -> None:
         self._base_path = base_path
         self._max_size = max_size
+
+        if upload_format not in _FORMATS + (None,):
+            raise ValueError(
+                f"Invalid {upload_format=}. Must be one of {_FORMATS}"
+            )
+
+        if upload_format is None:
+            environ_format = environ.get(
+                OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT, "json"
+            ).lower()
+            if environ_format not in _FORMATS:
+                upload_format = "json"
+            else:
+                upload_format = environ_format
+
+        self._format: Final[Literal["json", "jsonl"]] = upload_format
 
         # Use a ThreadPoolExecutor for its queueing and thread management. The semaphore
         # limits the number of queued tasks. If the queue is full, data will be dropped.
@@ -139,27 +166,37 @@ class FsspecUploadCompletionHook(CompletionHook):
         uuid_str = str(uuid4())
         return CompletionRefs(
             inputs_ref=posixpath.join(
-                self._base_path, f"{uuid_str}_inputs.json"
+                self._base_path, f"{uuid_str}_inputs.{self._format}"
             ),
             outputs_ref=posixpath.join(
-                self._base_path, f"{uuid_str}_outputs.json"
+                self._base_path, f"{uuid_str}_outputs.{self._format}"
             ),
             system_instruction_ref=posixpath.join(
-                self._base_path, f"{uuid_str}_system_instruction.json"
+                self._base_path,
+                f"{uuid_str}_system_instruction.{self._format}",
             ),
         )
 
-    @staticmethod
     def _do_upload(
-        path: str, json_encodeable: Callable[[], JsonEncodeable]
+        self, path: str, json_encodeable: Callable[[], JsonEncodeable]
     ) -> None:
+        if self._format == "json":
+            message_lines = [json_encodeable()]
+        else:
+            message_lines = json_encodeable()
+            # add an index for streaming readers of jsonl
+            for message_idx, line in enumerate(message_lines):
+                line[_MESSAGE_INDEX_KEY] = message_idx
+
         with fsspec_open(path, "w") as file:
-            json.dump(
-                json_encodeable(),
-                file,
-                separators=(",", ":"),
-                cls=Base64JsonEncoder,
-            )
+            for message in message_lines:
+                json.dump(
+                    message,
+                    file,
+                    separators=(",", ":"),
+                    cls=Base64JsonEncoder,
+                )
+                file.write("\n")
 
     def on_completion(
         self,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
@@ -43,3 +43,13 @@ information, see
    <https://filesystem-spec.readthedocs.io/en/latest/features.html#url-chaining>`_ for advanced
    use cases.
 """
+
+OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT = (
+    "OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT"
+)
+"""
+.. envvar:: OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT
+
+The format to use when uploading prompt and response data. Must be one of ``json`` or
+``jsonl``. Defaults to ``json``.
+"""


### PR DESCRIPTION
# Description

The schemas for GenAI types are already arrays. It's much more efficient to parse [jsonlines](https://jsonlines.org/) than an array and it is a commonly used for https://jsonlines.org/.

Also adds a `index` field to the json lines so they can be processed out of order/in parallel

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added lots of new test cases

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
