### PR TITLE
openai-v2: use GEN_AI_REQUEST_ENCODING_FORMATS constant

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -253,11 +253,12 @@ def get_llm_request_attributes(
     ):
         # Add embedding dimensions if specified
         if (dimensions := kwargs.get("dimensions")) is not None:
+            # TODO: move to GEN_AI_EMBEDDINGS_DIMENSION_COUNT when 1.39.0 is baseline
             attributes["gen_ai.embeddings.dimension.count"] = dimensions
 
         # Add encoding format if specified
         if "encoding_format" in kwargs:
-            attributes["gen_ai.request.encoding_formats"] = [
+            attributes[GenAIAttributes.GEN_AI_REQUEST_ENCODING_FORMATS] = [
                 kwargs["encoding_format"]
             ]
 


### PR DESCRIPTION
# Description

Use the GEN_AI_REQUEST_ENCODING_FORMATS instead of open coded attribute name.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
