### PR TITLE
docs: add link to AGENTS.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ Before you can contribute, you will need to sign the [Contributor License Agreem
 
 Please also read the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md).
 
+If you are using AI agents to assist with contributions, please read [AGENTS.md](AGENTS.md) for guidance on how to use them responsibly in this project.
+
 ## Index
 
 - [Contributing to opentelemetry-python-contrib](#contributing-to-opentelemetry-python-contrib)


### PR DESCRIPTION
## Description

Adds a reference to `AGENTS.md` in `CONTRIBUTING.md` so contributors using AI agents are directed to the guidance file when they read the contributing docs.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

N/A — documentation only change.