### PR TITLE
Prepare anthropic and google-genai for util-genai release

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "opentelemetry-util-genai >= 0.2b0, <0.3b0",
+  "opentelemetry-util-genai >= 0.2b0, <0.4b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~=1.37",
   "opentelemetry-instrumentation >=0.58b0, <2",
   "opentelemetry-semantic-conventions >=0.58b0, <2",
-  "opentelemetry-util-genai >= 0.2b0, <0.3b0", # TODO: update version after release (https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4221)
+  "opentelemetry-util-genai >= 0.2b0, <0.4b0", # TODO: update version after release (https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4221)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

This fixes the build on the release branch https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/22198949165/job/64206533123?pr=4223 which is failing becaues when `opentelemetry-util-genai` version gets bumped to `v0.3b0`, the dependency specifiers are too strict.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I cherry picked the release PR on top of this to verify the build works

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

