### PR TITLE
fix(google-genai): prevent TypeError when handling Pydantic model class

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/dict_util.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/dict_util.py
@@ -188,9 +188,17 @@ def _flatten_compound_value(
             rename_keys=rename_keys,
             flatten_functions=flatten_functions,
         )
-    if hasattr(value, "model_dump"):
+    if hasattr(value, "model_dump") and not isinstance(value, type):
         return _flatten_dict(
             value.model_dump(),
+            key_prefix=key,
+            exclude_keys=exclude_keys,
+            rename_keys=rename_keys,
+            flatten_functions=flatten_functions,
+        )
+    if hasattr(value, "model_json_schema"):
+        return _flatten_dict(
+            value.model_json_schema(),
             key_prefix=key,
             exclude_keys=exclude_keys,
             rename_keys=rename_keys,

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -161,8 +161,10 @@ def _determine_genai_system(models_object: Union[Models, AsyncModels]):
 def _to_dict(value: object):
     if isinstance(value, dict):
         return value
-    if hasattr(value, "model_dump"):
+    if hasattr(value, "model_dump") and not isinstance(value, type):
         return value.model_dump()
+    if hasattr(value, "model_json_schema"):
+        return value.model_json_schema()
     return json.loads(json.dumps(value))
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
@@ -54,8 +54,12 @@ def _to_otel_value(python_value):
         return {
             key: _to_otel_value(val) for (key, val) in python_value.items()
         }
-    if hasattr(python_value, "model_dump"):
+    if hasattr(python_value, "model_dump") and not isinstance(
+        python_value, type
+    ):
         return python_value.model_dump()
+    if hasattr(python_value, "model_json_schema"):
+        return python_value.model_json_schema()
     if hasattr(python_value, "__dict__"):
         return _to_otel_value(python_value.__dict__)
     return repr(python_value)

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/utils/test_dict_util.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/utils/test_dict_util.py
@@ -207,6 +207,25 @@ def test_flatten_with_mixed_structures():
     }
 
 
+def test_flatten_with_pydantic_class_not_instance():
+    """Test that passing a Pydantic class (not instance) doesn't cause model_dump() error."""
+    input_dict = {
+        "foo": PydanticModel,  # Class, not instance
+        "bar": "value",
+    }
+
+    # Should not raise "BaseModel.model_dump() missing 1 required positional argument: 'self'"
+    output = dict_util.flatten_dict(input_dict)
+    # The class should be converted using JSON serialization fallback
+    assert "bar" in output
+    assert output["bar"] == "value"
+    assert "foo.description" in output
+    assert "foo.properties.int_value.title" in output
+    assert "foo.properties.int_value.default" in output
+    assert "foo.properties.str_value.title" in output
+    assert "foo.properties.str_value.default" in output
+
+
 def test_converts_tuple_with_json_fallback():
     input_dict = {
         "foo": ("abc", 123),


### PR DESCRIPTION
# Description

This PR fixes a bug in the `opentelemetry-instrumentation-google-genai` package where passing an uninstantiated Pydantic model class (instead of an instance) to dict conversion functions would cause a `TypeError`:

```
BaseModel.model_dump() missing 1 required positional argument: 'self'
```

The issue occurred in three functions that attempt to convert objects to dictionaries:
- `_to_dict()` in `generate_content.py`
- `_to_otel_value()` in `tool_call_wrapper.py`
- `_flatten_dict()` in `dict_util.py`

These functions check `hasattr(value, "model_dump")` which returns `True` for both Pydantic classes and instances, but `model_dump()` is an instance method that cannot be called on the class itself.

**Solution:**
- Added `isinstance(value, type)` check to distinguish between classes and instances before calling `model_dump()`
- When a Pydantic class is detected, the code now calls `model_json_schema()` (a classmethod) to get the schema representation
- Added comprehensive test coverage for both class and instance scenarios

Fixes #3596 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests to verify the fix:

1. **test_flatten_with_pydantic_class_not_instance** in `tests/utils/test_dict_util.py`
   - Verifies that passing a Pydantic class (not instance) doesn't raise the `model_dump()` error
   - Confirms the class is properly serialized using `model_json_schema()`

2. **test_handles_pydantic_class_not_instance** in `tests/utils/test_tool_call_wrapper.py`
   - Tests the same scenario for the tool call wrapper functionality
   - Ensures proper handling of Pydantic model classes in tool call contexts

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated (not needed - internal implementation fix)

