### PR TITLE
pika: update type hints

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
@@ -90,7 +90,7 @@ class TestPika(TestCase):
         instrument_channel_consumers: mock.MagicMock,
         instrument_basic_consume: mock.MagicMock,
         instrument_channel_functions: mock.MagicMock,
-    ):
+    ) -> None:
         PikaInstrumentor.instrument_channel(channel=self.blocking_channel)
         assert hasattr(
             self.blocking_channel, "_is_instrumented_by_opentelemetry"
@@ -113,7 +113,7 @@ class TestPika(TestCase):
         instrument_channel_consumers: mock.MagicMock,
         instrument_basic_consume: mock.MagicMock,
         instrument_channel_functions: mock.MagicMock,
-    ):
+    ) -> None:
         PikaInstrumentor.instrument_channel(channel=self.channel)
         assert hasattr(self.channel, "_is_instrumented_by_opentelemetry"), (
             "channel is not marked as instrumented!"


### PR DESCRIPTION
# Description

Update the type hints for opentelemetry-instrumentation-pika.

I tried to not change anything that would have runtime effects. The type hints reflect the current state of this code and the pika library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `tox run -e $(tox --listenvs | grep pika | tr '\n' ',')`
- [ ] `uv run mypy src/opentelemetry/instrumentation/pika`
     - ~25 errors still remaining

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
