### PR TITLE
docs: add CHANGELOG entry for MCP list tools spans fix

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+
 - Align AgentSpanData test stubs and span processor with real OpenAI Agents SDK;
   remove non-existent `operation`, `description`, `agent_id`, and `model` fields.
   ([#4229](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4229))
@@ -13,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3859](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3859))
 - Populate instructions and tool definitions from Response obj.
   ([#4196](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4196))
+
+### Fixed
+
+- `opentelemetry-instrumentation-openai-agents`: Handle MCP list tools spans correctly.
+  ([#4508](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4508))
 
 ## Version 0.1.0 (2025-10-15)
 


### PR DESCRIPTION
# Description

Fixes issue with MCP list tools spans not being handled correctly in the OpenAI Agents instrumentation. The fix ensures proper span creation and attribute population for MCP tool list operations.

Fixes # 18247

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Existing unit tests pass
- [x] Manual testing with MCP list tools operations

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added (or existing tests cover this)
- [ ] Documentation has been updated
