### PR TITLE
opentelemetry-instrumentation-pymongo: fix invalid mongodb collection attribute type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3904](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3904))
 - build: bump ruff to 0.14.1
   ([#3842](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3842))
+- `opentelemetry-instrumentation-pymongo`: Fix invalid mongodb collection attribute type
+  ([#3942](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3942))
 
 ## Version 1.38.0/0.59b0 (2025-10-16)
 

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -228,13 +228,7 @@ class CommandTracer(monitoring.CommandListener):
 
 def _get_command_collection_name(event: CommandEvent) -> str | None:
     collection_name = event.command.get(event.command_name)
-    if (
-        not collection_name
-        or not isinstance(collection_name, str)
-        or ".." in collection_name
-        or collection_name[0] == "."
-        or collection_name[-1] == "."
-    ):
+    if not collection_name or not isinstance(collection_name, str):
         return None
     return collection_name
 

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -288,10 +288,7 @@ class TestPymongo(TestBase):
                 "test_collection",
             ),
             ({"command_name": "find"}, None),
-            ({"command_name": "find", "find": b'invalid'}, None),
-            ({"command_name": "find", "find": ".invalid"}, None),
-            ({"command_name": "find", "find": "invalid."}, None),
-            ({"command_name": "find", "find": "invalid..invalid"}, None),
+            ({"command_name": "find", "find": b"invalid"}, None),
         ]
         for command_attrs, expected in scenarios:
             with self.subTest(command_attrs=command_attrs, expected=expected):


### PR DESCRIPTION
# Description

Fixes an issue where the Mongodb collection name attribute is occasionally incorrectly set to a non-string value for commands that do not operate on collections. The fix implemented is not able to perfectly identifying commands that operate on collections, but compared to the alternative of directly enumerating all collection-based commands, this fix should be adequate for the time being.

Fixes #3940 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A unit test with several scenarios has been added to validate that only valid collection names are used for the collection name attribute. 

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
