### PR TITLE
Uses iscoroutinefunction from inspect module

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiokafka/src/opentelemetry/instrumentation/aiokafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiokafka/src/opentelemetry/instrumentation/aiokafka/__init__.py
@@ -95,7 +95,7 @@ ___
 
 from __future__ import annotations
 
-from asyncio import iscoroutinefunction
+from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Collection
 
 import aiokafka

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import typing
 from collections.abc import Coroutine
 
@@ -197,7 +197,7 @@ class _ContextManager(Coroutine):
 
     async def __aexit__(self, exc_type, exc, t_b):
         try:
-            if asyncio.iscoroutinefunction(self._obj.close):
+            if inspect.iscoroutinefunction(self._obj.close):
                 await self._obj.close()
             else:
                 self._obj.close()

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -225,8 +225,8 @@ from __future__ import annotations
 
 import logging
 import typing
-from asyncio import iscoroutinefunction
 from functools import partial
+from inspect import iscoroutinefunction
 from timeit import default_timer
 from types import TracebackType
 

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -16,6 +16,7 @@
 
 import abc
 import asyncio
+import inspect
 import typing
 from unittest import mock
 
@@ -1086,7 +1087,7 @@ class BaseTestCases:
         def test_response_hook(self):
             response_hook_key = (
                 "async_response_hook"
-                if asyncio.iscoroutinefunction(self.response_hook)
+                if inspect.iscoroutinefunction(self.response_hook)
                 else "response_hook"
             )
             response_hook_kwargs = {response_hook_key: self.response_hook}
@@ -1133,7 +1134,7 @@ class BaseTestCases:
         def test_request_hook(self):
             request_hook_key = (
                 "async_request_hook"
-                if asyncio.iscoroutinefunction(self.request_hook)
+                if inspect.iscoroutinefunction(self.request_hook)
                 else "request_hook"
             )
             request_hook_kwargs = {request_hook_key: self.request_hook}


### PR DESCRIPTION
# Description

Fixes deprecation warning message:

```bash
site-packages/opentelemetry/util/_decorator.py:66: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(func):
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
