### PR TITLE
docs-requirements: fix warning with remoulade > 5

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -44,7 +44,8 @@ PyMySQL~=1.1.1
 pymssql~=2.3.2
 pyramid>=1.7
 redis>=2.6
-remoulade>=0.50
+remoulade[limits]>=5.0.0 ; python_version >= "3.12"
+remoulade>=0.50.0 ; python_version < "3.12"
 sqlalchemy>=1.0
 starlette~=0.50
 tornado>=5.1.1


### PR DESCRIPTION
# Description

On Python 3.12 where remoulade 5 is available this warns locally because `RateLimitEnqueue` has been moved to an optional package:

```
sphinx.errors.SphinxWarning: autodoc: failed to import module 'remoulade' from module 'opentelemetry.instrumentation'; the following exception was raised: cannot import name 'RateLimitEnqueue' from 'remoulade.rate_limits' (/home/rm/src/opentelemetry-python-contrib/.tox/docs/lib/python3.12/site-packages/remoulade/rate_limits/__init__.py)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
