### PR TITLE
openai-v2: default empty string for GEN_AI_REQUEST_MODEL on missing model

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extraction improvements
   ([#4337](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4337))
 - Default empty string for `GEN_AI_REQUEST_MODEL` attribute on missing model.
-  ([#4337](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4337))
+  ([#4494](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4494))
 
 ## Version 2.3b0 (2025-12-24)
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add strongly typed Responses API extractors with validation and content
   extraction improvements
   ([#4337](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4337))
-- Default empty string for `GEN_AI_REQUEST_MODEL` attribute on missing model.
+- Default empty string for `gen_ai.request.model` attribute on missing model.
   ([#4494](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4494))
 
 ## Version 2.3b0 (2025-12-24)

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add strongly typed Responses API extractors with validation and content
   extraction improvements
   ([#4337](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4337))
+- Default empty string for `GEN_AI_REQUEST_MODEL` attribute on missing model.
+  ([#4337](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4337))
 
 ## Version 2.3b0 (2025-12-24)
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/patch.py
@@ -68,7 +68,9 @@ def chat_completions_create_v_old(
             **get_llm_request_attributes(kwargs, instance, False)
         }
 
-        span_name = f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
+        operation_name = span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        model = span_attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        span_name = f"{operation_name} {model}" if model else operation_name
         with tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -173,7 +175,9 @@ def async_chat_completions_create_v_old(
             **get_llm_request_attributes(kwargs, instance, False)
         }
 
-        span_name = f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
+        operation_name = span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        model = span_attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        span_name = f"{operation_name} {model}" if model else operation_name
         with tracer.start_as_current_span(
             name=span_name,
             kind=SpanKind.CLIENT,
@@ -373,7 +377,9 @@ def async_embeddings_create(
 
 def _get_embeddings_span_name(span_attributes):
     """Get span name for embeddings operations."""
-    return f"{span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]} {span_attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]}"
+    operation_name = span_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+    model = span_attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+    return f"{operation_name} {model}" if model else operation_name
 
 
 def _record_metrics(

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -214,7 +214,7 @@ def get_llm_request_attributes(
 
     attributes = {
         GenAIAttributes.GEN_AI_OPERATION_NAME: operation_name,
-        GenAIAttributes.GEN_AI_REQUEST_MODEL: kwargs.get("model"),
+        GenAIAttributes.GEN_AI_REQUEST_MODEL: kwargs.get("model", ""),
     }
 
     if latest_experimental_enabled:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -210,12 +210,15 @@ def get_llm_request_attributes(
     latest_experimental_enabled,
     operation_name=GenAIAttributes.GenAiOperationNameValues.CHAT.value,
 ):
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-locals
 
     attributes = {
         GenAIAttributes.GEN_AI_OPERATION_NAME: operation_name,
-        GenAIAttributes.GEN_AI_REQUEST_MODEL: kwargs.get("model", ""),
     }
+
+    model = kwargs.get("model")
+    if model:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] = model
 
     if latest_experimental_enabled:
         attributes.update(

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -1484,5 +1484,20 @@ def chat_completion_multiple_tools_streaming(
         )
 
 
+def test_chat_completion_model_attribute(
+    span_exporter, openai_client, instrument_no_content, vcr
+):
+    """Verify GEN_AI_REQUEST_MODEL defaults to '' when model is not provided."""
+    with vcr.use_cassette("test_chat_completion_no_content.yaml"):
+        openai_client.chat.completions.create(
+            messages=USER_ONLY_PROMPT, stream=False
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
+    assert spans[0].name == "chat "
+
+
 def assert_no_invalid_type_warning(caplog):
     assert "Invalid type" not in caplog.text

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -1490,7 +1490,7 @@ def test_chat_completion_model_attribute(
     """Verify GEN_AI_REQUEST_MODEL defaults to '' when model is not provided."""
     with vcr.use_cassette("test_chat_completion_no_content.yaml"):
         openai_client.chat.completions.create(
-            messages=USER_ONLY_PROMPT, stream=False
+            messages=USER_ONLY_PROMPT, model=None, stream=False
         )
 
     spans = span_exporter.get_finished_spans()

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -1484,20 +1484,5 @@ def chat_completion_multiple_tools_streaming(
         )
 
 
-def test_chat_completion_model_attribute(
-    span_exporter, openai_client, instrument_no_content, vcr
-):
-    """Verify GEN_AI_REQUEST_MODEL defaults to '' when model is not provided."""
-    with vcr.use_cassette("test_chat_completion_no_content.yaml"):
-        openai_client.chat.completions.create(
-            messages=USER_ONLY_PROMPT, model=None, stream=False
-        )
-
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    assert spans[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
-    assert spans[0].name == "chat "
-
-
 def assert_no_invalid_type_warning(caplog):
     assert "Invalid type" not in caplog.text

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_request_attributes.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_request_attributes.py
@@ -1,0 +1,68 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for get_llm_request_attributes in utils.py."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry.instrumentation.openai_v2.utils import (
+    get_llm_request_attributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_vcr():
+    """No VCR needed for these unit tests."""
+    yield
+
+
+def _make_client(base_url=None):
+    return SimpleNamespace(_base_url=base_url)
+
+
+def test_model_defaults_to_empty_string_when_missing():
+    """When 'model' is not in kwargs, GEN_AI_REQUEST_MODEL should be empty string."""
+    attrs = get_llm_request_attributes(
+        kwargs={},
+        client_instance=_make_client(),
+        latest_experimental_enabled=False,
+    )
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL in attrs
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
+
+
+def test_model_defaults_to_empty_string_when_missing_experimental():
+    """Same as above but with latest_experimental_enabled=True."""
+    attrs = get_llm_request_attributes(
+        kwargs={},
+        client_instance=_make_client(),
+        latest_experimental_enabled=True,
+    )
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL in attrs
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
+
+
+def test_model_preserved_when_provided():
+    """When 'model' is in kwargs, GEN_AI_REQUEST_MODEL should be set to its value."""
+    attrs = get_llm_request_attributes(
+        kwargs={"model": "gpt-4o-mini"},
+        client_instance=_make_client(),
+        latest_experimental_enabled=False,
+    )
+    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "gpt-4o-mini"

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_request_attributes.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_request_attributes.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for get_llm_request_attributes in utils.py."""
+"""Unit tests for get_llm_request_attributes and span name logic in utils.py."""
 
 from types import SimpleNamespace
 
 import pytest
 
+from opentelemetry.instrumentation.openai_v2.patch import (
+    _get_embeddings_span_name,
+)
 from opentelemetry.instrumentation.openai_v2.utils import (
     get_llm_request_attributes,
 )
@@ -36,26 +39,24 @@ def _make_client(base_url=None):
     return SimpleNamespace(_base_url=base_url)
 
 
-def test_model_defaults_to_empty_string_when_missing():
-    """When 'model' is not in kwargs, GEN_AI_REQUEST_MODEL should be empty string."""
+def test_model_omitted_when_missing():
+    """When 'model' is not in kwargs, GEN_AI_REQUEST_MODEL should be absent."""
     attrs = get_llm_request_attributes(
         kwargs={},
         client_instance=_make_client(),
         latest_experimental_enabled=False,
     )
-    assert GenAIAttributes.GEN_AI_REQUEST_MODEL in attrs
-    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL not in attrs
 
 
-def test_model_defaults_to_empty_string_when_missing_experimental():
+def test_model_omitted_when_missing_experimental():
     """Same as above but with latest_experimental_enabled=True."""
     attrs = get_llm_request_attributes(
         kwargs={},
         client_instance=_make_client(),
         latest_experimental_enabled=True,
     )
-    assert GenAIAttributes.GEN_AI_REQUEST_MODEL in attrs
-    assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == ""
+    assert GenAIAttributes.GEN_AI_REQUEST_MODEL not in attrs
 
 
 def test_model_preserved_when_provided():
@@ -66,3 +67,49 @@ def test_model_preserved_when_provided():
         latest_experimental_enabled=False,
     )
     assert attrs[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "gpt-4o-mini"
+
+
+def test_span_name_includes_model_when_present():
+    """Span name should be '{operation} {model}' when model is provided."""
+    attrs = get_llm_request_attributes(
+        kwargs={"model": "gpt-4o"},
+        client_instance=_make_client(),
+        latest_experimental_enabled=False,
+    )
+    operation_name = attrs[GenAIAttributes.GEN_AI_OPERATION_NAME]
+    model = attrs.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+    span_name = f"{operation_name} {model}" if model else operation_name
+    assert span_name == "chat gpt-4o"
+
+
+def test_span_name_uses_operation_only_when_model_missing():
+    """Span name should be just '{operation}' when model is not provided."""
+    attrs = get_llm_request_attributes(
+        kwargs={},
+        client_instance=_make_client(),
+        latest_experimental_enabled=False,
+    )
+    operation_name = attrs[GenAIAttributes.GEN_AI_OPERATION_NAME]
+    model = attrs.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+    span_name = f"{operation_name} {model}" if model else operation_name
+    assert span_name == "chat"
+
+
+def test_embeddings_span_name_includes_model():
+    """Embeddings span name should be '{operation} {model}' when model is present."""
+    span_attributes = {
+        GenAIAttributes.GEN_AI_OPERATION_NAME: "embeddings",
+        GenAIAttributes.GEN_AI_REQUEST_MODEL: "text-embedding-3-small",
+    }
+    assert (
+        _get_embeddings_span_name(span_attributes)
+        == "embeddings text-embedding-3-small"
+    )
+
+
+def test_embeddings_span_name_without_model():
+    """Embeddings span name should be just '{operation}' when model is absent."""
+    span_attributes = {
+        GenAIAttributes.GEN_AI_OPERATION_NAME: "embeddings",
+    }
+    assert _get_embeddings_span_name(span_attributes) == "embeddings"


### PR DESCRIPTION
When model is not provided in kwargs, default to empty string instead of None for the GEN_AI_REQUEST_MODEL attribute to avoid invalid attribute values. This can occur for some custom implementations of OpenAi client like [AzureOpenAi](https://github.com/openai/openai-python/blob/e507a4ebeea4c3f93cd48986014a3e2ca79230c2/src/openai/lib/azure.py#L90).
