### PR TITLE
feat: Add support for excluding ASGI receive/send spans via environment variable in FastAPI

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -218,6 +218,7 @@ from opentelemetry.util.http import (
     parse_excluded_urls,
     sanitize_method,
 )
+from opentelemetry.instrumentation.fastapi.utils import get_excluded_spans
 
 _excluded_urls_from_env = get_excluded_urls("FASTAPI")
 _logger = logging.getLogger(__name__)
@@ -278,6 +279,10 @@ class FastAPIInstrumentor(BaseInstrumentor):
                 excluded_urls = _excluded_urls_from_env
             else:
                 excluded_urls = parse_excluded_urls(excluded_urls)
+
+            if exclude_spans is None:
+                exclude_spans = get_excluded_spans()
+
             tracer = get_tracer(
                 __name__,
                 __version__,

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/environment_variables.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/environment_variables.py
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Exclude HTTP `send` and/or `receive` spans from the trace.
+"""
+
+OTEL_PYTHON_FASTAPI_EXCLUDE_SPANS = "OTEL_PYTHON_FASTAPI_EXCLUDE_SPANS"

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/utils.py
@@ -1,0 +1,44 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from typing import Literal, Union
+
+from opentelemetry.instrumentation.fastapi.environment_variables import (
+    OTEL_PYTHON_FASTAPI_EXCLUDE_SPANS,
+)
+
+SpanType = Literal["receive", "send"]
+
+
+def get_excluded_spans() -> Union[list[SpanType], None]:
+    raw = os.getenv(OTEL_PYTHON_FASTAPI_EXCLUDE_SPANS)
+
+    if not raw:
+        return None
+
+    values = [v.strip() for v in raw.split(",") if v.strip()]
+
+    allowed: set[str] = {"receive", "send"}
+    result: list[SpanType] = []
+
+    for value in values:
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid excluded span: '{value}'. Allowed values are: {allowed}"
+            )
+        result.append(value)  # type: ignore[arg-type]
+
+    return result


### PR DESCRIPTION
# Description

Added the enviornment variable `OTEL_PYTHON_FASTAPI_EXCLUDE_SPANS` to support excluding the send and receive spans that the ASGI middleware generates.

Fixes #3992 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Disable send spans and check that send spans are ignored
- [x] Disable receive spans and check that receive spans are ignore
- [x] Disable both send and receive spans and check that both are ignored
- [x] Exception raised when invalid values are passed to environment variable 
- [x] Check that `exclude_spans` argument takes priority over the environment variable

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
