### PR TITLE
Improvements Confluent Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `opentelemetry-instrumentation-confluent-kafka`: Fix incorrect attribute mapping for message offset and partition. Ensure partition is correctly extracted and recorded in producer spans. Fix produce span operation type. Remove extraneous `recv` spans from consumer to align with semantic conventions. Create span only after record is received while polling.
+
+
 - `opentelemetry-instrumentation-asyncpg`: Hydrate span attributes before creation so samplers can filter on database details
   ([#3841](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3841))
 - `opentelemetry-instrumentation-django`: Fix exemplars generation for `http.server.(request.)duration`

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   #"opentelemetry-instrumentation == 0.61b0.dev",
-  "opentelemetry-instrumentation == 0.61b0",
+  "opentelemetry-instrumentation == 0.60b1",
   "opentelemetry-api == 1.39.1",
   "wrapt >= 1.0.0, < 2.0.0",
 ]

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
   #"opentelemetry-instrumentation == 0.61b0.dev",
   "opentelemetry-instrumentation == 0.61b0",
-  "opentelemetry-api ~= 1.12",
+  "opentelemetry-api == 1.39.1",
   "wrapt >= 1.0.0, < 2.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -25,8 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  #"opentelemetry-instrumentation == 0.61b0.dev",
-  "opentelemetry-instrumentation == 0.60b1",
+  "opentelemetry-instrumentation == 0.61b0.dev",
   "opentelemetry-api == 1.39.1",
   "wrapt >= 1.0.0, < 2.0.0",
 ]

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "opentelemetry-instrumentation == 0.61b0.dev",
+  #"opentelemetry-instrumentation == 0.61b0.dev",
+  "opentelemetry-instrumentation == 0.61b0",
   "opentelemetry-api ~= 1.12",
   "wrapt >= 1.0.0, < 2.0.0",
 ]

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -346,29 +346,30 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
 
     @staticmethod
     def wrap_produce(func, instance, tracer, args, kwargs):
-        topic = kwargs.get("topic")
-        if not topic:
-            topic = args[0]
+        topic = KafkaPropertiesExtractor.extract_produce_topic(args, kwargs)
+
+        headers = KafkaPropertiesExtractor.extract_produce_headers(
+            args, kwargs
+        )
+        if headers is None:
+            headers = []
+            kwargs["headers"] = headers
+
+        partition = KafkaPropertiesExtractor.extract_produce_partition(
+            args, kwargs
+        )
 
         span_name = _get_span_name("send", topic)
         with tracer.start_as_current_span(
-            name=span_name, kind=trace.SpanKind.PRODUCER
+            name=span_name,
+            kind=trace.SpanKind.PRODUCER,
         ) as span:
