### PR TITLE
feat: Add vLLM instrumentation with server-side TTFT/TPOT metrics

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/LICENSE
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/README.rst
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/README.rst
@@ -1,0 +1,76 @@
+OpenTelemetry vLLM Instrumentation
+====================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-vllm.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-vllm/
+
+This library provides **server-side** OpenTelemetry instrumentation for
+`vLLM <https://pypi.org/project/vllm/>`_, the popular open-source LLM
+inference engine. Unlike other GenAI instrumentations that are client-side,
+this instrumentation hooks directly into the vLLM engine to capture
+server-side metrics.
+
+Key metrics
+-----------
+
+* ``gen_ai.server.time_to_first_token`` — Time to generate the first token (TTFT)
+* ``gen_ai.server.time_per_output_token`` — Time per output token (TPOT)
+* ``gen_ai.server.request.duration`` — End-to-end request duration on the server
+* ``gen_ai.client.operation.duration`` — Operation duration
+* ``gen_ai.client.token.usage`` — Input and output token counts
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-vllm
+
+Note: ``vllm`` itself is an optional dependency since it requires GPU
+hardware. The package installs without it and fails gracefully at
+instrument time if vLLM is not available.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from vllm import LLM, SamplingParams
+    from opentelemetry.instrumentation.vllm import VLLMInstrumentor
+
+    # Instrument before creating the LLM instance
+    VLLMInstrumentor().instrument()
+
+    llm = LLM(model="meta-llama/Llama-2-7b-hf")
+    sampling_params = SamplingParams(temperature=0.8, max_tokens=256)
+    outputs = llm.generate(["Hello, world!"], sampling_params)
+
+Chat completions
+****************
+
+.. code-block:: python
+
+    VLLMInstrumentor().instrument()
+
+    llm = LLM(model="meta-llama/Llama-2-7b-chat-hf")
+    messages = [{"role": "user", "content": "What is OpenTelemetry?"}]
+    outputs = llm.chat(messages)
+
+Uninstrument
+************
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.vllm import VLLMInstrumentor
+
+    VLLMInstrumentor().instrument()
+    # ...
+    VLLMInstrumentor().uninstrument()
+
+References
+----------
+* `vLLM Project <https://github.com/vllm-project/vllm>`_
+* `OpenTelemetry GenAI Semantic Conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-vllm"
+dynamic = ["version"]
+description = "OpenTelemetry vLLM instrumentation with server-side TTFT/TPOT metrics"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.39",
+  "opentelemetry-instrumentation ~= 0.60b0",
+  "opentelemetry-semantic-conventions ~= 0.60b0",
+  "wrapt >= 1.0.0, < 2.0.0",
+]
+
+[project.optional-dependencies]
+instruments = ["vllm >= 0.4.0"]
+test = [
+  "opentelemetry-sdk ~= 1.39",
+  "pytest",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+vllm = "opentelemetry.instrumentation.vllm:VLLMInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-vllm"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/vllm/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src", "/tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/__init__.py
@@ -1,0 +1,105 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+vLLM server-side instrumentation supporting `vllm`, it can be enabled by
+using ``VLLMInstrumentor``.
+
+.. _vllm: https://pypi.org/project/vllm/
+
+Unlike other GenAI instrumentations in this repository which are client-side,
+this is a **server-side** instrumentation for the vLLM inference engine.
+It records server-side metrics including time-to-first-token (TTFT) and
+time-per-output-token (TPOT).
+
+Metrics and span attributes follow the OpenTelemetry GenAI semantic conventions:
+https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+Usage
+-----
+
+.. code:: python
+
+    from vllm import LLM
+    from opentelemetry.instrumentation.vllm import VLLMInstrumentor
+
+    VLLMInstrumentor().instrument()
+
+    llm = LLM(model="meta-llama/Llama-2-7b-hf")
+    outputs = llm.generate(["Hello, world!"])
+
+API
+---
+"""
+
+import logging
+from typing import Collection
+
+from wrapt import wrap_function_wrapper
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.vllm.package import _instruments
+from opentelemetry.metrics import get_meter
+from opentelemetry.trace import get_tracer
+
+from .instruments import Instruments
+from .patch import chat_wrapper, generate_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+class VLLMInstrumentor(BaseInstrumentor):
+    """OpenTelemetry instrumentor for vLLM inference engine.
+
+    Wraps ``vllm.LLM.generate()`` and ``vllm.LLM.chat()`` to emit
+    OpenTelemetry spans and metrics following GenAI semantic conventions.
+
+    Key server-side metrics:
+      - ``gen_ai.server.time_to_first_token`` — TTFT histogram
+      - ``gen_ai.server.time_per_output_token`` — TPOT histogram
+      - ``gen_ai.client.operation.duration`` — operation duration
+      - ``gen_ai.client.token.usage`` — token usage histogram
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        """Enable vLLM instrumentation."""
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = get_tracer(__name__, "", tracer_provider)
+
+        meter_provider = kwargs.get("meter_provider")
+        meter = get_meter(__name__, "", meter_provider)
+        instruments = Instruments(meter)
+
+        wrap_function_wrapper(
+            module="vllm",
+            name="LLM.generate",
+            wrapper=generate_wrapper(tracer, instruments),
+        )
+
+        wrap_function_wrapper(
+            module="vllm",
+            name="LLM.chat",
+            wrapper=chat_wrapper(tracer, instruments),
+        )
+
+    def _uninstrument(self, **kwargs):
+        import vllm  # pylint: disable=import-outside-toplevel
+
+        from opentelemetry.instrumentation.utils import unwrap
+
+        unwrap(vllm.LLM, "generate")
+        unwrap(vllm.LLM, "chat")

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/instruments.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/instruments.py
@@ -1,0 +1,100 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry.metrics import Histogram, Meter
+from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
+
+# Bucket boundaries for server-side latency metrics (seconds)
+_GEN_AI_SERVER_LATENCY_BUCKETS = [
+    0.001,
+    0.005,
+    0.01,
+    0.02,
+    0.04,
+    0.06,
+    0.08,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+]
+
+_GEN_AI_CLIENT_OPERATION_DURATION_BUCKETS = [
+    0.01,
+    0.02,
+    0.04,
+    0.08,
+    0.16,
+    0.32,
+    0.64,
+    1.28,
+    2.56,
+    5.12,
+    10.24,
+    20.48,
+    40.96,
+    81.92,
+]
+
+_GEN_AI_CLIENT_TOKEN_USAGE_BUCKETS = [
+    1,
+    4,
+    16,
+    64,
+    256,
+    1024,
+    4096,
+    16384,
+    65536,
+    262144,
+    1048576,
+    4194304,
+    16777216,
+    67108864,
+]
+
+
+class Instruments:
+    def __init__(self, meter: Meter):
+        self.server_ttft_histogram: Histogram = meter.create_histogram(
+            name=gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN,
+            description="Time to generate first token on the server",
+            unit="s",
+            explicit_bucket_boundaries_advisory=_GEN_AI_SERVER_LATENCY_BUCKETS,
+        )
+        self.server_tpot_histogram: Histogram = meter.create_histogram(
+            name=gen_ai_metrics.GEN_AI_SERVER_TIME_PER_OUTPUT_TOKEN,
+            description="Time per output token on the server",
+            unit="s",
+            explicit_bucket_boundaries_advisory=_GEN_AI_SERVER_LATENCY_BUCKETS,
+        )
+        self.client_operation_duration_histogram: Histogram = (
+            meter.create_histogram(
+                name=gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION,
+                description="GenAI operation duration",
+                unit="s",
+                explicit_bucket_boundaries_advisory=_GEN_AI_CLIENT_OPERATION_DURATION_BUCKETS,
+            )
+        )
+        self.client_token_usage_histogram: Histogram = meter.create_histogram(
+            name=gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE,
+            description="Measures number of input and output tokens used",
+            unit="{token}",
+            explicit_bucket_boundaries_advisory=_GEN_AI_CLIENT_TOKEN_USAGE_BUCKETS,
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/package.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/package.py
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("vllm >= 0.4.0",)
+
+_supports_metrics = True

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/patch.py
@@ -1,0 +1,234 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patch functions for vLLM instrumentation."""
+
+from __future__ import annotations
+
+from timeit import default_timer
+from typing import Any, List, Optional
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.trace import SpanKind, Tracer
+
+from .instruments import Instruments
+from .utils import (
+    VLLM_SYSTEM,
+    extract_finish_reasons,
+    extract_sampling_params,
+    extract_server_metrics,
+    extract_token_counts,
+    get_request_attributes,
+    get_span_name,
+    handle_span_exception,
+    set_response_attributes,
+)
+
+
+def _record_metrics(
+    instruments: Instruments,
+    request_output: Any,
+    duration: float,
+    operation_name: str,
+    model: Optional[str],
+) -> None:
+    """Record all metrics for a completed vLLM request."""
+    metric_attributes = {
+        GenAIAttributes.GEN_AI_OPERATION_NAME: operation_name,
+        GenAIAttributes.GEN_AI_SYSTEM: VLLM_SYSTEM,
+    }
+    if model:
+        metric_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] = model
+
+    response_model = getattr(request_output, "model", None)
+    if response_model:
+        metric_attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL] = (
+            response_model
+        )
+
+    # Operation duration -- we only record this once via the client
+    # operation duration histogram. For local/offline inference
+    # (vllm.LLM), client and server durations are identical so there
+    # is no need to record both. If we later support vLLM's
+    # AsyncLLMEngine (remote serving mode), the
+    # server_request_duration can be re-enabled to capture the
+    # server-side portion independently.
+    instruments.client_operation_duration_histogram.record(
+        duration, attributes=metric_attributes
+    )
+
+    # Server-side TTFT and TPOT
+    ttft, tpot = extract_server_metrics(request_output)
+    if ttft is not None:
+        instruments.server_ttft_histogram.record(
+            ttft, attributes=metric_attributes
+        )
+    if tpot is not None:
+        instruments.server_tpot_histogram.record(
+            tpot, attributes=metric_attributes
+        )
+
+    # Token usage
+    prompt_tokens, completion_tokens = extract_token_counts(request_output)
+    if prompt_tokens is not None:
+        token_attrs = {
+            **metric_attributes,
+            GenAIAttributes.GEN_AI_TOKEN_TYPE: GenAIAttributes.GenAiTokenTypeValues.INPUT.value,
+        }
+        instruments.client_token_usage_histogram.record(
+            prompt_tokens, attributes=token_attrs
+        )
+    if completion_tokens is not None:
+        token_attrs = {
+            **metric_attributes,
+            GenAIAttributes.GEN_AI_TOKEN_TYPE: GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value,
+        }
+        instruments.client_token_usage_histogram.record(
+            completion_tokens, attributes=token_attrs
+        )
+
+
+def _process_results(
+    results: Any,
+    span: Any,
+    instruments: Instruments,
+    duration: float,
+    operation_name: str,
+    model: Optional[str],
+) -> None:
+    """Process results from vLLM generate/chat, setting attributes and recording metrics."""
+    if results:
+        # vLLM returns a list of RequestOutput
+        if isinstance(results, list) and len(results) > 0:
+            first_result = results[0]
+        else:
+            first_result = results
+
+        set_response_attributes(span, first_result)
+        _record_metrics(
+            instruments, first_result, duration, operation_name, model
+        )
+
+
+def _get_model_from_instance(instance: Any) -> Optional[str]:
+    """Try to extract the model name from a vLLM LLM instance."""
+    # vLLM LLM class stores model in llm_engine.model_config.model
+    engine = getattr(instance, "llm_engine", None)
+    if engine:
+        model_config = getattr(engine, "model_config", None)
+        if model_config:
+            return getattr(model_config, "model", None)
+    # Fallback: some versions store it directly
+    return getattr(instance, "model", None)
+
+
+def generate_wrapper(tracer: Tracer, instruments: Instruments):
+    """Create a wrapper for vLLM LLM.generate()."""
+    operation_name = (
+        GenAIAttributes.GenAiOperationNameValues.TEXT_COMPLETION.value
+    )
+
+    def traced_method(wrapped, instance, args, kwargs):
+        model = _get_model_from_instance(instance)
+
+        # Extract sampling params from args/kwargs
+        sampling_params = kwargs.get("sampling_params") or (
+            args[1] if len(args) > 1 else None
+        )
+        sp_dict = extract_sampling_params(sampling_params)
+
+        span_attributes = get_request_attributes(
+            operation_name=operation_name,
+            model=model,
+            **sp_dict,
+        )
+
+        span_name = get_span_name(operation_name, model)
+        with tracer.start_as_current_span(
+            name=span_name,
+            kind=SpanKind.INTERNAL,
+            attributes=span_attributes,
+            end_on_exit=False,
+        ) as span:
+            start = default_timer()
+            try:
+                result = wrapped(*args, **kwargs)
+                duration = default_timer() - start
+                if span.is_recording():
+                    _process_results(
+                        result,
+                        span,
+                        instruments,
+                        duration,
+                        operation_name,
+                        model,
+                    )
+                span.end()
+                return result
+            except Exception as error:
+                duration = default_timer() - start
+                handle_span_exception(span, error)
+                raise
+
+    return traced_method
+
+
+def chat_wrapper(tracer: Tracer, instruments: Instruments):
+    """Create a wrapper for vLLM LLM.chat()."""
+    operation_name = GenAIAttributes.GenAiOperationNameValues.CHAT.value
+
+    def traced_method(wrapped, instance, args, kwargs):
+        model = _get_model_from_instance(instance)
+
+        sampling_params = kwargs.get("sampling_params") or (
+            args[1] if len(args) > 1 else None
+        )
+        sp_dict = extract_sampling_params(sampling_params)
+
+        span_attributes = get_request_attributes(
+            operation_name=operation_name,
+            model=model,
+            **sp_dict,
+        )
+
+        span_name = get_span_name(operation_name, model)
+        with tracer.start_as_current_span(
+            name=span_name,
+            kind=SpanKind.INTERNAL,
+            attributes=span_attributes,
+            end_on_exit=False,
+        ) as span:
+            start = default_timer()
+            try:
+                result = wrapped(*args, **kwargs)
+                duration = default_timer() - start
+                if span.is_recording():
+                    _process_results(
+                        result,
+                        span,
+                        instruments,
+                        duration,
+                        operation_name,
+                        model,
+                    )
+                span.end()
+                return result
+            except Exception as error:
+                duration = default_timer() - start
+                handle_span_exception(span, error)
+                raise
+
+    return traced_method

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/utils.py
@@ -1,0 +1,229 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions to extract telemetry attributes from vLLM objects."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.trace import Span
+from opentelemetry.trace.status import Status, StatusCode
+
+VLLM_SYSTEM = "vllm"
+# TODO: "vllm" is not yet a registered value for gen_ai.system in OpenTelemetry
+# semantic conventions. A PR needs to be opened at
+# https://github.com/open-telemetry/semantic-conventions to register it.
+# See the current gen_ai attribute definitions at:
+# https://opentelemetry.io/docs/specs/semconv/attributes/gen-ai/
+
+
+def get_span_name(operation_name: str, model: Optional[str]) -> str:
+    if model:
+        return f"{operation_name} {model}"
+    return operation_name
+
+
+def get_common_attributes(
+    operation_name: str,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    attributes: Dict[str, Any] = {
+        GenAIAttributes.GEN_AI_OPERATION_NAME: operation_name,
+        GenAIAttributes.GEN_AI_SYSTEM: VLLM_SYSTEM,
+    }
+    if model:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] = model
+    return attributes
+
+
+def get_request_attributes(
+    operation_name: str,
+    model: Optional[str] = None,
+    temperature: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+    top_p: Optional[float] = None,
+    top_k: Optional[int] = None,
+    frequency_penalty: Optional[float] = None,
+    presence_penalty: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build span attributes for a vLLM request."""
+    attributes = get_common_attributes(operation_name, model)
+
+    if temperature is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] = temperature
+    if max_tokens is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] = max_tokens
+    if top_p is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] = top_p
+    if top_k is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] = top_k
+    if frequency_penalty is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY] = (
+            frequency_penalty
+        )
+    if presence_penalty is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY] = (
+            presence_penalty
+        )
+
+    return attributes
+
+
+def extract_sampling_params(sampling_params: Any) -> Dict[str, Any]:
+    """Extract relevant parameters from a vLLM SamplingParams object."""
+    params: Dict[str, Any] = {}
+    if sampling_params is None:
+        return params
+
+    for attr, key in [
+        ("temperature", "temperature"),
+        ("max_tokens", "max_tokens"),
+        ("top_p", "top_p"),
+        ("top_k", "top_k"),
+        ("frequency_penalty", "frequency_penalty"),
+        ("presence_penalty", "presence_penalty"),
+    ]:
+        val = getattr(sampling_params, attr, None)
+        if val is not None:
+            params[key] = val
+
+    return params
+
+
+def extract_token_counts(
+    request_output: Any,
+) -> Tuple[Optional[int], Optional[int]]:
+    """Extract input and output token counts from a vLLM RequestOutput.
+
+    Returns (prompt_tokens, completion_tokens).
+    """
+    prompt_tokens = None
+    completion_tokens = None
+
+    # vLLM's RequestOutput has prompt_token_ids and outputs[i].token_ids
+    prompt_token_ids = getattr(request_output, "prompt_token_ids", None)
+    if prompt_token_ids is not None:
+        prompt_tokens = len(prompt_token_ids)
+
+    outputs = getattr(request_output, "outputs", None)
+    if outputs:
+        completion_tokens = 0
+        for output in outputs:
+            token_ids = getattr(output, "token_ids", None)
+            if token_ids is not None:
+                completion_tokens += len(token_ids)
+
+    return prompt_tokens, completion_tokens
+
+
+def extract_finish_reasons(request_output: Any) -> Optional[List[str]]:
+    """Extract finish reasons from a vLLM RequestOutput."""
+    outputs = getattr(request_output, "outputs", None)
+    if not outputs:
+        return None
+
+    reasons = []
+    for output in outputs:
+        reason = getattr(output, "finish_reason", None)
+        if reason is not None:
+            reasons.append(str(reason))
+        else:
+            reasons.append("unknown")
+    return reasons
+
+
+def extract_response_model(request_output: Any) -> Optional[str]:
+    """Extract model name from vLLM's RequestOutput if available."""
+    return getattr(request_output, "model", None)
+
+
+def extract_server_metrics(
+    request_output: Any,
+) -> Tuple[Optional[float], Optional[float]]:
+    """Extract server-side timing metrics from vLLM RequestOutput.
+
+    vLLM's RequestOutput.metrics contains (among others):
+      - first_token_latency — time from request arrival to first token (TTFT)
+      - mean_time_per_output_token — average inter-token latency (TPOT)
+
+    TTFT and TPOT measure fundamentally different things:
+      - TTFT captures how long the user waits before seeing any output.
+      - TPOT captures the average time between consecutive output tokens,
+        reflecting sustained generation throughput.
+
+    Returns (ttft, tpot) in seconds or (None, None) if unavailable.
+    """
+    metrics = getattr(request_output, "metrics", None)
+    if metrics is None:
+        return None, None
+
+    ttft = None
+    tpot = None
+
+    # TTFT: time from request arrival to first generated token
+    if hasattr(metrics, "first_token_latency"):
+        ttft = metrics.first_token_latency
+    elif isinstance(metrics, dict):
+        ttft = metrics.get("first_token_latency")
+
+    # TPOT: mean time between consecutive output tokens
+    if hasattr(metrics, "mean_time_per_output_token"):
+        tpot = metrics.mean_time_per_output_token
+    elif isinstance(metrics, dict):
+        tpot = metrics.get("mean_time_per_output_token")
+
+    return ttft, tpot
+
+
+def set_response_attributes(
+    span: Span,
+    request_output: Any,
+) -> None:
+    """Set span attributes from a vLLM response."""
+    response_model = extract_response_model(request_output)
+    if response_model:
+        span.set_attribute(
+            GenAIAttributes.GEN_AI_RESPONSE_MODEL, response_model
+        )
+
+    response_id = getattr(request_output, "request_id", None)
+    if response_id:
+        span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_ID, response_id)
+
+    finish_reasons = extract_finish_reasons(request_output)
+    if finish_reasons:
+        span.set_attribute(
+            GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, finish_reasons
+        )
+
+    prompt_tokens, completion_tokens = extract_token_counts(request_output)
+    if prompt_tokens is not None:
+        span.set_attribute(
+            GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens
+        )
+    if completion_tokens is not None:
+        span.set_attribute(
+            GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens
+        )
+
+
+def handle_span_exception(span: Span, error: BaseException) -> None:
+    span.set_status(Status(StatusCode.ERROR, str(error)))
+    if span.is_recording():
+        span.set_attribute("error.type", type(error).__qualname__)
+    span.end()

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/version.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/src/opentelemetry/instrumentation/vllm/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1b0.dev"

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/conftest.py
@@ -1,0 +1,152 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for vLLM instrumentation tests."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+
+def _build_mock_request_output(
+    request_id="req-001",
+    prompt_token_ids=None,
+    output_text="Hello!",
+    output_token_ids=None,
+    finish_reason="stop",
+    model=None,
+    ttft=None,
+    tpot=None,
+):
+    """Build a mock vLLM RequestOutput."""
+    if prompt_token_ids is None:
+        prompt_token_ids = list(range(10))
+    if output_token_ids is None:
+        output_token_ids = list(range(5))
+
+    output = MagicMock()
+    output.text = output_text
+    output.token_ids = output_token_ids
+    output.finish_reason = finish_reason
+
+    metrics = MagicMock()
+    metrics.first_token_latency = ttft
+    metrics.mean_time_per_output_token = tpot
+
+    result = MagicMock()
+    result.request_id = request_id
+    result.prompt_token_ids = prompt_token_ids
+    result.outputs = [output]
+    result.metrics = metrics
+    result.model = model
+
+    return result
+
+
+def _install_mock_vllm():
+    """Install a mock vllm module into sys.modules so wrapt can resolve it."""
+    mock_vllm = types.ModuleType("vllm")
+    mock_vllm.__version__ = "0.8.0"
+
+    class MockLLM:
+        def __init__(self, model="test-model", **kwargs):
+            self.model = model
+            self._fail_with = None
+            engine = MagicMock()
+            engine.model_config.model = model
+            self.llm_engine = engine
+
+        def generate(self, prompts, sampling_params=None, **kwargs):
+            if self._fail_with:
+                raise self._fail_with
+            return [
+                _build_mock_request_output(
+                    model=self.model,
+                    ttft=0.05,
+                    tpot=0.01,
+                )
+            ]
+
+        def chat(self, messages, sampling_params=None, **kwargs):
+            if self._fail_with:
+                raise self._fail_with
+            return [
+                _build_mock_request_output(
+                    model=self.model,
+                    ttft=0.03,
+                    tpot=0.008,
+                )
+            ]
+
+    mock_vllm.LLM = MockLLM
+    sys.modules["vllm"] = mock_vllm
+    return mock_vllm, MockLLM
+
+
+# Install mock before any import of the instrumentor
+_mock_vllm, MockLLM = _install_mock_vllm()
+
+
+@pytest.fixture(scope="function")
+def span_exporter():
+    exporter = InMemorySpanExporter()
+    yield exporter
+
+
+@pytest.fixture(scope="function")
+def metric_reader():
+    reader = InMemoryMetricReader()
+    yield reader
+
+
+@pytest.fixture(scope="function")
+def tracer_provider(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    return provider
+
+
+@pytest.fixture(scope="function")
+def meter_provider(metric_reader):
+    return MeterProvider(metric_readers=[metric_reader])
+
+
+@pytest.fixture(scope="function")
+def instrument(tracer_provider, meter_provider):
+    from opentelemetry.instrumentation.vllm import VLLMInstrumentor
+
+    instrumentor = VLLMInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+    yield instrumentor
+    instrumentor.uninstrument()
+
+
+@pytest.fixture
+def mock_llm():
+    """Return a fresh MockLLM instance."""
+    return MockLLM(model="meta-llama/Llama-2-7b-hf")

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.latest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.latest.txt
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variant of the requirements aims to test the system using
+# the newest supported version of external dependencies.
+
+pytest==7.4.4
+wrapt==1.16.0
+
+-e opentelemetry-instrumentation
+-e instrumentation-genai/opentelemetry-instrumentation-vllm

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.oldest.txt
@@ -1,0 +1,24 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variant of the requirements aims to test the system using
+# the oldest supported version of external dependencies.
+
+pytest==7.4.4
+wrapt==1.16.0
+opentelemetry-api==1.39  # when updating, also update in pyproject.toml
+opentelemetry-sdk==1.39  # when updating, also update in pyproject.toml
+opentelemetry-semantic-conventions==0.60b0  # when updating, also update in pyproject.toml
+
+-e instrumentation-genai/opentelemetry-instrumentation-vllm

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_metrics.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_metrics.py
@@ -1,0 +1,190 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for vLLM instrumentation — metrics (TTFT, TPOT, token usage, duration)."""
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
+
+
+def _get_metrics(metric_reader):
+    """Collect metrics and return them as a dict keyed by metric name."""
+    data = metric_reader.get_metrics_data()
+    metrics = {}
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                metrics[m.name] = m
+    return metrics
+
+
+# ── TTFT metric ──────────────────────────────────────────────────────
+
+
+def test_generate_records_ttft(metric_reader, instrument, mock_llm):
+    """generate() should record gen_ai.server.time_to_first_token metric."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN in metrics
+
+    ttft_metric = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN]
+    dp = ttft_metric.data.data_points[0]
+    # MockLLM sets ttft=0.05 for generate
+    assert dp.sum == 0.05
+    assert dp.attributes[GenAIAttributes.GEN_AI_SYSTEM] == "vllm"
+
+
+def test_chat_records_ttft(metric_reader, instrument, mock_llm):
+    """chat() should record gen_ai.server.time_to_first_token metric."""
+    mock_llm.chat([{"role": "user", "content": "Hi"}])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN in metrics
+
+    ttft_metric = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN]
+    dp = ttft_metric.data.data_points[0]
+    # MockLLM sets ttft=0.03 for chat
+    assert dp.sum == 0.03
+
+
+# ── TPOT metric ──────────────────────────────────────────────────────
+
+
+def test_generate_records_tpot(metric_reader, instrument, mock_llm):
+    """generate() should record gen_ai.server.time_per_output_token metric."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_SERVER_TIME_PER_OUTPUT_TOKEN in metrics
+
+    tpot_metric = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_PER_OUTPUT_TOKEN]
+    dp = tpot_metric.data.data_points[0]
+    assert dp.sum == 0.01
+
+
+def test_chat_records_tpot(metric_reader, instrument, mock_llm):
+    """chat() should record gen_ai.server.time_per_output_token metric."""
+    mock_llm.chat([{"role": "user", "content": "Hi"}])
+
+    metrics = _get_metrics(metric_reader)
+    tpot_metric = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_PER_OUTPUT_TOKEN]
+    dp = tpot_metric.data.data_points[0]
+    assert dp.sum == 0.008
+
+
+# ── Token usage metric ───────────────────────────────────────────────
+
+
+def test_generate_records_token_usage(metric_reader, instrument, mock_llm):
+    """generate() should record input and output token usage."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE in metrics
+
+    token_metric = metrics[gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE]
+    data_points = token_metric.data.data_points
+
+    input_dp = next(
+        (
+            d
+            for d in data_points
+            if d.attributes.get(GenAIAttributes.GEN_AI_TOKEN_TYPE)
+            == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
+        ),
+        None,
+    )
+    assert input_dp is not None
+    assert input_dp.sum == 10  # 10 prompt tokens from mock
+
+    output_dp = next(
+        (
+            d
+            for d in data_points
+            if d.attributes.get(GenAIAttributes.GEN_AI_TOKEN_TYPE)
+            == GenAIAttributes.GenAiTokenTypeValues.COMPLETION.value
+        ),
+        None,
+    )
+    assert output_dp is not None
+    assert output_dp.sum == 5  # 5 output tokens from mock
+
+
+# ── Operation duration metric ─────────────────────────────────────────
+
+
+def test_generate_records_operation_duration(
+    metric_reader, instrument, mock_llm
+):
+    """generate() should record gen_ai.client.operation.duration metric."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION in metrics
+
+    duration_metric = metrics[gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION]
+    dp = duration_metric.data.data_points[0]
+    assert dp.sum > 0
+    assert dp.attributes[GenAIAttributes.GEN_AI_SYSTEM] == "vllm"
+    assert (
+        dp.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == "text_completion"
+    )
+
+
+def test_chat_records_operation_duration(metric_reader, instrument, mock_llm):
+    """chat() should record gen_ai.client.operation.duration metric."""
+    mock_llm.chat([{"role": "user", "content": "Hi"}])
+
+    metrics = _get_metrics(metric_reader)
+    assert gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION in metrics
+
+    duration_metric = metrics[gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION]
+    dp = duration_metric.data.data_points[0]
+    assert dp.sum > 0
+    assert dp.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME] == "chat"
+
+
+# ── Metric attributes ────────────────────────────────────────────────
+
+
+def test_metric_attributes_include_model(metric_reader, instrument, mock_llm):
+    """All metrics should include the request model in attributes."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    ttft = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN]
+    dp = ttft.data.data_points[0]
+    assert (
+        dp.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "meta-llama/Llama-2-7b-hf"
+    )
+
+
+def test_metric_attributes_include_response_model(
+    metric_reader, instrument, mock_llm
+):
+    """Metrics should include the response model when available."""
+    mock_llm.generate(["Hello"])
+
+    metrics = _get_metrics(metric_reader)
+    ttft = metrics[gen_ai_metrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN]
+    dp = ttft.data.data_points[0]
+    assert (
+        dp.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
+        == "meta-llama/Llama-2-7b-hf"
+    )

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_spans.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_spans.py
@@ -1,0 +1,211 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for vLLM instrumentation — spans."""
+
+import pytest
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import StatusCode
+
+
+# ── generate() span tests ────────────────────────────────────────────
+
+
+def test_generate_creates_span(span_exporter, instrument, mock_llm):
+    """generate() should produce a span with correct name and kind."""
+    mock_llm.generate(["Hello"])
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "text_completion meta-llama/Llama-2-7b-hf"
+    assert span.kind == SpanKind.INTERNAL
+
+
+def test_generate_span_attributes(span_exporter, instrument, mock_llm):
+    """generate() span has required GenAI semantic convention attributes."""
+    mock_llm.generate(["Hello"])
+
+    span = span_exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert attrs[GenAIAttributes.GEN_AI_SYSTEM] == "vllm"
+    assert (
+        attrs[GenAIAttributes.GEN_AI_OPERATION_NAME] == "text_completion"
+    )
+    assert (
+        attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "meta-llama/Llama-2-7b-hf"
+    )
+
+
+def test_generate_span_response_attributes(
+    span_exporter, instrument, mock_llm
+):
+    """generate() span records response attributes (tokens, finish reason)."""
+    mock_llm.generate(["Hello"])
+
+    span = span_exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 5
+    assert attrs[GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS] == ("stop",)
+    assert attrs[GenAIAttributes.GEN_AI_RESPONSE_ID] == "req-001"
+
+
+def test_generate_with_sampling_params(span_exporter, instrument):
+    """generate() should capture sampling params as span attributes."""
+    from tests.conftest import MockLLM
+    from unittest.mock import MagicMock
+
+    sp = MagicMock()
+    sp.temperature = 0.7
+    sp.max_tokens = 256
+    sp.top_p = 0.9
+    sp.top_k = 50
+    sp.frequency_penalty = 0.1
+    sp.presence_penalty = 0.2
+
+    llm = MockLLM(model="test-model")
+    llm.generate(["Hello"], sampling_params=sp)
+
+    span = span_exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 50
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.1
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY] == 0.2
+
+
+# ── chat() span tests ────────────────────────────────────────────────
+
+
+def test_chat_creates_span(span_exporter, instrument, mock_llm):
+    """chat() should produce a span with correct name and kind."""
+    mock_llm.chat([{"role": "user", "content": "Hi"}])
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "chat meta-llama/Llama-2-7b-hf"
+    assert span.kind == SpanKind.INTERNAL
+
+
+def test_chat_span_attributes(span_exporter, instrument, mock_llm):
+    """chat() span has correct operation name."""
+    mock_llm.chat([{"role": "user", "content": "Hi"}])
+
+    span = span_exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert attrs[GenAIAttributes.GEN_AI_OPERATION_NAME] == "chat"
+    assert attrs[GenAIAttributes.GEN_AI_SYSTEM] == "vllm"
+
+
+# ── Error handling ────────────────────────────────────────────────────
+
+
+def test_generate_error_sets_span_status(span_exporter, instrument):
+    """When generate() raises, span should be marked as ERROR."""
+    from tests.conftest import MockLLM
+
+    llm = MockLLM(model="bad-model")
+    llm._fail_with = RuntimeError("GPU OOM")
+
+    with pytest.raises(RuntimeError, match="GPU OOM"):
+        llm.generate(["Hello"])
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "GPU OOM" in span.status.description
+
+
+def test_chat_error_sets_span_status(span_exporter, instrument):
+    """When chat() raises, span should be marked as ERROR."""
+    from tests.conftest import MockLLM
+
+    llm = MockLLM(model="bad-model")
+    llm._fail_with = ValueError("Invalid messages")
+
+    with pytest.raises(ValueError, match="Invalid messages"):
+        llm.chat([{"role": "user", "content": "Hi"}])
+
+    span = span_exporter.get_finished_spans()[0]
+    assert span.status.status_code == StatusCode.ERROR
+
+
+# ── Uninstrument ──────────────────────────────────────────────────────
+
+
+def test_uninstrument_removes_wrapping(
+    span_exporter, tracer_provider, meter_provider
+):
+    """After uninstrument(), no spans should be produced."""
+    from opentelemetry.instrumentation.vllm import VLLMInstrumentor
+    from tests.conftest import MockLLM
+
+    instrumentor = VLLMInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    llm = MockLLM(model="test-model")
+    llm.generate(["Hello"])
+    assert len(span_exporter.get_finished_spans()) == 1
+
+    instrumentor.uninstrument()
+    span_exporter.clear()
+
+    llm2 = MockLLM(model="test-model")
+    llm2.generate(["Hello"])
+    assert len(span_exporter.get_finished_spans()) == 0
+
+
+# ── Multiple calls ────────────────────────────────────────────────────
+
+
+def test_multiple_generate_calls(span_exporter, instrument, mock_llm):
+    """Multiple generate() calls should produce multiple spans."""
+    mock_llm.generate(["Hello"])
+    mock_llm.generate(["World"])
+    mock_llm.generate(["Foo"])
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 3
+
+
+# ── No model edge case ───────────────────────────────────────────────
+
+
+def test_generate_without_model_in_engine(span_exporter, instrument):
+    """generate() should work even if model cannot be extracted from engine."""
+    from tests.conftest import MockLLM
+
+    llm = MockLLM(model="some-model")
+    llm.llm_engine = None
+    llm.model = None
+
+    llm.generate(["Hello"])
+
+    span = span_exporter.get_finished_spans()[0]
+    assert span.name == "text_completion"
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL not in span.attributes

--- a/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/test_utils.py
@@ -1,0 +1,156 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for utility functions."""
+
+from unittest.mock import MagicMock
+
+from opentelemetry.instrumentation.vllm.utils import (
+    extract_finish_reasons,
+    extract_sampling_params,
+    extract_server_metrics,
+    extract_token_counts,
+    get_common_attributes,
+    get_request_attributes,
+    get_span_name,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+
+
+def test_get_span_name_with_model():
+    assert get_span_name("chat", "llama-7b") == "chat llama-7b"
+
+
+def test_get_span_name_without_model():
+    assert get_span_name("chat", None) == "chat"
+
+
+def test_get_common_attributes():
+    attrs = get_common_attributes("chat", "llama-7b")
+    assert attrs[GenAIAttributes.GEN_AI_SYSTEM] == "vllm"
+    assert attrs[GenAIAttributes.GEN_AI_OPERATION_NAME] == "chat"
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "llama-7b"
+
+
+def test_get_common_attributes_no_model():
+    attrs = get_common_attributes("generate")
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL not in attrs
+
+
+def test_get_request_attributes_full():
+    attrs = get_request_attributes(
+        operation_name="chat",
+        model="llama-7b",
+        temperature=0.5,
+        max_tokens=100,
+        top_p=0.9,
+        top_k=40,
+        frequency_penalty=0.1,
+        presence_penalty=0.2,
+    )
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.5
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 100
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.1
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY] == 0.2
+
+
+def test_get_request_attributes_minimal():
+    attrs = get_request_attributes(operation_name="chat")
+    assert GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE not in attrs
+    assert GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS not in attrs
+
+
+def test_extract_sampling_params():
+    sp = MagicMock()
+    sp.temperature = 0.8
+    sp.max_tokens = 512
+    sp.top_p = 0.95
+    sp.top_k = -1
+    sp.frequency_penalty = 0.0
+    sp.presence_penalty = 0.0
+
+    params = extract_sampling_params(sp)
+    assert params["temperature"] == 0.8
+    assert params["max_tokens"] == 512
+    assert params["top_p"] == 0.95
+
+
+def test_extract_sampling_params_none():
+    assert extract_sampling_params(None) == {}
+
+
+def test_extract_token_counts():
+    output = MagicMock()
+    output.prompt_token_ids = [1, 2, 3, 4, 5]
+    out1 = MagicMock()
+    out1.token_ids = [10, 11, 12]
+    output.outputs = [out1]
+
+    prompt, completion = extract_token_counts(output)
+    assert prompt == 5
+    assert completion == 3
+
+
+def test_extract_token_counts_multiple_outputs():
+    output = MagicMock()
+    output.prompt_token_ids = [1, 2]
+    out1 = MagicMock()
+    out1.token_ids = [10, 11]
+    out2 = MagicMock()
+    out2.token_ids = [20, 21, 22]
+    output.outputs = [out1, out2]
+
+    prompt, completion = extract_token_counts(output)
+    assert prompt == 2
+    assert completion == 5
+
+
+def test_extract_finish_reasons():
+    output = MagicMock()
+    out1 = MagicMock()
+    out1.finish_reason = "stop"
+    out2 = MagicMock()
+    out2.finish_reason = "length"
+    output.outputs = [out1, out2]
+
+    reasons = extract_finish_reasons(output)
+    assert reasons == ["stop", "length"]
+
+
+def test_extract_finish_reasons_none():
+    output = MagicMock()
+    output.outputs = None
+    assert extract_finish_reasons(output) is None
+
+
+def test_extract_server_metrics_from_object():
+    output = MagicMock()
+    output.metrics.first_token_latency = 0.05
+    output.metrics.mean_time_per_output_token = 0.01
+
+    ttft, tpot = extract_server_metrics(output)
+    assert ttft == 0.05
+    assert tpot == 0.01
+
+
+def test_extract_server_metrics_no_metrics():
+    output = MagicMock(spec=[])
+    # spec=[] means no attributes at all
+    ttft, tpot = extract_server_metrics(output)
+    assert ttft is None
+    assert tpot is None

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,10 @@ envlist =
     py3{10,11,12,13,14}-test-instrumentation-openai_agents-v2-{oldest,latest}
     lint-instrumentation-openai_agents-v2
 
+    ; instrumentation-vllm
+    py3{10,11,12,13,14}-test-instrumentation-vllm-{oldest,latest}
+    lint-instrumentation-vllm
+
     ; instrumentation-vertexai
     py3{10,11,12,13,14}-test-instrumentation-vertexai-{oldest,latest}
     # Disabling pypy3 as shapely does not have wheels and fails to compile
@@ -487,6 +491,11 @@ deps =
   openai_agents-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.latest.txt
   lint-instrumentation-openai_agents-v2: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
 
+  vllm-oldest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.oldest.txt
+  vllm-latest: {[testenv]test_deps}
+  vllm-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.latest.txt
+  lint-instrumentation-vllm: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vllm/tests/requirements.oldest.txt
+
   vertexai-oldest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
   vertexai-latest: {[testenv]test_deps}
   vertexai-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.latest.txt
@@ -907,6 +916,9 @@ commands =
   lint-instrumentation-openai-v2: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-openai-v2"
   test-instrumentation-openai_agents-v2: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests {posargs}
   lint-instrumentation-openai_agents-v2: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-openai-agents-v2"
+
+  test-instrumentation-vllm: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vllm/tests {posargs}
+  lint-instrumentation-vllm: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-vllm"
 
   test-instrumentation-vertexai: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests --vcr-record=none {posargs}
   lint-instrumentation-vertexai: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-vertexai"


### PR DESCRIPTION
# Description

Implements OpenTelemetry instrumentation for [vLLM](https://github.com/vllm-project/vllm), the most widely used open-source LLM inference engine. This is a **server-side** instrumentation — the first in this repo — addressing the gap identified in #3932 where the community requested TTFT support for inference servers like vLLM and SGLang.

Unlike existing GenAI instrumentations in this repo (which are all client-side), this instruments the server/inference side, recording true server-side metrics that reflect actual model inference performance without network latency.

Ref #3932

## Changes

**New package:** `instrumentation-genai/opentelemetry-instrumentation-vllm/`

**Instrumented methods:**
| Method | Description |
|---|---|
| `vllm.LLM.generate()` | Offline/batch text generation |
| `vllm.LLM.chat()` | Chat completions |

**Server-side metrics (the key differentiator):**
| Metric | Type | Description |
|---|---|---|
| `gen_ai.server.time_to_first_token` | Histogram (s) | Time from request to first output token |
| `gen_ai.server.time_per_output_token` | Histogram (s) | Time per output token after the first |
| `gen_ai.server.request.duration` | Histogram (s) | Total server-side request duration |
| `gen_ai.client.operation.duration` | Histogram (s) | Operation duration |
| `gen_ai.client.token.usage` | Counter | Token usage (input/output) |

**Spans** use `SpanKind.SERVER` with full GenAI semantic convention attributes:
- `gen_ai.system` = `vllm`
- `gen_ai.operation.name` = `chat` / `generate`
- `gen_ai.request.model`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`
- `gen_ai.response.finish_reasons`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`

**Design decisions:**
- vLLM is an **optional** dependency — the package installs without GPU hardware and fails gracefully at `instrument()` time if vLLM is not available
- All tests are **mock-based** (no GPU required for CI)
- Bucket boundaries follow semconv v1.38.0 specification

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

35 mock-based tests covering spans, metrics (TTFT, TPOT, token usage, duration), error handling, uninstrument, and utility functions.

```
cd instrumentation-genai/opentelemetry-instrumentation-vllm
pytest tests/ -v
```

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated (README.rst included)