### PR TITLE
fix(asyncpg): record exception in spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -196,6 +196,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
             finally:
                 if span.is_recording() and exception is not None:
                     span.set_status(Status(StatusCode.ERROR))
+                    span.record_exception(exception)
 
         return result
 
@@ -239,6 +240,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
             finally:
                 if span.is_recording() and exception is not None:
                     span.set_status(Status(StatusCode.ERROR))
+                    span.record_exception(exception)
 
         if not stop:
             return result


### PR DESCRIPTION
# Description

Added span.record_exception(exception) in _do_execute and _do_cursor_execute methods to ensure that exceptions are properly recorded in spans. This provides better visibility into database errors by capturing the exception type, message, and stack trace, following OpenTelemetry semantic conventions

Fixes #4202

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified the code changes by inspecting the instrumentation logic. Manual local test execution was limited due to environment-specific dependency conflicts on Windows; however, the implementation follows the standard pattern used in other OpenTelemetry Python instrumentations and relies on the project's CI for cross-platform validation

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
