### PR TITLE
fix(pika): use ObjectProxy for ReadyMessagesDequeProxy to restore iterability with wrapt 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `pylint` to `4.0.5`
   ([#4244](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4244))
 
+### Fixed
+
+- `opentelemetry-instrumentation-pika` Use `ObjectProxy` instead of `BaseObjectProxy` for `ReadyMessagesDequeProxy` to restore iterability with wrapt 2.x
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/XXXX))
+
 ### Breaking changes
 
 - Drop Python 3.9 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `opentelemetry-instrumentation-pika` Use `ObjectProxy` instead of `BaseObjectProxy` for `ReadyMessagesDequeProxy` to restore iterability with wrapt 2.x
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/XXXX))
+  ([#4461](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4461))
 
 ### Breaking changes
 

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -7,7 +7,6 @@ from pika.adapters.blocking_connection import (
 )
 from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
-
 from wrapt import ObjectProxy
 
 from opentelemetry import context, propagate, trace

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -8,11 +8,7 @@ from pika.adapters.blocking_connection import (
 from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
 
-try:
-    # wrapt 2.0.0+
-    from wrapt import BaseObjectProxy  # pylint: disable=no-name-in-module
-except ImportError:
-    from wrapt import ObjectProxy as BaseObjectProxy
+from wrapt import ObjectProxy
 
 from opentelemetry import context, propagate, trace
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
@@ -201,7 +197,7 @@ def _enrich_span(
 
 
 # pylint:disable=abstract-method
-class ReadyMessagesDequeProxy(BaseObjectProxy):
+class ReadyMessagesDequeProxy(ObjectProxy):
     def __init__(
         self,
         wrapped,

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
@@ -568,3 +568,14 @@ class TestUtils(TestCase):
         get_span.assert_not_called()
         consume_hook.assert_not_called()
         returned_span.end.assert_not_called()
+
+    def test_deque_proxy_is_iterable(self) -> None:
+        deque = collections.deque([1, 2, 3])
+        generator_info = mock.MagicMock(
+            spec=_QueueConsumerGeneratorInfo,
+            consumer_tag="mock_task_name",
+        )
+        proxy = utils.ReadyMessagesDequeProxy(
+            deque, generator_info, None
+        )
+        self.assertEqual(list(proxy), [1, 2, 3])

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
@@ -575,7 +575,5 @@ class TestUtils(TestCase):
             spec=_QueueConsumerGeneratorInfo,
             consumer_tag="mock_task_name",
         )
-        proxy = utils.ReadyMessagesDequeProxy(
-            deque, generator_info, None
-        )
+        proxy = utils.ReadyMessagesDequeProxy(deque, generator_info, None)
         self.assertEqual(list(proxy), [1, 2, 3])


### PR DESCRIPTION
# Description

The wrapt 2.x migration (PR #4203) switched `ReadyMessagesDequeProxy` from `ObjectProxy` to `BaseObjectProxy`. In wrapt 2.x, `BaseObjectProxy` no longer proxies `__iter__()`, which breaks iteration over the wrapped `deque`.

This switches `ReadyMessagesDequeProxy` to use `ObjectProxy` which proxies all dunder methods including `__iter__`, restoring full deque behavior through the proxy.

`ObjectProxy` exists in both wrapt 1.x and 2.x so the compatibility shim is no longer needed.

Contributes to https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4462

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Added `test_deque_proxy_is_iterable` test that verifies iteration over the proxied deque
- [X] All 31 existing pika tests pass with both wrapt 1.x and wrapt 2.x

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated