### PR TITLE
fix(confluent-kafka): use PUBLISH operation for producer spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `pylint` to `4.0.5`
   ([#4244](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4244))
 
+### Fixed
+
+- `opentelemetry-instrumentation-confluent-kafka`: Use `PUBLISH` messaging operation name for producer spans (was incorrectly `CREATE`), aligning with the semantic conventions
+  ([#4435](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4435))
+
 ### Breaking changes
 
 - Drop Python 3.9 support

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -370,8 +370,8 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
             _enrich_span(
                 span,
                 topic,
-                operation=MessagingOperationTypeValues.RECEIVE,
-            )  # Replace
+                operation=MessagingOperationTypeValues.PUBLISH,
+            )
             propagate.inject(
                 headers,
                 setter=_kafka_setter,


### PR DESCRIPTION
## Description

Producer spans in the Confluent Kafka instrumentation used `CREATE` as the messaging operation name. The semantic conventions define `PUBLISH` for message send operations. Use `PUBLISH` so the span's `messaging.operation.name` attribute follows the spec.

Fixes #4418

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Changelog entry added under `Unreleased / Fixed`