### PR TITLE
feat(openai): Instrument structured outputs (chat.completions.parse)

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pass tool definitions from `tools` kwarg to `InferenceInvocation.tool_definitions`
   so `gen_ai.tool.definitions` span attribute is populated on chat completion spans
   ([#4554](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4554))
+- Add instrumentation for `chat.completions.parse()` structured outputs
+  ([#4416](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4416))
 
 ## Version 2.4b0 (2026-05-01)
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -111,6 +111,7 @@ def _is_parse_supported():
 class OpenAIInstrumentor(BaseInstrumentor):
     def __init__(self):
         self._meter = None
+        self._parse_supported = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -93,6 +93,21 @@ from .patch import (
 )
 
 
+def _is_parse_supported():
+    """Check if the parse() method is available on the Completions class.
+
+    The parse() method for structured outputs was added in openai >= 1.40.0.
+    """
+    try:
+        from openai.resources.chat.completions import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+            Completions,
+        )
+
+        return hasattr(Completions, "parse")
+    except ImportError:
+        return False
+
+
 class OpenAIInstrumentor(BaseInstrumentor):
     def __init__(self):
         self._meter = None
@@ -177,6 +192,36 @@ class OpenAIInstrumentor(BaseInstrumentor):
             ),
         )
 
+        # parse() wraps create() internally in the OpenAI SDK and returns a
+        # ParsedChatCompletion. The telemetry-relevant fields (model, usage,
+        # choices, finish_reason) are identical to ChatCompletion, so the
+        # existing create() wrappers handle it correctly.
+        self._parse_supported = _is_parse_supported()
+        if self._parse_supported:
+            wrap_function_wrapper(
+                module="openai.resources.chat.completions",
+                name="Completions.parse",
+                wrapper=(
+                    chat_completions_create_v_new(handler, content_mode)
+                    if latest_experimental_enabled
+                    else chat_completions_create_v_old(
+                        tracer, logger, instruments, is_content_enabled()
+                    )
+                ),
+            )
+
+            wrap_function_wrapper(
+                module="openai.resources.chat.completions",
+                name="AsyncCompletions.parse",
+                wrapper=(
+                    async_chat_completions_create_v_new(handler, content_mode)
+                    if latest_experimental_enabled
+                    else async_chat_completions_create_v_old(
+                        tracer, logger, instruments, is_content_enabled()
+                    )
+                ),
+            )
+
     def _uninstrument(self, **kwargs):
         import openai  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
 
@@ -184,3 +229,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
         unwrap(openai.resources.chat.completions.AsyncCompletions, "create")
         unwrap(openai.resources.embeddings.Embeddings, "create")
         unwrap(openai.resources.embeddings.AsyncEmbeddings, "create")
+
+        if self._parse_supported:
+            unwrap(openai.resources.chat.completions.Completions, "parse")
+            unwrap(openai.resources.chat.completions.AsyncCompletions, "parse")

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -200,10 +200,10 @@ class OpenAIInstrumentor(BaseInstrumentor):
         self._parse_supported = _is_parse_supported()
         if self._parse_supported:
             wrap_function_wrapper(
-                module="openai.resources.chat.completions",
-                name="Completions.parse",
-                wrapper=(
-                    chat_completions_create_v_new(handler, content_mode)
+                "openai.resources.chat.completions",
+                "Completions.parse",
+                (
+                    chat_completions_create_v_new(handler)
                     if latest_experimental_enabled
                     else chat_completions_create_v_old(
                         tracer, logger, instruments, is_content_enabled()
@@ -212,10 +212,10 @@ class OpenAIInstrumentor(BaseInstrumentor):
             )
 
             wrap_function_wrapper(
-                module="openai.resources.chat.completions",
-                name="AsyncCompletions.parse",
-                wrapper=(
-                    async_chat_completions_create_v_new(handler, content_mode)
+                "openai.resources.chat.completions",
+                "AsyncCompletions.parse",
+                (
+                    async_chat_completions_create_v_new(handler)
                     if latest_experimental_enabled
                     else async_chat_completions_create_v_old(
                         tracer, logger, instruments, is_content_enabled()

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -273,7 +273,14 @@ def get_llm_request_attributes(
             # response_format may be string, object with a string in the `type` key,
             # or a type (e.g. Pydantic model class used with parse())
             if isinstance(response_format, type):
-                attributes[request_response_format_attr_key] = "json"
+                if latest_experimental_enabled:
+                    attributes[request_response_format_attr_key] = (
+                        GenAIAttributes.GenAiOutputTypeValues.JSON.value
+                    )
+                else:
+                    attributes[request_response_format_attr_key] = (
+                        GenAIAttributes.GenAiOpenaiRequestResponseFormatValues.JSON_SCHEMA.value
+                    )
             elif isinstance(response_format, Mapping):
                 if (
                     response_format_type := response_format.get("type")
@@ -360,7 +367,9 @@ def create_chat_invocation(
         # response_format may be string, object with a string in the `type` key,
         # or a type (e.g. Pydantic model class used with parse())
         if isinstance(response_format, type):
-            invocation.attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = "json"
+            invocation.attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = (
+                GenAIAttributes.GenAiOutputTypeValues.JSON.value
+            )
         elif isinstance(response_format, Mapping):
             if (
                 response_format_type := get_value(response_format.get("type"))

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -155,7 +155,9 @@ def choice_to_event(choice, capture_content):
     if choice.message:
         message = {
             "role": (
-                choice.message.role if choice.message and choice.message.role else None
+                choice.message.role
+                if choice.message and choice.message.role
+                else None
             )
         }
         tool_calls = extract_tool_calls(choice.message, capture_content)
@@ -240,10 +242,14 @@ def get_llm_request_attributes(
     if operation_name == GenAIAttributes.GenAiOperationNameValues.CHAT.value:
         attributes.update(
             {
-                GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE: kwargs.get("temperature"),
+                GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE: kwargs.get(
+                    "temperature"
+                ),
                 GenAIAttributes.GEN_AI_REQUEST_TOP_P: kwargs.get("p")
                 or kwargs.get("top_p"),
-                GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS: kwargs.get("max_tokens"),
+                GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS: kwargs.get(
+                    "max_tokens"
+                ),
                 GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY: kwargs.get(
                     "presence_penalty"
                 ),
@@ -257,12 +263,16 @@ def get_llm_request_attributes(
         if (choice_count := kwargs.get("n")) is not None:
             # Only add non default, meaningful values
             if isinstance(choice_count, int) and choice_count != 1:
-                attributes[GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT] = choice_count
+                attributes[GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT] = (
+                    choice_count
+                )
 
         if (stop_sequences := kwargs.get("stop")) is not None:
             if isinstance(stop_sequences, str):
                 stop_sequences = [stop_sequences]
-            attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] = stop_sequences
+            attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] = (
+                stop_sequences
+            )
 
         request_response_format_attr_key = (
             GenAIAttributes.GEN_AI_OUTPUT_TYPE
@@ -308,7 +318,10 @@ def get_llm_request_attributes(
         )
 
     # Add embeddings-specific attributes
-    elif operation_name == GenAIAttributes.GenAiOperationNameValues.EMBEDDINGS.value:
+    elif (
+        operation_name
+        == GenAIAttributes.GenAiOperationNameValues.EMBEDDINGS.value
+    ):
         # Add embedding dimensions if specified
         if (dimensions := kwargs.get("dimensions")) is not None:
             # TODO: move to GEN_AI_EMBEDDINGS_DIMENSION_COUNT when 1.39.0 is baseline
@@ -363,7 +376,9 @@ def create_chat_invocation(
                 GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT
             ] = choice_count
 
-    if (response_format := get_value(kwargs.get("response_format"))) is not None:
+    if (
+        response_format := get_value(kwargs.get("response_format"))
+    ) is not None:
         # response_format may be string, object with a string in the `type` key,
         # or a type (e.g. Pydantic model class used with parse())
         if isinstance(response_format, type):
@@ -414,13 +429,16 @@ def get_value(v: Any):
 def handle_span_exception(span, error: BaseException):
     span.set_status(Status(StatusCode.ERROR, str(error)))
     if span.is_recording():
-        span.set_attribute(ErrorAttributes.ERROR_TYPE, type(error).__qualname__)
+        span.set_attribute(
+            ErrorAttributes.ERROR_TYPE, type(error).__qualname__
+        )
     span.end()
 
 
 def _is_text_part(content: Any) -> bool:
     return isinstance(content, str) or (
-        isinstance(content, Iterable) and all(isinstance(part, str) for part in content)
+        isinstance(content, Iterable)
+        and all(isinstance(part, str) for part in content)
     )
 
 
@@ -471,7 +489,9 @@ def extract_tool_calls_new(tool_calls) -> list[ToolCallRequest]:
                     arguments = arguments_str
 
         # TODO: support custom
-        parts.append(ToolCallRequest(id=call_id, name=func_name, arguments=arguments))
+        parts.append(
+            ToolCallRequest(id=call_id, name=func_name, arguments=arguments)
+        )
     return parts
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -280,8 +280,11 @@ def get_llm_request_attributes(
             else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
         )
         if (response_format := kwargs.get("response_format")) is not None:
-            # response_format may be string or object with a string in the `type` key
-            if isinstance(response_format, Mapping):
+            # response_format may be string, object with a string in the `type` key,
+            # or a type (e.g. Pydantic model class used with parse())
+            if isinstance(response_format, type):
+                attributes[request_response_format_attr_key] = "json_schema"
+            elif isinstance(response_format, Mapping):
                 if (
                     response_format_type := response_format.get("type")
                 ) is not None:
@@ -369,8 +372,11 @@ def create_chat_invocation(
     if (
         response_format := get_value(kwargs.get("response_format"))
     ) is not None:
-        # response_format may be string or object with a string in the `type` key
-        if isinstance(response_format, Mapping):
+        # response_format may be string, object with a string in the `type` key,
+        # or a type (e.g. Pydantic model class used with parse())
+        if isinstance(response_format, type):
+            attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = "json_schema"
+        elif isinstance(response_format, Mapping):
             if (
                 response_format_type := get_value(response_format.get("type"))
             ) is not None:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -155,9 +155,7 @@ def choice_to_event(choice, capture_content):
     if choice.message:
         message = {
             "role": (
-                choice.message.role
-                if choice.message and choice.message.role
-                else None
+                choice.message.role if choice.message and choice.message.role else None
             )
         }
         tool_calls = extract_tool_calls(choice.message, capture_content)
@@ -242,14 +240,10 @@ def get_llm_request_attributes(
     if operation_name == GenAIAttributes.GenAiOperationNameValues.CHAT.value:
         attributes.update(
             {
-                GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE: kwargs.get(
-                    "temperature"
-                ),
+                GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE: kwargs.get("temperature"),
                 GenAIAttributes.GEN_AI_REQUEST_TOP_P: kwargs.get("p")
                 or kwargs.get("top_p"),
-                GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS: kwargs.get(
-                    "max_tokens"
-                ),
+                GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS: kwargs.get("max_tokens"),
                 GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY: kwargs.get(
                     "presence_penalty"
                 ),
@@ -263,16 +257,12 @@ def get_llm_request_attributes(
         if (choice_count := kwargs.get("n")) is not None:
             # Only add non default, meaningful values
             if isinstance(choice_count, int) and choice_count != 1:
-                attributes[GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT] = (
-                    choice_count
-                )
+                attributes[GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT] = choice_count
 
         if (stop_sequences := kwargs.get("stop")) is not None:
             if isinstance(stop_sequences, str):
                 stop_sequences = [stop_sequences]
-            attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] = (
-                stop_sequences
-            )
+            attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] = stop_sequences
 
         request_response_format_attr_key = (
             GenAIAttributes.GEN_AI_OUTPUT_TYPE
@@ -283,7 +273,7 @@ def get_llm_request_attributes(
             # response_format may be string, object with a string in the `type` key,
             # or a type (e.g. Pydantic model class used with parse())
             if isinstance(response_format, type):
-                attributes[request_response_format_attr_key] = "json_schema"
+                attributes[request_response_format_attr_key] = "json"
             elif isinstance(response_format, Mapping):
                 if (
                     response_format_type := response_format.get("type")
@@ -311,10 +301,7 @@ def get_llm_request_attributes(
         )
 
     # Add embeddings-specific attributes
-    elif (
-        operation_name
-        == GenAIAttributes.GenAiOperationNameValues.EMBEDDINGS.value
-    ):
+    elif operation_name == GenAIAttributes.GenAiOperationNameValues.EMBEDDINGS.value:
         # Add embedding dimensions if specified
         if (dimensions := kwargs.get("dimensions")) is not None:
             # TODO: move to GEN_AI_EMBEDDINGS_DIMENSION_COUNT when 1.39.0 is baseline
@@ -369,13 +356,11 @@ def create_chat_invocation(
                 GenAIAttributes.GEN_AI_REQUEST_CHOICE_COUNT
             ] = choice_count
 
-    if (
-        response_format := get_value(kwargs.get("response_format"))
-    ) is not None:
+    if (response_format := get_value(kwargs.get("response_format"))) is not None:
         # response_format may be string, object with a string in the `type` key,
         # or a type (e.g. Pydantic model class used with parse())
         if isinstance(response_format, type):
-            attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = "json_schema"
+            invocation.attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = "json"
         elif isinstance(response_format, Mapping):
             if (
                 response_format_type := get_value(response_format.get("type"))
@@ -420,16 +405,13 @@ def get_value(v: Any):
 def handle_span_exception(span, error: BaseException):
     span.set_status(Status(StatusCode.ERROR, str(error)))
     if span.is_recording():
-        span.set_attribute(
-            ErrorAttributes.ERROR_TYPE, type(error).__qualname__
-        )
+        span.set_attribute(ErrorAttributes.ERROR_TYPE, type(error).__qualname__)
     span.end()
 
 
 def _is_text_part(content: Any) -> bool:
     return isinstance(content, str) or (
-        isinstance(content, Iterable)
-        and all(isinstance(part, str) for part in content)
+        isinstance(content, Iterable) and all(isinstance(part, str) for part in content)
     )
 
 
@@ -480,9 +462,7 @@ def extract_tool_calls_new(tool_calls) -> list[ToolCallRequest]:
                     arguments = arguments_str
 
         # TODO: support custom
-        parts.append(
-            ToolCallRequest(id=call_id, name=func_name, arguments=arguments)
-        )
+        parts.append(ToolCallRequest(id=call_id, name=func_name, arguments=arguments))
     return parts
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_no_content.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_no_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-004",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_004
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_with_content.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_with_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-003",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_003
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_no_content.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_no_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-002",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_002
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_with_content.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_with_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-001",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_001
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
@@ -1,0 +1,45 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared test definitions for structured outputs (parse) tests."""
+
+from pydantic import BaseModel
+
+
+class CalendarEvent(BaseModel):
+    name: str
+    date: str
+    participants: list
+
+
+STRUCTURED_OUTPUT_PROMPT = [
+    {
+        "role": "user",
+        "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob",
+    }
+]
+
+STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES = [
+    {
+        "role": "user",
+        "parts": [
+            {
+                "type": "text",
+                "content": STRUCTURED_OUTPUT_PROMPT[0]["content"],
+            }
+        ],
+    }
+]
+
+EXPECTED_RESPONSE_CONTENT = '{"name": "Team Meeting", "date": "2024-01-15", "participants": ["Alice", "Bob"]}'

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 class CalendarEvent(BaseModel):
     name: str
     date: str
-    participants: list
+    participants: list[str]
 
 
 STRUCTURED_OUTPUT_PROMPT = [

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -1,0 +1,162 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for async OpenAI structured outputs (chat.completions.parse) instrumentation."""
+
+import pytest
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.util.genai.utils import is_experimental_mode
+
+from .structured_outputs_utils import (
+    STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+    STRUCTURED_OUTPUT_PROMPT,
+    CalendarEvent,
+)
+from .test_utils import (
+    DEFAULT_MODEL,
+    assert_all_attributes,
+    assert_message_in_logs,
+    assert_messages_attribute,
+    format_simple_expected_output_message,
+)
+
+
+@pytest.mark.asyncio()
+async def test_async_structured_output_with_content(
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_async_structured_output_with_content.yaml"):
+        response = await async_openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+
+    if latest_experimental_enabled:
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.input.messages"],
+            STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+        )
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.output.messages"],
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
+        )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 2
+
+        user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            },
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
+
+
+@pytest.mark.asyncio()
+async def test_async_structured_output_no_content(
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_async_structured_output_no_content.yaml"):
+        response = await async_openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+
+    logs = log_exporter.get_finished_logs()
+    if latest_experimental_enabled:
+        assert len(logs) == 0
+        assert "gen_ai.input.messages" not in spans[0].attributes
+        assert "gen_ai.output.messages" not in spans[0].attributes
+    else:
+        assert len(logs) == 2
+
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", None, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant"},
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -148,9 +148,7 @@ async def test_async_structured_output_no_content(
     else:
         assert len(logs) == 2
 
-        assert_message_in_logs(
-            logs[0], "gen_ai.user.message", None, spans[0]
-        )
+        assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
 
         choice_event = {
             "index": 0,

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -52,6 +52,9 @@ async def test_async_structured_output_with_content(
             response_format=CalendarEvent,
         )
 
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     assert_all_attributes(
@@ -69,7 +72,8 @@ async def test_async_structured_output_with_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
 
     if latest_experimental_enabled:
         assert_messages_attribute(
@@ -78,18 +82,14 @@ async def test_async_structured_output_with_content(
         )
         assert_messages_attribute(
             spans[0].attributes["gen_ai.output.messages"],
-            format_simple_expected_output_message(
-                response.choices[0].message.content
-            ),
+            format_simple_expected_output_message(response.choices[0].message.content),
         )
     else:
         logs = log_exporter.get_finished_logs()
         assert len(logs) == 2
 
         user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
-        assert_message_in_logs(
-            logs[0], "gen_ai.user.message", user_message, spans[0]
-        )
+        assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, spans[0])
 
         choice_event = {
             "index": 0,
@@ -99,9 +99,7 @@ async def test_async_structured_output_with_content(
                 "content": response.choices[0].message.content,
             },
         }
-        assert_message_in_logs(
-            logs[1], "gen_ai.choice", choice_event, spans[0]
-        )
+        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
 
 
 @pytest.mark.asyncio()
@@ -121,6 +119,9 @@ async def test_async_structured_output_no_content(
             response_format=CalendarEvent,
         )
 
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     assert_all_attributes(
@@ -138,7 +139,8 @@ async def test_async_structured_output_no_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
 
     logs = log_exporter.get_finished_logs()
     if latest_experimental_enabled:
@@ -155,6 +157,4 @@ async def test_async_structured_output_no_content(
             "finish_reason": "stop",
             "message": {"role": "assistant"},
         }
-        assert_message_in_logs(
-            logs[1], "gen_ai.choice", choice_event, spans[0]
-        )
+        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -82,14 +82,18 @@ async def test_async_structured_output_with_content(
         )
         assert_messages_attribute(
             spans[0].attributes["gen_ai.output.messages"],
-            format_simple_expected_output_message(response.choices[0].message.content),
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
         )
     else:
         logs = log_exporter.get_finished_logs()
         assert len(logs) == 2
 
         user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
-        assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, spans[0])
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
 
         choice_event = {
             "index": 0,
@@ -99,7 +103,9 @@ async def test_async_structured_output_with_content(
                 "content": response.choices[0].message.content,
             },
         }
-        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
 
 
 @pytest.mark.asyncio()
@@ -157,4 +163,6 @@ async def test_async_structured_output_no_content(
             "finish_reason": "stop",
             "message": {"role": "assistant"},
         }
-        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -15,6 +15,7 @@
 """Tests for async OpenAI structured outputs (chat.completions.parse) instrumentation."""
 
 import pytest
+from openai.resources.chat.completions import Completions
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
@@ -32,6 +33,11 @@ from .test_utils import (
     assert_message_in_logs,
     assert_messages_attribute,
     format_simple_expected_output_message,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(Completions, "parse"),
+    reason="parse() requires openai >= 1.40.0",
 )
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -14,20 +14,12 @@
 
 """Tests for OpenAI structured outputs (chat.completions.parse) instrumentation."""
 
-import json
-
-import pytest
-
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
-)
-from opentelemetry.semconv._incubating.attributes import (
-    server_attributes as ServerAttributes,
 )
 from opentelemetry.util.genai.utils import is_experimental_mode
 
 from .structured_outputs_utils import (
-    EXPECTED_RESPONSE_CONTENT,
     STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
     STRUCTURED_OUTPUT_PROMPT,
     CalendarEvent,

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -62,7 +62,7 @@ def test_structured_output_with_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == "json"
 
     if latest_experimental_enabled:
         assert_messages_attribute(
@@ -71,18 +71,14 @@ def test_structured_output_with_content(
         )
         assert_messages_attribute(
             spans[0].attributes["gen_ai.output.messages"],
-            format_simple_expected_output_message(
-                response.choices[0].message.content
-            ),
+            format_simple_expected_output_message(response.choices[0].message.content),
         )
     else:
         logs = log_exporter.get_finished_logs()
         assert len(logs) == 2
 
         user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
-        assert_message_in_logs(
-            logs[0], "gen_ai.user.message", user_message, spans[0]
-        )
+        assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, spans[0])
 
         choice_event = {
             "index": 0,
@@ -92,9 +88,7 @@ def test_structured_output_with_content(
                 "content": response.choices[0].message.content,
             },
         }
-        assert_message_in_logs(
-            logs[1], "gen_ai.choice", choice_event, spans[0]
-        )
+        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
 
 
 def test_structured_output_no_content(
@@ -126,7 +120,7 @@ def test_structured_output_no_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == "json"
 
     logs = log_exporter.get_finished_logs()
     if latest_experimental_enabled:
@@ -143,6 +137,4 @@ def test_structured_output_no_content(
             "finish_reason": "stop",
             "message": {"role": "assistant"},
         }
-        assert_message_in_logs(
-            logs[1], "gen_ai.choice", choice_event, spans[0]
-        )
+        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -45,6 +45,9 @@ def test_structured_output_with_content(
             response_format=CalendarEvent,
         )
 
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     assert_all_attributes(
@@ -62,7 +65,8 @@ def test_structured_output_with_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json"
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
 
     if latest_experimental_enabled:
         assert_messages_attribute(
@@ -103,6 +107,9 @@ def test_structured_output_no_content(
             response_format=CalendarEvent,
         )
 
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     assert_all_attributes(
@@ -120,7 +127,8 @@ def test_structured_output_no_content(
         if latest_experimental_enabled
         else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
     )
-    assert spans[0].attributes[output_type_attr_key] == "json"
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
 
     logs = log_exporter.get_finished_logs()
     if latest_experimental_enabled:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -1,0 +1,158 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OpenAI structured outputs (chat.completions.parse) instrumentation."""
+
+import json
+
+import pytest
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    server_attributes as ServerAttributes,
+)
+from opentelemetry.util.genai.utils import is_experimental_mode
+
+from .structured_outputs_utils import (
+    EXPECTED_RESPONSE_CONTENT,
+    STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+    STRUCTURED_OUTPUT_PROMPT,
+    CalendarEvent,
+)
+from .test_utils import (
+    DEFAULT_MODEL,
+    assert_all_attributes,
+    assert_message_in_logs,
+    assert_messages_attribute,
+    format_simple_expected_output_message,
+)
+
+
+def test_structured_output_with_content(
+    span_exporter, log_exporter, openai_client, instrument_with_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_structured_output_with_content.yaml"):
+        response = openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+
+    if latest_experimental_enabled:
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.input.messages"],
+            STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+        )
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.output.messages"],
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
+        )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 2
+
+        user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            },
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
+
+
+def test_structured_output_no_content(
+    span_exporter, log_exporter, openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_structured_output_no_content.yaml"):
+        response = openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    assert spans[0].attributes[output_type_attr_key] == "json_schema"
+
+    logs = log_exporter.get_finished_logs()
+    if latest_experimental_enabled:
+        assert len(logs) == 0
+        assert "gen_ai.input.messages" not in spans[0].attributes
+        assert "gen_ai.output.messages" not in spans[0].attributes
+    else:
+        assert len(logs) == 2
+
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", None, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant"},
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -136,9 +136,7 @@ def test_structured_output_no_content(
     else:
         assert len(logs) == 2
 
-        assert_message_in_logs(
-            logs[0], "gen_ai.user.message", None, spans[0]
-        )
+        assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
 
         choice_event = {
             "index": 0,

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -14,6 +14,9 @@
 
 """Tests for OpenAI structured outputs (chat.completions.parse) instrumentation."""
 
+import pytest
+from openai.resources.chat.completions import Completions
+
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -30,6 +33,11 @@ from .test_utils import (
     assert_message_in_logs,
     assert_messages_attribute,
     format_simple_expected_output_message,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(Completions, "parse"),
+    reason="parse() requires openai >= 1.40.0",
 )
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -75,14 +75,18 @@ def test_structured_output_with_content(
         )
         assert_messages_attribute(
             spans[0].attributes["gen_ai.output.messages"],
-            format_simple_expected_output_message(response.choices[0].message.content),
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
         )
     else:
         logs = log_exporter.get_finished_logs()
         assert len(logs) == 2
 
         user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
-        assert_message_in_logs(logs[0], "gen_ai.user.message", user_message, spans[0])
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
 
         choice_event = {
             "index": 0,
@@ -92,7 +96,9 @@ def test_structured_output_with_content(
                 "content": response.choices[0].message.content,
             },
         }
-        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
 
 
 def test_structured_output_no_content(
@@ -145,4 +151,6 @@ def test_structured_output_no_content(
             "finish_reason": "stop",
             "message": {"role": "assistant"},
         }
-        assert_message_in_logs(logs[1], "gen_ai.choice", choice_event, spans[0])
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )


### PR DESCRIPTION
# Description

The OpenAI v2 instrumentation currently wraps `chat.completions.create()` but not `chat.completions.parse()`. The `parse()` method is used for [structured outputs](https://platform.openai.com/docs/guides/structured-outputs). Calls to `parse()` generate zero telemetry even when instrumentors are configured.

This PR adds instrumentation for both sync and async `parse()` methods, reusing the existing chat completion wrapper logic.

Fixes #3449

## Changes
- Added `_is_parse_supported()` version guard and wrap/unwrap calls for parse methods
- Handle `response_format` being a Python type by recording `json_schema` as the output type attribute
- 8 new test cases (sync + async x content capture x semconv variants)
- 4 VCR cassettes for structured output calls

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
All 8 new tests pass. All 84 existing tests continue to pass.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
