### PR TITLE
ci: only check new links on pull requests to avoid rate limiting

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Get changed markdown files
         id: changed-files
@@ -42,11 +44,41 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm install -g markdown-link-check@v3.12.2
 
-      - name: Run markdown-link-check
-        if: steps.changed-files.outputs.any_changed == 'true'
+      - name: Check links on push to main
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'push'
         run: |
           markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
             ${{ steps.changed-files.outputs.all_changed_files }} \
+            || { echo "Check that anchor links are lowercase"; exit 1; }
+
+      - name: Check new links only on pull requests
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+        run: |
+          # Extract URLs only from added lines in the diff to avoid
+          # rate limiting when checking all links in large files like
+          # CHANGELOG.md. Only new/changed links are checked on PRs;
+          # pushes to main still check all links in changed files.
+          git diff "origin/${{ github.base_ref }}...HEAD" -- \
+            ${{ steps.changed-files.outputs.all_changed_files }} \
+            | grep '^+' | grep -v '^+++' \
+            | grep -oP 'https?://[^\s\)\]\"'"'"'`>]+' \
+            | sort -u > /tmp/new_links.txt
+
+          if [ ! -s /tmp/new_links.txt ]; then
+            echo "No new links found in diff, skipping check"
+            exit 0
+          fi
+
+          echo "Checking $(wc -l < /tmp/new_links.txt) new links:"
+          cat /tmp/new_links.txt
+
+          # Write links as markdown so markdown-link-check can parse them
+          awk '{print "- <" $0 ">"}' /tmp/new_links.txt > /tmp/new_links.md
+
+          markdown-link-check \
+            --verbose \
+            --config .github/workflows/check_links_config.json \
+            /tmp/new_links.md \
             || { echo "Check that anchor links are lowercase"; exit 1; }


### PR DESCRIPTION
## Description

The `check-links` CI job checks all links in changed markdown files. For files like `CHANGELOG.md` that contain hundreds of URLs, this triggers HTTP 502 rate limits from GitHub, causing spurious CI failures across many PRs.

### Changes

- **Pull requests**: only URLs from added lines in the diff are extracted and checked. This avoids re-checking hundreds of existing links that haven't changed.
- **Push to main**: unchanged — all links in changed files are still checked for full validation.
- Added `fetch-depth: 0` to the checkout step so `git diff` has access to the base branch.

### How it works

```
git diff origin/$base...HEAD -- <changed files>
  | grep '^+'           # only added lines
  | grep -v '^+++'      # skip diff headers
  | grep -oP 'https?:…' # extract URLs
  | sort -u             # deduplicate
```

The extracted URLs are written to a temporary markdown file and passed to `markdown-link-check`.

Mirrors open-telemetry/opentelemetry-python#5162 which reduced the check-links job from 17 minutes to 20 seconds.