### PR TITLE
Rename "fsspec_upload" entry point and classes to more generic "upload"

### DIFF
--- a/docs/instrumentation-genai/util.rst
+++ b/docs/instrumentation-genai/util.rst
@@ -26,6 +26,6 @@ OpenTelemetry Python - GenAI Util
     :undoc-members:
     :show-inheritance:
 
-.. automodule:: opentelemetry.util.genai._fsspec_upload
+.. automodule:: opentelemetry.util.genai._upload
     :members:
     :show-inheritance:

--- a/tox.ini
+++ b/tox.ini
@@ -1072,7 +1072,7 @@ deps =
   {[testenv]test_deps}
   {toxinidir}/opentelemetry-instrumentation
   {toxinidir}/util/opentelemetry-util-http
-  {toxinidir}/util/opentelemetry-util-genai[fsspec]
+  {toxinidir}/util/opentelemetry-util-genai[upload]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai[instruments]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-google-genai[instruments]
   {toxinidir}/instrumentation/opentelemetry-instrumentation-aiokafka[instruments]

--- a/util/opentelemetry-util-genai/CHANGELOG.md
+++ b/util/opentelemetry-util-genai/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add jsonlines support to fsspec uploader
   ([https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3791](#3791))
+- Rename "fsspec_upload" entry point and classes to more generic "upload"
+  ([https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3798](#3798))
 
 ## Version 0.1b0 (2025-09-24)
 

--- a/util/opentelemetry-util-genai/pyproject.toml
+++ b/util/opentelemetry-util-genai/pyproject.toml
@@ -31,11 +31,11 @@ dependencies = [
 ]
 
 [project.entry-points.opentelemetry_genai_completion_hook]
-fsspec_upload = "opentelemetry.util.genai._fsspec_upload:fsspec_completion_upload_hook"
+upload = "opentelemetry.util.genai._upload:upload_completion_hook"
 
 [project.optional-dependencies]
 test = ["pytest>=7.0.0"]
-fsspec = ["fsspec>=2025.9.0"]
+upload = ["fsspec>=2025.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-genai"

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_upload/__init__.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_upload/__init__.py
@@ -25,12 +25,12 @@ from opentelemetry.util.genai.environment_variables import (
 )
 
 
-def fsspec_completion_upload_hook() -> CompletionHook:
+def upload_completion_hook() -> CompletionHook:
     # If fsspec is not installed the hook will be a no-op.
     try:
         # pylint: disable=import-outside-toplevel
-        from opentelemetry.util.genai._fsspec_upload.completion_hook import (
-            FsspecUploadCompletionHook,
+        from opentelemetry.util.genai._upload.completion_hook import (
+            UploadCompletionHook,
         )
     except ImportError:
         return _NoOpCompletionHook()
@@ -39,4 +39,4 @@ def fsspec_completion_upload_hook() -> CompletionHook:
     if not base_path:
         return _NoOpCompletionHook()
 
-    return FsspecUploadCompletionHook(base_path=base_path)
+    return UploadCompletionHook(base_path=base_path)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_upload/completion_hook.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_upload/completion_hook.py
@@ -83,17 +83,17 @@ def fsspec_open(urlpath: str, mode: Literal["w"]) -> TextIO:
     return cast(TextIO, fsspec.open(urlpath, mode))  # pyright: ignore[reportUnknownMemberType]
 
 
-class FsspecUploadCompletionHook(CompletionHook):
+class UploadCompletionHook(CompletionHook):
     """An completion hook using ``fsspec`` to upload to external storage
 
     This function can be used as the
     :func:`~opentelemetry.util.genai.completion_hook.load_completion_hook` implementation by
-    setting :envvar:`OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK` to ``fsspec_upload``.
+    setting :envvar:`OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK` to ``upload``.
     :envvar:`OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH` must be configured to specify the
     base path for uploads.
 
     Both the ``fsspec`` and ``opentelemetry-sdk`` packages should be installed, or a no-op
-    implementation will be used instead. You can use ``opentelemetry-util-genai[fsspec]``
+    implementation will be used instead. You can use ``opentelemetry-util-genai[upload]``
     as a requirement to achieve this.
     """
 
@@ -133,7 +133,7 @@ class FsspecUploadCompletionHook(CompletionHook):
             try:
                 future.result()
             except Exception:  # pylint: disable=broad-except
-                _logger.exception("fsspec uploader failed")
+                _logger.exception("uploader failed")
             finally:
                 self._semaphore.release()
 
@@ -141,7 +141,7 @@ class FsspecUploadCompletionHook(CompletionHook):
             # could not acquire, drop data
             if not self._semaphore.acquire(blocking=False):  # pylint: disable=consider-using-with
                 _logger.warning(
-                    "fsspec upload queue is full, dropping upload %s",
+                    "upload queue is full, dropping upload %s",
                     path,
                 )
                 continue
@@ -153,7 +153,7 @@ class FsspecUploadCompletionHook(CompletionHook):
                 fut.add_done_callback(done)
             except RuntimeError:
                 _logger.info(
-                    "attempting to upload file after FsspecUploadCompletionHook.shutdown() was already called"
+                    "attempting to upload file after UploadCompletionHook.shutdown() was already called"
                 )
                 self._semaphore.release()
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/environment_variables.py
@@ -39,9 +39,6 @@ information, see
 * `Configuration
   <https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration>`_ for
   configuring a backend with environment variables.
-*  `URL Chaining
-   <https://filesystem-spec.readthedocs.io/en/latest/features.html#url-chaining>`_ for advanced
-   use cases.
 """
 
 OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT = (

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -4019,22 +4019,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-fsspec = [
-    { name = "fsspec" },
-]
 test = [
     { name = "pytest" },
+]
+upload = [
+    { name = "fsspec" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2025.9.0" },
+    { name = "fsspec", marker = "extra == 'upload'", specifier = ">=2025.9.0" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
     { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
 ]
-provides-extras = ["fsspec", "test"]
+provides-extras = ["test", "upload"]
 
 [[package]]
 name = "opentelemetry-util-http"


### PR DESCRIPTION
# Description

Decided to rename to not draw attention to the implementation details. I left docs that explain which schemes are supported and how to install new ones. If fsspec doesn't work out, we can also pivot.

This is breaking change since last Friday's release but not a big deal.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Simple renames but tests are fine

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
