### PR TITLE
feat(langchain): add semconv attributes, operation mapping, and content recording modules [1/5]

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/content_recording.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/content_recording.py
@@ -1,0 +1,109 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin integration layer over the shared genai content capture utilities.
+
+Provides clear APIs for the LangChain callback handler to decide what
+content should be recorded on spans and events.
+"""
+
+from typing import Optional
+
+from opentelemetry.util.genai.types import ContentCapturingMode
+from opentelemetry.util.genai.utils import (
+    get_content_capturing_mode,
+    is_experimental_mode,
+    should_emit_event,
+)
+
+
+class ContentPolicy:
+    """Determines what content should be recorded on spans and events.
+
+    Wraps the shared genai utility functions to provide a clean API
+    for the callback handler. All properties are evaluated lazily so
+    that environment variable changes are picked up immediately.
+    """
+
+    @property
+    def should_record_content_on_spans(self) -> bool:
+        """Whether message/tool content should be recorded as span attributes."""
+        return self.mode in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        )
+
+    @property
+    def should_emit_events(self) -> bool:
+        """Whether content events should be emitted."""
+        return should_emit_event()
+
+    @property
+    def record_content(self) -> bool:
+        """Whether content should be recorded at all (spans or events)."""
+        return self.should_record_content_on_spans or self.should_emit_events
+
+    @property
+    def mode(self) -> ContentCapturingMode:
+        """The current content capturing mode.
+
+        Returns ``NO_CONTENT`` when not running in experimental mode.
+        """
+        if not is_experimental_mode():
+            return ContentCapturingMode.NO_CONTENT
+        return get_content_capturing_mode()
+
+
+# -- Helper functions for specific content types ------------------------------
+# All opt-in content types follow the same underlying policy today.  Separate
+# helpers are provided so call-sites read clearly and so that per-type
+# overrides can be added later without changing every caller.
+
+
+def should_record_messages(policy: ContentPolicy) -> bool:
+    """Whether input/output messages should be recorded on spans."""
+    return policy.should_record_content_on_spans
+
+
+def should_record_tool_content(policy: ContentPolicy) -> bool:
+    """Whether tool arguments and results should be recorded on spans."""
+    return policy.should_record_content_on_spans
+
+
+def should_record_retriever_content(policy: ContentPolicy) -> bool:
+    """Whether retriever queries and document content should be recorded."""
+    return policy.should_record_content_on_spans
+
+
+def should_record_system_instructions(policy: ContentPolicy) -> bool:
+    """Whether system instructions should be recorded on spans."""
+    return policy.should_record_content_on_spans
+
+
+# -- Default singleton --------------------------------------------------------
+
+_default_policy: Optional[ContentPolicy] = None
+
+
+def get_content_policy() -> ContentPolicy:
+    """Get the content policy based on current environment configuration.
+
+    Returns a module-level singleton.  Because the policy reads
+    environment variables lazily on every property access, a single
+    instance is sufficient.
+    """
+    global _default_policy  # noqa: PLW0603
+    if _default_policy is None:
+        _default_policy = ContentPolicy()
+    return _default_policy

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/operation_mapping.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/operation_mapping.py
@@ -1,0 +1,256 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Callback-to-semconv operation mapping for LangChain callbacks.
+
+Maps each LangChain callback to the correct GenAI semantic convention
+operation name.  Direct callbacks (``on_chat_model_start``,
+``on_llm_start``, ``on_tool_start``, ``on_retriever_start``) have a
+fixed 1-to-1 mapping.  ``on_chain_start`` requires heuristic
+classification because LangChain emits this callback for agents,
+workflows, and internal plumbing alike.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+
+__all__ = [
+    "OperationName",
+    "classify_chain_run",
+    "resolve_agent_name",
+    "should_ignore_chain",
+]
+
+# ---------------------------------------------------------------------------
+# Operation name constants (sourced from the GenAI semconv enum where
+# available, with string fallbacks for values not yet in the enum).
+# ---------------------------------------------------------------------------
+
+
+class OperationName:
+    """Canonical GenAI semantic convention operation names."""
+
+    CHAT: str = GenAI.GenAiOperationNameValues.CHAT.value
+    TEXT_COMPLETION: str = GenAI.GenAiOperationNameValues.TEXT_COMPLETION.value
+    INVOKE_AGENT: str = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value
+    EXECUTE_TOOL: str = GenAI.GenAiOperationNameValues.EXECUTE_TOOL.value
+    # invoke_workflow is not yet in the semconv enum; use the expected
+    # string value so the mapping is forward-compatible.
+    INVOKE_WORKFLOW: str = "invoke_workflow"
+
+
+# ---------------------------------------------------------------------------
+# LangGraph markers – names and prefixes produced by LangGraph that must
+# be recognized when classifying ``on_chain_start`` callbacks.
+# ---------------------------------------------------------------------------
+
+LANGGRAPH_NODE_KEY = "langgraph_node"
+LANGGRAPH_START_NODE = "__start__"
+MIDDLEWARE_PREFIX = "Middleware."
+LANGGRAPH_IDENTIFIER = "LangGraph"
+
+# Metadata keys used by callers to override classification.
+_META_AGENT_SPAN = "otel_agent_span"
+_META_WORKFLOW_SPAN = "otel_workflow_span"
+_META_AGENT_NAME = "agent_name"
+_META_AGENT_TYPE = "agent_type"
+_META_OTEL_TRACE = "otel_trace"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_agent_name(
+    serialized: dict[str, Any],
+    metadata: Optional[dict[str, Any]],
+    kwargs: dict[str, Any],
+) -> Optional[str]:
+    """Derive the best-effort agent name from callback arguments.
+
+    Checks (in priority order):
+    1. ``metadata["agent_name"]``
+    2. ``kwargs["name"]``
+    3. ``serialized["name"]``
+    4. ``metadata["langgraph_node"]`` (if present and not a start node)
+    """
+    if metadata:
+        name = metadata.get(_META_AGENT_NAME)
+        if name:
+            return str(name)
+
+    name = kwargs.get("name")
+    if name:
+        return str(name)
+
+    name = serialized.get("name")
+    if name:
+        return str(name)
+
+    if metadata:
+        node = metadata.get(LANGGRAPH_NODE_KEY)
+        if node and node != LANGGRAPH_START_NODE:
+            return str(node)
+
+    return None
+
+
+def _has_agent_signals(metadata: Optional[dict[str, Any]]) -> bool:
+    """Return True when metadata contains any signal that the chain is an agent."""
+    if not metadata:
+        return False
+    return bool(
+        metadata.get(_META_AGENT_SPAN)
+        or metadata.get(_META_AGENT_NAME)
+        or metadata.get(_META_AGENT_TYPE)
+    )
+
+
+def _is_langgraph_agent_node(
+    serialized: dict[str, Any],
+    metadata: Optional[dict[str, Any]],
+    kwargs: dict[str, Any],
+) -> bool:
+    """Detect a LangGraph agent node that is not a start/middleware node."""
+    if not metadata:
+        return False
+
+    node = metadata.get(LANGGRAPH_NODE_KEY)
+    if not node:
+        return False
+
+    # Exclude start and middleware nodes.
+    if node == LANGGRAPH_START_NODE:
+        return False
+
+    name = resolve_agent_name(serialized, metadata, kwargs)
+    if name and name.startswith(MIDDLEWARE_PREFIX):
+        return False
+
+    return True
+
+
+def _looks_like_workflow(
+    serialized: dict[str, Any],
+    metadata: Optional[dict[str, Any]],
+    parent_run_id: Optional[UUID],
+) -> bool:
+    """Return True if the chain looks like a top-level workflow/graph."""
+    if parent_run_id is not None:
+        return False
+
+    # An explicit workflow override is authoritative.
+    if metadata and metadata.get(_META_WORKFLOW_SPAN):
+        return True
+
+    # Heuristic: check for LangGraph identifier in the serialized repr.
+    name = serialized.get("name", "")
+    graph_id = (
+        serialized.get("graph", {}).get("id", "")
+        if isinstance(serialized.get("graph"), dict)
+        else ""
+    )
+    return LANGGRAPH_IDENTIFIER in name or LANGGRAPH_IDENTIFIER in graph_id
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def should_ignore_chain(
+    metadata: Optional[dict[str, Any]],
+    agent_name: Optional[str],
+    parent_run_id: Optional[UUID],
+    kwargs: dict[str, Any],
+) -> bool:
+    """Return True if the chain callback should be silently suppressed.
+
+    Suppression happens when:
+    * The node is the LangGraph ``__start__`` node.
+    * The name carries the ``Middleware.`` prefix.
+    * ``metadata["otel_trace"]`` is explicitly ``False``.
+    * ``metadata["otel_agent_span"]`` is explicitly ``False`` and no other
+      agent signals are present.
+    """
+    if metadata:
+        node = metadata.get(LANGGRAPH_NODE_KEY)
+        if node == LANGGRAPH_START_NODE:
+            return True
+
+        if metadata.get(_META_OTEL_TRACE) is False:
+            return True
+
+        if (
+            metadata.get(_META_AGENT_SPAN) is False
+            and not metadata.get(_META_AGENT_NAME)
+            and not metadata.get(_META_AGENT_TYPE)
+        ):
+            return True
+
+    if agent_name and agent_name.startswith(MIDDLEWARE_PREFIX):
+        return True
+
+    name_from_kwargs = kwargs.get("name", "")
+    if isinstance(name_from_kwargs, str) and name_from_kwargs.startswith(
+        MIDDLEWARE_PREFIX
+    ):
+        return True
+
+    return False
+
+
+def classify_chain_run(
+    serialized: dict[str, Any],
+    metadata: Optional[dict[str, Any]],
+    kwargs: dict[str, Any],
+    parent_run_id: Optional[UUID] = None,
+) -> Optional[str]:
+    """Classify a ``on_chain_start`` callback into a semconv operation.
+
+    Returns one of the :class:`OperationName` constants, or ``None`` when
+    the chain should be suppressed (no span emitted).
+
+    Classification order:
+    1. Check for explicit suppression signals.
+    2. Check for agent signals → ``invoke_agent``.
+    3. Check for workflow signals → ``invoke_workflow``.
+    4. Default: ``None`` (suppress – unclassified chains are not emitted).
+    """
+    agent_name = resolve_agent_name(serialized, metadata, kwargs)
+
+    # 1. Suppress known noise.
+    if should_ignore_chain(metadata, agent_name, parent_run_id, kwargs):
+        return None
+
+    # 2. Agent detection.
+    if _has_agent_signals(metadata):
+        return OperationName.INVOKE_AGENT
+
+    if _is_langgraph_agent_node(serialized, metadata, kwargs):
+        return OperationName.INVOKE_AGENT
+
+    # 3. Workflow / orchestration detection.
+    if _looks_like_workflow(serialized, metadata, parent_run_id):
+        return OperationName.INVOKE_WORKFLOW
+
+    # 4. Default: suppress unclassified chains.
+    return None

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/semconv_attributes.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/semconv_attributes.py
@@ -1,0 +1,313 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-operation attribute matrix based on OTel GenAI semantic conventions.
+
+Single source of truth for which attributes apply to which operations
+in the LangChain instrumentor. Attribute requirement levels follow:
+https://opentelemetry.io/docs/specs/semconv/gen-ai/
+"""
+
+from __future__ import annotations
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    server_attributes as Server,
+)
+from opentelemetry.semconv.attributes import (
+    error_attributes as Error,
+)
+from opentelemetry.trace import SpanKind
+
+# ---------------------------------------------------------------------------
+# Operation name constants
+# ---------------------------------------------------------------------------
+
+OP_CHAT = GenAI.GenAiOperationNameValues.CHAT.value  # "chat"
+OP_TEXT_COMPLETION = (
+    GenAI.GenAiOperationNameValues.TEXT_COMPLETION.value
+)  # "text_completion"
+OP_INVOKE_AGENT = (
+    GenAI.GenAiOperationNameValues.INVOKE_AGENT.value
+)  # "invoke_agent"
+OP_EXECUTE_TOOL = (
+    GenAI.GenAiOperationNameValues.EXECUTE_TOOL.value
+)  # "execute_tool"
+
+# These operations are not yet in the semconv enum; define as literals.
+OP_INVOKE_WORKFLOW = "invoke_workflow"
+OP_RETRIEVAL = "retrieval"
+
+# ---------------------------------------------------------------------------
+# Attribute key aliases (not yet in the released semconv package)
+# ---------------------------------------------------------------------------
+
+GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
+GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
+    "gen_ai.usage.cache_creation.input_tokens"
+)
+GEN_AI_AGENT_VERSION = "gen_ai.agent.version"
+GEN_AI_WORKFLOW_NAME = "gen_ai.workflow.name"
+
+# ---------------------------------------------------------------------------
+# Attribute sets per operation, grouped by requirement level
+#
+# Requirement levels (per OpenTelemetry specification):
+#   REQUIRED           – MUST be provided.
+#   CONDITIONALLY_REQ  – MUST be provided when the stated condition is met.
+#   RECOMMENDED        – SHOULD be provided.
+#   OPT_IN             – MAY be provided; typically gated by a config flag.
+# ---------------------------------------------------------------------------
+
+# ---- chat / text_completion (inference client spans) ----------------------
+
+INFERENCE_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_OPERATION_NAME,
+        GenAI.GEN_AI_PROVIDER_NAME,
+    }
+)
+
+INFERENCE_CONDITIONALLY_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_REQUEST_MODEL,  # if available
+        Error.ERROR_TYPE,  # if response is an error
+        Server.SERVER_PORT,  # if server.address is set
+        GenAI.GEN_AI_REQUEST_SEED,  # if present in request
+        GenAI.GEN_AI_REQUEST_CHOICE_COUNT,  # if != 1
+        GenAI.GEN_AI_OUTPUT_TYPE,  # if applicable
+        GenAI.GEN_AI_CONVERSATION_ID,  # if available
+    }
+)
+
+INFERENCE_RECOMMENDED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_REQUEST_MAX_TOKENS,
+        GenAI.GEN_AI_REQUEST_TEMPERATURE,
+        GenAI.GEN_AI_REQUEST_TOP_P,
+        GenAI.GEN_AI_REQUEST_TOP_K,
+        GenAI.GEN_AI_REQUEST_STOP_SEQUENCES,
+        GenAI.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+        GenAI.GEN_AI_REQUEST_PRESENCE_PENALTY,
+        GenAI.GEN_AI_RESPONSE_ID,
+        GenAI.GEN_AI_RESPONSE_MODEL,
+        GenAI.GEN_AI_RESPONSE_FINISH_REASONS,
+        GenAI.GEN_AI_USAGE_INPUT_TOKENS,
+        GenAI.GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+        Server.SERVER_ADDRESS,
+    }
+)
+
+INFERENCE_OPT_IN: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_SYSTEM_INSTRUCTIONS,
+        GenAI.GEN_AI_INPUT_MESSAGES,
+        GenAI.GEN_AI_OUTPUT_MESSAGES,
+        GenAI.GEN_AI_TOOL_DEFINITIONS,
+    }
+)
+
+# ---- invoke_agent --------------------------------------------------------
+
+AGENT_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_OPERATION_NAME,
+        GenAI.GEN_AI_PROVIDER_NAME,
+    }
+)
+
+AGENT_CONDITIONALLY_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_AGENT_ID,
+        GenAI.GEN_AI_AGENT_NAME,
+        GenAI.GEN_AI_AGENT_DESCRIPTION,
+        GEN_AI_AGENT_VERSION,
+        GenAI.GEN_AI_REQUEST_MODEL,
+        GenAI.GEN_AI_DATA_SOURCE_ID,
+        Error.ERROR_TYPE,  # if response is an error
+        GenAI.GEN_AI_CONVERSATION_ID,
+    }
+)
+
+AGENT_RECOMMENDED: frozenset[str] = frozenset(
+    {
+        Server.SERVER_ADDRESS,
+        # All inference request/response attributes are also recommended
+        GenAI.GEN_AI_REQUEST_MAX_TOKENS,
+        GenAI.GEN_AI_REQUEST_TEMPERATURE,
+        GenAI.GEN_AI_REQUEST_TOP_P,
+        GenAI.GEN_AI_REQUEST_TOP_K,
+        GenAI.GEN_AI_REQUEST_STOP_SEQUENCES,
+        GenAI.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+        GenAI.GEN_AI_REQUEST_PRESENCE_PENALTY,
+        GenAI.GEN_AI_RESPONSE_ID,
+        GenAI.GEN_AI_RESPONSE_MODEL,
+        GenAI.GEN_AI_RESPONSE_FINISH_REASONS,
+        GenAI.GEN_AI_USAGE_INPUT_TOKENS,
+        GenAI.GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+    }
+)
+
+AGENT_OPT_IN: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_SYSTEM_INSTRUCTIONS,
+        GenAI.GEN_AI_INPUT_MESSAGES,
+        GenAI.GEN_AI_OUTPUT_MESSAGES,
+    }
+)
+
+# ---- execute_tool --------------------------------------------------------
+
+TOOL_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_OPERATION_NAME,
+    }
+)
+
+TOOL_CONDITIONALLY_REQUIRED: frozenset[str] = frozenset(
+    {
+        Error.ERROR_TYPE,  # if response is an error
+    }
+)
+
+TOOL_RECOMMENDED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_TOOL_NAME,
+        GenAI.GEN_AI_TOOL_CALL_ID,
+        GenAI.GEN_AI_TOOL_DESCRIPTION,
+        GenAI.GEN_AI_TOOL_TYPE,
+    }
+)
+
+TOOL_OPT_IN: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_TOOL_CALL_ARGUMENTS,
+        GenAI.GEN_AI_TOOL_CALL_RESULT,
+    }
+)
+
+# ---- invoke_workflow -----------------------------------------------------
+
+WORKFLOW_REQUIRED: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_OPERATION_NAME,
+    }
+)
+
+WORKFLOW_CONDITIONALLY_REQUIRED: frozenset[str] = frozenset(
+    {
+        Error.ERROR_TYPE,  # if response is an error
+        GEN_AI_WORKFLOW_NAME,  # if available
+    }
+)
+
+WORKFLOW_RECOMMENDED: frozenset[str] = frozenset()
+
+WORKFLOW_OPT_IN: frozenset[str] = frozenset(
+    {
+        GenAI.GEN_AI_INPUT_MESSAGES,
+        GenAI.GEN_AI_OUTPUT_MESSAGES,
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Aggregate lookup: operation → (required, conditionally_required,
+#                                 recommended, opt_in)
+# ---------------------------------------------------------------------------
+
+OPERATION_ATTRIBUTES: dict[
+    str,
+    tuple[
+        frozenset[str],
+        frozenset[str],
+        frozenset[str],
+        frozenset[str],
+    ],
+] = {
+    OP_CHAT: (
+        INFERENCE_REQUIRED,
+        INFERENCE_CONDITIONALLY_REQUIRED,
+        INFERENCE_RECOMMENDED,
+        INFERENCE_OPT_IN,
+    ),
+    OP_TEXT_COMPLETION: (
+        INFERENCE_REQUIRED,
+        INFERENCE_CONDITIONALLY_REQUIRED,
+        INFERENCE_RECOMMENDED,
+        INFERENCE_OPT_IN,
+    ),
+    OP_INVOKE_AGENT: (
+        AGENT_REQUIRED,
+        AGENT_CONDITIONALLY_REQUIRED,
+        AGENT_RECOMMENDED,
+        AGENT_OPT_IN,
+    ),
+    OP_EXECUTE_TOOL: (
+        TOOL_REQUIRED,
+        TOOL_CONDITIONALLY_REQUIRED,
+        TOOL_RECOMMENDED,
+        TOOL_OPT_IN,
+    ),
+    OP_INVOKE_WORKFLOW: (
+        WORKFLOW_REQUIRED,
+        WORKFLOW_CONDITIONALLY_REQUIRED,
+        WORKFLOW_RECOMMENDED,
+        WORKFLOW_OPT_IN,
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# SpanKind helper
+# ---------------------------------------------------------------------------
+
+_CLIENT_OPERATIONS: frozenset[str] = frozenset(
+    {OP_CHAT, OP_TEXT_COMPLETION, OP_INVOKE_AGENT}
+)
+
+
+def get_operation_span_kind(operation: str) -> SpanKind:
+    """Return the correct SpanKind for the given operation.
+
+    * ``chat``, ``text_completion``, ``invoke_agent`` → ``SpanKind.CLIENT``
+    * ``execute_tool``, ``invoke_workflow``, and others → ``SpanKind.INTERNAL``
+    """
+    if operation in _CLIENT_OPERATIONS:
+        return SpanKind.CLIENT
+    return SpanKind.INTERNAL
+
+
+# ---------------------------------------------------------------------------
+# Metric applicability
+#
+# Maps metric instrument names to the set of operations they apply to.
+# ---------------------------------------------------------------------------
+
+METRIC_OPERATION_DURATION = "gen_ai.client.operation.duration"
+METRIC_TOKEN_USAGE = "gen_ai.client.token.usage"
+METRIC_TIME_TO_FIRST_CHUNK = "gen_ai.client.operation.time_to_first_chunk"
+METRIC_TIME_PER_OUTPUT_CHUNK = "gen_ai.client.operation.time_per_output_chunk"
+
+METRIC_APPLICABLE_OPERATIONS: dict[str, frozenset[str]] = {
+    METRIC_OPERATION_DURATION: frozenset({OP_CHAT, OP_TEXT_COMPLETION}),
+    METRIC_TOKEN_USAGE: frozenset({OP_CHAT, OP_TEXT_COMPLETION}),
+    # Streaming-only metrics (chat / text_completion)
+    METRIC_TIME_TO_FIRST_CHUNK: frozenset({OP_CHAT, OP_TEXT_COMPLETION}),
+    METRIC_TIME_PER_OUTPUT_CHUNK: frozenset({OP_CHAT, OP_TEXT_COMPLETION}),
+}

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/tests/test_content_recording.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/tests/test_content_recording.py
@@ -1,0 +1,263 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from opentelemetry.instrumentation._semconv import (
+    _OpenTelemetrySemanticConventionStability,
+)
+from opentelemetry.instrumentation.langchain.content_recording import (
+    ContentPolicy,
+    should_record_messages,
+    should_record_retriever_content,
+    should_record_system_instructions,
+    should_record_tool_content,
+)
+from opentelemetry.util.genai.types import ContentCapturingMode
+
+
+@pytest.fixture(autouse=True)
+def _reset_semconv_stability(monkeypatch):
+    """Reset semconv stability cache so each test can set its own env vars."""
+    orig_initialized = _OpenTelemetrySemanticConventionStability._initialized
+    orig_mapping = _OpenTelemetrySemanticConventionStability._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING.copy()
+
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    _OpenTelemetrySemanticConventionStability._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = {}
+
+    monkeypatch.delenv("OTEL_SEMCONV_STABILITY_OPT_IN", raising=False)
+    monkeypatch.delenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False
+    )
+    monkeypatch.delenv("OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT", raising=False)
+
+    yield
+
+    _OpenTelemetrySemanticConventionStability._initialized = orig_initialized
+    _OpenTelemetrySemanticConventionStability._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = orig_mapping
+
+
+def _enter_experimental(monkeypatch, capture_mode):
+    """Set env vars for experimental mode and re-initialize stability."""
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", capture_mode
+    )
+    _OpenTelemetrySemanticConventionStability._initialize()
+
+
+# ---------------------------------------------------------------------------
+# ContentPolicy – experimental mode with each ContentCapturingMode
+# ---------------------------------------------------------------------------
+
+
+class TestContentPolicySpanOnly:
+    """SPAN_ONLY: content on spans, no events."""
+
+    def test_should_record_content_on_spans(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_ONLY")
+        assert ContentPolicy().should_record_content_on_spans is True
+
+    def test_should_emit_events(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_ONLY")
+        assert ContentPolicy().should_emit_events is False
+
+    def test_record_content(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_ONLY")
+        assert ContentPolicy().record_content is True
+
+    def test_mode(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_ONLY")
+        assert ContentPolicy().mode == ContentCapturingMode.SPAN_ONLY
+
+
+class TestContentPolicyEventOnly:
+    """EVENT_ONLY: events enabled without duplicating content on spans."""
+
+    def test_should_record_content_on_spans(self, monkeypatch):
+        _enter_experimental(monkeypatch, "EVENT_ONLY")
+        assert ContentPolicy().should_record_content_on_spans is False
+
+    def test_should_emit_events(self, monkeypatch):
+        _enter_experimental(monkeypatch, "EVENT_ONLY")
+        assert ContentPolicy().should_emit_events is True
+
+    def test_record_content(self, monkeypatch):
+        _enter_experimental(monkeypatch, "EVENT_ONLY")
+        assert ContentPolicy().record_content is True
+
+    def test_mode(self, monkeypatch):
+        _enter_experimental(monkeypatch, "EVENT_ONLY")
+        assert ContentPolicy().mode == ContentCapturingMode.EVENT_ONLY
+
+
+class TestContentPolicySpanAndEvent:
+    """SPAN_AND_EVENT: both spans and events active."""
+
+    def test_should_record_content_on_spans(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_AND_EVENT")
+        assert ContentPolicy().should_record_content_on_spans is True
+
+    def test_should_emit_events(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_AND_EVENT")
+        assert ContentPolicy().should_emit_events is True
+
+    def test_record_content(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_AND_EVENT")
+        assert ContentPolicy().record_content is True
+
+    def test_mode(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_AND_EVENT")
+        assert ContentPolicy().mode == ContentCapturingMode.SPAN_AND_EVENT
+
+
+class TestContentPolicyNoContent:
+    """NO_CONTENT: nothing recorded."""
+
+    def test_should_record_content_on_spans(self, monkeypatch):
+        _enter_experimental(monkeypatch, "NO_CONTENT")
+        assert ContentPolicy().should_record_content_on_spans is False
+
+    def test_should_emit_events(self, monkeypatch):
+        _enter_experimental(monkeypatch, "NO_CONTENT")
+        assert ContentPolicy().should_emit_events is False
+
+    def test_record_content(self, monkeypatch):
+        _enter_experimental(monkeypatch, "NO_CONTENT")
+        assert ContentPolicy().record_content is False
+
+    def test_mode(self, monkeypatch):
+        _enter_experimental(monkeypatch, "NO_CONTENT")
+        assert ContentPolicy().mode == ContentCapturingMode.NO_CONTENT
+
+
+class TestContentPolicyRecordContentCombined:
+    """record_content is True when either spans or events are enabled."""
+
+    @pytest.mark.parametrize(
+        "capture_mode, expected",
+        [
+            ("SPAN_ONLY", True),
+            ("EVENT_ONLY", True),
+            ("SPAN_AND_EVENT", True),
+            ("NO_CONTENT", False),
+        ],
+    )
+    def test_record_content(self, monkeypatch, capture_mode, expected):
+        _enter_experimental(monkeypatch, capture_mode)
+        assert ContentPolicy().record_content is expected
+
+
+# ---------------------------------------------------------------------------
+# ContentPolicy – outside experimental mode
+# ---------------------------------------------------------------------------
+
+
+class TestContentPolicyNonExperimental:
+    """Without experimental opt-in everything is disabled."""
+
+    def test_should_record_content_on_spans(self):
+        _OpenTelemetrySemanticConventionStability._initialize()
+        assert ContentPolicy().should_record_content_on_spans is False
+
+    def test_should_emit_events(self):
+        _OpenTelemetrySemanticConventionStability._initialize()
+        assert ContentPolicy().should_emit_events is False
+
+    def test_record_content(self):
+        _OpenTelemetrySemanticConventionStability._initialize()
+        assert ContentPolicy().record_content is False
+
+    def test_mode_is_no_content(self):
+        _OpenTelemetrySemanticConventionStability._initialize()
+        assert ContentPolicy().mode == ContentCapturingMode.NO_CONTENT
+
+
+# ---------------------------------------------------------------------------
+# Helper functions – delegates to policy.should_record_content_on_spans
+# ---------------------------------------------------------------------------
+
+
+class _StubPolicy:
+    """Minimal stand-in for ContentPolicy with a fixed boolean."""
+
+    def __init__(self, value: bool):
+        self.should_record_content_on_spans = value
+
+
+class TestShouldRecordMessages:
+    def test_true_when_policy_enabled(self):
+        assert should_record_messages(_StubPolicy(True)) is True
+
+    def test_false_when_policy_disabled(self):
+        assert should_record_messages(_StubPolicy(False)) is False
+
+
+class TestShouldRecordToolContent:
+    def test_true_when_policy_enabled(self):
+        assert should_record_tool_content(_StubPolicy(True)) is True
+
+    def test_false_when_policy_disabled(self):
+        assert should_record_tool_content(_StubPolicy(False)) is False
+
+
+class TestShouldRecordRetrieverContent:
+    def test_true_when_policy_enabled(self):
+        assert should_record_retriever_content(_StubPolicy(True)) is True
+
+    def test_false_when_policy_disabled(self):
+        assert should_record_retriever_content(_StubPolicy(False)) is False
+
+
+class TestShouldRecordSystemInstructions:
+    def test_true_when_policy_enabled(self):
+        assert should_record_system_instructions(_StubPolicy(True)) is True
+
+    def test_false_when_policy_disabled(self):
+        assert should_record_system_instructions(_StubPolicy(False)) is False
+
+
+# ---------------------------------------------------------------------------
+# Helper functions – integration with real ContentPolicy via env vars
+# ---------------------------------------------------------------------------
+
+
+class TestHelperFunctionsIntegration:
+    """Verify helpers produce correct results with a real ContentPolicy."""
+
+    def test_all_helpers_true_with_span_only(self, monkeypatch):
+        _enter_experimental(monkeypatch, "SPAN_ONLY")
+        policy = ContentPolicy()
+        assert should_record_messages(policy) is True
+        assert should_record_tool_content(policy) is True
+        assert should_record_retriever_content(policy) is True
+        assert should_record_system_instructions(policy) is True
+
+    def test_all_helpers_false_with_no_content(self, monkeypatch):
+        _enter_experimental(monkeypatch, "NO_CONTENT")
+        policy = ContentPolicy()
+        assert should_record_messages(policy) is False
+        assert should_record_tool_content(policy) is False
+        assert should_record_retriever_content(policy) is False
+        assert should_record_system_instructions(policy) is False
+
+    def test_all_helpers_false_outside_experimental(self):
+        _OpenTelemetrySemanticConventionStability._initialize()
+        policy = ContentPolicy()
+        assert should_record_messages(policy) is False
+        assert should_record_tool_content(policy) is False
+        assert should_record_retriever_content(policy) is False
+        assert should_record_system_instructions(policy) is False

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/tests/test_operation_mapping.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/tests/test_operation_mapping.py
@@ -1,0 +1,336 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid4
+
+from opentelemetry.instrumentation.langchain.operation_mapping import (
+    OperationName,
+    classify_chain_run,
+    resolve_agent_name,
+    should_ignore_chain,
+)
+
+# ---------------------------------------------------------------------------
+# classify_chain_run
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyChainRunAgentDetection:
+    """Agent signals → invoke_agent."""
+
+    def test_otel_agent_span_true(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"otel_agent_span": True},
+            kwargs={},
+        )
+        assert result == OperationName.INVOKE_AGENT
+
+    def test_metadata_agent_name(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"agent_name": "my-agent"},
+            kwargs={},
+        )
+        assert result == OperationName.INVOKE_AGENT
+
+    def test_metadata_agent_type(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"agent_type": "react"},
+            kwargs={},
+        )
+        assert result == OperationName.INVOKE_AGENT
+
+    def test_langgraph_agent_node(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"langgraph_node": "researcher"},
+            kwargs={},
+        )
+        assert result == OperationName.INVOKE_AGENT
+
+    def test_agent_signals_override_workflow(self):
+        """Agent signals take priority over workflow heuristics."""
+        result = classify_chain_run(
+            serialized={"name": "LangGraph"},
+            metadata={"otel_agent_span": True},
+            kwargs={},
+            parent_run_id=None,
+        )
+        assert result == OperationName.INVOKE_AGENT
+
+
+class TestClassifyChainRunWorkflowDetection:
+    """Workflow signals → invoke_workflow."""
+
+    def test_top_level_langgraph_by_name(self):
+        result = classify_chain_run(
+            serialized={"name": "LangGraph"},
+            metadata={},
+            kwargs={},
+            parent_run_id=None,
+        )
+        assert result == OperationName.INVOKE_WORKFLOW
+
+    def test_top_level_langgraph_by_graph_id(self):
+        result = classify_chain_run(
+            serialized={"name": "other", "graph": {"id": "LangGraph-abc"}},
+            metadata={},
+            kwargs={},
+            parent_run_id=None,
+        )
+        assert result == OperationName.INVOKE_WORKFLOW
+
+    def test_otel_workflow_span_true(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"otel_workflow_span": True},
+            kwargs={},
+            parent_run_id=None,
+        )
+        assert result == OperationName.INVOKE_WORKFLOW
+
+    def test_not_workflow_when_has_parent(self):
+        """LangGraph name alone is not enough when there is a parent run."""
+        result = classify_chain_run(
+            serialized={"name": "LangGraph"},
+            metadata={},
+            kwargs={},
+            parent_run_id=uuid4(),
+        )
+        assert result is None
+
+
+class TestClassifyChainRunSuppression:
+    """Chains that should be suppressed (return None)."""
+
+    def test_start_node_suppressed(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"langgraph_node": "__start__"},
+            kwargs={},
+        )
+        assert result is None
+
+    def test_middleware_prefix_suppressed(self):
+        result = classify_chain_run(
+            serialized={"name": "Middleware.auth"},
+            metadata={"langgraph_node": "Middleware.auth"},
+            kwargs={"name": "Middleware.auth"},
+        )
+        assert result is None
+
+    def test_otel_trace_false(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"otel_trace": False},
+            kwargs={},
+        )
+        assert result is None
+
+    def test_otel_agent_span_false_no_other_signals(self):
+        result = classify_chain_run(
+            serialized={},
+            metadata={"otel_agent_span": False},
+            kwargs={},
+        )
+        assert result is None
+
+    def test_unclassified_generic_chain(self):
+        result = classify_chain_run(
+            serialized={"name": "RunnableSequence"},
+            metadata={},
+            kwargs={},
+            parent_run_id=uuid4(),
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# should_ignore_chain
+# ---------------------------------------------------------------------------
+
+
+class TestShouldIgnoreChain:
+    """Suppression logic for known noise chains."""
+
+    def test_ignores_start_node(self):
+        assert should_ignore_chain(
+            metadata={"langgraph_node": "__start__"},
+            agent_name=None,
+            parent_run_id=None,
+            kwargs={},
+        )
+
+    def test_ignores_middleware_agent_name(self):
+        assert should_ignore_chain(
+            metadata={},
+            agent_name="Middleware.something",
+            parent_run_id=None,
+            kwargs={},
+        )
+
+    def test_ignores_middleware_in_kwargs_name(self):
+        assert should_ignore_chain(
+            metadata={},
+            agent_name=None,
+            parent_run_id=None,
+            kwargs={"name": "Middleware.guard"},
+        )
+
+    def test_ignores_otel_trace_false(self):
+        assert should_ignore_chain(
+            metadata={"otel_trace": False},
+            agent_name=None,
+            parent_run_id=None,
+            kwargs={},
+        )
+
+    def test_ignores_otel_agent_span_false_no_signals(self):
+        assert should_ignore_chain(
+            metadata={"otel_agent_span": False},
+            agent_name=None,
+            parent_run_id=None,
+            kwargs={},
+        )
+
+    def test_does_not_ignore_otel_agent_span_false_with_agent_name(self):
+        """otel_agent_span=False is overridden when agent_name is present."""
+        assert not should_ignore_chain(
+            metadata={"otel_agent_span": False, "agent_name": "planner"},
+            agent_name="planner",
+            parent_run_id=None,
+            kwargs={},
+        )
+
+    def test_does_not_ignore_normal_agent_node(self):
+        assert not should_ignore_chain(
+            metadata={"langgraph_node": "researcher"},
+            agent_name="researcher",
+            parent_run_id=uuid4(),
+            kwargs={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# resolve_agent_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAgentName:
+    """Best-effort agent name resolution from callback arguments."""
+
+    def test_from_metadata_agent_name(self):
+        assert (
+            resolve_agent_name(
+                serialized={},
+                metadata={"agent_name": "planner"},
+                kwargs={},
+            )
+            == "planner"
+        )
+
+    def test_from_kwargs_name(self):
+        assert (
+            resolve_agent_name(
+                serialized={},
+                metadata={},
+                kwargs={"name": "tool-caller"},
+            )
+            == "tool-caller"
+        )
+
+    def test_from_serialized_name(self):
+        assert (
+            resolve_agent_name(
+                serialized={"name": "MyAgent"},
+                metadata={},
+                kwargs={},
+            )
+            == "MyAgent"
+        )
+
+    def test_from_langgraph_node(self):
+        assert (
+            resolve_agent_name(
+                serialized={},
+                metadata={"langgraph_node": "researcher"},
+                kwargs={},
+            )
+            == "researcher"
+        )
+
+    def test_langgraph_start_node_excluded(self):
+        assert (
+            resolve_agent_name(
+                serialized={},
+                metadata={"langgraph_node": "__start__"},
+                kwargs={},
+            )
+            is None
+        )
+
+    def test_returns_none_when_nothing_available(self):
+        assert (
+            resolve_agent_name(serialized={}, metadata={}, kwargs={}) is None
+        )
+
+    def test_returns_none_with_none_metadata(self):
+        assert (
+            resolve_agent_name(serialized={}, metadata=None, kwargs={}) is None
+        )
+
+    def test_priority_metadata_over_kwargs(self):
+        """metadata agent_name has higher priority than kwargs name."""
+        assert (
+            resolve_agent_name(
+                serialized={"name": "serialized"},
+                metadata={"agent_name": "meta"},
+                kwargs={"name": "kw"},
+            )
+            == "meta"
+        )
+
+    def test_priority_kwargs_over_serialized(self):
+        assert (
+            resolve_agent_name(
+                serialized={"name": "serialized"},
+                metadata={},
+                kwargs={"name": "kw"},
+            )
+            == "kw"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OperationName constants
+# ---------------------------------------------------------------------------
+
+
+class TestOperationNameConstants:
+    def test_chat(self):
+        assert OperationName.CHAT == "chat"
+
+    def test_text_completion(self):
+        assert OperationName.TEXT_COMPLETION == "text_completion"
+
+    def test_invoke_agent(self):
+        assert OperationName.INVOKE_AGENT == "invoke_agent"
+
+    def test_execute_tool(self):
+        assert OperationName.EXECUTE_TOOL == "execute_tool"
+
+    def test_invoke_workflow(self):
+        assert OperationName.INVOKE_WORKFLOW == "invoke_workflow"


### PR DESCRIPTION
# Description

Add foundation modules for enhanced LangChain GenAI semantic convention tracing. These are internal building-block modules that will be consumed by subsequent PRs in this series.

## New Modules

### `semconv_attributes.py`
Per-operation attribute matrix based on OTel GenAI semantic conventions. Single source of truth for which attributes apply to which operations (chat, text_completion, invoke_agent, execute_tool, invoke_workflow, retrieval). Defines requirement levels (REQUIRED, CONDITIONALLY_REQUIRED, RECOMMENDED, OPT_IN) following the [GenAI semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/).

### `operation_mapping.py`
Callback-to-semconv operation mapping. Maps each LangChain callback to the correct GenAI semantic convention operation name. Includes heuristic classification for `on_chain_start` callbacks (agents vs workflows vs internal plumbing) and LangGraph marker recognition.

### `content_recording.py`
Thin integration layer over the shared genai content capture utilities. Provides clear APIs for the callback handler to decide what content should be recorded on spans and events.

## Tests
- `test_operation_mapping.py` — comprehensive tests for chain classification, agent name resolution, LangGraph markers
- `test_content_recording.py` — tests for content policy modes, redaction behavior

## PR Series
This is **PR 1 of 5** breaking down [#4389](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4389) into smaller reviewable units:
1. **Foundation modules** (this PR)
2. Provider inference, message formatting, W3C propagation utilities
3. Span manager enhancements + Event emitter
4. Callback handler — model, chain, agent callbacks + wiring
5. Callback handler — tool, retriever callbacks + E2E tests

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
