### PR TITLE
fix(celery): clear task timing state after postrun

### DIFF
--- a/.changelog/4504.fixed
+++ b/.changelog/4504.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-celery`: clear completed task ids from `task_id_to_start_time`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4341](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4341))
 - `opentelemetry-instrumentation-flask`: Stop reading the deprecated (from 3.1) `flask.__version__` attribute; resolve the Flask version via `importlib.metadata`
   ([#4422](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4422))
-- `opentelemetry-instrumentation-celery`: Clear completed task ids from `task_id_to_start_time` to prevent task timing state from accumulating across finished tasks
-  ([#4504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4504))
 - `opentelemetry-instrumentation-celery`: Coerce non-string values to strings in `CeleryGetter.get()` to prevent `TypeError` in `TraceState.from_header()` when Celery request attributes contain ints
   ([#4360](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4360))
 - `opentelemetry-instrumentation-aiohttp-server`: Use `canonical` attribute of the `Resource` as a span name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4341](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4341))
 - `opentelemetry-instrumentation-flask`: Stop reading the deprecated (from 3.1) `flask.__version__` attribute; resolve the Flask version via `importlib.metadata`
   ([#4422](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4422))
+- `opentelemetry-instrumentation-celery`: Clear completed task ids from `task_id_to_start_time` to prevent task timing state from accumulating across finished tasks
+  ([#4504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4504))
 - `opentelemetry-instrumentation-celery`: Coerce non-string values to strings in `CeleryGetter.get()` to prevent `TypeError` in `TraceState.from_header()` when Celery request attributes contain ints
   ([#4360](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4360))
 - `opentelemetry-instrumentation-aiohttp-server`: Use `canonical` attribute of the `Resource` as a span name

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -117,8 +117,10 @@ celery_getter = CeleryGetter()
 class CeleryInstrumentor(BaseInstrumentor):
     def __init__(self):
         super().__init__()
-        self.metrics = None
-        self.task_id_to_start_time = {}
+        if not hasattr(self, "metrics"):
+            self.metrics = None
+        if not hasattr(self, "task_id_to_start_time"):
+            self.task_id_to_start_time = {}
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -115,8 +115,10 @@ celery_getter = CeleryGetter()
 
 
 class CeleryInstrumentor(BaseInstrumentor):
-    metrics = None
-    task_id_to_start_time = {}
+    def __init__(self):
+        super().__init__()
+        self.metrics = None
+        self.task_id_to_start_time = {}
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -139,6 +141,7 @@ class CeleryInstrumentor(BaseInstrumentor):
             schema_url="https://opentelemetry.io/schemas/1.11.0",
         )
 
+        self.task_id_to_start_time = {}
         self.create_celery_metrics(meter)
 
         signals.task_prerun.connect(self._trace_prerun, weak=False)
@@ -159,6 +162,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         signals.after_task_publish.disconnect(self._trace_after_publish)
         signals.task_failure.disconnect(self._trace_failure)
         signals.task_retry.disconnect(self._trace_retry)
+        self.task_id_to_start_time = {}
 
     def _trace_prerun(self, *args, **kwargs):
         task = utils.retrieve_task(kwargs)
@@ -213,6 +217,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         self.update_task_duration_time(task_id)
         labels = {"task": task.name, "worker": task.request.hostname}
         self._record_histograms(task_id, labels)
+        self.task_id_to_start_time.pop(task_id, None)
         # if the process sending the task is not instrumented
         # there's no incoming context and no token to detach
         if token is not None:

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -92,6 +92,24 @@ class TestCeleryInstrumentation(TestBase):
         self.assertEqual(consumer.parent.span_id, producer.context.span_id)
         self.assertEqual(consumer.context.trace_id, producer.context.trace_id)
 
+    def test_task_clears_start_time_cache(self):
+        """Test that the `task_id_to_start_time` cache is cleared after a task finishes,
+        to prevent memory leaks."""
+        instrumentor = CeleryInstrumentor()
+        instrumentor.instrument()
+
+        result = task_add.delay(1, 2)
+
+        timeout = time.time() + 60 * 1  # 1 minutes from now
+        while not result.ready():
+            if time.time() > timeout:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(result.ready())
+        self.assertEqual(result.result, 3)
+        self.assertEqual(instrumentor.task_id_to_start_time, {})
+
     def test_task_raises(self):
         CeleryInstrumentor().instrument()
 


### PR DESCRIPTION
## Description

Split out of #4439.

This PR keeps the Celery fix narrowly focused on the `task_id_to_start_time` lifecycle:
- keep the timing map instance-scoped while preserving singleton state across repeated `CeleryInstrumentor()` calls
- reset it when instrumenting and uninstrumenting
- remove completed task ids in `_trace_postrun`
- add regression coverage that verifies completed tasks clear the timing cache

## Testing

- `uv run tox -e py311-test-instrumentation-celery -- -q`
