### PR TITLE
docker-tests: use docker from the system

### DIFF
--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -70,7 +70,7 @@ jobs:
 
       {%- if job_data == "docker-tests" %}
 
-      - name: Install Microsft SQL ODBC driver
+      - name: Install Microsoft SQL ODBC driver
         run: sudo apt update -y && ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
       {%- endif %}
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -68,6 +68,12 @@ jobs:
       - name: Install tox
         run: pip install tox-uv
 
+      {%- if job_data == "docker-tests" %}
+
+      - name: Install Microsft SQL ODBC driver
+        run: sudo apt update -y && ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
+      {%- endif %}
+
       - name: Run tests
         run: tox -e {{ job_data }}
       {%- if job_data == "generate-workflows" %}

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -58,8 +58,9 @@ jobs:
 
       - name: Install tox
         run: pip install tox-uv
+
       - name: Install Microsft SQL ODBC driver
-        run: ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
+        run: sudo apt update -y && ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
 
       - name: Run tests
         run: tox -e docker-tests

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Install tox
         run: pip install tox-uv
+      - name: Install Microsft SQL ODBC driver
+        run: ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
 
       - name: Run tests
         run: tox -e docker-tests

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install tox
         run: pip install tox-uv
 
-      - name: Install Microsft SQL ODBC driver
+      - name: Install Microsoft SQL ODBC driver
         run: sudo apt update -y && ACCEPT_EULA=Y sudo apt install -y msodbcsql18 unixodbc-dev unixodbc
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4360](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4360))
 - `opentelemetry-instrumentation-aiohttp-server`: Use `canonical` attribute of the `Resource` as a span name
   ([#3896](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3896))
-- `docker-tests`: Don't require sudo, debian based distro and MS SQL ODBC driver to run locally
+- `docker-tests`: Don't require sudo, debian based distro and MS SQL ODBC driver to run locally. Instead require docker and unixodbc
   ([#4478](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4478))
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4360](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4360))
 - `opentelemetry-instrumentation-aiohttp-server`: Use `canonical` attribute of the `Resource` as a span name
   ([#3896](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3896))
+- `docker-tests`: Don't require sudo, debian based distro and MS SQL ODBC driver to run locally
+  ([#4478](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4478))
 
 ### Breaking changes
 

--- a/tests/opentelemetry-docker-tests/tests/check_availability.py
+++ b/tests/opentelemetry-docker-tests/tests/check_availability.py
@@ -130,8 +130,11 @@ def check_docker_services_availability():
     check_mysql_connection()
     check_postgres_connection()
     check_redis_connection()
-    check_mssql_connection()
-    setup_mssql_db()
+
+    # make accepting EULA for ms sql odbc driver optional
+    if "ODBC Driver 18 for SQL Server" in pyodbc.drivers():
+        check_mssql_connection()
+        setup_mssql_db()
 
 
 check_docker_services_availability()

--- a/tests/opentelemetry-docker-tests/tests/docker-compose.yml
+++ b/tests/opentelemetry-docker-tests/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   otmongo:
     ports:

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
@@ -33,7 +33,7 @@ MSSQL_CONFIG = {
 
 @pytest.mark.skipif(
     "ODBC Driver 18 for SQL Server" not in pyodbc.drivers(),
-    reason="No MS SQL odbc driver installed",
+    reason="No MS SQL ODBC driver installed",
 )
 class MssqlConnectorTestCase(SQLAlchemyTestMixin):
     """TestCase for pyodbc engine"""

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/test_mssql.py
@@ -3,6 +3,7 @@
 
 import os
 
+import pyodbc
 import pytest
 from sqlalchemy.exc import ProgrammingError
 
@@ -30,6 +31,10 @@ MSSQL_CONFIG = {
 }
 
 
+@pytest.mark.skipif(
+    "ODBC Driver 18 for SQL Server" not in pyodbc.drivers(),
+    reason="No MS SQL odbc driver installed",
+)
 class MssqlConnectorTestCase(SQLAlchemyTestMixin):
     """TestCase for pyodbc engine"""
 

--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -3,7 +3,6 @@ amqp==5.2.0
 asgiref==3.8.1
 async-timeout==4.0.3
 asyncpg==0.29.0
-attrs==23.2.0
 bcrypt==5.0.0
 billiard==4.2.0
 celery==5.3.6
@@ -15,13 +14,8 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
 cryptography==46.0.7
-distro==1.9.0
 Django==4.2.30
 dnspython==2.6.1
-docker==5.0.3
-docker-compose==1.29.2
-dockerpty==0.4.1
-docopt==0.6.2
 exceptiongroup==1.2.0
 flaky==3.7.0
 flask==3.1.3
@@ -29,7 +23,6 @@ greenlet==3.0.3
 grpcio==1.63.2
 idna==3.7
 iniconfig==2.0.0
-jsonschema==3.2.0
 kombu==5.3.5
 mysql-connector-python==8.3.0
 mysqlclient==2.1.1
@@ -50,24 +43,19 @@ PyMySQL==1.1.1
 PyNaCl==1.6.2
 # prerequisite: install unixodbc
 pyodbc==5.0.1
-pyrsistent==0.20.0
 pytest==8.0.2
 pytest-celery==0.0.0
 python-dateutil==2.9.0.post0
-python-dotenv==0.21.1
 pytz==2024.1
-PyYAML==5.3.1
 redis==5.0.1
 requests==2.31.0
 six==1.16.0
 SQLAlchemy==1.4.52
-texttable==1.7.0
 tomli==2.0.1
 typing_extensions==4.12.2
 tzdata==2024.1
 urllib3==1.26.19
 vine==5.1.0
 wcwidth==0.2.13
-websocket-client==0.59.0
 wrapt==1.16.0
 zipp==3.19.1

--- a/tox.ini
+++ b/tox.ini
@@ -1084,6 +1084,8 @@ changedir =
 
 allowlist_externals =
   docker
+  pytest
+  sh
 
 commands_pre =
   ; this assumes an ubuntu system

--- a/tox.ini
+++ b/tox.ini
@@ -1085,11 +1085,10 @@ changedir =
 allowlist_externals =
   docker
   pytest
-  sh
 
 commands_pre =
-  sh -c "docker --version || echo 'Docker with compose subcommand is required' && /bin/false"
-  sh -c "python -c 'import pyodbc; print(pyodbc.drivers())' || echo 'You need to install unixODBC'"
+  docker --version || echo 'Docker with compose subcommand is required' && /bin/false
+  python -c 'import pyodbc; print(pyodbc.drivers())' || echo 'You need to install unixODBC' && /bin/false
   docker compose up -d
   python check_availability.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1088,11 +1088,8 @@ allowlist_externals =
   sh
 
 commands_pre =
-  ; this assumes an ubuntu system
-  sh -c "sudo apt update -y"
-  sh -c "docker --version || sudo apt install -y docker.io docker-compose-v2"
-  sh -c "sudo ACCEPT_EULA=Y apt install -y msodbcsql18 unixodbc-dev unixodbc"
-  python -c "import pyodbc; print(pyodbc.drivers())"
+  sh -c "docker --version || echo "Docker with compose subcommand is required" && /bin/false"
+  sh -c "python -c 'import pyodbc; print(pyodbc.drivers())' || echo "You need to install unixODBC"
   docker compose up -d
   python check_availability.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1088,8 +1088,8 @@ allowlist_externals =
   sh
 
 commands_pre =
-  sh -c "docker --version || echo "Docker with compose subcommand is required" && /bin/false"
-  sh -c "python -c 'import pyodbc; print(pyodbc.drivers())' || echo "You need to install unixODBC"
+  sh -c "docker --version || echo 'Docker with compose subcommand is required' && /bin/false"
+  sh -c "python -c 'import pyodbc; print(pyodbc.drivers())' || echo 'You need to install unixODBC'"
   docker compose up -d
   python check_availability.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1082,6 +1082,9 @@ deps =
 changedir =
   tests/opentelemetry-docker-tests/tests
 
+allowlist_externals =
+  docker
+
 commands_pre =
   ; this assumes an ubuntu system
   sh -c "sudo apt update -y"

--- a/tox.ini
+++ b/tox.ini
@@ -1083,16 +1083,18 @@ changedir =
   tests/opentelemetry-docker-tests/tests
 
 commands_pre =
-  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev unixodbc"
+  ; this assumes an ubuntu image
+  sh -c "docker --version || sudo apt install docker.io docker-compose-v2"
+  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt install -y msodbcsql18 unixodbc-dev unixodbc"
   python -c "import pyodbc; print(pyodbc.drivers())"
-  docker-compose up -d
+  docker compose up -d
   python check_availability.py
 
 commands =
   pytest {posargs}
 
 commands_post =
-  docker-compose down -v
+  docker compose down -v
 
 [testenv:generate]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1083,9 +1083,10 @@ changedir =
   tests/opentelemetry-docker-tests/tests
 
 commands_pre =
-  ; this assumes an ubuntu image
-  sh -c "docker --version || sudo apt install docker.io docker-compose-v2"
-  sh -c "sudo apt update -y && sudo ACCEPT_EULA=Y apt install -y msodbcsql18 unixodbc-dev unixodbc"
+  ; this assumes an ubuntu system
+  sh -c "sudo apt update -y"
+  sh -c "docker --version || sudo apt install -y docker.io docker-compose-v2"
+  sh -c "sudo ACCEPT_EULA=Y apt install -y msodbcsql18 unixodbc-dev unixodbc"
   python -c "import pyodbc; print(pyodbc.drivers())"
   docker compose up -d
   python check_availability.py


### PR DESCRIPTION
# Description

Stop using the ancient docker-compose and docker packaged in Python and rely on the one available in the system.

Fixes #4477

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
