### PR TITLE
Fix changelog update from #4142

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Fix bug in how tokens are counted when using the streaming `generateContent` method.  ([#4152](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4152)).
-
-## Version 0.7b0 (2026-02-03)
-
 - Add `gen_ai.tool.definitions` attribute to `gen_ai.client.inference.operation.details` log event ([#4142](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4142)).
 
 ## Version 0.6b0 (2026-01-27)


### PR DESCRIPTION
Changelog was incorrectly updated in https://github.com/open-telemetry/opentelemetry-python-contrib/commit/b162ac1572e815911791e8a47c864afc5c434bf0. This PR fixes it by moving the update to the unreleased section. 