### PR TITLE
mysqlclient instrumentor: improved keyword argument handling (#2894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added 
+### Added
 
 - `opentelemetry-instrumentation-aiohttp-client`: add support for url exclusions via `OTEL_PYTHON_EXCLUDED_URLS` / `OTEL_PYTHON_AIOHTTP_CLIENT_EXCLUDED_URLS`
   ([#3850](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3850))
@@ -42,10 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3882](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3882))
 - `opentelemetry-instrumentation-aiohttp-server`: delay initialization of tracer, meter and excluded urls to instrumentation for testability
   ([#3836](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3836))
-- Replace Python 3.14-deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`. 
+- Replace Python 3.14-deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`.
   ([#3880](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3880))
 - `opentelemetry-instrumentation-elasticsearch`: Enhance elasticsearch query body sanitization
-  ([#3919](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3919)) 
+  ([#3919](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3919))
 - `opentelemetry-instrumentation-pymongo`: Fix span error descriptions
   ([#3904](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3904))
 - build: bump ruff to 0.14.1
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3941](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3941))
 - `opentelemetry-instrumentation-pymongo`: Fix invalid mongodb collection attribute type
   ([#3942](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3942))
+- `opentelemetry-instrumentation-mysqlclient`: Pass all keyword parameters
+  ([#3950](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3950))
 
 ## Version 1.38.0/0.59b0 (2025-10-16)
 
@@ -76,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3743](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3743))
 - Add `rstcheck` to pre-commit to stop introducing invalid RST
   ([#3777](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3777))
-- `opentelemetry-exporter-credential-provider-gcp`: create this package which provides support for supplying your machine's Application Default 
+- `opentelemetry-exporter-credential-provider-gcp`: create this package which provides support for supplying your machine's Application Default
   Credentials (https://cloud.google.com/docs/authentication/application-default-credentials) to the OTLP Exporters created automatically by OpenTelemetry Python's auto instrumentation. These credentials authorize OTLP traces to be sent to `telemetry.googleapis.com`. [#3766](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3766).
 - `opentelemetry-instrumentation-psycopg`: Add missing parameter `capture_parameters` to instrumentor.
   ([#3676](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3676))

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -160,12 +160,13 @@ class MySQLClientInstrumentor(BaseInstrumentor):
         """Integrate with the mysqlclient library.
         https://github.com/PyMySQL/mysqlclient/
         """
-        tracer_provider = kwargs.get("tracer_provider")
-        enable_sqlcommenter = kwargs.get("enable_commenter", False)
-        commenter_options = kwargs.get("commenter_options", {})
-        enable_attribute_commenter = kwargs.get(
-            "enable_attribute_commenter", False
-        )
+        kwargs_with_defaults = {
+            "tracer_provider": None,
+            "enable_commenter": False,
+            "commenter_options": {},
+            "enable_attribute_commenter": False,
+            **kwargs,
+        }
 
         dbapi.wrap_connect(
             __name__,
@@ -174,10 +175,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             _DATABASE_SYSTEM,
             _CONNECTION_ATTRIBUTES,
             version=__version__,
-            tracer_provider=tracer_provider,
-            enable_commenter=enable_sqlcommenter,
-            commenter_options=commenter_options,
-            enable_attribute_commenter=enable_attribute_commenter,
+            **kwargs_with_defaults,
         )
 
     def _uninstrument(self, **kwargs):  # pylint: disable=no-self-use

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/tests/test_mysqlclient_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/tests/test_mysqlclient_integration.py
@@ -507,3 +507,33 @@ class TestMySQLClientIntegration(TestBase):
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 0)
+
+    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
+    @mock.patch("MySQLdb.connect")
+    # pylint: disable=unused-argument
+    def test_missing_capture_parameters_if_not_specified(
+        self,
+        _mock_connect,
+        mock_wrap_connect,
+    ):
+        instrumentor = MySQLClientInstrumentor()
+        instrumentor.instrument()
+        kwargs = mock_wrap_connect.call_args[1]
+        self.assertNotIn("capture_parameters", kwargs)
+
+    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
+    @mock.patch("MySQLdb.connect")
+    # pylint: disable=unused-argument
+    def test_passes_capture_parameters_if_specified(
+        self,
+        _mock_connect,
+        mock_wrap_connect,
+    ):
+        """
+        MySQLClientInstrumentor.instrument should pass any provided,
+        arbitrary kwargs to DB-API wrap_connect
+        """
+        instrumentor = MySQLClientInstrumentor()
+        instrumentor.instrument(capture_parameters=True)
+        kwargs = mock_wrap_connect.call_args[1]
+        self.assertTrue(kwargs["capture_parameters"])


### PR DESCRIPTION
# Description

This pull request implements forwarding "all" keyword arguments to `wrap_connect()`, our concrete use case is the one as described in #2894. Defaults are kept as defined previously.

Fixes #2894 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] added new unittests which first failed, ran them with `tox -e test-instrumentation-mysqlclient`
- [x] ran `tox -e lint-instrumentation-mysqlclient`
- [x] ran `tox -e precommit`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
