### PR TITLE
Update completion upload hook to make input / output / system instructions optional

### DIFF
--- a/util/opentelemetry-util-genai/tests/test_upload.py
+++ b/util/opentelemetry-util-genai/tests/test_upload.py
@@ -162,6 +162,21 @@ class TestUploadCompletionHook(TestCase):
             "should have uploaded 3 files",
         )
 
+    def test_upload_when_inputs_outputs_empty(self):
+        self.hook.on_completion(
+            inputs=[],
+            outputs=[],
+            system_instruction=FAKE_SYSTEM_INSTRUCTION,
+        )
+        # all items should be consumed
+        self.hook.shutdown()
+
+        self.assertEqual(
+            self.mock_fs.open.call_count,
+            1,
+            "should have uploaded 1 file",
+        )
+
     def test_upload_blocked(self):
         with self.block_upload():
             # fill the queue


### PR DESCRIPTION
# Description

It's possible inputs/ouputs/system_instruction are empty for a given request, so making these 3 params optional and obviously will not do a file upload when they are..

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x ] Followed the style guidelines of this project
- [x ] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
