### PR TITLE
fix(pika): use ObjectProxy for ReadyMessagesDequeProxy to restore iterability with wrapt 2.x (#4461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The following components are released independently and maintain individual CHANGELOG files.
 > Use [this search for a list of all CHANGELOG.md files in this repo](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-python-contrib+path%3A**%2FCHANGELOG.md&type=code).
 
+## Unreleased
+
+### Fixed
+
+- `opentelemetry-instrumentation-pika` Use `ObjectProxy` instead of `BaseObjectProxy` for `ReadyMessagesDequeProxy` to restore iterability with wrapt 2.x
+  ([#4461](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4461))
+
 ## Version 1.41.0/0.62b0 (2026-04-09)
   
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -7,12 +7,7 @@ from pika.adapters.blocking_connection import (
 )
 from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
-
-try:
-    # wrapt 2.0.0+
-    from wrapt import BaseObjectProxy  # pylint: disable=no-name-in-module
-except ImportError:
-    from wrapt import ObjectProxy as BaseObjectProxy
+from wrapt import ObjectProxy
 
 from opentelemetry import context, propagate, trace
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
@@ -201,7 +196,7 @@ def _enrich_span(
 
 
 # pylint:disable=abstract-method
-class ReadyMessagesDequeProxy(BaseObjectProxy):
+class ReadyMessagesDequeProxy(ObjectProxy):
     def __init__(
         self,
         wrapped,

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
@@ -568,3 +568,12 @@ class TestUtils(TestCase):
         get_span.assert_not_called()
         consume_hook.assert_not_called()
         returned_span.end.assert_not_called()
+
+    def test_deque_proxy_is_iterable(self) -> None:
+        deque = collections.deque([1, 2, 3])
+        generator_info = mock.MagicMock(
+            spec=_QueueConsumerGeneratorInfo,
+            consumer_tag="mock_task_name",
+        )
+        proxy = utils.ReadyMessagesDequeProxy(deque, generator_info, None)
+        self.assertEqual(list(proxy), [1, 2, 3])


### PR DESCRIPTION
# Description

wrapt 2.x BaseObjectProxy does not proxy `__iter__`, breaking iteration over the wrapped deque. Switch to ObjectProxy which proxies all dunder methods including `__iter__`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
