### PR TITLE
starlette: use test_base to fetch metrics for assertions or filter lo…

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/tests/test_starlette_instrumentation.py
@@ -182,7 +182,9 @@ class TestStarletteManualInstrumentation(TestBase):
         self._client.get("/foobar")
         number_data_point_seen = False
         histogram_data_point_seen = False
-        metrics = self.get_sorted_metrics(scope="opentelemetry.instrumentation.starlette")
+        metrics = self.get_sorted_metrics(
+            scope="opentelemetry.instrumentation.starlette"
+        )
         self.assertTrue(len(metrics) == 3)
         for metric in metrics:
             self.assertIn(metric.name, _expected_metric_names)
@@ -195,9 +197,7 @@ class TestStarletteManualInstrumentation(TestBase):
                 if isinstance(point, NumberDataPoint):
                     number_data_point_seen = True
                 for attr in point.attributes:
-                    self.assertIn(
-                        attr, _recommended_attrs[metric.name]
-                    )
+                    self.assertIn(attr, _recommended_attrs[metric.name])
         self.assertTrue(number_data_point_seen and histogram_data_point_seen)
 
     def test_basic_post_request_metric_success(self):
@@ -225,7 +225,9 @@ class TestStarletteManualInstrumentation(TestBase):
         duration = max(round((default_timer() - start) * 1000), 0)
         response_size = int(response.headers.get("content-length"))
         request_size = int(response.request.headers.get("content-length"))
-        metrics = self.get_sorted_metrics(scope="opentelemetry.instrumentation.starlette")
+        metrics = self.get_sorted_metrics(
+            scope="opentelemetry.instrumentation.starlette"
+        )
         for metric in metrics:
             for point in list(metric.data.data_points):
                 if isinstance(point, HistogramDataPoint):
@@ -252,7 +254,9 @@ class TestStarletteManualInstrumentation(TestBase):
         self._instrumentor.uninstrument_app(self._app)
         self._client.get("/foobar")
         self._client.get("/foobar")
-        metrics = self.get_sorted_metrics(scope="opentelemetry.instrumentation.starlette")
+        metrics = self.get_sorted_metrics(
+            scope="opentelemetry.instrumentation.starlette"
+        )
         for metric in metrics:
             for point in list(metric.data.data_points):
                 if isinstance(point, HistogramDataPoint):
@@ -271,7 +275,9 @@ class TestStarletteManualInstrumentation(TestBase):
         client.get("/foobar")
         client.get("/foobar")
         client.get("/foobar")
-        metrics = self.get_sorted_metrics(scope="opentelemetry.instrumentation.starlette")
+        metrics = self.get_sorted_metrics(
+            scope="opentelemetry.instrumentation.starlette"
+        )
         for metric in metrics:
             for point in list(metric.data.data_points):
                 if isinstance(point, HistogramDataPoint):


### PR DESCRIPTION
# Description

I am helping implement SDK metrics in https://github.com/open-telemetry/opentelemetry-python/pull/4880. By nature of their definition, they are present by usage of the SDK itself, meaning the metrics are populated in instrumentation tests too. Unfortunately, many instrumentation tests have strict checks on generated metrics so extra metrics cause them to fail.

@xrmx suggested we can try adding filtering in TestBase, and using TestBase more instead of doing management in unit tests simplifies them anyways, so I am helping with these migrations. Some locations do manual filtering locally where still needed until having access to a new helper in TestBase.

As it's testing infrastructure only, this PR should be skip-changelog.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