-            headers = KafkaPropertiesExtractor.extract_produce_headers(
-                args, kwargs
-            )
-            if headers is None:
-                headers = []
-                kwargs["headers"] = headers
-
-            topic = KafkaPropertiesExtractor.extract_produce_topic(
-                args, kwargs
-            )
             _enrich_span(
                 span,
                 topic,
-                operation=MessagingOperationTypeValues.RECEIVE,
-            )  # Replace
+                partition=partition,
+                operation=MessagingOperationTypeValues.SEND,
+            )
             propagate.inject(
                 headers,
                 setter=_kafka_setter,

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -429,7 +429,6 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
         ######
         records = func(*args, **kwargs)
 
-        # create a new span for each message
         if len(records) > 0:
             _create_new_consume_span(instance, tracer, records)
             _enrich_span(

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -380,19 +380,30 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
         if instance._current_consume_span:
             _end_current_consume_span(instance)
 
-        with tracer.start_as_current_span(
-            "recv", end_on_exit=True, kind=trace.SpanKind.CONSUMER
-        ):
-            record = func(*args, **kwargs)
-            if record:
-                _create_new_consume_span(instance, tracer, [record])
-                _enrich_span(
-                    instance._current_consume_span,
-                    record.topic(),
-                    record.partition(),
-                    record.offset(),
-                    operation=MessagingOperationTypeValues.PROCESS,
-                )
+        ######
+        # Notes on Spans Surrounding Poll
+        # we don't wrap the poll operation in a span because there's no context to extract yet
+        # creating a span here would create a new span for each poll call
+        # if more work is done in poll() function, such as in the DeserializingConsumer,
+        # that is hard to trace for the same reason
+
+        # Based on the diagram in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/kafka.md
+        # a span around poll should be created by the client, not the consumer
+        # in this case the client is librdkafka, so we don't create a span here
+        #####
+        record = func(*args, **kwargs)
+
+        # create a new span for the message
+        if record:
+            _create_new_consume_span(instance, tracer, [record])
+            _enrich_span(
+                instance._current_consume_span,
+                record.topic(),
+                partition=record.partition(),
+                offset=record.offset(),
+                operation=MessagingOperationTypeValues.PROCESS,
+            )
+
         instance._current_context_token = context.attach(
             trace.set_span_in_context(instance._current_consume_span)
         )
@@ -404,17 +415,29 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
         if instance._current_consume_span:
             _end_current_consume_span(instance)
 
-        with tracer.start_as_current_span(
-            "recv", end_on_exit=True, kind=trace.SpanKind.CONSUMER
-        ):
-            records = func(*args, **kwargs)
-            if len(records) > 0:
-                _create_new_consume_span(instance, tracer, records)
-                _enrich_span(
-                    instance._current_consume_span,
-                    records[0].topic(),
-                    operation=MessagingOperationTypeValues.PROCESS,
-                )
+        ######
+        # Notes on Spans Surrounding Consume
+        # since consume can return multiple records, we _could_ wrap the call in a span
+        # and then create a new span for each record
+        # however, this span is awkward because there is no obvious trace to assign to it
+        # before the messages are returned, and afterwards it's can't be modified
+
+        # Based on the diagram in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/kafka.md
+        # a span around consume should be created by the client, not the consumer
+        # in this case the client is librdkafka, so we don't create a span here
+        ######
+        records = func(*args, **kwargs)
+
+        # create a new span for each message
+        if len(records) > 0:
+            _create_new_consume_span(instance, tracer, records)
+            _enrich_span(
+                instance._current_consume_span,
+                records[0].topic(),
+                partition=records[0].partition(),
+                offset=records[0].offset(),
+                operation=MessagingOperationTypeValues.PROCESS,
+            )
 
         instance._current_context_token = context.attach(
             trace.set_span_in_context(instance._current_consume_span)

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -102,11 +102,13 @@ def _end_current_consume_span(instance):
 
 
 def _create_new_consume_span(instance, tracer, records):
+    ctx = propagate.extract(records[0].headers(), getter=_kafka_getter)
     links = _get_links_from_records(records)
     instance._current_consume_span = tracer.start_span(
         name=f"{records[0].topic()} process",
         links=links,
         kind=SpanKind.CONSUMER,
+        context=ctx,
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -35,6 +35,13 @@ class KafkaPropertiesExtractor:
         return kwargs.get("topic") or (args[0] if args else "unknown")
 
     @staticmethod
+    def extract_produce_partition(args, kwargs):
+        """extract partition from `produce` method arguments in Producer class"""
+        return KafkaPropertiesExtractor._extract_argument(
+            "partition", 3, None, args, kwargs
+        )
+
+    @staticmethod
     def extract_produce_headers(args, kwargs):
         """extract headers from `produce` method arguments in Producer class"""
         return KafkaPropertiesExtractor._extract_argument(

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -140,6 +140,11 @@ def _enrich_span(
     if partition is not None:
         span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)
 
+    if offset is not None:
+        span.set_attribute(
+            SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, offset
+        )
+
     span.set_attribute(
         SpanAttributes.MESSAGING_DESTINATION_KIND,
         MessagingDestinationKindValues.QUEUE.value,

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -14,6 +14,7 @@ from opentelemetry.semconv.trace import (
     SpanAttributes,
 )
 from opentelemetry.trace import Link, SpanKind
+from opentelemetry.util import types
 
 _LOG = getLogger(__name__)
 
@@ -134,34 +135,29 @@ def _enrich_span(
     if not span.is_recording():
         return
 
-    span.set_attribute(MESSAGING_SYSTEM, "kafka")
-    span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
+    _attributes: dict[str, types.AttributeValue] = {
+        MESSAGING_SYSTEM: "kafka",
+        SpanAttributes.MESSAGING_DESTINATION: topic,
+        SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
+    }
 
     if partition is not None:
-        span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)
+        _attributes[SpanAttributes.MESSAGING_KAFKA_PARTITION] = partition
 
     if offset is not None:
-        span.set_attribute(
-            SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET, offset
-        )
-
-    span.set_attribute(
-        SpanAttributes.MESSAGING_DESTINATION_KIND,
-        MessagingDestinationKindValues.QUEUE.value,
-    )
+        _attributes[SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET] = offset
 
     if operation:
-        span.set_attribute(MESSAGING_OPERATION, operation.value)
+        _attributes[MESSAGING_OPERATION] = operation.value
     else:
-        span.set_attribute(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)
+        _attributes[SpanAttributes.MESSAGING_TEMP_DESTINATION] = True
 
     # https://stackoverflow.com/questions/65935155/identify-and-find-specific-message-in-kafka-topic
     # A message within Kafka is uniquely defined by its topic name, topic partition and offset.
     if partition is not None and offset is not None and topic:
-        span.set_attribute(
-            MESSAGING_MESSAGE_ID,
-            f"{topic}.{partition}.{offset}",
-        )
+        _attributes[MESSAGING_MESSAGE_ID] = f"{topic}.{partition}.{offset}"
+
+    span.set_attributes(_attributes)
 
 
 _kafka_setter = KafkaContextSetter()

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.61b0.dev"
+__version__ = "0.60b1"

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.60b1"
+__version__ = "0.61b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_instrumentation.py
@@ -123,7 +123,6 @@ class TestConfluentKafka(TestBase):
             MockedMessage("topic-30", 1, 3, []),
         ]
         expected_spans = [
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-10 process",
                 "attributes": {
@@ -133,9 +132,9 @@ class TestConfluentKafka(TestBase):
                     SpanAttributes.MESSAGING_DESTINATION: "topic-10",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-10.0.0",
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 0,
                 },
             },
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-20 process",
                 "attributes": {
@@ -145,9 +144,9 @@ class TestConfluentKafka(TestBase):
                     SpanAttributes.MESSAGING_DESTINATION: "topic-20",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-20.2.4",
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 4,
                 },
             },
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-30 process",
                 "attributes": {
@@ -157,9 +156,9 @@ class TestConfluentKafka(TestBase):
                     SpanAttributes.MESSAGING_DESTINATION: "topic-30",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-30.1.3",
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 3,
                 },
             },
-            {"name": "recv", "attributes": {}},
         ]
 
         consumer = MockConsumer(
@@ -191,7 +190,6 @@ class TestConfluentKafka(TestBase):
             MockedMessage("topic-2", 0, 1, []),
         ]
         expected_spans = [
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-1 process",
                 "attributes": {
@@ -199,9 +197,10 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_SYSTEM: "kafka",
                     SpanAttributes.MESSAGING_DESTINATION: "topic-1",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
+                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 0,
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 0,
                 },
             },
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-2 process",
                 "attributes": {
@@ -209,9 +208,10 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_SYSTEM: "kafka",
                     SpanAttributes.MESSAGING_DESTINATION: "topic-2",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
+                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 0,
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 0,
                 },
             },
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-3 process",
                 "attributes": {
@@ -219,9 +219,10 @@ class TestConfluentKafka(TestBase):
                     MESSAGING_SYSTEM: "kafka",
                     SpanAttributes.MESSAGING_DESTINATION: "topic-3",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
+                    SpanAttributes.MESSAGING_KAFKA_PARTITION: 0,
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 3,
                 },
             },
