### PR TITLE
Try out basedpyright with baseline file

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 pylint==3.0.2
 httpretty==1.1.4
 pyright==v1.1.404
+basedpyright==1.38.0
 sphinx==7.1.2
 sphinx-rtd-theme==2.0.0rc4
 sphinx-autodoc-typehints==1.25.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,33 +198,17 @@ pythonVersion = "3.9"
 reportPrivateUsage = false  # Ignore private attributes added by instrumentation packages.
 # Add progressively instrumentation packages here.
 include = [
-  "instrumentation/opentelemetry-instrumentation-aiokafka",
-  "instrumentation/opentelemetry-instrumentation-asyncclick",
-  "instrumentation/opentelemetry-instrumentation-threading",
-  "instrumentation-genai/opentelemetry-instrumentation-anthropic",
-  "instrumentation-genai/opentelemetry-instrumentation-vertexai",
-  "instrumentation-genai/opentelemetry-instrumentation-langchain",
-  "instrumentation-genai/opentelemetry-instrumentation-weaviate",
-  "util/opentelemetry-util-genai",
-  "exporter/opentelemetry-exporter-credential-provider-gcp",
-  "instrumentation/opentelemetry-instrumentation-aiohttp-client",
-]
-# We should also add type hints to the test suite - It helps on finding bugs.
-# We are excluding for now because it's easier, and more important to add to the instrumentation packages.
-exclude = [
-  "instrumentation/opentelemetry-instrumentation-aiokafka/tests/**/*.py",
-  "instrumentation/opentelemetry-instrumentation-asyncclick/tests/**/*.py",
-  "instrumentation/opentelemetry-instrumentation-threading/tests/**",
-  "instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-anthropic/examples/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-vertexai/examples/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-langchain/tests/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-langchain/examples/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-weaviate/tests/**/*.py",
-  "instrumentation-genai/opentelemetry-instrumentation-weaviate/examples/**/*.py",
-  "util/opentelemetry-util-genai/tests/**/*.py",
-  "instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/**/*.py",
+  "instrumentation/",
+  "instrumentation-genai/",
+  "util/",
+  "exporter/",
+  "opentelemetry-contrib-instrumentations/",
+  "opentelemetry-distro/",
+  "opentelemetry-instrumentation/",
+  "processor/",
+  "propagator/",
+  "resource/",
+  "sdk-extension/",
 ]
 
 [dependency-groups]

--- a/tox.ini
+++ b/tox.ini
@@ -1100,7 +1100,7 @@ commands =
 [testenv:typecheck]
 deps =
   -c {toxinidir}/dev-requirements.txt
-  pyright
+  basedpyright
   {[testenv]test_deps}
   {toxinidir}/opentelemetry-instrumentation
   {toxinidir}/util/opentelemetry-util-http
@@ -1115,4 +1115,4 @@ deps =
   {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client[instruments]
 
 commands =
-  pyright
+  basedpyright


### PR DESCRIPTION
Enables typechecking on python packages, examples, tests in the repo using basedpyright's baseline feature https://docs.basedpyright.com/latest/benefits-over-pyright/baseline/

Downsides to this approach:
- VSCode's default python settings doesn't recognize this file and will complain about tons of errors. You can recommend basedpyright LSP instead https://docs.basedpyright.com/latest/installation/ides/#vscode-vscodium
- The `.basedpyright/baseline.json` is pretty enormous
- Typechecking becomes much slower (more files). Takes 28 seconds on my machine.

Benefit:
- All new code even in existing files will be forced to type check
- Don't litter codebase with `# type: ignore`