### PR TITLE
Update package-prepare-release workflow to work when release was previously aborted

### DIFF
--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -33,6 +33,8 @@ jobs:
       next_version: ${{ steps.verify.outputs.next_version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - id: verify
         name: Verify prerequisites


### PR DESCRIPTION
# Description

If the release branch already exists but has no commits (no successful release yet), re-running package-prepare-release should be able to fast-forward it.

It's failing now presumably because the local repo doesn't know this is a fast forward:
```
Run git push origin HEAD:$RELEASE_BRANCH_NAME
To https://github.com/open-telemetry/opentelemetry-python-contrib
 ! [rejected]        HEAD -> package-release/opentelemetry-util-genai/v0.3bx (fetch first)
error: failed to push some refs to 'https://github.com/open-telemetry/opentelemetry-python-contrib'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

Fetching more history should fix that. Note this workflow never force pushes and we have branch protection rules on release branches.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Can't really test it until merging this.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.