### PR TITLE
Add AWS_LAMBDA_RESOURCE_MAPPING_ID Semantic Convention Support for AWS Lambda SDK

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/lmbd.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/lmbd.py
@@ -16,17 +16,26 @@ import abc
 import inspect
 import json
 import re
-from typing import Dict
+from typing import Dict, Final
 
 from opentelemetry.instrumentation.botocore.extensions.types import (
     _AttributeMapT,
     _AwsSdkCallContext,
     _AwsSdkExtension,
     _BotocoreInstrumentorContext,
+    _BotoResultT,
 )
 from opentelemetry.propagate import inject
+from opentelemetry.semconv._incubating.attributes.aws_attributes import (
+    AWS_LAMBDA_RESOURCE_MAPPING_ID,
+)
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.span import Span
+
+# Work is underway to add these two keys to the SemConv AWS registry, in line with other AWS resources.
+# https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/aws.md#amazon-lambda-attributes
+AWS_LAMBDA_FUNCTION_ARN: Final = "aws.lambda.function.arn"
+AWS_LAMBDA_FUNCTION_NAME: Final = "aws.lambda.function.name"
 
 
 class _LambdaOperation(abc.ABC):
@@ -68,12 +77,16 @@ class _OpInvoke(_LambdaOperation):
         )
         attributes[SpanAttributes.FAAS_INVOKED_REGION] = call_context.region
 
-    @classmethod
-    def _parse_function_name(cls, call_context: _AwsSdkCallContext):
+    @staticmethod
+    def _parse_function_name(call_context: _AwsSdkCallContext):
         function_name_or_arn = call_context.params.get("FunctionName")
-        matches = cls.ARN_LAMBDA_PATTERN.match(function_name_or_arn)
-        function_name = matches.group(1)
-        return function_name_or_arn if function_name is None else function_name
+        if function_name_or_arn is None:
+            return None
+        matches = _OpInvoke.ARN_LAMBDA_PATTERN.match(function_name_or_arn)
+        if matches:
+            function_name = matches.group(1)
+            return function_name if function_name else function_name_or_arn
+        return function_name_or_arn
 
     @classmethod
     def before_service_call(cls, call_context: _AwsSdkCallContext, span: Span):
@@ -115,6 +128,13 @@ class _LambdaExtension(_AwsSdkExtension):
         self._op = _OPERATION_MAPPING.get(call_context.operation)
 
     def extract_attributes(self, attributes: _AttributeMapT):
+        function_name = _OpInvoke._parse_function_name(self._call_context)
+        if function_name:
+            attributes[AWS_LAMBDA_FUNCTION_NAME] = function_name
+        resource_mapping_id = self._call_context.params.get("UUID")
+        if resource_mapping_id:
+            attributes[AWS_LAMBDA_RESOURCE_MAPPING_ID] = resource_mapping_id
+
         if self._op is None:
             return
 
@@ -127,3 +147,20 @@ class _LambdaExtension(_AwsSdkExtension):
             return
 
         self._op.before_service_call(self._call_context, span)
+
+    def on_success(
+        self,
+        span: Span,
+        result: _BotoResultT,
+        instrumentor_context: _BotocoreInstrumentorContext,
+    ):
+        resource_mapping_id = result.get("UUID")
+        if resource_mapping_id:
+            span.set_attribute(
+                AWS_LAMBDA_RESOURCE_MAPPING_ID, resource_mapping_id
+            )
+
+        lambda_configuration = result.get("Configuration", {})
+        function_arn = lambda_configuration.get("FunctionArn")
+        if function_arn:
+            span.set_attribute(AWS_LAMBDA_FUNCTION_ARN, function_arn)


### PR DESCRIPTION
# Description

This PR adds support for the AWS_LAMBDA_RESOURCE_MAPPING_ID semantic convention attribute in the AWS Lambda SDK instrumentation library.

https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/aws.md#amazon-lambda-attributes

It also introduces the following two experimental attributes. Work is currently underway to add these keys to the AWS section of the Semantic Conventions registry:

aws.lambda.function.arn
aws.lambda.function.name

Name is extracted from request object.
ARN is extracted from response object.
Resource Mapping ID is extracted from both request and response objects. This behavior is covered by unit tests.

Backward Compatibility
This change is backward compatible. It only adds instrumentation for additional AWS resources and does not modify existing behavior in the auto-instrumentation library.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added new unit tests (passing).

Verified with:
tox -e py312-test-instrumentation-botocore
tox -e spellcheck
tox -e lint-instrumentation-botocore
tox -e ruff

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
