### PR TITLE
Add __iter__ method to TracedCursorProxy (#4427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-instrumentation-pika` Use `ObjectProxy` instead of `BaseObjectProxy` for `ReadyMessagesDequeProxy` to restore iterability with wrapt 2.x
   ([#4461](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4461))
+- `opentelemetry-instrumentation-dbapi` Use `ObjectProxy` instead of `BaseObjectProxy` for `TracedCursorProxy` to restore iterability with wrapt 2.x
+  ([#4427](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4427))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
   

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -49,6 +49,7 @@ sqlalchemy>=1.0
 starlette~=0.50
 tornado>=5.1.1
 tortoise-orm>=0.17.0
+wrapt~=2.1
 
 # required by opamp
 uuid_utils

--- a/docs/nitpick-exceptions.ini
+++ b/docs/nitpick-exceptions.ini
@@ -44,6 +44,7 @@ py-class=
     psycopg.Connection
     psycopg.AsyncConnection
     ObjectProxy
+    wrapt.proxies.ObjectProxy
     fastapi.applications.FastAPI
     starlette.applications.Starlette
     _contextvars.Token

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -177,8 +177,12 @@ from wrapt import wrap_function_wrapper
 
 try:
     # wrapt 2.0.0+
-    from wrapt import BaseObjectProxy  # pylint: disable=no-name-in-module
+    from wrapt import (  # pylint: disable=no-name-in-module
+        BaseObjectProxy,
+        ObjectProxy,
+    )
 except ImportError:
+    from wrapt import ObjectProxy
     from wrapt import ObjectProxy as BaseObjectProxy
 
 from opentelemetry import trace as trace_api
@@ -805,14 +809,14 @@ class CursorTracer(Generic[CursorT]):
 
 
 # pylint: disable=abstract-method,no-member
-class TracedCursorProxy(BaseObjectProxy, Generic[CursorT]):
+class TracedCursorProxy(ObjectProxy, Generic[CursorT]):
     # pylint: disable=unused-argument
     def __init__(
         self,
         cursor: CursorT,
         db_api_integration: DatabaseApiIntegration,
     ):
-        BaseObjectProxy.__init__(self, cursor)
+        ObjectProxy.__init__(self, cursor)
         self._self_cursor_tracer = CursorTracer[CursorT](db_api_integration)
 
     def execute(self, *args: Any, **kwargs: Any):

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -306,6 +306,20 @@ class TestDBApiIntegration(TestBase):
         span = spans_list[0]
         self.assertEqual(span.attributes[DB_STATEMENT], "Test query")
 
+    # pylint: disable=no-self-use
+    def test_executemany_iterable_cursor(self):
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name", "testcomponent"
+        )
+        mock_connection = db_integration.wrapped_connection(
+            mock_connect, {}, {}
+        )
+        cursor = mock_connection.cursor()
+        cursor.executemany("Test query")
+
+        for _row in cursor:
+            pass
+
     def test_executemany_comment(self):
         connect_module = mock.MagicMock()
         connect_module.__name__ = "test"
@@ -1296,12 +1310,16 @@ class MockCursor:
         self._cnx._cmysql.get_client_info = mock.MagicMock(
             return_value="1.2.3"
         )
+        self._items = []
 
     # pylint: disable=unused-argument, no-self-use
     def execute(self, query, params=None, throw_exception=False):
         if throw_exception:
             # pylint: disable=broad-exception-raised
             raise Exception("Test Exception")
+
+    def __iter__(self):
+        yield from self._items
 
     # pylint: disable=unused-argument, no-self-use
     def executemany(self, query, params=None, throw_exception=False):

--- a/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
@@ -111,6 +111,16 @@ class TestFunctionalMysql(TestBase):
             self._cursor.executemany(stmt, data)
         self.validate_spans("INSERT")
 
+    def test_executemany_with_cursor_iteration(self):
+        """Should create a child span for executemany while iterating over the cursor"""
+        stmt = "SELECT * FROM test"
+        with self._tracer.start_as_current_span("rootSpan"):
+            with self._connection.cursor() as cursor:
+                cursor.execute(stmt)
+                for _row in cursor:
+                    pass
+        self.validate_spans("SELECT")
+
     def test_callproc(self):
         """Should create a child span for callproc"""
         with (

--- a/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -102,6 +102,16 @@ class TestFunctionalPyMysql(TestBase):
             self._cursor.executemany(stmt, data)
         self.validate_spans("INSERT")
 
+    def test_executemany_with_cursor_iteration(self):
+        """Should create a child span for executemany while iterating over the cursor"""
+        stmt = "SELECT * FROM test"
+        with self._tracer.start_as_current_span("rootSpan"):
+            with self._connection.cursor() as cursor:
+                cursor.execute(stmt)
+                for _row in cursor:
+                    pass
+        self.validate_spans("SELECT")
+
     def test_callproc(self):
         """Should create a child span for callproc"""
         with (


### PR DESCRIPTION
# Description

Backport of regression fix for TracedCursorProxy not being iterable anymore with wrapt2.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
