### PR TITLE
feat(lambda): read cloud.account.id from symlink in Lambda detector

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/.changelog/4183.added
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/.changelog/4183.added
@@ -1,0 +1,1 @@
+Read `cloud.account.id` from symlink created by the OTel Lambda Extension in the Lambda resource detector

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
@@ -14,7 +14,7 @@ from opentelemetry.semconv.resource import (
 
 logger = logging.getLogger(__name__)
 
-_ACCOUNT_ID_SYMLINK_PATH = "/tmp/.otel-account-id"
+_ACCOUNT_ID_SYMLINK_PATH = "/tmp/.otel-aws-account-id"
 
 
 class AwsLambdaResourceDetector(ResourceDetector):

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 from os import environ
 
 from opentelemetry.sdk.resources import Resource, ResourceDetector
@@ -13,6 +14,8 @@ from opentelemetry.semconv.resource import (
 
 logger = logging.getLogger(__name__)
 
+_ACCOUNT_ID_SYMLINK_PATH = "/tmp/.otel-account-id"
+
 
 class AwsLambdaResourceDetector(ResourceDetector):
     """Detects attribute values only available when the app is running on AWS
@@ -23,25 +26,31 @@ class AwsLambdaResourceDetector(ResourceDetector):
 
     def detect(self) -> "Resource":
         try:
-            return Resource(
-                {
-                    ResourceAttributes.CLOUD_PROVIDER: CloudProviderValues.AWS.value,
-                    ResourceAttributes.CLOUD_PLATFORM: CloudPlatformValues.AWS_LAMBDA.value,
-                    ResourceAttributes.CLOUD_REGION: environ["AWS_REGION"],
-                    ResourceAttributes.FAAS_NAME: environ[
-                        "AWS_LAMBDA_FUNCTION_NAME"
-                    ],
-                    ResourceAttributes.FAAS_VERSION: environ[
-                        "AWS_LAMBDA_FUNCTION_VERSION"
-                    ],
-                    ResourceAttributes.FAAS_INSTANCE: environ[
-                        "AWS_LAMBDA_LOG_STREAM_NAME"
-                    ],
-                    ResourceAttributes.FAAS_MAX_MEMORY: int(
-                        environ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"]
-                    ),
-                }
-            )
+            attributes = {
+                ResourceAttributes.CLOUD_PROVIDER: CloudProviderValues.AWS.value,
+                ResourceAttributes.CLOUD_PLATFORM: CloudPlatformValues.AWS_LAMBDA.value,
+                ResourceAttributes.CLOUD_REGION: environ["AWS_REGION"],
+                ResourceAttributes.FAAS_NAME: environ[
+                    "AWS_LAMBDA_FUNCTION_NAME"
+                ],
+                ResourceAttributes.FAAS_VERSION: environ[
+                    "AWS_LAMBDA_FUNCTION_VERSION"
+                ],
+                ResourceAttributes.FAAS_INSTANCE: environ[
+                    "AWS_LAMBDA_LOG_STREAM_NAME"
+                ],
+                ResourceAttributes.FAAS_MAX_MEMORY: int(
+                    environ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"]
+                ),
+            }
+
+            try:
+                account_id = os.readlink(_ACCOUNT_ID_SYMLINK_PATH)
+                attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] = account_id
+            except OSError:
+                pass
+
+            return Resource(attributes)
         # pylint: disable=broad-except
         except Exception as exception:
             if self.raise_on_error:

--- a/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/src/opentelemetry/sdk/extension/aws/resource/_lambda.py
@@ -48,7 +48,7 @@ class AwsLambdaResourceDetector(ResourceDetector):
                 account_id = os.readlink(_ACCOUNT_ID_SYMLINK_PATH)
                 attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] = account_id
             except OSError:
-                pass
+                logger.debug("cloud.account.id not available via symlink")
 
             return Resource(attributes)
         # pylint: disable=broad-except

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
@@ -1,12 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import tempfile
 import unittest
 from collections import OrderedDict
 from unittest.mock import patch
 
 from opentelemetry.sdk.extension.aws.resource._lambda import (  # pylint: disable=no-name-in-module
     AwsLambdaResourceDetector,
+    _ACCOUNT_ID_SYMLINK_PATH,
 )
 from opentelemetry.semconv.resource import (
     CloudPlatformValues,
@@ -50,3 +53,115 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
         self.assertDictEqual(
             actual.attributes.copy(), OrderedDict(MockLambdaResourceAttributes)
         )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "AWS_REGION": MockLambdaResourceAttributes[
+                ResourceAttributes.CLOUD_REGION
+            ],
+            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_NAME
+            ],
+            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_VERSION
+            ],
+            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_INSTANCE
+            ],
+            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
+        },
+        clear=True,
+    )
+    def test_account_id_from_symlink(self):
+        """When the account ID symlink exists, cloud.account.id is set."""
+        symlink_path = None
+        try:
+            tmpdir = tempfile.mkdtemp()
+            symlink_path = os.path.join(tmpdir, ".otel-account-id")
+            os.symlink("123456789012", symlink_path)
+            with patch(
+                "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+                symlink_path,
+            ):
+                actual = AwsLambdaResourceDetector().detect()
+            self.assertEqual(
+                actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID],
+                "123456789012",
+            )
+        finally:
+            if symlink_path and os.path.islink(symlink_path):
+                os.unlink(symlink_path)
+            if tmpdir:
+                os.rmdir(tmpdir)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "AWS_REGION": MockLambdaResourceAttributes[
+                ResourceAttributes.CLOUD_REGION
+            ],
+            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_NAME
+            ],
+            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_VERSION
+            ],
+            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_INSTANCE
+            ],
+            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
+        },
+        clear=True,
+    )
+    def test_account_id_missing_symlink(self):
+        """When the symlink does not exist, cloud.account.id is absent and no exception is raised."""
+        with patch(
+            "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+            "/tmp/.otel-account-id-nonexistent",
+        ):
+            actual = AwsLambdaResourceDetector().detect()
+        self.assertNotIn(
+            ResourceAttributes.CLOUD_ACCOUNT_ID, actual.attributes
+        )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "AWS_REGION": MockLambdaResourceAttributes[
+                ResourceAttributes.CLOUD_REGION
+            ],
+            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_NAME
+            ],
+            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_VERSION
+            ],
+            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
+                ResourceAttributes.FAAS_INSTANCE
+            ],
+            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
+        },
+        clear=True,
+    )
+    def test_account_id_preserves_leading_zeros(self):
+        """Leading zeros in the account ID are preserved (treated as string)."""
+        symlink_path = None
+        try:
+            tmpdir = tempfile.mkdtemp()
+            symlink_path = os.path.join(tmpdir, ".otel-account-id")
+            os.symlink("000123456789", symlink_path)
+            with patch(
+                "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+                symlink_path,
+            ):
+                actual = AwsLambdaResourceDetector().detect()
+            self.assertEqual(
+                actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID],
+                "000123456789",
+            )
+        finally:
+            if symlink_path and os.path.islink(symlink_path):
+                os.unlink(symlink_path)
+            if tmpdir:
+                os.rmdir(tmpdir)

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
@@ -78,7 +78,7 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
         symlink_path = None
         try:
             tmpdir = tempfile.mkdtemp()
-            symlink_path = os.path.join(tmpdir, ".otel-account-id")
+            symlink_path = os.path.join(tmpdir, ".otel-aws-account-id")
             os.symlink("123456789012", symlink_path)
             with patch(
                 "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
@@ -118,7 +118,7 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
         """When the symlink does not exist, cloud.account.id is absent and no exception is raised."""
         with patch(
             "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
-            "/tmp/.otel-account-id-nonexistent",
+            "/tmp/.otel-aws-account-id-nonexistent",
         ):
             actual = AwsLambdaResourceDetector().detect()
         self.assertNotIn(
@@ -149,7 +149,7 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
         symlink_path = None
         try:
             tmpdir = tempfile.mkdtemp()
-            symlink_path = os.path.join(tmpdir, ".otel-account-id")
+            symlink_path = os.path.join(tmpdir, ".otel-aws-account-id")
             os.symlink("000123456789", symlink_path)
             with patch(
                 "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import tempfile
 import unittest
 from collections import OrderedDict
 from unittest.mock import patch
+
+import pytest
 
 from opentelemetry.sdk.extension.aws.resource._lambda import (  # pylint: disable=no-name-in-module
     AwsLambdaResourceDetector,
@@ -27,25 +28,19 @@ MockLambdaResourceAttributes = {
     ResourceAttributes.FAAS_MAX_MEMORY: 128,
 }
 
+MOCK_LAMBDA_ENV = {
+    "AWS_REGION": MockLambdaResourceAttributes[ResourceAttributes.CLOUD_REGION],
+    "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[ResourceAttributes.FAAS_NAME],
+    "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[ResourceAttributes.FAAS_VERSION],
+    "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[ResourceAttributes.FAAS_INSTANCE],
+    "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
+}
+
 
 class AwsLambdaResourceDetectorTest(unittest.TestCase):
     @patch.dict(
         "os.environ",
-        {
-            "AWS_REGION": MockLambdaResourceAttributes[
-                ResourceAttributes.CLOUD_REGION
-            ],
-            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_NAME
-            ],
-            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_VERSION
-            ],
-            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_INSTANCE
-            ],
-            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
-        },
+        MOCK_LAMBDA_ENV,
         clear=True,
     )
     def test_simple_create(self):
@@ -54,114 +49,47 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
             actual.attributes.copy(), OrderedDict(MockLambdaResourceAttributes)
         )
 
-    @patch.dict(
-        "os.environ",
-        {
-            "AWS_REGION": MockLambdaResourceAttributes[
-                ResourceAttributes.CLOUD_REGION
-            ],
-            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_NAME
-            ],
-            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_VERSION
-            ],
-            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_INSTANCE
-            ],
-            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
-        },
-        clear=True,
-    )
-    def test_account_id_from_symlink(self):
-        """When the account ID symlink exists, cloud.account.id is set."""
-        symlink_path = None
-        try:
-            tmpdir = tempfile.mkdtemp()
-            symlink_path = os.path.join(tmpdir, ".otel-aws-account-id")
-            os.symlink("123456789012", symlink_path)
-            with patch(
-                "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
-                symlink_path,
-            ):
-                actual = AwsLambdaResourceDetector().detect()
-            self.assertEqual(
-                actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID],
-                "123456789012",
-            )
-        finally:
-            if symlink_path and os.path.islink(symlink_path):
-                os.unlink(symlink_path)
-            if tmpdir:
-                os.rmdir(tmpdir)
 
-    @patch.dict(
-        "os.environ",
-        {
-            "AWS_REGION": MockLambdaResourceAttributes[
-                ResourceAttributes.CLOUD_REGION
-            ],
-            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_NAME
-            ],
-            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_VERSION
-            ],
-            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_INSTANCE
-            ],
-            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
-        },
-        clear=True,
-    )
-    def test_account_id_missing_symlink(self):
-        """When the symlink does not exist, cloud.account.id is absent and no exception is raised."""
-        with patch(
-            "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
-            "/tmp/.otel-aws-account-id-nonexistent",
-        ):
-            actual = AwsLambdaResourceDetector().detect()
-        self.assertNotIn(
-            ResourceAttributes.CLOUD_ACCOUNT_ID, actual.attributes
-        )
+@pytest.fixture
+def account_id_symlink(tmp_path):
+    """Create a symlink at a temporary path and patch the detector to use it."""
+    def _create(account_id):
+        symlink_path = tmp_path / ".otel-aws-account-id"
+        os.symlink(account_id, symlink_path)
+        return str(symlink_path)
+    return _create
 
-    @patch.dict(
-        "os.environ",
-        {
-            "AWS_REGION": MockLambdaResourceAttributes[
-                ResourceAttributes.CLOUD_REGION
-            ],
-            "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_NAME
-            ],
-            "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_VERSION
-            ],
-            "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
-                ResourceAttributes.FAAS_INSTANCE
-            ],
-            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
-        },
-        clear=True,
-    )
-    def test_account_id_preserves_leading_zeros(self):
-        """Leading zeros in the account ID are preserved (treated as string)."""
-        symlink_path = None
-        try:
-            tmpdir = tempfile.mkdtemp()
-            symlink_path = os.path.join(tmpdir, ".otel-aws-account-id")
-            os.symlink("000123456789", symlink_path)
-            with patch(
-                "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
-                symlink_path,
-            ):
-                actual = AwsLambdaResourceDetector().detect()
-            self.assertEqual(
-                actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID],
-                "000123456789",
-            )
-        finally:
-            if symlink_path and os.path.islink(symlink_path):
-                os.unlink(symlink_path)
-            if tmpdir:
-                os.rmdir(tmpdir)
+
+@patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
+def test_account_id_from_symlink(account_id_symlink):
+    """When the account ID symlink exists, cloud.account.id is set."""
+    symlink_path = account_id_symlink("123456789012")
+    with patch(
+        "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+        symlink_path,
+    ):
+        actual = AwsLambdaResourceDetector().detect()
+    assert actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] == "123456789012"
+
+
+@patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
+def test_account_id_missing_symlink():
+    """When the symlink does not exist, cloud.account.id is absent and no exception is raised."""
+    with patch(
+        "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+        "/tmp/.otel-aws-account-id-nonexistent",
+    ):
+        actual = AwsLambdaResourceDetector().detect()
+    assert ResourceAttributes.CLOUD_ACCOUNT_ID not in actual.attributes
+
+
+@patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
+def test_account_id_preserves_leading_zeros(account_id_symlink):
+    """Leading zeros in the account ID are preserved (treated as string)."""
+    symlink_path = account_id_symlink("000123456789")
+    with patch(
+        "opentelemetry.sdk.extension.aws.resource._lambda._ACCOUNT_ID_SYMLINK_PATH",
+        symlink_path,
+    ):
+        actual = AwsLambdaResourceDetector().detect()
+    assert actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] == "000123456789"

--- a/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/tests/resource/test__lambda.py
@@ -10,7 +10,6 @@ import pytest
 
 from opentelemetry.sdk.extension.aws.resource._lambda import (  # pylint: disable=no-name-in-module
     AwsLambdaResourceDetector,
-    _ACCOUNT_ID_SYMLINK_PATH,
 )
 from opentelemetry.semconv.resource import (
     CloudPlatformValues,
@@ -29,10 +28,18 @@ MockLambdaResourceAttributes = {
 }
 
 MOCK_LAMBDA_ENV = {
-    "AWS_REGION": MockLambdaResourceAttributes[ResourceAttributes.CLOUD_REGION],
-    "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[ResourceAttributes.FAAS_NAME],
-    "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[ResourceAttributes.FAAS_VERSION],
-    "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[ResourceAttributes.FAAS_INSTANCE],
+    "AWS_REGION": MockLambdaResourceAttributes[
+        ResourceAttributes.CLOUD_REGION
+    ],
+    "AWS_LAMBDA_FUNCTION_NAME": MockLambdaResourceAttributes[
+        ResourceAttributes.FAAS_NAME
+    ],
+    "AWS_LAMBDA_FUNCTION_VERSION": MockLambdaResourceAttributes[
+        ResourceAttributes.FAAS_VERSION
+    ],
+    "AWS_LAMBDA_LOG_STREAM_NAME": MockLambdaResourceAttributes[
+        ResourceAttributes.FAAS_INSTANCE
+    ],
     "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": f"{MockLambdaResourceAttributes[ResourceAttributes.FAAS_MAX_MEMORY]}",
 }
 
@@ -53,15 +60,17 @@ class AwsLambdaResourceDetectorTest(unittest.TestCase):
 @pytest.fixture
 def account_id_symlink(tmp_path):
     """Create a symlink at a temporary path and patch the detector to use it."""
+
     def _create(account_id):
         symlink_path = tmp_path / ".otel-aws-account-id"
         os.symlink(account_id, symlink_path)
         return str(symlink_path)
+
     return _create
 
 
 @patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
-def test_account_id_from_symlink(account_id_symlink):
+def test_account_id_from_symlink(account_id_symlink):  # pylint: disable=redefined-outer-name
     """When the account ID symlink exists, cloud.account.id is set."""
     symlink_path = account_id_symlink("123456789012")
     with patch(
@@ -69,7 +78,10 @@ def test_account_id_from_symlink(account_id_symlink):
         symlink_path,
     ):
         actual = AwsLambdaResourceDetector().detect()
-    assert actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] == "123456789012"
+    assert (
+        actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID]
+        == "123456789012"
+    )
 
 
 @patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
@@ -84,7 +96,7 @@ def test_account_id_missing_symlink():
 
 
 @patch.dict("os.environ", MOCK_LAMBDA_ENV, clear=True)
-def test_account_id_preserves_leading_zeros(account_id_symlink):
+def test_account_id_preserves_leading_zeros(account_id_symlink):  # pylint: disable=redefined-outer-name
     """Leading zeros in the account ID are preserved (treated as string)."""
     symlink_path = account_id_symlink("000123456789")
     with patch(
@@ -92,4 +104,7 @@ def test_account_id_preserves_leading_zeros(account_id_symlink):
         symlink_path,
     ):
         actual = AwsLambdaResourceDetector().detect()
-    assert actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID] == "000123456789"
+    assert (
+        actual.attributes[ResourceAttributes.CLOUD_ACCOUNT_ID]
+        == "000123456789"
+    )


### PR DESCRIPTION
## Summary

- Reads `cloud.account.id` from the symlink at `/tmp/.otel-aws-account-id` created by the OTel Lambda Extension
- Uses `os.readlink()` to read the symlink target (the AWS account ID)
- Logs at debug level if the symlink doesn't exist (`except OSError` guard)

## Depends on

- open-telemetry/opentelemetry-lambda#2127 (extension creates the symlink)

## Changes

- `_lambda.py` — Added readlink logic with `_ACCOUNT_ID_SYMLINK_PATH` constant
- Tests: happy path, leading zeros preserved, missing symlink handled gracefully

## Test plan

- [x] Unit test: symlink exists → `cloud.account.id` set correctly
- [x] Unit test: leading zeros preserved as string
- [x] Unit test: missing symlink → attribute absent, no error