### PR TITLE
Add exception recording to httpx instrumentation spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -678,6 +678,7 @@ class SyncOpenTelemetryTransport(httpx.BaseTransport):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
+                    span.record_exception(exception) 
                     metric_attributes[ERROR_TYPE] = type(
                         exception
                     ).__qualname__
@@ -879,6 +880,7 @@ class AsyncOpenTelemetryTransport(httpx.AsyncBaseTransport):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
+                    span.record_exception(exception) 
                     metric_attributes[ERROR_TYPE] = type(
                         exception
                     ).__qualname__
@@ -1116,6 +1118,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
+                    span.record_exception(exception) 
                     metric_attributes[ERROR_TYPE] = type(
                         exception
                     ).__qualname__
@@ -1238,6 +1241,7 @@ class HTTPXClientInstrumentor(BaseInstrumentor):
                     span.set_attribute(
                         ERROR_TYPE, type(exception).__qualname__
                     )
+                    span.record_exception(exception) 
                 raise exception.with_traceback(exception.__traceback__)
 
             if duration_histogram_old is not None:


### PR DESCRIPTION
# Description

This PR enhances the httpx instrumentation by recording exceptions directly in spans using span.record_exception(exception).
Previously, only span.set_status(StatusCode.ERROR) was set, which made it harder to inspect the actual error details in traces.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [X] No.

