### PR TITLE
fix(tornado): keep server span active during log_exception and log_request (#1063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop Python 3.9 support
   ([#4412](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4412))
 
+### Fixed
+
+- `opentelemetry-instrumentation-tornado`: Keep the server span active through `log_exception` and `log_request` so trace/span IDs are injected into Tornado error and access logs when a handler raises an exception
+  ([#1063](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1063))
+
 ## Version 1.41.0/0.62b0 (2026-04-09)
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -574,6 +574,7 @@ def _prepare(
     otel_handler_state = {
         _START_TIME: default_timer(),
         "exclude_request": _excluded_urls.url_disabled(request.uri),
+        "error": None,
     }
     setattr(handler, _HANDLER_STATE_KEY, otel_handler_state)
 
@@ -600,10 +601,12 @@ def _on_finish(
     try:
         return func(*args, **kwargs)
     finally:
+        otel_handler_state = getattr(handler, _HANDLER_STATE_KEY, None) or {}
+        error = otel_handler_state.get("error")
         _record_on_finish_metrics(
-            server_histograms, handler, None, sem_conv_opt_in_mode
+            server_histograms, handler, error, sem_conv_opt_in_mode
         )
-        _finish_span(tracer, handler, None, sem_conv_opt_in_mode)
+        _finish_span(tracer, handler, error, sem_conv_opt_in_mode)
 
 
 def _websockethandler_on_close(
@@ -633,15 +636,18 @@ def _log_exception(
     args,
     kwargs,
 ):
+    # Stash the exception so _on_finish can record it when it ends the span.
+    # The wrapped log_exception is called first so Tornado emits its log
+    # record (e.g. tornado.general) while the server span is still active,
+    # letting LoggingInstrumentor inject trace/span IDs. See issue #1063.
     error = None
     if len(args) == 3:
         error = args[1]
 
-    _record_on_finish_metrics(
-        server_histograms, handler, error, sem_conv_opt_in_mode
-    )
+    otel_handler_state = getattr(handler, _HANDLER_STATE_KEY, None)
+    if otel_handler_state is not None:
+        otel_handler_state["error"] = error
 
-    _finish_span(tracer, handler, error, sem_conv_opt_in_mode)
     return func(*args, **kwargs)
 
 

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -14,6 +14,7 @@
 
 
 import asyncio
+import logging
 from unittest.mock import Mock, patch
 
 import tornado.websocket
@@ -369,6 +370,81 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
                 HTTP_STATUS_CODE: 403,
             },
         )
+
+    def _capture_active_span_on_log(self, logger_names):
+        """Attach a logging handler that records the currently active
+        span each time a record is emitted. Returns (handler, records)."""
+
+        records = []
+
+        class _SpanCaptureHandler(logging.Handler):
+            def emit(self, record):
+                span_context = trace.get_current_span().get_span_context()
+                records.append(
+                    (
+                        record.name,
+                        span_context.trace_id,
+                        span_context.span_id,
+                    )
+                )
+
+        handler = _SpanCaptureHandler(level=logging.DEBUG)
+        loggers = [logging.getLogger(name) for name in logger_names]
+        prior_levels = [lg.level for lg in loggers]
+        for lg in loggers:
+            lg.addHandler(handler)
+            lg.setLevel(logging.DEBUG)
+
+        def cleanup():
+            for lg, prior in zip(loggers, prior_levels):
+                lg.removeHandler(handler)
+                lg.setLevel(prior)
+
+        return records, cleanup
+
+    def _assert_logs_have_active_span(self, path, expected_status):
+        records, cleanup = self._capture_active_span_on_log(
+            ["tornado.general", "tornado.access"]
+        )
+        try:
+            response = self.fetch(path)
+        finally:
+            cleanup()
+        self.assertEqual(response.code, expected_status)
+
+        spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
+        self.assertEqual(len(spans), 2)
+        server, _ = spans
+
+        self.assertTrue(
+            len(records) >= 1,
+            "expected at least one tornado.general/access log record",
+        )
+        for logger_name, trace_id, span_id in records:
+            self.assertNotEqual(
+                trace_id,
+                0,
+                f"{logger_name} emitted with trace_id=0 for {path}",
+            )
+            self.assertNotEqual(
+                span_id,
+                0,
+                f"{logger_name} emitted with span_id=0 for {path}",
+            )
+            self.assertEqual(trace_id, server.context.trace_id)
+            self.assertEqual(span_id, server.context.span_id)
+
+    def test_log_correlation_on_http_error(self):
+        """Regression test for issue #1063: when a handler raises
+        HTTPError, both tornado.general (via log_exception) and
+        tornado.access (via log_request inside finish()) must be
+        emitted while the server span is still active."""
+        self._assert_logs_have_active_span("/raise_403", 403)
+
+    def test_log_correlation_on_unhandled_exception(self):
+        """Regression test for issue #1063: uncaught exceptions that
+        map to 500 must also be logged within the active span."""
+        self._assert_logs_have_active_span("/div_by_zero", 500)
 
     def test_dynamic_handler(self):
         response = self.fetch("/dyna")

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/tornado_test_app.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/tornado_test_app.py
@@ -119,6 +119,11 @@ class RaiseHTTPErrorHandler(tornado.web.RequestHandler):
         raise tornado.web.HTTPError(403)
 
 
+class DivideByZeroHandler(tornado.web.RequestHandler):
+    def get(self):
+        1 / 0
+
+
 class EchoWebSocketHandler(tornado.websocket.WebSocketHandler):
     async def on_message(self, message):
         with self.application.tracer.start_as_current_span("audit_message"):
@@ -141,6 +146,7 @@ def make_app(tracer):
             (r"/ping", HealthCheckHandler),
             (r"/test_custom_response_headers", CustomResponseHeaderHandler),
             (r"/raise_403", RaiseHTTPErrorHandler),
+            (r"/div_by_zero", DivideByZeroHandler),
             (r"/slow", SlowHandler),
             (r"/echo_socket", EchoWebSocketHandler),
         ]


### PR DESCRIPTION
## Summary

- Fixes [#1063](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1063): Tornado's `tornado.general` (via `log_exception`) and `tornado.access` (via `log_request` inside `finish()`) log records were emitted with `trace_id=0 span_id=0` whenever a handler raised an exception, because the instrumentation ended the server span before those log records were produced.
- Defers span closure to `_on_finish` for both success and error paths. `_log_exception` now stashes the exception on handler state and calls the wrapped function first, so Tornado emits its logs while the span is still current — and `LoggingInstrumentor` injects the correct trace/span IDs.
- Aligns Tornado with the pattern used by every other HTTP server instrumentation in this repo (Django, Flask, Falcon, Pyramid, WSGI, ASGI, aiohttp-server), which all end the span after framework-level lifecycle work (including logging) completes.
- Also removes a latent double-recording of `_record_on_finish_metrics` on the error path (previously called from both `_log_exception` and `_on_finish`).

## Why this approach

- `LoggingInstrumentor` reads `trace.get_current_span()` at log-record construction time, so the only way to fix the IDs is to keep the span active when Tornado emits its logs.
- Patching Tornado's private `_handle_request_exception` (suggested in the issue discussion) would reach into a private framework method; the existing docstring in `tornado/__init__.py` already warns against patching private Tornado methods like `_execute` for contextvar-related reasons.
- Stashing per-request state on the handler is how Django (`request.META`), Falcon (`req.env`), Flask/Pyramid (`request.environ`) already do this.

## Test plan

- [x] New regression test `test_log_correlation_on_http_error` asserts that every `tornado.general` / `tornado.access` record emitted while handling `/raise_403` carries the server span's trace/span IDs (non-zero, matching the recorded span).
- [x] New regression test `test_log_correlation_on_unhandled_exception` covers the non-`HTTPError` path via a `ZeroDivisionError` (500).
- [x] Existing `test_http_error`, `test_404`, `test_bad_handler` still pass (4xx `HTTPError` still maps status without promoting the span to `ERROR` status; 5xx still records exception info on span end).
- [x] `test_metrics_instrumentation.py` (16 tests) still passes — metric counts remain correct after removing the duplicate `_record_on_finish_metrics` call.

Full suite: 28/28 in `test_instrumentation.py`, 16/16 in `test_metrics_instrumentation.py`.