### PR TITLE
botocore: document threading instrumentation for S3 multipart operations

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -65,15 +65,13 @@ API
 
 The `instrument` method accepts the following keyword args:
 
-* tracer_provider (TracerProvider) - an optional tracer provider
-* request_hook (Callable) - a function with extra user-defined logic to be performed before performing the request
-this function signature is:  ``def request_hook(span: Span, service_name: str, operation_name: str, api_params: dict) -> None``
-* response_hook (Callable) - a function with extra user-defined logic to be performed after performing the request
-this function signature is:  ``def response_hook(span: Span, service_name: str, operation_name: str, result: dict) -> None``
+* tracer_provider (``TracerProvider``) - an optional tracer provider
+* request_hook (``Callable[[Span, str, str, dict], None]``) - a function with extra user-defined logic to be performed before performing the request
+* response_hook (``Callable[[Span, str, str, dict], None]``) - a function with extra user-defined logic to be performed after performing the request
 
 for example:
 
-.. code: python
+.. code:: python
 
     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
     import botocore.session


### PR DESCRIPTION
Documents that users need to enable `ThreadingInstrumentor` alongside `BotocoreInstrumentor` for proper trace context propagation with S3 `upload_file` and `download_file` methods.

## Issue

boto3's S3 multipart operations (`upload_file`, `download_file`) spawn background threads via `ThreadPoolExecutor`. Without `ThreadingInstrumentor`, the OpenTelemetry context is not propagated to these threads, resulting in broken traces where child spans appear as separate traces instead of being linked to their parent.

The `opentelemetry-instrumentation-threading` module already wraps `ThreadPoolExecutor.submit()` to propagate context:

1. [Captures context](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py#L165) with `context.get_current()` when `submit()` is called
2. [Attaches context](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py#L170) in the worker thread before executing the task

## Changes

- Adds "Thread Context Propagation" section to botocore instrumentation module docstring
- Adds "Thread Context Propagation" section to botocore README.rst

## References

Closes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/298