### PR TITLE
opentelemetry-instrumentation-dbapi: fix libpq version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-dbapi`: fix crash retrieving libpq version when enabling commenter with psycopg
+  ([#3796](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3796))
+
 ### Added
 - `opentelemetry-instrumentation`: botocore: Add support for AWS Secrets Manager semantic convention attribute
   ([#3765](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3765))
 - Add `rstcheck` to pre-commit to stop introducing invalid RST
   ([#3777](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3777))
-
 - `opentelemetry-exporter-credential-provider-gcp`: create this package which provides support for supplying your machine's Application Default Credentials (https://cloud.google.com/docs/authentication/application-default-credentials) to the OTLP Exporters created automatically by OpenTelemetry Python's auto instrumentation. These credentials authorize OTLP traces to be sent to `telemetry.googleapis.com`. 
 [#3766](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3766).
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -355,7 +355,7 @@ class DatabaseApiIntegration:
             if hasattr(self.connect_module, "pq"):
                 try:
                     libpq_version = self.connect_module.pq.version()
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-raised
                     pass
 
             # psycopg2

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -355,7 +355,7 @@ class DatabaseApiIntegration:
             if hasattr(self.connect_module, "pq"):
                 try:
                     libpq_version = self.connect_module.pq.version()
-                except Exception:  # pylint: disable=broad-exception-raised
+                except Exception:  # pylint: disable=broad-exception-caught
                     pass
 
             # psycopg2

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -352,11 +352,10 @@ class DatabaseApiIntegration:
         if self.database_system == "postgresql":
             libpq_version = None
             # psycopg
-            if hasattr(self.connect_module, "pq"):
-                try:
-                    libpq_version = self.connect_module.pq.version()
-                except Exception:  # pylint: disable=broad-exception-caught
-                    pass
+            try:
+                libpq_version = self.connect_module.pq.version()
+            except AttributeError:
+                pass
 
             # psycopg2
             if libpq_version is None:
@@ -365,7 +364,7 @@ class DatabaseApiIntegration:
                     self.connect_module, "__libpq_version__", None
                 )
 
-            # psycopg also instrument modules that are not the root one, in that case you
+            # we instrument psycopg modules that are not the root one, in that case you
             # won't get the libpq_version
             if libpq_version is not None:
                 commenter_data.update({"libpq_version": libpq_version})

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -460,6 +460,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = mock.MagicMock()
+        connect_module.pq.version.side_effect = AttributeError
         connect_module.__libpq_version__ = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
@@ -528,7 +529,8 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = mock.MagicMock()
-        connect_module.pq = mock.MagicMock()
+        connect_module.pq.version.side_effect = AttributeError
+        connect_module.__libpq_version__ = None
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -629,8 +631,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "psycopg"
         connect_module.__version__ = "1.2.3"
-        connect_module.pq = mock.MagicMock()
-        connect_module.pq.__build_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -663,8 +664,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "psycopg"
         connect_module.__version__ = "1.2.3"
-        connect_module.pq = mock.MagicMock()
-        connect_module.pq.__build_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -918,8 +918,7 @@ class TestDBApiIntegration(TestBase):
     def test_executemany_flask_integration_comment(self):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
-        connect_module.__version__ = mock.MagicMock()
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -279,7 +279,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = mock.MagicMock()
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -312,7 +312,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = mock.MagicMock()
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -420,7 +420,7 @@ class TestDBApiIntegration(TestBase):
     ):
         connect_module = mock.MagicMock()
         connect_module.__version__ = mock.MagicMock()
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -564,6 +564,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "psycopg2"
         connect_module.__version__ = "1.2.3"
+        connect_module.pq.version.side_effect = AttributeError
         connect_module.__libpq_version__ = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
@@ -597,6 +598,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "psycopg2"
         connect_module.__version__ = "1.2.3"
+        connect_module.pq.version.side_effect = AttributeError
         connect_module.__libpq_version__ = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
@@ -934,7 +936,7 @@ class TestDBApiIntegration(TestBase):
         sqlcommenter_context = context.set_value(
             "SQLCOMMENTER_ORM_TAGS_AND_VALUES", {"flask": 1}, current_context
         )
-        context.attach(sqlcommenter_context)
+        token = context.attach(sqlcommenter_context)
 
         mock_connection = db_integration.wrapped_connection(
             mock_connect, {}, {}
@@ -953,16 +955,13 @@ class TestDBApiIntegration(TestBase):
             "Select 1;",
         )
 
-        clear_context = context.set_value(
-            "SQLCOMMENTER_ORM_TAGS_AND_VALUES", {}, current_context
-        )
-        context.attach(clear_context)
+        context.detach(token)
 
     def test_executemany_flask_integration_comment_stmt_enabled(self):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = mock.MagicMock()
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = 123
         connect_module.threadsafety = 123
         connect_module.paramstyle = "test"
@@ -979,7 +978,7 @@ class TestDBApiIntegration(TestBase):
         sqlcommenter_context = context.set_value(
             "SQLCOMMENTER_ORM_TAGS_AND_VALUES", {"flask": 1}, current_context
         )
-        context.attach(sqlcommenter_context)
+        token = context.attach(sqlcommenter_context)
 
         mock_connection = db_integration.wrapped_connection(
             mock_connect, {}, {}
@@ -998,10 +997,7 @@ class TestDBApiIntegration(TestBase):
             r"Select 1 /\*dbapi_threadsafety=123,driver_paramstyle='test',flask=1,libpq_version=123,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
         )
 
-        clear_context = context.set_value(
-            "SQLCOMMENTER_ORM_TAGS_AND_VALUES", {}, current_context
-        )
-        context.attach(clear_context)
+        context.detach(token)
 
     def test_callproc(self):
         db_integration = dbapi.DatabaseApiIntegration(
@@ -1126,7 +1122,7 @@ class TestDBApiIntegration(TestBase):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
         connect_module.__version__ = "1.0"
-        connect_module.__libpq_version__ = 123
+        connect_module.pq.version.return_value = 123
         connect_module.apilevel = "2.0"
         connect_module.threadsafety = 1
         connect_module.paramstyle = "test"

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -523,7 +523,7 @@ class TestDBApiIntegration(TestBase):
             "Select 1;",
         )
 
-    def test_no_build_version_where_we_dont_instrument_the_root_module(
+    def test_no_libpq_version_when_we_dont_instrument_the_root_module(
         self,
     ):
         connect_module = mock.MagicMock()

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
@@ -95,7 +95,7 @@ class TestFunctionalPsycopg(TestBase):
         cursor.execute("SELECT  1;")
         self.assertRegex(
             cursor._query.query.decode("ascii"),
-            r"SELECT  1 /\*db_driver='psycopg(.*)',dbapi_level='\d.\d',dbapi_threadsafety=\d,driver_paramstyle=(.*),traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
+            r"SELECT  1 /\*db_driver='Connection%%3Aunknown',dbapi_level='\d.\d',dbapi_threadsafety='unknown',driver_paramstyle='unknown',traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
         )
 
         cursor.close()

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_sqlcommenter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import psycopg
 import psycopg2
 from test_psycopg_functional import (
     POSTGRES_DB_NAME,
@@ -21,11 +22,12 @@ from test_psycopg_functional import (
     POSTGRES_USER,
 )
 
+from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
 from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 from opentelemetry.test.test_base import TestBase
 
 
-class TestFunctionalPsycopg(TestBase):
+class TestFunctionalPsycopg2(TestBase):
     def setUp(self):
         super().setUp()
         self._tracer = self.tracer_provider.get_tracer(__name__)
@@ -52,3 +54,49 @@ class TestFunctionalPsycopg(TestBase):
             self._cursor.query.decode("ascii"),
             r"SELECT  1 /\*db_driver='psycopg2(.*)',dbapi_level='\d.\d',dbapi_threadsafety=\d,driver_paramstyle=(.*),libpq_version=\d*,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
         )
+
+
+class TestFunctionalPsycopg(TestBase):
+    def setUp(self):
+        super().setUp()
+        PsycopgInstrumentor().instrument(enable_commenter=True)
+
+    def tearDown(self):
+        PsycopgInstrumentor().uninstrument()
+        super().tearDown()
+
+    def test_commenter_enabled_root_module(self):
+        connection = psycopg.connect(
+            dbname=POSTGRES_DB_NAME,
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+            host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
+        )
+        cursor = connection.cursor()
+        cursor.execute("SELECT  1;")
+        self.assertRegex(
+            cursor._query.query.decode("ascii"),
+            r"SELECT  1 /\*db_driver='psycopg(.*)',dbapi_level='\d.\d',dbapi_threadsafety=\d,driver_paramstyle=(.*),libpq_version=\d*,traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
+        )
+
+        cursor.close()
+        connection.close()
+
+    def test_commenter_enabled_not_root_module(self):
+        connection = psycopg.Connection.connect(
+            dbname=POSTGRES_DB_NAME,
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+            host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
+        )
+        cursor = connection.cursor()
+        cursor.execute("SELECT  1;")
+        self.assertRegex(
+            cursor._query.query.decode("ascii"),
+            r"SELECT  1 /\*db_driver='psycopg(.*)',dbapi_level='\d.\d',dbapi_threadsafety=\d,driver_paramstyle=(.*),traceparent='\d{1,2}-[a-zA-Z0-9_]{32}-[a-zA-Z0-9_]{16}-\d{1,2}'\*/;",
+        )
+
+        cursor.close()
+        connection.close()


### PR DESCRIPTION
# Description

This fixes a crash in the detection of libpq version in the psycopg module when we wrap a module that is not the one containing the pq module that has the version. In that case we just don't report the libpq version instead of crashing.

References:
- psycopg2 https://www.psycopg.org/docs/module.html#psycopg2.__libpq_version__
- psycopg https://www.psycopg.org/psycopg3/docs/api/pq.html#module-content

Fixes #3793

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
