### PR TITLE
pika: Fix `messaging.destination` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_key_serializer`/`_value_serializer` directly instead of the internal `_serialize` method
   whose signature changed in 0.13 from `(topic, key, value)` to `(key, value, headers)`
   ([#4379](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4379))
+- `opentelemetry-instrumentation-pika`: Fix `messaging.destination` attribute
+  ([#4268](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4268))
 
 ### Breaking changes
 

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -157,7 +157,7 @@ def _get_span(
         kind=span_kind,
     )
     if span.is_recording():
-        _enrich_span(span, channel, properties, task_name, operation)
+        _enrich_span(span, channel, properties, destination, operation)
     return span
 
 


### PR DESCRIPTION
# Description

These two attributes are mistakenly swapped around. ~~destination (exchange/routing-key) was used as span name and~~ `messaging.destination` was set to consumer-tag 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```sh
tox run -e $(tox --listenvs | grep pika | tr '\n' ',')
```

Also, instrumented app with updated library and observed that `messaging.destination` is no longer `ctag...`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
