### PR TITLE
fix(celery): coerce non-string values to str in CeleryGetter.get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `pylint` to `4.0.5`
   ([#4244](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4244))
 
+### Fixed
+
+- `opentelemetry-instrumentation-celery`: Coerce non-string header values to `str` in `CeleryGetter.get()` so context propagation does not fail when downstream libraries set non-string headers
+  ([#4434](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4434))
+
 ### Breaking changes
 
 - Drop Python 3.9 support

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -104,8 +104,14 @@ class CeleryGetter(Getter):
         value = getattr(carrier, key, None)
         if value is None:
             return None
-        if isinstance(value, str) or not isinstance(value, Iterable):
-            value = (value,)
+        if isinstance(value, str):
+            return (value,)
+        if not isinstance(value, Iterable):
+            # Coerce non-string, non-iterable values (e.g. int from Celery
+            # task attributes like timelimit) to str so that propagators
+            # such as TraceContext don't crash with a TypeError when calling
+            # re.split() on the value.
+            return (str(value),)
         return value
 
     def keys(self, carrier):


### PR DESCRIPTION
## Description

`CeleryGetter.get()` previously returned header values verbatim. When a downstream library sets a non-string value in the header map (e.g. an int), propagator machinery downstream fails because it expects `str`. Coerce non-string values with `str()` so context propagation is robust.

Fixes #4341

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Changelog entry added under `Unreleased / Fixed`