-            {"name": "recv", "attributes": {}},
         ]
 
         consumer = MockConsumer(
@@ -248,7 +249,6 @@ class TestConfluentKafka(TestBase):
             MockedMessage("topic-a", 0, 0, []),
         ]
         expected_spans = [
-            {"name": "recv", "attributes": {}},
             {
                 "name": "topic-a process",
                 "attributes": {
@@ -258,6 +258,7 @@ class TestConfluentKafka(TestBase):
                     SpanAttributes.MESSAGING_DESTINATION: "topic-a",
                     SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
                     MESSAGING_MESSAGE_ID: "topic-a.0.0",
+                    SpanAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 0,
                 },
             },
         ]
@@ -335,3 +336,44 @@ class TestConfluentKafka(TestBase):
         span_list = self.memory_exporter.get_finished_spans()
         self._assert_span_count(span_list, 1)
         self._assert_topic(span_list[0], "topic-1")
+
+    def test_poll_no_message(self) -> None:
+        instrumentation = ConfluentKafkaInstrumentor()
+        mocked_messages = []
+        consumer = MockConsumer(
+            mocked_messages,
+            {
+                "bootstrap.servers": "localhost:29092",
+                "group.id": "mygroup",
+                "auto.offset.reset": "earliest",
+            },
+        )
+        self.memory_exporter.clear()
+        consumer = instrumentation.instrument_consumer(consumer)
+        consumer.poll()
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+    def test_producer_with_partition(self) -> None:
+        instrumentation = ConfluentKafkaInstrumentor()
+        message_queue = []
+
+        producer = MockedProducer(
+            message_queue,
+            {
+                "bootstrap.servers": "localhost:29092",
+            },
+        )
+
+        producer = instrumentation.instrument_producer(producer)
+        producer.produce(
+            topic="topic-1", partition=1, key="key-1", value="value-1"
+        )
+        msg = producer.poll()
+        self.assertIsNotNone(msg)
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(
+            span_list[0].attributes[SpanAttributes.MESSAGING_KAFKA_PARTITION],
+            1,
+        )

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/test_utils.py
@@ -1,0 +1,43 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry.instrumentation.confluent_kafka.utils import (
+    KafkaPropertiesExtractor,
+)
+
+
+class TestKafkaPropertiesExtractor(unittest.TestCase):
+    def test_extract_produce_partition(self):
+        # Test with args
+        args = ("topic", "value", "key", 1)
+        kwargs = {}
+        self.assertEqual(
+            KafkaPropertiesExtractor.extract_produce_partition(args, kwargs), 1
+        )
+
+        # Test with kwargs
+        args = ()
+        kwargs = {"partition": 2}
+        self.assertEqual(
+            KafkaPropertiesExtractor.extract_produce_partition(args, kwargs), 2
+        )
+
+        # Test with no partition
+        args = ()
+        kwargs = {}
+        self.assertIsNone(
+            KafkaPropertiesExtractor.extract_produce_partition(args, kwargs)
+        )

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/tests/utils.py
@@ -64,7 +64,7 @@ class MockedProducer(Producer):
         self._queue.append(
             MockedMessage(
                 topic=kwargs.get("topic"),
-                partition=0,
+                partition=kwargs.get("partition"),
                 offset=0,
                 headers=[],
                 key=kwargs.get("key"),


### PR DESCRIPTION
# Description

This is a fix for some long standing issues with the ConfluentKafka span creation, particularly around `consume` and `poll`. In those cases, because the trace context isn't known until after the message is received (the context is extracted from the headers), any spans created are orphaned spans. So when the span is created for the poll operation, there is no parent trace. Then any spans created during message processing are children of that orphaned span, despite the span links, rather than part of the trace provided by the header context.

This is fixed in both cases by not creating a span for the poll or consume operations. According to the chart at the end of this semantics doc https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/kafka.md, the poll and consume operation spans would nominally be created by the client, rather than the producer or consumer. There are some semantics around what constitutes the client in this case, but the poll and consumer network operations are handled by librdkafka for the confluent-kafka producer and consumer.

On the producer side, this also fixes the `messaging.operation` value on the produce span and ensures the partition is extracted and recorded when supplied.

Attribute names are unchanged. Migrating to the current messaging semantic conventions is out of scope and can follow #4974.

Fixes #1966
Fixes #1674
Fixes #1678

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests

- [x] Unit Tests w/ Tox

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
