### PR TITLE
docker-tests: bump requests to 2.31.0

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -58,7 +58,7 @@ python-dotenv==0.21.1
 pytz==2024.1
 PyYAML==5.3.1
 redis==5.0.1
-requests==2.25.0
+requests==2.31.0
 six==1.16.0
 SQLAlchemy==1.4.52
 texttable==1.7.0


### PR DESCRIPTION
# Description

So that opentelemetry-test-utils is happy:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because only opentelemetry-test-utils==0.63b0.dev0 is available and
      opentelemetry-test-utils==0.63b0.dev0 depends on requests>=2.28,<3.dev0,
      we can conclude that all versions of opentelemetry-test-utils depend on
      requests>=2.28,<3.dev0.
      And because you require opentelemetry-test-utils and requests==2.25.0,
      we can conclude that your requirements are unsatisfiable.
```

but docker custom schema works too.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
