### PR TITLE
Use weak reference in langchain instrumentation span map

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/CHANGELOG.md
@@ -9,3 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added span support for genAI langchain llm invocation.
   ([#3665](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3665))
+- Use weak reference in langchain instrumentation span map.
+  ([#3735](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3735))

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 dependencies = [
   "opentelemetry-api >= 1.31.0",
   "opentelemetry-instrumentation ~= 0.57b0",
-  "opentelemetry-semantic-conventions ~= 0.57b0"
+  "opentelemetry-semantic-conventions ~= 0.57b0",
+  "cachetools >= 5.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

Use weak reference in langchain instrumentation span map to avoid memory leaks in long running applications via span storage. Added "cachetools >= 5.2.0" to dependencies.

Fixes #3735

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Added `test_ttl_cache_expires_spans` to `test_span_manager`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
