### PR TITLE
fix(fastapi): Fix FastAPI Instrumentation Compatibility with Middleware-Wrapped Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Use [this search for a list of all CHANGELOG.md files in this repo](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib+path%3A**%2FCHANGELOG.md&type=code).
 
 ## Unreleased
-- `opentelemetry-instrumentation-fastapi` Support for Middleware Wrapped FastAPI Application [#4041](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4031)
 
 ### Added
 
@@ -31,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-fastapi` Support for Middleware Wrapped FastAPI Application [#4041](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4031)
 - `opentelemetry-instrumentation-asyncpg`: Hydrate span attributes before creation so samplers can filter on database details
   ([#3841](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3841))
 - `opentelemetry-instrumentation-django`: Fix exemplars generation for `http.server.(request.)duration`

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -536,6 +536,8 @@ def _unwrap_middleware(app):
     Returns:
         The unwrapped FastAPI or Starlette application.
     """
+    if isinstance(app, fastapi.FastAPI):
+        return app
     while hasattr(app, "app"):
         app = app.app
     return app

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -1443,6 +1443,13 @@ class TestAutoInstrumentationLogic(unittest.TestCase):
         self.assertIs(original, should_be_original)
 
 
+class TestUnwrapMiddleware(unittest.TestCase):
+    def test_unwrap_fastapi_app(self):
+        app = fastapi.FastAPI()
+        app.app = "should not be returned"
+        self.assertIs(otel_fastapi._unwrap_middleware(app), app)
+
+
 class TestWrappedApplication(TestBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
# Description
This pull request resolves issue [#4031](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4031), which reported that FastAPI instrumentation did not work with middleware-wrapped applications such as `CORSMiddleware`. The changes here ensure that the `FastAPIInstrumentor` can properly identify and instrument `FastAPI` or `Starlette` instances, even if wrapped by middleware.

Fixes #4031

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
  - Added test coverage for middleware-wrapped FastAPI apps.
  - Verified instrumentation works as expected with middleware layers.


# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
