### PR TITLE
opentelemetry-instrumentation-logging: don't add out of spec attributes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+- `opentelemetry-instrumentation-logging`: Inject span context attributes into logging LogRecord only if configured to do so
+  ([#4112](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4112))
 - `opentelemetry-instrumentation-django`: Drop support for Django < 2.0
   ([#3848](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4083))
 

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -97,8 +97,8 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
         {DEFAULT_LOGGING_FORMAT}
 
         def log_hook(span: Span, record: LogRecord):
-                if span and span.is_recording():
-                    record.custom_user_attribute_from_log_hook = "some-value"
+            if span and span.is_recording():
+                record.custom_user_attribute_from_log_hook = "some-value"
 
     Args:
         tracer_provider: Tracer provider instance that can be used to fetch a tracer.
@@ -130,44 +130,6 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
 
         service_name = None
 
-        def record_factory(*args, **kwargs):
-            record = old_factory(*args, **kwargs)
-
-            record.otelSpanID = "0"
-            record.otelTraceID = "0"
-            record.otelTraceSampled = False
-
-            nonlocal service_name
-            if service_name is None:
-                resource = getattr(provider, "resource", None)
-                if resource:
-                    service_name = (
-                        resource.attributes.get("service.name") or ""
-                    )
-                else:
-                    service_name = ""
-
-            record.otelServiceName = service_name
-
-            span = get_current_span()
-            if span != INVALID_SPAN:
-                ctx = span.get_span_context()
-                if ctx != INVALID_SPAN_CONTEXT:
-                    record.otelSpanID = format(ctx.span_id, "016x")
-                    record.otelTraceID = format(ctx.trace_id, "032x")
-                    record.otelTraceSampled = ctx.trace_flags.sampled
-                    if callable(LoggingInstrumentor._log_hook):
-                        try:
-                            LoggingInstrumentor._log_hook(  # pylint: disable=E1102
-                                span, record
-                            )
-                        except Exception:  # pylint: disable=W0703
-                            pass
-
-            return record
-
-        logging.setLogRecordFactory(record_factory)
-
         set_logging_format = kwargs.get(
             "set_logging_format",
             environ.get(OTEL_PYTHON_LOG_CORRELATION, "false").lower()
@@ -186,6 +148,54 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
             log_level = log_level or logging.INFO
 
             logging.basicConfig(format=log_format, level=log_level)
+
+        def record_factory(*args, **kwargs):
+            record = old_factory(*args, **kwargs)
+
+            # this factory is a no-op if log correlation or log hook are not set
+            if not set_logging_format and not callable(
+                LoggingInstrumentor._log_hook
+            ):
+                return record
+
+            # out of spec attributes are added to the log record only if log correlation is specified
+            if set_logging_format:
+                record.otelSpanID = "0"
+                record.otelTraceID = "0"
+                record.otelTraceSampled = False
+
+                nonlocal service_name
+                if service_name is None:
+                    resource = getattr(provider, "resource", None)
+                    if resource:
+                        service_name = (
+                            resource.attributes.get("service.name") or ""
+                        )
+                    else:
+                        service_name = ""
+
+                record.otelServiceName = service_name
+
+            span = get_current_span()
+            if span != INVALID_SPAN:
+                ctx = span.get_span_context()
+                if ctx != INVALID_SPAN_CONTEXT:
+                    if callable(LoggingInstrumentor._log_hook):
+                        try:
+                            LoggingInstrumentor._log_hook(  # pylint: disable=E1102
+                                span, record
+                            )
+                        except Exception:  # pylint: disable=W0703
+                            pass
+
+                    if set_logging_format:
+                        record.otelSpanID = format(ctx.span_id, "016x")
+                        record.otelTraceID = format(ctx.trace_id, "032x")
+                        record.otelTraceSampled = ctx.trace_flags.sampled
+
+            return record
+
+        logging.setLogRecordFactory(record_factory)
 
     def _uninstrument(self, **kwargs):
         if LoggingInstrumentor._old_factory:

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -160,7 +160,7 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
             ):
                 return record
 
-            # out of spec attributes are added to the log record only if log correlation is specified
+            # out of spec attributes are added to the log record only if log correlation is set
             if set_logging_format:
                 record.otelSpanID = "0"
                 record.otelTraceID = "0"
@@ -182,6 +182,11 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
             if span != INVALID_SPAN:
                 ctx = span.get_span_context()
                 if ctx != INVALID_SPAN_CONTEXT:
+                    if set_logging_format:
+                        record.otelSpanID = format(ctx.span_id, "016x")
+                        record.otelTraceID = format(ctx.trace_id, "032x")
+                        record.otelTraceSampled = ctx.trace_flags.sampled
+
                     if callable(LoggingInstrumentor._log_hook):
                         try:
                             LoggingInstrumentor._log_hook(  # pylint: disable=E1102
@@ -189,11 +194,6 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
                             )
                         except Exception:  # pylint: disable=W0703
                             pass
-
-                    if set_logging_format:
-                        record.otelSpanID = format(ctx.span_id, "016x")
-                        record.otelTraceID = format(ctx.trace_id, "032x")
-                        record.otelTraceSampled = ctx.trace_flags.sampled
 
             return record
 

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -90,7 +90,7 @@ LEVELS = {
 class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
     __doc__ = f"""An instrumentor for stdlib logging module.
 
-    This instrumentor injects tracing context into logging records and optionally sets the global logging format to the following:
+    This instrumentor optionally injects tracing context into logging records and sets the global logging format to the following:
 
     .. code-block::
 
@@ -99,6 +99,8 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
         def log_hook(span: Span, record: LogRecord):
             if span and span.is_recording():
                 record.custom_user_attribute_from_log_hook = "some-value"
+                span_ctx = span.get_span_context()
+                record.from_sampled_span = span_ctx.trace_flags.sampled
 
     Args:
         tracer_provider: Tracer provider instance that can be used to fetch a tracer.

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -47,7 +47,9 @@ class TestLoggingInstrumentorProxyTracerProvider(TestBase):
 
     def setUp(self):
         super().setUp()
-        LoggingInstrumentor().instrument(tracer_provider=FakeTracerProvider())
+        LoggingInstrumentor().instrument(
+            tracer_provider=FakeTracerProvider(), set_logging_format=True
+        )
 
     def tearDown(self):
         super().tearDown()
@@ -94,7 +96,21 @@ class TestLoggingInstrumentor(TestBase):
             self.assertEqual(record.otelTraceSampled, trace_sampled)
             self.assertEqual(record.otelServiceName, "unknown_service")
 
-    def test_trace_context_injection(self):
+    @mock.patch.dict("os.environ", {"OTEL_PYTHON_LOG_CORRELATION": "true"})
+    def test_trace_context_injection_with_log_correlation_from_env_var(self):
+        LoggingInstrumentor().uninstrument()
+        LoggingInstrumentor().instrument()
+        with self.tracer.start_as_current_span("s1") as span:
+            span_id = format(span.get_span_context().span_id, "016x")
+            trace_id = format(span.get_span_context().trace_id, "032x")
+            trace_sampled = span.get_span_context().trace_flags.sampled
+            self.assert_trace_context_injected(
+                span_id, trace_id, trace_sampled
+            )
+
+    def test_trace_context_injection_with_log_correlation_instrument_arg(self):
+        LoggingInstrumentor().uninstrument()
+        LoggingInstrumentor().instrument(set_logging_format=True)
         with self.tracer.start_as_current_span("s1") as span:
             span_id = format(span.get_span_context().span_id, "016x")
             trace_id = format(span.get_span_context().trace_id, "032x")
@@ -104,6 +120,8 @@ class TestLoggingInstrumentor(TestBase):
             )
 
     def test_trace_context_injection_without_span(self):
+        LoggingInstrumentor().uninstrument()
+        LoggingInstrumentor().instrument(set_logging_format=True)
         self.assert_trace_context_injected("0", "0", False)
 
     @mock.patch("logging.basicConfig")
@@ -113,15 +131,13 @@ class TestLoggingInstrumentor(TestBase):
         self.assertFalse(basic_config_mock.called)
         LoggingInstrumentor().uninstrument()
 
-        env_patch = mock.patch.dict(
+        with mock.patch.dict(
             "os.environ", {"OTEL_PYTHON_LOG_CORRELATION": "true"}
-        )
-        env_patch.start()
-        LoggingInstrumentor().instrument()
-        basic_config_mock.assert_called_with(
-            format=DEFAULT_LOGGING_FORMAT, level=logging.INFO
-        )
-        env_patch.stop()
+        ):
+            LoggingInstrumentor().instrument()
+            basic_config_mock.assert_called_with(
+                format=DEFAULT_LOGGING_FORMAT, level=logging.INFO
+            )
 
     @mock.patch("logging.basicConfig")
     def test_custom_format_and_level_env(self, basic_config_mock):
@@ -130,20 +146,18 @@ class TestLoggingInstrumentor(TestBase):
         self.assertFalse(basic_config_mock.called)
         LoggingInstrumentor().uninstrument()
 
-        env_patch = mock.patch.dict(
+        with mock.patch.dict(
             "os.environ",
             {
                 "OTEL_PYTHON_LOG_CORRELATION": "true",
                 "OTEL_PYTHON_LOG_FORMAT": "%(message)s %(otelSpanID)s",
                 "OTEL_PYTHON_LOG_LEVEL": "error",
             },
-        )
-        env_patch.start()
-        LoggingInstrumentor().instrument()
-        basic_config_mock.assert_called_with(
-            format="%(message)s %(otelSpanID)s", level=logging.ERROR
-        )
-        env_patch.stop()
+        ):
+            LoggingInstrumentor().instrument()
+            basic_config_mock.assert_called_with(
+                format="%(message)s %(otelSpanID)s", level=logging.ERROR
+            )
 
     @mock.patch("logging.basicConfig")
     def test_custom_format_and_level_api(self, basic_config_mock):  # pylint: disable=no-self-use
@@ -158,6 +172,25 @@ class TestLoggingInstrumentor(TestBase):
         )
 
     def test_log_hook(self):
+        LoggingInstrumentor().uninstrument()
+        LoggingInstrumentor().instrument(
+            log_hook=log_hook,
+        )
+        with self.tracer.start_as_current_span("s1"):
+            with self.caplog.at_level(level=logging.INFO):
+                logger = logging.getLogger("test logger")
+                logger.info("hello")
+                self.assertEqual(len(self.caplog.records), 1)
+                record = self.caplog.records[0]
+                self.assertFalse(hasattr(record, "otelSpanID"))
+                self.assertFalse(hasattr(record, "otelTraceID"))
+                self.assertFalse(hasattr(record, "otelServiceName"))
+                self.assertFalse(hasattr(record, "otelTraceSampled"))
+                self.assertEqual(
+                    record.custom_user_attribute_from_log_hook, "some-value"
+                )
+
+    def test_log_hook_with_set_logging_format(self):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument(
             set_logging_format=True,
@@ -181,21 +214,8 @@ class TestLoggingInstrumentor(TestBase):
                 )
 
     def test_uninstrumented(self):
-        with self.tracer.start_as_current_span("s1") as span:
-            span_id = format(span.get_span_context().span_id, "016x")
-            trace_id = format(span.get_span_context().trace_id, "032x")
-            trace_sampled = span.get_span_context().trace_flags.sampled
-            self.assert_trace_context_injected(
-                span_id, trace_id, trace_sampled
-            )
-
         LoggingInstrumentor().uninstrument()
-
-        self.caplog.clear()
-        with self.tracer.start_as_current_span("s1") as span:
-            span_id = format(span.get_span_context().span_id, "016x")
-            trace_id = format(span.get_span_context().trace_id, "032x")
-            trace_sampled = span.get_span_context().trace_flags.sampled
+        with self.tracer.start_as_current_span("s1"):
             with self.caplog.at_level(level=logging.INFO):
                 logger = logging.getLogger("test logger")
                 logger.info("hello")
@@ -208,7 +228,9 @@ class TestLoggingInstrumentor(TestBase):
 
     def test_no_op_tracer_provider(self):
         LoggingInstrumentor().uninstrument()
-        LoggingInstrumentor().instrument(tracer_provider=NoOpTracerProvider())
+        LoggingInstrumentor().instrument(
+            tracer_provider=NoOpTracerProvider(), set_logging_format=True
+        )
 
         with self.caplog.at_level(level=logging.INFO):
             logger = logging.getLogger("test logger")

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -101,9 +101,10 @@ class TestLoggingInstrumentor(TestBase):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument()
         with self.tracer.start_as_current_span("s1") as span:
-            span_id = format(span.get_span_context().span_id, "016x")
-            trace_id = format(span.get_span_context().trace_id, "032x")
-            trace_sampled = span.get_span_context().trace_flags.sampled
+            span_ctx = span.get_span_context()
+            span_id = format(span_ctx.span_id, "016x")
+            trace_id = format(span_ctx.trace_id, "032x")
+            trace_sampled = span_ctx.trace_flags.sampled
             self.assert_trace_context_injected(
                 span_id, trace_id, trace_sampled
             )
@@ -112,9 +113,10 @@ class TestLoggingInstrumentor(TestBase):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument(set_logging_format=True)
         with self.tracer.start_as_current_span("s1") as span:
-            span_id = format(span.get_span_context().span_id, "016x")
-            trace_id = format(span.get_span_context().trace_id, "032x")
-            trace_sampled = span.get_span_context().trace_flags.sampled
+            span_ctx = span.get_span_context()
+            span_id = format(span_ctx.span_id, "016x")
+            trace_id = format(span_ctx.trace_id, "032x")
+            trace_sampled = span_ctx.trace_flags.sampled
             self.assert_trace_context_injected(
                 span_id, trace_id, trace_sampled
             )
@@ -197,9 +199,10 @@ class TestLoggingInstrumentor(TestBase):
             log_hook=log_hook,
         )
         with self.tracer.start_as_current_span("s1") as span:
-            span_id = format(span.get_span_context().span_id, "016x")
-            trace_id = format(span.get_span_context().trace_id, "032x")
-            trace_sampled = span.get_span_context().trace_flags.sampled
+            span_ctx = span.get_span_context()
+            span_id = format(span_ctx.span_id, "016x")
+            trace_id = format(span_ctx.trace_id, "032x")
+            trace_sampled = span_ctx.trace_flags.sampled
             with self.caplog.at_level(level=logging.INFO):
                 logger = logging.getLogger("test logger")
                 logger.info("hello")

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -121,6 +121,18 @@ class TestLoggingInstrumentor(TestBase):
                 span_id, trace_id, trace_sampled
             )
 
+    def test_no_trace_context_injection_by_default(self):
+        with self.tracer.start_as_current_span("s1"):
+            with self.caplog.at_level(level=logging.INFO):
+                logger = logging.getLogger("test logger")
+                logger.info("hello")
+                self.assertEqual(len(self.caplog.records), 1)
+                record = self.caplog.records[0]
+                self.assertFalse(hasattr(record, "otelServiceName"))
+                self.assertFalse(hasattr(record, "otelSpanID"))
+                self.assertFalse(hasattr(record, "otelTraceID"))
+                self.assertFalse(hasattr(record, "otelTraceSampled"))
+
     def test_trace_context_injection_without_span(self):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument(set_logging_format=True)
@@ -184,9 +196,9 @@ class TestLoggingInstrumentor(TestBase):
                 logger.info("hello")
                 self.assertEqual(len(self.caplog.records), 1)
                 record = self.caplog.records[0]
+                self.assertFalse(hasattr(record, "otelServiceName"))
                 self.assertFalse(hasattr(record, "otelSpanID"))
                 self.assertFalse(hasattr(record, "otelTraceID"))
-                self.assertFalse(hasattr(record, "otelServiceName"))
                 self.assertFalse(hasattr(record, "otelTraceSampled"))
                 self.assertEqual(
                     record.custom_user_attribute_from_log_hook, "some-value"
@@ -224,9 +236,9 @@ class TestLoggingInstrumentor(TestBase):
                 logger.info("hello")
                 self.assertEqual(len(self.caplog.records), 1)
                 record = self.caplog.records[0]
+                self.assertFalse(hasattr(record, "otelServiceName"))
                 self.assertFalse(hasattr(record, "otelSpanID"))
                 self.assertFalse(hasattr(record, "otelTraceID"))
-                self.assertFalse(hasattr(record, "otelServiceName"))
                 self.assertFalse(hasattr(record, "otelTraceSampled"))
 
     def test_no_op_tracer_provider(self):


### PR DESCRIPTION
# Description

Add span context attributes to logging module LogRecord only if the instrumentation has been configured to do so via set_logging_format argument or OTEL_PYTHON_LOG_CORRELATION environment variable.

Fixes #3687

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
