### PR TITLE
[system_metrics] Update system.disk.time to system.disk.operation.time 

### DIFF
--- a/.changelog/4248.changed
+++ b/.changelog/4248.changed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-system-metrics`: update deprecated `system.disk.time` metric to `system.disk.operation.time`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4139](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4139))
 
 ### Fixed
+- `opentelemetry-instrumentation-system-metrics`: Rename deprecated `system.disk.time` metric to `system.disk.operation.time` per updated semantic conventions.
+  ([#4248](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4248))
 - `opentelemetry-instrumentation-mysql`: Refactor MySQL integration test mocks to use concrete DBAPI connection attributes, reducing noisy attribute type warnings.
   ([#4116](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4116))
 - `opentelemetry-instrumentation-cassandra`: Use `_instruments_any` instead of `_instruments` for driver dependencies so that having either `cassandra-driver` or `scylla-driver` installed is sufficient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4139](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4139))
 
 ### Fixed
-- `opentelemetry-instrumentation-system-metrics`: Rename deprecated `system.disk.time` metric to `system.disk.operation.time` per updated semantic conventions.
-  ([#4248](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4248))
 - `opentelemetry-instrumentation-mysql`: Refactor MySQL integration test mocks to use concrete DBAPI connection attributes, reducing noisy attribute type warnings.
   ([#4116](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4116))
 - `opentelemetry-instrumentation-cassandra`: Use `_instruments_any` instead of `_instruments` for driver dependencies so that having either `cassandra-driver` or `scylla-driver` installed is sufficient

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py
@@ -29,7 +29,7 @@ following metrics are configured:
         "system.swap.utilization": ["used", "free"],
         "system.disk.io": ["read", "write"],
         "system.disk.operations": ["read", "write"],
-        "system.disk.time": ["read", "write"],
+        "system.disk.operation.time": ["read", "write"],
         "system.network.dropped.packets": ["transmit", "receive"],
         "system.network.packets": ["transmit", "receive"],
         "system.network.errors": ["transmit", "receive"],
@@ -131,7 +131,7 @@ _DEFAULT_CONFIG: dict[str, list[str] | None] = {
     "system.swap.utilization": ["used", "free"],
     "system.disk.io": ["read", "write"],
     "system.disk.operations": ["read", "write"],
-    "system.disk.time": ["read", "write"],
+    "system.disk.operation.time": ["read", "write"],
     "system.network.dropped.packets": ["transmit", "receive"],
     "system.network.packets": ["transmit", "receive"],
     "system.network.errors": ["transmit", "receive"],
@@ -332,10 +332,9 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
                 unit="operations",
             )
 
-        # FIXME: this has been replaced by system.disk.operation.time
-        if "system.disk.time" in self._config:
+        if "system.disk.operation.time" in self._config:
             self._meter.create_observable_counter(
-                name="system.disk.time",
+                name="system.disk.operation.time",
                 callbacks=[self._get_system_disk_time],
                 description="System disk time",
                 unit="s",
@@ -710,7 +709,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
     ) -> Iterable[Observation]:
         """Observer callback for disk time"""
         for device, counters in psutil.disk_io_counters(perdisk=True).items():
-            for metric in self._config["system.disk.time"]:
+            for metric in self._config["system.disk.operation.time"]:
                 if hasattr(counters, f"{metric}_time"):
                     self._system_disk_time_labels["device"] = device
                     self._system_disk_time_labels["direction"] = metric
@@ -728,7 +727,7 @@ class SystemMetricsInstrumentor(BaseInstrumentor):
         # operations or the value type should be Double
 
         for device, counters in psutil.disk_io_counters(perdisk=True).items():
-            for metric in self._config["system.disk.time"]:
+            for metric in self._config["system.disk.operation.time"]:
                 if hasattr(counters, f"{metric}_merged_count"):
                     self._system_disk_merged_labels["device"] = device
                     self._system_disk_merged_labels["direction"] = metric

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/tests/test_system_metrics.py
@@ -111,7 +111,7 @@ class TestSystemMetrics(TestBase):
             "system.swap.utilization",
             "system.disk.io",
             "system.disk.operations",
-            "system.disk.time",
+            "system.disk.operation.time",
             "system.network.dropped_packets",
             "system.network.packets",
             "system.network.errors",
@@ -511,7 +511,7 @@ class TestSystemMetrics(TestBase):
         self._test_metrics("system.disk.operations", expected)
 
     @mock.patch("psutil.disk_io_counters")
-    def test_system_disk_time(self, mock_disk_io_counters):
+    def test_system_disk_operation_time(self, mock_disk_io_counters):
         DiskIO = namedtuple(
             "DiskIO",
             [
@@ -562,7 +562,7 @@ class TestSystemMetrics(TestBase):
                 {"device": "sdb", "direction": "write"}, 14 / 1000
             ),
         ]
-        self._test_metrics("system.disk.time", expected)
+        self._test_metrics("system.disk.operation.time", expected)
 
     @mock.patch("psutil.net_io_counters")
     def test_system_network_dropped_packets(self, mock_net_io_counters):


### PR DESCRIPTION
# Description
This PR resolves a pending `FIXME` in the `opentelemetry-instrumentation-system-metrics` module by updating the deprecated `system.disk.time` semantic convention to the current standard `system.disk.operation.time`. 
- Migrated `system.disk.time` internal configurations and metric generation callbacks to the new `system.disk.operation.time` nomenclature.
- Updated local unit test [test_system_metrics.py]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran the full instrumentation tox testing suite and linter, confirming both the runtime assertions and the style compliance passed perfectly on the updated module.
- [x] `tox -e py311-instrumentation-system-metrics`
- [x] `tox -e lint-instrumentation-system-metrics`

# Does This PR Require a Core Repo Change?
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated