### PR TITLE
fix(flask): wrap wsgi_app call in try/finally to prevent active_requests gauge leak

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -415,48 +415,50 @@ def _rewrapped_app(
                     response_hook(span, status, response_headers)
             return start_response(status, response_headers, *args, **kwargs)
 
-        result = wsgi_app(wrapped_app_environ, _start_response)
+        try:
+            result = wsgi_app(wrapped_app_environ, _start_response)
 
-        # Note: Streaming response context cleanup is now handled in the Flask teardown function
-        # (_wrapped_teardown_request) to ensure proper cleanup following Logfire's recommendations
-        # for OpenTelemetry generator context management
+            # Note: Streaming response context cleanup is now handled in the Flask teardown function
+            # (_wrapped_teardown_request) to ensure proper cleanup following Logfire's recommendations
+            # for OpenTelemetry generator context management
 
-        if should_trace:
-            duration_s = default_timer() - start
-            # Get the span from wrapped_app_environ and re-create context manually
-            # to pass to histogram for exemplars generation
-            span = wrapped_app_environ.get(_ENVIRON_SPAN_KEY)
-            metrics_context = trace.set_span_in_context(span)
+            if should_trace:
+                duration_s = default_timer() - start
+                # Get the span from wrapped_app_environ and re-create context manually
+                # to pass to histogram for exemplars generation
+                span = wrapped_app_environ.get(_ENVIRON_SPAN_KEY)
+                metrics_context = trace.set_span_in_context(span)
 
-            if duration_histogram_old:
-                duration_attrs_old = otel_wsgi._parse_duration_attrs(
-                    attributes, _StabilityMode.DEFAULT
-                )
+                if duration_histogram_old:
+                    duration_attrs_old = otel_wsgi._parse_duration_attrs(
+                        attributes, _StabilityMode.DEFAULT
+                    )
 
-                if request_route:
-                    # http.target to be included in old semantic conventions
-                    duration_attrs_old[HTTP_TARGET] = str(request_route)
-                duration_histogram_old.record(
-                    max(round(duration_s * 1000), 0),
-                    duration_attrs_old,
-                    context=metrics_context,
-                )
-            if duration_histogram_new:
-                duration_attrs_new = otel_wsgi._parse_duration_attrs(
-                    attributes, _StabilityMode.HTTP
-                )
+                    if request_route:
+                        # http.target to be included in old semantic conventions
+                        duration_attrs_old[HTTP_TARGET] = str(request_route)
+                    duration_histogram_old.record(
+                        max(round(duration_s * 1000), 0),
+                        duration_attrs_old,
+                        context=metrics_context,
+                    )
+                if duration_histogram_new:
+                    duration_attrs_new = otel_wsgi._parse_duration_attrs(
+                        attributes, _StabilityMode.HTTP
+                    )
 
-                if request_route:
-                    duration_attrs_new[HTTP_ROUTE] = str(request_route)
+                    if request_route:
+                        duration_attrs_new[HTTP_ROUTE] = str(request_route)
 
-                duration_histogram_new.record(
-                    max(duration_s, 0),
-                    duration_attrs_new,
-                    context=metrics_context,
-                )
+                    duration_histogram_new.record(
+                        max(duration_s, 0),
+                        duration_attrs_new,
+                        context=metrics_context,
+                    )
 
-        active_requests_counter.add(-1, active_requests_count_attrs)
-        return result
+            return result
+        finally:
+            active_requests_counter.add(-1, active_requests_count_attrs)
 
     def _should_trace(excluded_urls) -> bool:
         return bool(

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -454,6 +454,45 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
 
+    def test_active_requests_counter_decremented_on_error(self):
+        """Verify http.server.active_requests is decremented even when the
+        view raises an exception.  Before the try/finally fix, the counter
+        would leak (permanently increment) on errors."""
+
+        # Successful request – counter should return to 0
+        resp = self.client.get("/hello/123")
+        self.assertEqual(200, resp.status_code)
+        resp.close()
+
+        # Request that triggers a 500 via ValueError in the view
+        resp = self.client.get("/hello/500")
+        self.assertEqual(500, resp.status_code)
+        resp.close()
+
+        # Collect metrics and find the active_requests counter
+        metrics_list = self.memory_metrics_reader.get_metrics_data()
+        active_requests_value = None
+        for resource_metric in metrics_list.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "http.server.active_requests":
+                        for point in metric.data.data_points:
+                            if isinstance(point, NumberDataPoint):
+                                active_requests_value = point.value
+
+        # The counter must be back to 0 — both the successful and the
+        # error request should have been properly decremented.
+        self.assertIsNotNone(
+            active_requests_value,
+            "http.server.active_requests metric not found",
+        )
+        self.assertEqual(
+            0,
+            active_requests_value,
+            "active_requests counter leaked: expected 0 after all "
+            "requests completed, but got %d" % active_requests_value,
+        )
+
     def test_exclude_lists_from_env(self):
         self.client.get("/env_excluded_arg/123")
         span_list = self.memory_exporter.get_finished_spans()


### PR DESCRIPTION
## Description

The `_rewrapped_app` function in the Flask instrumentation increments `active_requests_counter` before calling `wsgi_app()`, but the decrement is **not** protected by `try/finally`. If an exception propagates out of `wsgi_app()`, the counter is never decremented, causing a permanent gauge leak in `http.server.active_requests`.

This is particularly impactful when using this metric for Kubernetes HPA — leaked counters cause HPA to see phantom load and refuse to scale down.

## Changes

1. **`flask/__init__.py`**: Wrapped the `wsgi_app()` call + duration recording in `try/finally` to ensure `active_requests_counter.add(-1, ...)` always executes.

2. **`tests/test_programmatic.py`**: Added `test_active_requests_counter_decremented_on_error` that verifies the counter returns to 0 after both successful and error (500) requests.

## Rationale

The **WSGI instrumentation** already uses the correct pattern:

```python
# wsgi/__init__.py — correct
try:
    with trace.use_span(span):
        iterable = self.wsgi(environ, start_response)
        return _end_span_after_iterating(iterable, span, token)
except Exception as ex:
    raise
finally:
    self.active_requests_counter.add(-1, active_requests_count_attrs)
```

The Flask instrumentation should be consistent.

## How to reproduce

1. Run a Flask app with `opentelemetry-instrument` and gunicorn
2. Send requests that trigger unhandled exceptions or OOM-kill workers mid-request
3. Observe `http.server.active_requests` — it increments but never decrements for crashed requests
4. The gauge stays permanently elevated until the process restarts

Fixes #4431