### PR TITLE
docs: fix broken CHANGELOG links reported by check-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,7 +1177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1573](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1573))
 - Add metric instrumentation for urllib
   ([#1553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1553))
-- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/cloud-provider/aws/ecs.md) and [`aws.logs.*`](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/cloud_provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
+- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/ecs/ and [`aws.logs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
   ([#1212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1212))
 - `opentelemetry-instrumentation-aio-pika` Support `aio_pika` 8.x
   ([#1481](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1481))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,7 +1177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1573](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1573))
 - Add metric instrumentation for urllib
   ([#1553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1553))
-- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/ecs/ and [`aws.logs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
+- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/ecs/) and [`aws.logs.*`](https://opentelemetry.io/docs/specs/semconv/resource/cloud-provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
   ([#1212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1212))
 - `opentelemetry-instrumentation-aio-pika` Support `aio_pika` 8.x
   ([#1481](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1481))
@@ -2394,8 +2394,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-ext-http-requests` Updates for core library changes
 
 - `Added support for PyPy3` Initial release
-
-## [#1033](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1033)
+  ([#1033](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1033))
 
 ## Version 0.1a0 (2019-09-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1169,7 +1169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support `aio_pika` 9.x (([#1670](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1670])
+- Support `aio_pika` 9.x ([#1670](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1670))
 - `opentelemetry-instrumentation-redis` Add `sanitize_query` config option to allow query sanitization. ([#1572](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1572))
 - `opentelemetry-instrumentation-elasticsearch` Add optional db.statement query sanitization.
   ([#1598](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1598))
@@ -1177,7 +1177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1573](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1573))
 - Add metric instrumentation for urllib
   ([#1553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1553))
-- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/cloud_provider/aws/ecs.md) and [`aws.logs.*`](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/cloud_provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
+- `opentelemetry/sdk/extension/aws` Implement [`aws.ecs.*`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/cloud-provider/aws/ecs.md) and [`aws.logs.*`](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/cloud_provider/aws/logs/) resource attributes in the `AwsEcsResourceDetector` detector when the ECS Metadata v4 is available
   ([#1212](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1212))
 - `opentelemetry-instrumentation-aio-pika` Support `aio_pika` 8.x
   ([#1481](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1481))
@@ -1373,7 +1373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a test for asgi using NoOpTracerProvider
   ([#1367](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1367))
 
-## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2-0.32b0) - 2022-07-01
+## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2) - 2022-07-01
 
 - Pyramid: Only categorize 500s server exceptions as errors
   ([#1037](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1037))
@@ -2007,7 +2007,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-grpc` Add tests for grpc span attributes, grpc `abort()` conditions
   ([#236](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/236))
 - Add README and example app for Prometheus Remote Write Exporter
-  ([#227](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/227]))
+  ([#227](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/227))
 - `opentelemetry-instrumentation-botocore` Adds a field to report the number of retries it take to complete an API call
   ([#275](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/275))
 - `opentelemetry-instrumentation-requests` Use instanceof to check if responses are valid Response objects
@@ -2395,7 +2395,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Added support for PyPy3` Initial release
 
-## [#1033](https://github.com/open-telemetryopentelemetry-python-contrib/issues/1033)
+## [#1033](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1033)
 
 ## Version 0.1a0 (2019-09-30)
 


### PR DESCRIPTION
# Description

Fixes #4465.

The check-links workflow reported five 404s in \`CHANGELOG.md\`. This PR resolves each of them:

| # | Before | After |
|---|--------|-------|
| 1 | \`pull/1670]\` with stray leading \`(\` | \`pull/1670\` with balanced parens |
| 2 | \`opentelemetry-specification/.../aws/ecs.md\` (moved) | \`semantic-conventions/docs/resource/cloud-provider/aws/ecs.md\` |
| 3 | \`releases/tag/v1.12.0rc2-0.32b0\` (no such tag) | \`releases/tag/v1.12.0rc2\` (existing release on opentelemetry-python) |
| 4 | \`pull/227]\` (stray \`]\` inside URL) | \`pull/227\` |
| 5 | \`open-telemetryopentelemetry-python-contrib\` (missing \`/\`) | \`open-telemetry/opentelemetry-python-contrib\` |

All replacement URLs verified to return HTTP 200.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Manually verified each replacement URL with a HEAD request (all 200).
- Changes are contained to \`CHANGELOG.md\` entries for already-released versions, so there is no runtime impact.

# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [x] No.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated (this PR's only target is the changelog itself)
- [ ] Unit tests have been added (not applicable)
- [x] Documentation has been updated