### PR TITLE
Fix RecursionError by preventing duplicate instrumentation in urllib3

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -199,7 +199,7 @@ _URL_OPEN_ARG_TO_INDEX_MAPPING = {
 class URLLib3Instrumentor(BaseInstrumentor):
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
-
+    _instrumented = False
     def _instrument(self, **kwargs):
         """Instruments the urllib3 module
 
@@ -214,6 +214,9 @@ class URLLib3Instrumentor(BaseInstrumentor):
                     list of regexes used to exclude URLs from tracking
         """
         # initialize semantic conventions opt-in if needed
+        if self._instrumented:
+            return
+        self._instrumented = True
         _OpenTelemetrySemanticConventionStability._initialize()
         sem_conv_opt_in_mode = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
             _OpenTelemetryStabilitySignalType.HTTP,


### PR DESCRIPTION
### Summary
This PR fixes RecursionError reported in issue [#4532](https://github.com/open-telemetry/opentelemetry-python/issues/4532).

### Fix
A `_instrumented` guard flag was added to urllib3 instrumentation to ensure
that `_instrument()` cannot run multiple times. The absence of this guard
caused recursive instrumentation and eventually RecursionError.

### Details
The change:
- Adds `_instrumented = False` at the class level
- Early-returns from `_instrument()` if instrumentation already happened

### Result
This prevents infinite recursion and ensures stable instrumentation behavior.

Fixes: [#4532](https://github.com/open-telemetry/opentelemetry-python/issues/4532)
