### PR TITLE
fix(redis): extract ClusterPipeline commands from _execution_strategy in redis-py 6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `pylint` to `4.0.5`
   ([#4244](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4244))
 
+### Fixed
+
+- `opentelemetry-instrumentation-redis`: Extract `ClusterPipeline` commands from `_execution_strategy` in redis-py 6+ so span attributes include the pipelined commands instead of being empty
+  ([#4436](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4436))
+
 ### Breaking changes
 
 - Drop Python 3.9 support

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/util.py
@@ -184,11 +184,17 @@ def _build_span_meta_data_for_pipeline(
     instance: PipelineInstance | AsyncPipelineInstance,
 ) -> tuple[list[Any], str, str]:
     try:
-        command_stack = (
-            instance.command_stack
-            if hasattr(instance, "command_stack")
-            else instance._command_stack
-        )
+        # redis-py 6+ ClusterPipeline stores commands on _execution_strategy.
+        # Fall back to command_stack / _command_stack for older versions and
+        # non-cluster pipelines.
+        if hasattr(instance, "_execution_strategy") and hasattr(
+            instance._execution_strategy, "command_queue"
+        ):
+            command_stack = instance._execution_strategy.command_queue
+        elif hasattr(instance, "command_stack"):
+            command_stack = instance.command_stack
+        else:
+            command_stack = instance._command_stack
 
         cmds = [
             _format_command_args(c.args if hasattr(c, "args") else c[0])


### PR DESCRIPTION
## Description

In redis-py 6+, `ClusterPipeline` moved its pending command list from a direct attribute to an internal `_execution_strategy` object. The instrumentation still read the old attribute path and therefore saw an empty command list, so span attributes for pipelined cluster commands were blank.

Extract the command list from `_execution_strategy` when present so the span attributes reflect the actual pipelined commands.

Fixes #4420

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Changelog entry added under `Unreleased / Fixed`