### PR TITLE
feat: add ability to configure flush behavior for AWS lambda instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4141](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4141))
 - `opentelemetry-instrumentation-pyramid`: pass request attributes at span creation
   ([#4139](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4139))
+- `opentelemetry-instrumentation-aws-lambda`: add ability to configure flush behavior
+  ([#4158](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4158))
 
 ### Fixed
 

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -40,17 +40,35 @@ Usage
 
     AwsLambdaInstrumentor().instrument()
 
+Configuration
+-------------
+
+Force Flush
+***********
+By default, the instrumentation force flushes both traces and metrics after each Lambda invocation.
+This behavior can be controlled with the following environment variables:
+
+* ``OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH``: Enables or disables force flushing for all signal types. Defaults to ``true``.
+* ``OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES``: Enables or disables force flushing for traces. Defaults to ``true``.
+* ``OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS``: Enables or disables force flushing for metrics. Defaults to ``true``.
+* ``OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT``: The timeout in milliseconds for force flushing. Defaults to ``30000``.
+
+A specific signal type will be force flushed if either the general ``OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH``
+or the specific environment variable for that signal type is set to true.
+
 API
 ---
 
 The `instrument` method accepts the following keyword args:
 
-tracer_provider (TracerProvider) - an optional tracer provider
-meter_provider (MeterProvider) - an optional meter provider
-event_context_extractor (Callable) - a function that returns an OTel Trace
-Context given the Lambda Event the AWS Lambda was invoked with
-this function signature is: def event_context_extractor(lambda_event: Any) -> Context
-for example:
+* ``tracer_provider`` (TracerProvider) - an optional tracer provider
+* ``meter_provider`` (MeterProvider) - an optional meter provider
+* ``event_context_extractor`` (Callable) - a function that returns an OTel Trace Context given the Lambda Event the AWS Lambda was invoked with this function signature is: def event_context_extractor(lambda_event: Any) -> Context
+* ``force_flush`` (bool) - enables or disables force flushing for all signal types. Defaults to True.
+* ``flush_traces`` (bool) - enables or disables force flushing for traces. Defaults to True.
+* ``flush_metrics`` (bool) - enables or disables force flushing for metrics. Defaults to True.
+
+Example usage:
 
 .. code:: python
 
@@ -63,10 +81,10 @@ for example:
         return get_global_textmap().extract(lambda_event["foo"]["headers"])
 
     AwsLambdaInstrumentor().instrument(
-        event_context_extractor=custom_event_context_extractor
+        event_context_extractor=custom_event_context_extractor,
+        force_flush=False,
+        flush_metrics=True,
     )
-
----
 """
 
 import logging
@@ -122,6 +140,22 @@ ORIG_HANDLER = "ORIG_HANDLER"
 OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT = (
     "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT"
 )
+OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH = (
+    "OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH"
+)
+OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES = (
+    "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES"
+)
+OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS = (
+    "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS"
+)
+
+
+def _get_env_bool(env_var: str, default: bool) -> bool:
+    value = os.environ.get(env_var)
+    if value is None:
+        return default
+    return value.lower() in ("yes", "true", "1")
 
 
 def _default_event_context_extractor(lambda_event: Any) -> Context:
@@ -272,6 +306,9 @@ def _instrument(
     event_context_extractor: Callable[[Any], Context],
     tracer_provider: TracerProvider = None,
     meter_provider: MeterProvider = None,
+    force_flush: bool = True,
+    flush_traces: bool = True,
+    flush_metrics: bool = True,
 ):
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
@@ -389,19 +426,25 @@ def _instrument(
 
         now = time.time()
         _tracer_provider = tracer_provider or get_tracer_provider()
-        if hasattr(_tracer_provider, "force_flush"):
+        if (force_flush or flush_traces) and hasattr(
+            _tracer_provider, "force_flush"
+        ):
             try:
                 # NOTE: `force_flush` before function quit in case of Lambda freeze.
                 _tracer_provider.force_flush(flush_timeout)
             except Exception:  # pylint: disable=broad-except
                 logger.exception("TracerProvider failed to flush traces")
-        else:
+        elif (force_flush or flush_traces) and not hasattr(
+            _tracer_provider, "force_flush"
+        ):
             logger.warning(
                 "TracerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
             )
 
         _meter_provider = meter_provider or get_meter_provider()
-        if hasattr(_meter_provider, "force_flush"):
+        if (force_flush or flush_metrics) and hasattr(
+            _meter_provider, "force_flush"
+        ):
             rem = flush_timeout - (time.time() - now) * 1000
             if rem > 0:
                 try:
@@ -409,7 +452,9 @@ def _instrument(
                     _meter_provider.force_flush(rem)
                 except Exception:  # pylint: disable=broad-except
                     logger.exception("MeterProvider failed to flush metrics")
-        else:
+        elif (force_flush or flush_metrics) and not hasattr(
+            _meter_provider, "force_flush"
+        ):
             logger.warning(
                 "MeterProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
             )
@@ -444,6 +489,12 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
                     Event as input and extracts an OTel Context from it. By default,
                     the context is extracted from the HTTP headers of an API Gateway
                     request.
+                ``force_flush``: if True, force flush all signal types after each
+                    invocation. Defaults to True.
+                ``flush_traces``: if True, force flush traces after each
+                    invocation. Defaults to False.
+                ``flush_metrics``: if True, force flush metrics after each
+                    invocation. Defaults to False.
         """
 
         # Don't try if we are not running on AWS Lambda
@@ -489,6 +540,24 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
             ),
             tracer_provider=kwargs.get("tracer_provider"),
             meter_provider=kwargs.get("meter_provider"),
+            force_flush=kwargs.get(
+                "force_flush",
+                _get_env_bool(
+                    OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH, True
+                ),
+            ),
+            flush_traces=kwargs.get(
+                "flush_traces",
+                _get_env_bool(
+                    OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES, True
+                ),
+            ),
+            flush_metrics=kwargs.get(
+                "flush_metrics",
+                _get_env_bool(
+                    OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS, True
+                ),
+            ),
         )
 
     def _uninstrument(self, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -587,8 +587,6 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
         "os.environ",
         {
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH: "false",
-            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS: "false",
-            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES: "false",
         },
     )
     def test_force_flush_disabled_globally(
@@ -612,7 +610,6 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
         {
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH: "false",
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES: "true",
-            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS: "false",
         },
     )
     def test_force_flush_selective_traces(
@@ -635,7 +632,6 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
         "os.environ",
         {
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH: "false",
-            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES: "false",
             OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS: "true",
         },
     )
@@ -656,6 +652,50 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
     @mock.patch("opentelemetry.instrumentation.aws_lambda.get_meter_provider")
     @mock.patch("opentelemetry.instrumentation.aws_lambda.get_tracer_provider")
     @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TRACES: "false",
+        },
+    )
+    def test_force_flush_disabled_selective_traces(
+        self, mock_get_tracer_provider, mock_get_meter_provider
+    ):
+        mock_tracer_provider = mock.Mock()
+        mock_meter_provider = mock.Mock()
+        mock_get_tracer_provider.return_value = mock_tracer_provider
+        mock_get_meter_provider.return_value = mock_meter_provider
+
+        AwsLambdaInstrumentor().instrument()
+        mock_execute_lambda()
+
+        mock_tracer_provider.force_flush.assert_not_called()
+        mock_meter_provider.force_flush.assert_called_once()
+
+    @mock.patch("opentelemetry.instrumentation.aws_lambda.get_meter_provider")
+    @mock.patch("opentelemetry.instrumentation.aws_lambda.get_tracer_provider")
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_METRICS: "false",
+        },
+    )
+    def test_force_flush_disabled_selective_metrics(
+        self, mock_get_tracer_provider, mock_get_meter_provider
+    ):
+        mock_tracer_provider = mock.Mock()
+        mock_meter_provider = mock.Mock()
+        mock_get_tracer_provider.return_value = mock_tracer_provider
+        mock_get_meter_provider.return_value = mock_meter_provider
+
+        AwsLambdaInstrumentor().instrument()
+        mock_execute_lambda()
+
+        mock_tracer_provider.force_flush.assert_called_once()
+        mock_meter_provider.force_flush.assert_not_called()
+
+    @mock.patch("opentelemetry.instrumentation.aws_lambda.get_meter_provider")
+    @mock.patch("opentelemetry.instrumentation.aws_lambda.get_tracer_provider")
+    @mock.patch.dict(
         "os.environ", {OTEL_INSTRUMENTATION_AWS_LAMBDA_FORCE_FLUSH: "true"}
     )
     def test_force_flush_instrumentation_options_override(
@@ -670,7 +710,6 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
         AwsLambdaInstrumentor().instrument(
             force_flush=False,
             flush_metrics=True,
-            flush_traces=False,
         )
         mock_execute_lambda()
 


### PR DESCRIPTION


# Description

Adds ability to configure flush behavior in AWS Lambda instrumentation. 

Fixes #4157 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
tox run -e $(tox --listenvs | grep aws-lambda | tr '\n' ',')
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
