### PR TITLE
anthropic and claude-agent-sdk: bump opentelemetry-util-genai

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
+  ([#4520](hhttps://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
 - Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls
   ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))
 

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
-  ([#4520](hhttps://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
+  ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
 - Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls
   ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))
 

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.39",
   "opentelemetry-instrumentation ~= 0.60b0",
   "opentelemetry-semantic-conventions ~= 0.60b0",
-  "opentelemetry-util-genai >= 0.2b0, <0.4b0",
+  "opentelemetry-util-genai >= 0.4b0.dev, <0.5b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
@@ -15,7 +15,7 @@
 # This variant of the requirements aims to test the system using
 # the oldest supported version of external dependencies.
 
--e util/opentelemetry-util-genai
+-e util/opentelemetry-util-genai # todo: update to 0.4b0 when it's released
 anthropic==0.51.0
 pytest==7.4.4
 pytest-vcr==1.0.2

--- a/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -7,5 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
+  ([#4520](hhttps://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
+
 ### Added
 

--- a/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
-  ([#4520](hhttps://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
+  ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
 
 ### Added
 

--- a/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "opentelemetry-api ~= 1.39",
   "opentelemetry-instrumentation ~= 0.60b0",
   "opentelemetry-semantic-conventions ~= 0.60b0",
-  "opentelemetry-util-genai >= 0.2b0",
+  "opentelemetry-util-genai >= 0.2b0, <0.5b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "opentelemetry-api ~= 1.39",
   "opentelemetry-instrumentation ~= 0.60b0",
   "opentelemetry-semantic-conventions ~= 0.60b0",
-  "opentelemetry-util-genai >= 0.2b0, <0.4b0",
+  "opentelemetry-util-genai >= 0.2b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/tests/requirements.oldest.txt
@@ -15,7 +15,6 @@
 # This variant of the requirements aims to test the system using
 # the oldest supported version of external dependencies.
 
--e util/opentelemetry-util-genai
 claude-agent-sdk==0.1.14
 pytest==7.4.4
 pytest-vcr==1.0.2
@@ -24,5 +23,6 @@ wrapt==1.16.0
 opentelemetry-api==1.39  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.39  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.60b0  # when updating, also update in pyproject.toml
+opentelemetry-util-genai==0.2b0 # when updating, also update in pyproject.toml
 
 -e instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4516 is all red because of `"opentelemetry-util-genai >= 0.2b0, <0.4b0"` in anthropic and claude-agent SDK toml files.

updating range to actually supported one with `0.5b0` as an upper bound.