### PR TITLE
Add PR labeler workflow for genai label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+gen-ai:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'instrumentation-genai/**'
+          - 'util/opentelemetry-util-genai/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,4 @@ gen-ai:
       - any-glob-to-any-file:
           - 'instrumentation-genai/**'
           - 'util/opentelemetry-util-genai/**'
+          - 'docs/instrumentation-genai/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false


### PR DESCRIPTION
Adds actions/labeler to automatically apply the 'gen-ai' label to PRs that modify files under instrumentation-genai/ or util/opentelemetry-util-genai/.


