### PR TITLE
opentelemetry-instrumentation-dbapi: instrument commit and rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-psycopg2`: Add parameter `capture_parameters` to instrumentor.
   ([#4212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4212))
 
+- `opentelemetry-instrumentation-dbapi`: Add instrumentation for `commit()` and `rollback()` transaction operations
+  ([#3964](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3964))
+- `opentelemetry-instrumentation-dbapi`: Add `enable_transaction_spans` configuration flag to control transaction span creation (default: `True`)
+  ([#3964](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3964))
+- `opentelemetry-instrumentation-pymysql`, `opentelemetry-instrumentation-mysql`, `opentelemetry-instrumentation-mysqlclient`, `opentelemetry-instrumentation-psycopg`, `opentelemetry-instrumentation-psycopg2`, `opentelemetry-instrumentation-sqlite3`, `opentelemetry-instrumentation-pymssql`: Add support for transaction span instrumentation via `enable_transaction_spans` parameter
+  ([#3964](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3964))
+
 ### Fixed
 
 - Fix intermittent `Core Contrib Test` CI failures caused by GitHub git CDN SHA propagation lag by installing core packages from the already-checked-out local copy instead of a second git clone

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -223,6 +223,7 @@ def trace_integration(
     db_api_integration_factory: type[DatabaseApiIntegration] | None = None,
     enable_attribute_commenter: bool = False,
     commenter_options: dict[str, Any] | None = None,
+    enable_transaction_spans: bool = True,
 ):
     """Integrate with DB API library.
     https://www.python.org/dev/peps/pep-0249/
@@ -242,6 +243,7 @@ def trace_integration(
             default one is used.
         enable_attribute_commenter: Flag to enable/disable sqlcomment inclusion in `db.statement` span attribute. Only available if enable_commenter=True.
         commenter_options: Configurations for tags to be appended at the sql query.
+        enable_transaction_spans: Flag to enable/disable transaction spans (commit/rollback). Defaults to True.
     """
     wrap_connect(
         __name__,
@@ -256,6 +258,7 @@ def trace_integration(
         db_api_integration_factory=db_api_integration_factory,
         enable_attribute_commenter=enable_attribute_commenter,
         commenter_options=commenter_options,
+        enable_transaction_spans=enable_transaction_spans,
     )
 
 
@@ -272,6 +275,7 @@ def wrap_connect(
     db_api_integration_factory: type[DatabaseApiIntegration] | None = None,
     commenter_options: dict[str, Any] | None = None,
     enable_attribute_commenter: bool = False,
+    enable_transaction_spans: bool = True,
 ):
     """Integrate with DB API library.
     https://www.python.org/dev/peps/pep-0249/
@@ -291,6 +295,7 @@ def wrap_connect(
             default one is used.
         commenter_options: Configurations for tags to be appended at the sql query.
         enable_attribute_commenter: Flag to enable/disable sqlcomment inclusion in `db.statement` span attribute. Only available if enable_commenter=True.
+        enable_transaction_spans: Flag to enable/disable transaction spans (commit/rollback). Defaults to True.
 
     """
     db_api_integration_factory = (
@@ -315,6 +320,7 @@ def wrap_connect(
             commenter_options=commenter_options,
             connect_module=connect_module,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
         return db_integration.wrapped_connection(wrapped, args, kwargs)
 
@@ -352,6 +358,7 @@ def instrument_connection(
     connect_module: Callable[..., Any] | None = None,
     enable_attribute_commenter: bool = False,
     db_api_integration_factory: type[DatabaseApiIntegration] | None = None,
+    enable_transaction_spans: bool = True,
 ) -> TracedConnectionProxy[ConnectionT]:
     """Enable instrumentation in a database connection.
 
@@ -373,6 +380,7 @@ def instrument_connection(
             replacement for :class:`DatabaseApiIntegration`. Can be used to
             obtain connection attributes from the connect method instead of
             from the connection itself (as done by the pymssql intrumentor).
+        enable_transaction_spans: Flag to enable/disable transaction spans (commit/rollback). Defaults to True.
 
     Returns:
         An instrumented connection.
@@ -396,6 +404,7 @@ def instrument_connection(
         commenter_options=commenter_options,
         connect_module=connect_module,
         enable_attribute_commenter=enable_attribute_commenter,
+        enable_transaction_spans=enable_transaction_spans,
     )
     db_integration.get_connection_attributes(connection)
     return get_traced_connection_proxy(connection, db_integration)
@@ -432,6 +441,7 @@ class DatabaseApiIntegration:
         commenter_options: dict[str, Any] | None = None,
         connect_module: Callable[..., Any] | None = None,
         enable_attribute_commenter: bool = False,
+        enable_transaction_spans: bool = True,
     ):
         if connection_attributes is None:
             self.connection_attributes = {
@@ -454,6 +464,7 @@ class DatabaseApiIntegration:
         self.enable_commenter = enable_commenter
         self.commenter_options = commenter_options
         self.enable_attribute_commenter = enable_attribute_commenter
+        self.enable_transaction_spans = enable_transaction_spans
         self.database_system = database_system
         self.connection_props: dict[str, Any] = {}
         self.span_attributes: dict[str, Any] = {}
@@ -569,6 +580,17 @@ class DatabaseApiIntegration:
         if port is not None:
             self.span_attributes[NET_PEER_PORT] = port
 
+    def populate_common_span_attributes(self, span: trace_api.Span) -> None:
+        """Populate span with common database connection attributes."""
+        if not span.is_recording():
+            return
+
+        span.set_attribute(DB_SYSTEM, self.database_system)
+        span.set_attribute(DB_NAME, self.database)
+
+        for attribute_key, attribute_value in self.span_attributes.items():
+            span.set_attribute(attribute_key, attribute_value)
+
 
 # pylint: disable=abstract-method,no-member
 class TracedConnectionProxy(BaseObjectProxy, Generic[ConnectionT]):
@@ -577,23 +599,54 @@ class TracedConnectionProxy(BaseObjectProxy, Generic[ConnectionT]):
         self,
         connection: ConnectionT,
         db_api_integration: DatabaseApiIntegration | None = None,
+        wrap_cursors: bool = True,
     ):
         BaseObjectProxy.__init__(self, connection)
         self._self_db_api_integration = db_api_integration
+        self._self_wrap_cursors = wrap_cursors
 
     def __getattribute__(self, name: str):
-        if object.__getattribute__(self, name):
+        # Try to get the attribute from the proxy first
+        try:
             return object.__getattribute__(self, name)
-
-        return object.__getattribute__(
-            object.__getattribute__(self, "_connection"), name
-        )
+        except AttributeError:
+            # If not found on proxy, try the wrapped connection
+            return object.__getattribute__(
+                object.__getattribute__(self, "__wrapped__"), name
+            )
 
     def cursor(self, *args: Any, **kwargs: Any):
-        return get_traced_cursor_proxy(
-            self.__wrapped__.cursor(*args, **kwargs),
-            self._self_db_api_integration,
-        )
+        cursor = self.__wrapped__.cursor(*args, **kwargs)
+
+        # For databases like psycopg/psycopg2 that use cursor_factory,
+        # cursor tracing is already handled by the factory, so skip wrapping
+        if not self._self_wrap_cursors:
+            return cursor
+
+        # For standard dbapi connections, wrap the cursor
+        return get_traced_cursor_proxy(cursor, self._self_db_api_integration)
+
+    def _traced_tx_operation(
+        self, operation_name: str, operation_method: Callable[[], None]
+    ) -> None:
+        """Execute a traced transaction operation (commit, rollback)."""
+        if not is_instrumentation_enabled():
+            return operation_method()
+
+        if not self._self_db_api_integration.enable_transaction_spans:
+            return operation_method()
+
+        with self._self_db_api_integration._tracer.start_as_current_span(
+            operation_name, kind=trace_api.SpanKind.CLIENT
+        ) as span:
+            self._self_db_api_integration.populate_common_span_attributes(span)
+            return operation_method()
+
+    def commit(self):
+        return self._traced_tx_operation("COMMIT", self.__wrapped__.commit)
+
+    def rollback(self):
+        return self._traced_tx_operation("ROLLBACK", self.__wrapped__.rollback)
 
     def __enter__(self):
         self.__wrapped__.__enter__()
@@ -603,13 +656,78 @@ class TracedConnectionProxy(BaseObjectProxy, Generic[ConnectionT]):
         self.__wrapped__.__exit__(*args, **kwargs)
 
 
+class AsyncTracedConnectionProxy(TracedConnectionProxy[ConnectionT]):
+    async def _traced_tx_operation_async(
+        self, operation_name: str, operation_method: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Execute a traced async transaction operation (commit, rollback)."""
+        if not is_instrumentation_enabled():
+            return await operation_method()
+
+        if not self._self_db_api_integration.enable_transaction_spans:
+            return await operation_method()
+
+        with self._self_db_api_integration._tracer.start_as_current_span(
+            operation_name, kind=trace_api.SpanKind.CLIENT
+        ) as span:
+            self._self_db_api_integration.populate_common_span_attributes(span)
+            return await operation_method()
+
+    async def commit(self):
+        """Async commit for async connections (e.g., psycopg.AsyncConnection)."""
+        return await self._traced_tx_operation_async("COMMIT", self.__wrapped__.commit)
+
+    async def rollback(self):
+        """Async rollback for async connections (e.g., psycopg.AsyncConnection)."""
+        return await self._traced_tx_operation_async("ROLLBACK", self.__wrapped__.rollback)
+
+    # Async context manager support
+    async def __aenter__(self):
+        if hasattr(self.__wrapped__, "__aenter__"):
+            await self.__wrapped__.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any):
+        if hasattr(self.__wrapped__, "__aexit__"):
+            return await self.__wrapped__.__aexit__(*args, **kwargs)
+
+
 def get_traced_connection_proxy(
     connection: ConnectionT,
     db_api_integration: DatabaseApiIntegration | None,
+    wrap_cursors: bool = True,
     *args: Any,
     **kwargs: Any,
 ) -> TracedConnectionProxy[ConnectionT]:
-    return TracedConnectionProxy(connection, db_api_integration)
+    """Get a traced connection proxy for sync connections.
+
+    Args:
+        connection: The database connection to wrap.
+        db_api_integration: The database API integration instance.
+        wrap_cursors: Whether to wrap cursors returned by connection.cursor().
+            Set to False for databases like psycopg/psycopg2 that handle cursor
+            tracing via cursor_factory. Defaults to True.
+    """
+    return TracedConnectionProxy(connection, db_api_integration, wrap_cursors)
+
+
+def get_traced_async_connection_proxy(
+    connection: ConnectionT,
+    db_api_integration: DatabaseApiIntegration | None,
+    wrap_cursors: bool = True,
+    *args: Any,
+    **kwargs: Any,
+) -> AsyncTracedConnectionProxy[ConnectionT]:
+    """Get a traced connection proxy for async connections.
+
+    Args:
+        connection: The async database connection to wrap.
+        db_api_integration: The database API integration instance.
+        wrap_cursors: Whether to wrap cursors returned by connection.cursor().
+            Set to False for databases like psycopg/psycopg2 that handle cursor
+            tracing via cursor_factory. Defaults to True.
+    """
+    return AsyncTracedConnectionProxy(connection, db_api_integration, wrap_cursors)
 
 
 class CursorTracer(Generic[CursorT]):
@@ -694,16 +812,11 @@ class CursorTracer(Generic[CursorT]):
     ):
         if not span.is_recording():
             return
-        statement = self.get_statement(cursor, args)
-        span.set_attribute(DB_SYSTEM, self._db_api_integration.database_system)
-        span.set_attribute(DB_NAME, self._db_api_integration.database)
-        span.set_attribute(DB_STATEMENT, statement)
 
-        for (
-            attribute_key,
-            attribute_value,
-        ) in self._db_api_integration.span_attributes.items():
-            span.set_attribute(attribute_key, attribute_value)
+        self._db_api_integration.populate_common_span_attributes(span)
+
+        statement = self.get_statement(cursor, args)
+        span.set_attribute(DB_STATEMENT, statement)
 
         if self._db_api_integration.capture_parameters and len(args) > 1:
             span.set_attribute("db.statement.parameters", str(args[1]))

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -1047,6 +1047,62 @@ class TestDBApiIntegration(TestBase):
             "Test stored procedure",
         )
 
+    def test_commit(self):
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name", "testcomponent"
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, {}
+        )
+        mock_connection.commit()
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "COMMIT")
+
+    def test_rollback(self):
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name", "testcomponent"
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, {}
+        )
+        mock_connection.rollback()
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "ROLLBACK")
+
+    def test_commit_with_suppress_instrumentation(self):
+        """Test that commit doesn't create a span when instrumentation is suppressed"""
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name",
+            "testcomponent",
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, {}
+        )
+        with suppress_instrumentation():
+            mock_connection.commit()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+    def test_rollback_with_suppress_instrumentation(self):
+        """Test that rollback doesn't create a span when instrumentation is suppressed"""
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name",
+            "testcomponent",
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, {}
+        )
+        with suppress_instrumentation():
+            mock_connection.rollback()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
     @mock.patch("opentelemetry.instrumentation.dbapi")
     def test_wrap_connect(self, mock_dbapi):
         dbapi.wrap_connect(self.tracer, mock_dbapi, "connect", "-")
@@ -1283,6 +1339,14 @@ class MockConnection:
     # pylint: disable=no-self-use
     def cursor(self):
         return MockCursor()
+
+    # pylint: disable=no-self-use
+    def commit(self):
+        pass
+
+    # pylint: disable=no-self-use
+    def rollback(self):
+        pass
 
 
 class MockCursor:

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -182,6 +182,7 @@ class MySQLInstrumentor(BaseInstrumentor):
         enable_attribute_commenter = kwargs.get(
             "enable_attribute_commenter", False
         )
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
 
         dbapi.wrap_connect(
             __name__,
@@ -194,6 +195,7 @@ class MySQLInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs):
@@ -208,6 +210,7 @@ class MySQLInstrumentor(BaseInstrumentor):
         enable_commenter=None,
         commenter_options=None,
         enable_attribute_commenter=None,
+        enable_transaction_spans=True,
     ):
         """Enable instrumentation in a MySQL connection.
 
@@ -225,6 +228,8 @@ class MySQLInstrumentor(BaseInstrumentor):
                 Optional configurations for tags to be appended at the sql query.
             enable_attribute_commenter:
                 Optional flag to enable/disable addition of sqlcomment to span attribute (default False). Requires enable_commenter=True.
+            enable_transaction_spans:
+                Flag to enable/disable transaction spans (commit/rollback). Defaults to True.
 
         Returns:
             An instrumented MySQL connection with OpenTelemetry tracing enabled.
@@ -240,6 +245,7 @@ class MySQLInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             connect_module=mysql.connector,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def uninstrument_connection(self, connection):

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -166,6 +166,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
         enable_attribute_commenter = kwargs.get(
             "enable_attribute_commenter", False
         )
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
 
         dbapi.wrap_connect(
             __name__,
@@ -178,6 +179,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs):  # pylint: disable=no-self-use
@@ -191,6 +193,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
         enable_commenter=None,
         commenter_options=None,
         enable_attribute_commenter=None,
+        enable_transaction_spans=True,
     ):
         """Enable instrumentation in a mysqlclient connection.
 
@@ -215,6 +218,8 @@ class MySQLClientInstrumentor(BaseInstrumentor):
                     - `mysql_client_version`: Adds the MySQL client version.
                     - `driver_paramstyle`: Adds the parameter style.
                     - `opentelemetry_values`: Includes traceparent values.
+            enable_transaction_spans:
+                Flag to enable/disable transaction spans (commit/rollback). Defaults to True.
         Returns:
             An instrumented MySQL connection with OpenTelemetry support enabled.
         """
@@ -230,6 +235,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             connect_module=MySQLdb,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
@@ -188,6 +188,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             "enable_attribute_commenter", False
         )
         capture_parameters = kwargs.get("capture_parameters", False)
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
         dbapi.wrap_connect(
             __name__,
             psycopg,
@@ -201,6 +202,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
             capture_parameters=capture_parameters,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
         dbapi.wrap_connect(
@@ -216,6 +218,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
             capture_parameters=capture_parameters,
+            enable_transaction_spans=enable_transaction_spans,
         )
         dbapi.wrap_connect(
             __name__,
@@ -230,6 +233,7 @@ class PsycopgInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
             capture_parameters=capture_parameters,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs: Any):
@@ -309,7 +313,8 @@ class DatabaseApiIntegration(dbapi.DatabaseApiIntegration):
         kwargs["cursor_factory"] = _new_cursor_factory(**new_factory_kwargs)
         connection = connect_method(*args, **kwargs)
         self.get_connection_attributes(connection)
-        return connection
+        # psycopg uses cursor_factory for cursor tracing, so disable cursor wrapping
+        return dbapi.get_traced_connection_proxy(connection, self, wrap_cursors=False)
 
 
 class DatabaseApiAsyncIntegration(dbapi.DatabaseApiIntegration):
@@ -329,7 +334,8 @@ class DatabaseApiAsyncIntegration(dbapi.DatabaseApiIntegration):
         )
         connection = await connect_method(*args, **kwargs)
         self.get_connection_attributes(connection)
-        return connection
+        # psycopg uses cursor_factory for cursor tracing, so disable cursor wrapping
+        return dbapi.get_traced_async_connection_proxy(connection, self, wrap_cursors=False)
 
 
 class CursorTracer(dbapi.CursorTracer):

--- a/instrumentation/opentelemetry-instrumentation-psycopg/tests/test_psycopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/tests/test_psycopg_integration.py
@@ -103,18 +103,18 @@ class MockConnection:
 
 
 class MockAsyncConnection(psycopg.AsyncConnection):
-    commit = mock.MagicMock(spec=types.MethodType)
-    commit.__name__ = "commit"
-
-    rollback = mock.MagicMock(spec=types.MethodType)
-    rollback.__name__ = "rollback"
-
     def __init__(self, *args, **kwargs):
         self.cursor_factory = kwargs.pop("cursor_factory", None)
 
     @staticmethod
     async def connect(*args, **kwargs):
         return MockAsyncConnection(**kwargs)
+
+    async def commit(self):
+        pass
+
+    async def rollback(self):
+        pass
 
     def cursor(self, *args, **kwargs):
         if self.cursor_factory:
@@ -441,6 +441,28 @@ class TestPostgresqlIntegration(PostgresqlIntegrationTestMixin, TestBase):
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
 
+    def test_commit(self):
+        PsycopgInstrumentor().instrument()
+
+        cnx = psycopg.connect(database="test")
+        cnx.commit()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "COMMIT")
+
+    def test_rollback(self):
+        PsycopgInstrumentor().instrument()
+
+        cnx = psycopg.connect(database="test")
+        cnx.rollback()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "ROLLBACK")
+
     @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
     def test_sqlcommenter_enabled(self, event_mocked):
         cnx = psycopg.connect(database="test")
@@ -588,6 +610,32 @@ class TestPostgresqlIntegrationAsync(
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)
             self.assertFalse(mock_span.set_status.called)
+
+        PsycopgInstrumentor().uninstrument()
+
+    async def test_async_commit(self):
+        PsycopgInstrumentor().instrument()
+
+        cnx = await psycopg.AsyncConnection.connect("test")
+        await cnx.commit()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "COMMIT")
+
+        PsycopgInstrumentor().uninstrument()
+
+    async def test_async_rollback(self):
+        PsycopgInstrumentor().instrument()
+
+        cnx = await psycopg.AsyncConnection.connect("test")
+        await cnx.rollback()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "ROLLBACK")
 
         PsycopgInstrumentor().uninstrument()
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -227,6 +227,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
             "enable_attribute_commenter", False
         )
         capture_parameters = kwargs.get("capture_parameters", False)
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
         dbapi.wrap_connect(
             __name__,
             psycopg2,
@@ -240,6 +241,7 @@ class Psycopg2Instrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
             capture_parameters=capture_parameters,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs):
@@ -320,7 +322,8 @@ class DatabaseApiIntegration(dbapi.DatabaseApiIntegration):
         kwargs["cursor_factory"] = _new_cursor_factory(**new_factory_kwargs)
         connection = connect_method(*args, **kwargs)
         self.get_connection_attributes(connection)
-        return connection
+        # psycopg2 uses cursor_factory for cursor tracing, so disable cursor wrapping
+        return dbapi.get_traced_connection_proxy(connection, self, wrap_cursors=False)
 
 
 class CursorTracer(dbapi.CursorTracer):

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_instrumentation.py
@@ -197,6 +197,7 @@ class TestPsycopg2InstrumentorParameters(TestBase):
             commenter_options={},
             enable_attribute_commenter=False,
             capture_parameters=False,
+            enable_transaction_spans=True,
         )
 
     def test_instrument_capture_parameters(self, mock_dbapi):

--- a/instrumentation/opentelemetry-instrumentation-pymssql/src/opentelemetry/instrumentation/pymssql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymssql/src/opentelemetry/instrumentation/pymssql/__init__.py
@@ -157,6 +157,7 @@ class PyMSSQLInstrumentor(BaseInstrumentor):
         https://github.com/pymssql/pymssql/
         """
         tracer_provider = kwargs.get("tracer_provider")
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
 
         dbapi.wrap_connect(
             __name__,
@@ -169,6 +170,7 @@ class PyMSSQLInstrumentor(BaseInstrumentor):
             # instead, we get the attributes from the connect method (which is done
             # via PyMSSQLDatabaseApiIntegration.wrapped_connection)
             db_api_integration_factory=_PyMSSQLDatabaseApiIntegration,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs):
@@ -176,13 +178,15 @@ class PyMSSQLInstrumentor(BaseInstrumentor):
         dbapi.unwrap_connect(pymssql, "connect")
 
     @staticmethod
-    def instrument_connection(connection, tracer_provider=None):
+    def instrument_connection(connection, tracer_provider=None, enable_transaction_spans=True):
         """Enable instrumentation in a pymssql connection.
 
         Args:
             connection: The connection to instrument.
             tracer_provider: The optional tracer provider to use. If omitted
                 the current globally configured one is used.
+            enable_transaction_spans: Flag to enable/disable transaction spans
+                (commit/rollback). Defaults to True.
 
         Returns:
             An instrumented connection.
@@ -195,6 +199,7 @@ class PyMSSQLInstrumentor(BaseInstrumentor):
             version=__version__,
             tracer_provider=tracer_provider,
             db_api_integration_factory=_PyMSSQLDatabaseApiIntegration,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -189,6 +189,7 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         enable_attribute_commenter = kwargs.get(
             "enable_attribute_commenter", False
         )
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
 
         dbapi.wrap_connect(
             __name__,
@@ -201,6 +202,7 @@ class PyMySQLInstrumentor(BaseInstrumentor):
             enable_commenter=enable_sqlcommenter,
             commenter_options=commenter_options,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     def _uninstrument(self, **kwargs):  # pylint: disable=no-self-use
@@ -214,6 +216,7 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         enable_commenter=None,
         commenter_options=None,
         enable_attribute_commenter=None,
+        enable_transaction_spans=True,
     ):
         """Enable instrumentation in a PyMySQL connection.
 
@@ -232,6 +235,8 @@ class PyMySQLInstrumentor(BaseInstrumentor):
                 You can specify various options, such as enabling driver information, database version logging,
                 traceparent propagation, and other customizable metadata enhancements.
                 See *SQLCommenter Configurations* above for more information.
+            enable_transaction_spans:
+                A flag to enable/disable transaction spans (commit/rollback). Defaults to True.
         Returns:
             An instrumented connection.
         """
@@ -247,6 +252,7 @@ class PyMySQLInstrumentor(BaseInstrumentor):
             commenter_options=commenter_options,
             connect_module=pymysql,
             enable_attribute_commenter=enable_attribute_commenter,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-pymysql/tests/test_pymysql_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/tests/test_pymysql_integration.py
@@ -22,6 +22,7 @@ from opentelemetry.instrumentation.pymysql import PyMySQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_STATEMENT,
+    DB_SYSTEM,
 )
 from opentelemetry.test.test_base import TestBase
 
@@ -482,3 +483,56 @@ class TestPyMysqlIntegration(TestBase):
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
+
+    @mock.patch("pymysql.connect")
+    # pylint: disable=unused-argument
+    def test_commit(self, mock_connect):
+        """Test that commit creates a span"""
+        PyMySQLInstrumentor().instrument()
+        cnx = pymysql.connect(database="test")
+        cnx.commit()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "COMMIT")
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes[DB_SYSTEM], "mysql")
+
+    @mock.patch("pymysql.connect")
+    # pylint: disable=unused-argument
+    def test_rollback(self, mock_connect):
+        """Test that rollback creates a span"""
+        PyMySQLInstrumentor().instrument()
+        cnx = pymysql.connect(database="test")
+        cnx.rollback()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.name, "ROLLBACK")
+        self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes[DB_SYSTEM], "mysql")
+
+    @mock.patch("pymysql.connect")
+    # pylint: disable=unused-argument
+    def test_commit_and_query(self, mock_connect):
+        """Test that both execute and commit create spans"""
+        PyMySQLInstrumentor().instrument()
+        cnx = pymysql.connect(database="test")
+        cursor = cnx.cursor()
+        cursor.execute("SELECT * FROM test")
+        cnx.commit()
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 2)
+
+        # First span should be the SELECT
+        select_span = spans_list[0]
+        self.assertEqual(select_span.name, "SELECT")
+        self.assertIs(select_span.kind, trace_api.SpanKind.CLIENT)
+
+        # Second span should be the COMMIT
+        commit_span = spans_list[1]
+        self.assertEqual(commit_span.name, "COMMIT")
+        self.assertIs(commit_span.kind, trace_api.SpanKind.CLIENT)

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -89,6 +89,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
         https://docs.python.org/3/library/sqlite3.html
         """
         tracer_provider = kwargs.get("tracer_provider")
+        enable_transaction_spans = kwargs.get("enable_transaction_spans", True)
 
         for module in self._TO_WRAP:
             dbapi.wrap_connect(
@@ -99,6 +100,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
                 _CONNECTION_ATTRIBUTES,
                 version=__version__,
                 tracer_provider=tracer_provider,
+                enable_transaction_spans=enable_transaction_spans,
             )
 
     def _uninstrument(self, **kwargs: Any) -> None:
@@ -110,6 +112,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
     def instrument_connection(
         connection: SQLite3Connection,
         tracer_provider: TracerProvider | None = None,
+        enable_transaction_spans: bool = True,
     ) -> SQLite3Connection:
         """Enable instrumentation in a SQLite connection.
 
@@ -117,6 +120,8 @@ class SQLite3Instrumentor(BaseInstrumentor):
             connection: The connection to instrument.
             tracer_provider: The optional tracer provider to use. If omitted
                 the current globally configured one is used.
+            enable_transaction_spans: Flag to enable/disable transaction spans
+                (commit/rollback). Defaults to True.
 
         Returns:
             An instrumented SQLite connection that supports
@@ -130,6 +135,7 @@ class SQLite3Instrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
+            enable_transaction_spans=enable_transaction_spans,
         )
 
     @staticmethod


### PR DESCRIPTION
# Description

Adds instrumentation for database `commit()` and `rollback()` transaction operations across all DB-API instrumentations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

- Added `commit()` and `rollback()` span instrumentation to `dbapi` module
- Added `enable_transaction_spans` configuration flag (default: `True`)
- Created `AsyncTracedConnectionProxy` for async connections (psycopg)
- Plumbed configuration through all dependent instrumentors: pymysql, mysql, mysqlclient, psycopg, psycopg2, sqlite3, pymssql

# How Has This Been Tested?

- Added unit tests for sync commit/rollback in `test_dbapi_integration.py`
- Added unit tests for sync and async commit/rollback in `test_psycopg_integration.py`
- Added functional tests for pymysql in `test_pymysql_functional.py`
- [x] All existing tests pass

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated