### PR TITLE
fix(precommit): ignore autodoc_entry.rst in rstcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,4 @@ repos:
       - id: rstcheck
         additional_dependencies: ['rstcheck[sphinx]']
         args: ["--report-level", "warning"]
+        exclude: ^_template/autodoc_entry\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
     rev: 77490ffa33bfc0928975ae3cf904219903db755d # frozen: v6.2.5
     hooks:
       - id: rstcheck
-        additional_dependencies: ['rstcheck[sphinx]']
+        additional_dependencies:
+          - rstcheck[sphinx]
+          - rstcheck-core==1.3.0
         args: ["--report-level", "warning"]
         exclude: ^_template/autodoc_entry\.rst$


### PR DESCRIPTION
~i don't understand why it's failing now, since it was running fine for 7months~. main changes i see are https://github.com/rstcheck/rstcheck-core/blob/main/CHANGELOG.md#v130-2026-05-04 

https://github.com/rstcheck/rstcheck-core/pull/114