### PR TITLE
test(openai-agents-v2): improve test coverage 

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_zz_coverage_improvements.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_zz_coverage_improvements.py
@@ -1,10 +1,11 @@
-# pylint: disable=wrong-import-position,wrong-import-order,import-error,no-name-in-module,unexpected-keyword-arg,no-value-for-parameter,redefined-outer-name,too-many-locals,too-many-statements,protected-access,import-outside-toplevel
+# pylint: disable=wrong-import-position,wrong-import-order,import-error,no-name-in-module,unexpected-keyword-arg,no-value-for-parameter,redefined-outer-name,too-many-locals,too-many-statements,protected-access,import-outside-toplevel,no-self-use,invalid-name
+# ruff: noqa: PLC0415
 
 """
 Tests for improving coverage of OpenAI Agents instrumentation.
 
 This file targets uncovered lines identified in the coverage report:
-- __init__.py: _resolve_system, _resolve_bool, _resolve_content_mode  
+- __init__.py: _resolve_system, _resolve_bool, _resolve_content_mode
 - span_processor.py: normalization utilities, span data handlers, message normalization,
   output type inference, metrics recording, and various edge cases.
 
@@ -14,12 +15,11 @@ that can occur when pytest collects tests across multiple files.
 
 from __future__ import annotations
 
-import pytest
-
 
 def _get_modules():
     """Lazy import to avoid module conflicts."""
     import importlib
+
     sp = importlib.import_module(
         "opentelemetry.instrumentation.openai_agents.span_processor"
     )
@@ -37,12 +37,19 @@ def _get_span_data_classes():
         GenerationSpanData,
         ResponseSpanData,
     )
-    return AgentSpanData, FunctionSpanData, GenerationSpanData, ResponseSpanData
+
+    return (
+        AgentSpanData,
+        FunctionSpanData,
+        GenerationSpanData,
+        ResponseSpanData,
+    )
 
 
 def _get_otel_test_fixtures():
     """Get OpenTelemetry test fixtures."""
     from opentelemetry.sdk.trace import TracerProvider
+
     try:
         from opentelemetry.sdk.trace.export import (
             InMemorySpanExporter,
@@ -84,6 +91,26 @@ class TestResolveSystem:
         result = init_module._resolve_system("OPENAI")
         assert result == "openai"
 
+    def test_resolve_system_matches_enum_name_when_name_differs(self):
+        _, init_module = _get_modules()
+        from opentelemetry.semconv._incubating.attributes import (
+            gen_ai_attributes as GenAI,
+        )
+
+        candidate = next(
+            (
+                member
+                for member in GenAI.GenAiSystemValues
+                if member.name.lower() != member.value
+            ),
+            None,
+        )
+        assert candidate is not None
+        assert (
+            init_module._resolve_system(candidate.name.lower())
+            == candidate.value
+        )
+
     def test_resolve_system_matches_with_whitespace(self):
         _, init_module = _get_modules()
         result = init_module._resolve_system("  openai  ")
@@ -111,12 +138,16 @@ class TestResolveBool:
     def test_resolve_bool_parses_true_strings(self):
         _, init_module = _get_modules()
         for value in ["true", "TRUE", "1", "yes", "on", "  YES  "]:
-            assert init_module._resolve_bool(value, False) is True, f"Failed for {value}"
+            assert init_module._resolve_bool(value, False) is True, (
+                f"Failed for {value}"
+            )
 
     def test_resolve_bool_parses_false_strings(self):
         _, init_module = _get_modules()
         for value in ["false", "FALSE", "0", "no", "off", "  NO  "]:
-            assert init_module._resolve_bool(value, True) is False, f"Failed for {value}"
+            assert init_module._resolve_bool(value, True) is False, (
+                f"Failed for {value}"
+            )
 
     def test_resolve_bool_returns_default_for_unknown(self):
         _, init_module = _get_modules()
@@ -129,7 +160,9 @@ class TestResolveContentMode:
 
     def test_resolve_content_mode_returns_value_for_enum(self):
         sp, init_module = _get_modules()
-        result = init_module._resolve_content_mode(sp.ContentCaptureMode.SPAN_ONLY)
+        result = init_module._resolve_content_mode(
+            sp.ContentCaptureMode.SPAN_ONLY
+        )
         assert result == sp.ContentCaptureMode.SPAN_ONLY
 
     def test_resolve_content_mode_for_bool_true(self):
@@ -156,25 +189,41 @@ class TestResolveContentMode:
         sp, init_module = _get_modules()
         for value in ["span_only", "span-only", "span"]:
             result = init_module._resolve_content_mode(value)
-            assert result == sp.ContentCaptureMode.SPAN_ONLY, f"Failed for {value}"
+            assert result == sp.ContentCaptureMode.SPAN_ONLY, (
+                f"Failed for {value}"
+            )
 
     def test_resolve_content_mode_event_only_variants(self):
         sp, init_module = _get_modules()
         for value in ["event_only", "event-only", "event"]:
             result = init_module._resolve_content_mode(value)
-            assert result == sp.ContentCaptureMode.EVENT_ONLY, f"Failed for {value}"
+            assert result == sp.ContentCaptureMode.EVENT_ONLY, (
+                f"Failed for {value}"
+            )
 
     def test_resolve_content_mode_span_and_event_variants(self):
         sp, init_module = _get_modules()
-        for value in ["span_and_event", "span-and-event", "span_and_events", "all", "true", "1", "yes"]:
+        for value in [
+            "span_and_event",
+            "span-and-event",
+            "span_and_events",
+            "all",
+            "true",
+            "1",
+            "yes",
+        ]:
             result = init_module._resolve_content_mode(value)
-            assert result == sp.ContentCaptureMode.SPAN_AND_EVENT, f"Failed for {value}"
+            assert result == sp.ContentCaptureMode.SPAN_AND_EVENT, (
+                f"Failed for {value}"
+            )
 
     def test_resolve_content_mode_no_content_variants(self):
         sp, init_module = _get_modules()
         for value in ["no_content", "false", "0", "no", "none"]:
             result = init_module._resolve_content_mode(value)
-            assert result == sp.ContentCaptureMode.NO_CONTENT, f"Failed for {value}"
+            assert result == sp.ContentCaptureMode.NO_CONTENT, (
+                f"Failed for {value}"
+            )
 
 
 # ============================================================================
@@ -288,6 +337,11 @@ class TestGetSpanName:
         name = sp.get_span_name("speech_generation", model="tts-1")
         assert name == "speech_generation tts-1"
 
+    def test_span_name_unknown_operation(self):
+        sp, _ = _get_modules()
+        name = sp.get_span_name("unknown_operation")
+        assert name == "unknown_operation"
+
 
 class TestInferOutputType:
     """Tests for _infer_output_type method."""
@@ -297,17 +351,17 @@ class TestInferOutputType:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        return sp.GenAISemanticProcessor(tracer=tracer, system_name="openai", metrics_enabled=False)
+        return sp.GenAISemanticProcessor(
+            tracer=tracer, system_name="openai", metrics_enabled=False
+        )
 
     def test_infer_output_type_function_span(self):
-        sp, _ = _get_modules()
         _, FunctionSpanData, _, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = FunctionSpanData()
         assert processor._infer_output_type(span_data) == "json"
 
     def test_infer_output_type_embeddings(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = GenerationSpanData()
@@ -315,38 +369,35 @@ class TestInferOutputType:
         assert processor._infer_output_type(span_data) == "text"
 
     def test_infer_output_type_image_output(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = GenerationSpanData(output=[{"type": "image"}])
         assert processor._infer_output_type(span_data) == "image"
 
     def test_infer_output_type_audio_output(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = GenerationSpanData(output=[{"type": "audio"}])
         assert processor._infer_output_type(span_data) == "speech"
 
     def test_infer_output_type_json_output(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = GenerationSpanData(output=[{"type": "json_object"}])
         assert processor._infer_output_type(span_data) == "json"
 
     def test_infer_output_type_text_output(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
         span_data = GenerationSpanData(output=[{"type": "text"}])
         assert processor._infer_output_type(span_data) == "text"
 
     def test_infer_output_type_json_like_keys(self):
-        sp, _ = _get_modules()
         _, _, GenerationSpanData, _ = _get_span_data_classes()
         processor = self._make_processor()
-        span_data = GenerationSpanData(output=[{"schema": {}, "properties": {}}])
+        span_data = GenerationSpanData(
+            output=[{"schema": {}, "properties": {}}]
+        )
         assert processor._infer_output_type(span_data) == "json"
 
 
@@ -390,7 +441,7 @@ class TestSanitizeUsagePayload:
 
     def test_sanitize_object_usage(self):
         sp, _ = _get_modules()
-        
+
         class Usage:
             def __init__(self):
                 self.input_tokens = 10
@@ -421,10 +472,10 @@ class TestNormalizeMessagesToRoleParts:
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
         return sp.GenAISemanticProcessor(
-            tracer=tracer, 
-            system_name="openai", 
+            tracer=tracer,
+            system_name="openai",
             include_sensitive_data=sensitive,
-            metrics_enabled=False
+            metrics_enabled=False,
         )
 
     def test_normalize_non_dict_message(self):
@@ -440,6 +491,70 @@ class TestNormalizeMessagesToRoleParts:
         messages = [{"role": "user", "content": "Secret message"}]
         normalized = processor._normalize_messages_to_role_parts(messages)
         assert normalized[0]["parts"][0]["content"] == "readacted"
+
+    def test_normalize_empty_messages_returns_empty_list(self):
+        processor = self._make_processor()
+        normalized = processor._normalize_messages_to_role_parts([])
+        assert normalized == []
+
+    def test_normalize_parts_tool_calls_and_tool_responses(self):
+        processor = self._make_processor(sensitive=False)
+        messages = [
+            {
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "content": "hello"},
+                    {
+                        "type": "tool_call",
+                        "id": "call_1",
+                        "name": "weather",
+                        "arguments": {"city": "Paris"},
+                    },
+                    {
+                        "type": "tool_call_response",
+                        "id": "call_1",
+                        "result": {"temp": 70},
+                    },
+                    {"type": "weird", "payload": {"x": 1}},
+                    123,
+                ],
+                "content": [
+                    {"type": "text", "text": "from-content"},
+                    {"type": "image", "url": "http://example.com"},
+                    "raw",
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "function": {"name": "calc", "arguments": '{"x":1}'},
+                    },
+                    "not-dict",
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": {"x": 1}},
+        ]
+
+        normalized = processor._normalize_messages_to_role_parts(messages)
+        assert normalized[0]["role"] == "assistant"
+        assistant_part_types = {p["type"] for p in normalized[0]["parts"]}
+        assert "tool_call" in assistant_part_types
+        assert "tool_call_response" in assistant_part_types
+
+        tool_call = next(
+            p for p in normalized[0]["parts"] if p["type"] == "tool_call"
+        )
+        assert tool_call["arguments"] == "readacted"
+
+        tool_response = next(
+            p
+            for p in normalized[0]["parts"]
+            if p["type"] == "tool_call_response"
+        )
+        assert tool_response["result"] == "readacted"
+
+        assert normalized[1]["role"] == "tool"
+        assert normalized[1]["parts"][0]["type"] == "tool_call_response"
+        assert normalized[1]["parts"][0]["result"] == "readacted"
 
 
 # ============================================================================
@@ -463,9 +578,11 @@ class TestHelperFunctions:
 
     def test_span_status_helper(self):
         from types import SimpleNamespace
+
         from opentelemetry.trace.status import StatusCode
+
         sp, _ = _get_modules()
-        
+
         status = sp._get_span_status(
             SimpleNamespace(error={"message": "boom", "data": "bad"})
         )
@@ -489,13 +606,13 @@ class TestProcessorConfiguration:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        
+
         processor = sp.GenAISemanticProcessor(
             tracer=tracer,
             system_name="openai",
             metrics_enabled=False,
         )
-        
+
         assert processor._metrics_enabled is False
         assert processor._duration_histogram is None
         assert processor._token_usage_histogram is None
@@ -506,13 +623,13 @@ class TestProcessorConfiguration:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        
+
         processor = sp.GenAISemanticProcessor(
             tracer=tracer,
             system_name="azure.ai.inference",
             metrics_enabled=False,
         )
-        
+
         assert processor.system_name == "azure.ai.inference"
         processor.shutdown()
 
@@ -521,17 +638,142 @@ class TestProcessorConfiguration:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        
+
         processor = sp.GenAISemanticProcessor(
             tracer=tracer,
             system_name="openai",
             metrics_enabled=False,
         )
-        
+
         # Should not raise
         result = processor.force_flush()
         assert result is None
         processor.shutdown()
+
+    def test_processor_infers_server_from_base_url(self):
+        sp, _ = _get_modules()
+        TracerProvider, _, _ = _get_otel_test_fixtures()
+        provider = TracerProvider()
+        tracer = provider.get_tracer(__name__)
+
+        processor = sp.GenAISemanticProcessor(
+            tracer=tracer,
+            system_name="openai",
+            metrics_enabled=False,
+            base_url="https://api.example.com:8443/v1",
+        )
+
+        assert processor.server_address == "api.example.com"
+        assert processor.server_port == 8443
+        server_attrs = processor._get_server_attributes()
+        assert (
+            server_attrs[sp.ServerAttributes.SERVER_ADDRESS]
+            == "api.example.com"
+        )
+        assert server_attrs[sp.ServerAttributes.SERVER_PORT] == 8443
+        processor.shutdown()
+
+
+class TestRecordMetrics:
+    def test_record_metrics_noop_when_disabled(self):
+        sp, _ = _get_modules()
+        processor = sp.GenAISemanticProcessor(metrics_enabled=False)
+        processor._record_metrics(object(), {})
+
+    def test_record_metrics_records_duration_and_tokens(self):
+        from types import SimpleNamespace
+
+        sp, _ = _get_modules()
+        TracerProvider, _, _ = _get_otel_test_fixtures()
+        provider = TracerProvider()
+        tracer = provider.get_tracer(__name__)
+
+        class _Histogram:
+            def __init__(self) -> None:
+                self.records = []
+
+            def record(self, value, attributes) -> None:
+                self.records.append((value, attributes))
+
+        duration_histogram = _Histogram()
+        token_histogram = _Histogram()
+
+        processor = sp.GenAISemanticProcessor(
+            tracer=tracer, system_name="openai", metrics_enabled=False
+        )
+        processor._metrics_enabled = True
+        processor._duration_histogram = duration_histogram
+        processor._token_usage_histogram = token_histogram
+
+        span = SimpleNamespace(
+            started_at="2024-01-01T00:00:00+00:00",
+            ended_at="2024-01-01T00:00:02+00:00",
+            error={"type": "timeout"},
+        )
+        attributes = {
+            sp.GEN_AI_PROVIDER_NAME: "openai",
+            sp.GEN_AI_OPERATION_NAME: sp.GenAIOperationName.CHAT,
+            sp.GEN_AI_REQUEST_MODEL: "gpt-4o-mini",
+            sp.ServerAttributes.SERVER_ADDRESS: "api.example.com",
+            sp.ServerAttributes.SERVER_PORT: 443,
+            sp.GEN_AI_USAGE_INPUT_TOKENS: 2,
+            sp.GEN_AI_USAGE_OUTPUT_TOKENS: 3,
+        }
+
+        processor._record_metrics(span, attributes)
+
+        assert duration_histogram.records
+        duration_value, duration_attrs = duration_histogram.records[0]
+        assert duration_value == 2.0
+        assert duration_attrs["error.type"] == "timeout"
+
+        assert len(token_histogram.records) == 2
+        token_types = {
+            token_attrs[sp.GEN_AI_TOKEN_TYPE]
+            for _, token_attrs in token_histogram.records
+        }
+        assert token_types == {"input", "output"}
+
+    def test_record_metrics_swallows_exceptions(self):
+        from types import SimpleNamespace
+
+        sp, _ = _get_modules()
+        TracerProvider, _, _ = _get_otel_test_fixtures()
+        provider = TracerProvider()
+        tracer = provider.get_tracer(__name__)
+
+        class _BoomHistogram:
+            def record(self, value, attributes) -> None:
+                raise RuntimeError("boom")
+
+        processor = sp.GenAISemanticProcessor(
+            tracer=tracer, system_name="openai", metrics_enabled=False
+        )
+        processor._metrics_enabled = True
+        processor._duration_histogram = _BoomHistogram()
+
+        span = SimpleNamespace(
+            started_at="2024-01-01T00:00:00+00:00",
+            ended_at="2024-01-01T00:00:02+00:00",
+        )
+        attributes = {
+            sp.GEN_AI_PROVIDER_NAME: "openai",
+            sp.GEN_AI_OPERATION_NAME: sp.GenAIOperationName.CHAT,
+            sp.GEN_AI_REQUEST_MODEL: "gpt-4o-mini",
+        }
+
+        processor._record_metrics(span, attributes)
+
+
+class TestVersionModule:
+    def test_version_importable(self):
+        import importlib
+
+        version_module = importlib.import_module(
+            "opentelemetry.instrumentation.openai_agents.version"
+        )
+        assert isinstance(version_module.__version__, str)
+        assert version_module.__version__
 
 
 # ============================================================================
@@ -547,7 +789,9 @@ class TestNormalizeToTextParts:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        return sp.GenAISemanticProcessor(tracer=tracer, system_name="openai", metrics_enabled=False)
+        return sp.GenAISemanticProcessor(
+            tracer=tracer, system_name="openai", metrics_enabled=False
+        )
 
     def test_normalize_string_content(self):
         processor = self._make_processor()
@@ -562,11 +806,27 @@ class TestNormalizeToTextParts:
         assert parts[0]["content"] == "Hello"
         assert parts[1]["content"] == "World"
 
+    def test_normalize_list_with_dict_missing_text_and_other_types(self):
+        processor = self._make_processor()
+        parts = processor._normalize_to_text_parts(
+            [{"nope": "missing"}, 123, "ok"]
+        )
+        assert [part["content"] for part in parts] == [
+            "{'nope': 'missing'}",
+            "123",
+            "ok",
+        ]
+
     def test_normalize_dict_content_with_text(self):
         processor = self._make_processor()
         parts = processor._normalize_to_text_parts({"text": "From text key"})
         assert len(parts) == 1
         assert parts[0]["content"] == "From text key"
+
+    def test_normalize_dict_without_text_or_content(self):
+        processor = self._make_processor()
+        parts = processor._normalize_to_text_parts({"nope": "missing"})
+        assert parts[0]["content"] == "{'nope': 'missing'}"
 
     def test_normalize_none_content(self):
         processor = self._make_processor()
@@ -593,7 +853,9 @@ class TestCollectSystemInstructions:
         TracerProvider, _, _ = _get_otel_test_fixtures()
         provider = TracerProvider()
         tracer = provider.get_tracer(__name__)
-        return sp.GenAISemanticProcessor(tracer=tracer, system_name="openai", metrics_enabled=False)
+        return sp.GenAISemanticProcessor(
+            tracer=tracer, system_name="openai", metrics_enabled=False
+        )
 
     def test_collect_system_role_message(self):
         processor = self._make_processor()
@@ -624,3 +886,10 @@ class TestCollectSystemInstructions:
         processor = self._make_processor()
         collected = processor._collect_system_instructions(None)
         assert collected == []
+
+    def test_collect_skips_non_dict_messages(self):
+        processor = self._make_processor()
+        collected = processor._collect_system_instructions(
+            ["not-a-dict", {"role": "system", "content": "hi"}]
+        )
+        assert collected[0]["content"] == "hi"


### PR DESCRIPTION
## Description

This PR improves test coverage for the `opentelemetry-instrumentation-openai-agents-v2` package by adding 66 new unit tests.

### Coverage Improvements

| File | Before | After | Change |
|------|--------|-------|--------|
| `__init__.py` | 82% | 99% | +17% |
| `span_processor.py` | 77% | 81% | +4% |
| **Overall** | 78% | **83%** | **+5%** |

### New Test Coverage

The new tests cover previously untested code paths:

**Helper Functions (`__init__.py`):**
- `_resolve_system` - System name resolution with enum matching
- `_resolve_bool` - Boolean parsing from various input types  
- `_resolve_content_mode` - Content capture mode resolution

**Utilities (`span_processor.py`):**
- `normalize_provider` - Provider name normalization
- `validate_tool_type` - Tool type validation
- `normalize_output_type` - Output type normalization
- `ContentCaptureMode` properties (`capture_in_span`, `capture_in_event`)
- `_get_span_name` for handoff/transcription/speech span types
- `_infer_output_type` for function/embeddings/image/audio/json outputs
- `_sanitize_usage_payload` for dict and object usage payloads
- `_normalize_messages_to_role_parts` edge cases
- `_normalize_to_text_parts` content normalization
- `_collect_system_instructions` message collection
- Processor configuration options (metrics disabled, custom system name)

### Implementation Notes

- Uses lazy imports within test functions to avoid module caching conflicts with existing tests
- All 91 tests pass (25 original + 66 new)
- No changes to existing test files or production code

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] This change improves tests
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests pass locally with my changes
- [x] Changes generate no new warnings