### PR TITLE
fix(auto-instrumentation): print debug startup messages

### DIFF
--- a/.changelog/4542.fixed
+++ b/.changelog/4542.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation`: show startup debug output on stderr

--- a/.changelog/4542.fixed
+++ b/.changelog/4542.fixed
@@ -1,1 +1,1 @@
-`opentelemetry-instrumentation`: show startup debug output on stderr
+`opentelemetry-instrumentation`: show startup debug output on stderr when enabled by `OTEL_LOG_LEVEL`

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -2,7 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cached_property
-from logging import DEBUG, NOTSET, Logger, LoggerAdapter, getLogger
+from logging import (
+    DEBUG,
+    NOTSET,
+    Logger,
+    LoggerAdapter,
+    NullHandler,
+    getLogger,
+)
 from os import environ
 from sys import stderr
 
@@ -50,20 +57,12 @@ class _OtelLogLevelLoggerAdapter(LoggerAdapter):
     OTEL_LOG_LEVEL asks for debug output and Python logging would not emit them.
     """
 
-    def __init__(self, logger, extra):
-        super().__init__(logger, extra)
-        # This adapter is built when this module is imported. That covers the
-        # sitecustomize path where auto-instrumentation runs before application
-        # logging setup, and the edge case where Python logging is set up and then
-        # auto_instrumentation.initialize() is invoked explicitly. If this adapter
-        # is used after application code can change logging, it should be modified
-        # to not use the cached value in the _logger_emits_debug field.
-        self._logger_emits_debug = self._logger_would_emit(DEBUG)
-
     def debug(self, msg: str, *args: object, **kwargs: object) -> None:
         super().debug(msg, *args, **kwargs)
 
-        if not _otel_log_level_allows_debug() or self._logger_emits_debug:
+        if not _otel_log_level_allows_debug() or self._logger_would_emit(
+            DEBUG
+        ):
             return
 
         message = msg
@@ -81,6 +80,9 @@ class _OtelLogLevelLoggerAdapter(LoggerAdapter):
         logger: Logger | None = self.logger
         while logger:
             for handler in logger.handlers:
+                if isinstance(handler, NullHandler):
+                    continue
+
                 if handler.level == NOTSET or level >= handler.level:
                     return True
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cached_property
-from logging import getLogger
+from logging import DEBUG, getLogger
 from os import environ
+from sys import stderr
 
 from opentelemetry.instrumentation.dependencies import (
     DependencyConflictError,
@@ -25,6 +26,37 @@ from opentelemetry.util._importlib_metadata import (
 _logger = getLogger(__name__)
 
 SKIPPED_INSTRUMENTATIONS_WILDCARD = "*"
+OTEL_LOG_LEVEL = "OTEL_LOG_LEVEL"
+_DEBUG_LOG_LEVELS = frozenset(("trace", "debug"))
+
+
+def _diagnostic_debug_enabled() -> bool:
+    log_level = environ.get(OTEL_LOG_LEVEL, "").strip().lower()
+    return log_level in _DEBUG_LOG_LEVELS
+
+
+def _logger_handles_debug() -> bool:
+    return _logger.isEnabledFor(DEBUG) and _logger.hasHandlers()
+
+
+def _format_diagnostic_arg(arg: object) -> object:
+    if isinstance(arg, str):
+        return repr(arg)
+
+    return arg
+
+
+def _debug(message: str, *args: object) -> None:
+    _logger.debug(message, *args)
+
+    if not _diagnostic_debug_enabled() or _logger_handles_debug():
+        return
+
+    if args:
+        message = message % tuple(_format_diagnostic_arg(arg) for arg in args)
+
+    stderr.write(f"DEBUG:{__name__}:{message}\n")
+    stderr.flush()
 
 
 class _EntryPointDistFinder:
@@ -56,12 +88,12 @@ def _load_distro() -> BaseDistro:
             if distro_name is None or distro_name == entry_point.name:
                 distro = entry_point.load()()
                 if not isinstance(distro, BaseDistro):
-                    _logger.debug(
+                    _debug(
                         "%s is not an OpenTelemetry Distro. Skipping",
                         entry_point.name,
                     )
                     continue
-                _logger.debug(
+                _debug(
                     "Distribution %s will be configured", entry_point.name
                 )
                 return distro
@@ -89,7 +121,7 @@ def _load_instrumentors(distro):
             break
 
         if entry_point.name in package_to_exclude:
-            _logger.debug(
+            _debug(
                 "Instrumentation skipped for library %s", entry_point.name
             )
             continue
@@ -98,7 +130,7 @@ def _load_instrumentors(distro):
             entry_point_dist = entry_point_finder.dist_for(entry_point)
             conflict = get_dist_dependency_conflicts(entry_point_dist)
             if conflict:
-                _logger.debug(
+                _debug(
                     "Skipping instrumentation %s: %s",
                     entry_point.name,
                     conflict,
@@ -107,13 +139,13 @@ def _load_instrumentors(distro):
 
             # tell instrumentation to not run dep checks again as we already did it above
             distro.load_instrumentor(entry_point, skip_dep_check=True)
-            _logger.debug("Instrumented %s", entry_point.name)
+            _debug("Instrumented %s", entry_point.name)
         except DependencyConflictError as exc:
             # Dependency conflicts are generally caught from get_dist_dependency_conflicts
             # returning a DependencyConflict. Keeping this error handling in case custom
             # distro and instrumentor behavior raises a DependencyConflictError later.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610
-            _logger.debug(
+            _debug(
                 "Skipping instrumentation %s: %s",
                 entry_point.name,
                 exc.conflict,
@@ -123,7 +155,7 @@ def _load_instrumentors(distro):
             # ModuleNotFoundError is raised when the library is not installed
             # and the instrumentation is not required to be loaded.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3421
-            _logger.debug(
+            _debug(
                 "Skipping instrumentation %s: %s", entry_point.name, exc.msg
             )
             continue

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from functools import cached_property
 from logging import (
     DEBUG,
@@ -11,7 +12,6 @@ from logging import (
     getLogger,
 )
 from os import environ
-from sys import stderr
 
 from opentelemetry.instrumentation.dependencies import (
     DependencyConflictError,
@@ -47,6 +47,16 @@ def _format_log_arg(arg: object) -> object:
     return arg
 
 
+def _format_log_message(msg: str, args: tuple[object, ...]) -> str:
+    if not args:
+        return msg
+
+    try:
+        return msg % tuple(_format_log_arg(arg) for arg in args)
+    except Exception:  # pylint: disable=broad-except
+        return msg
+
+
 class _OtelLogLevelLoggerAdapter(LoggerAdapter):
     """Write startup debug messages to stderr when logging would drop them.
 
@@ -65,12 +75,9 @@ class _OtelLogLevelLoggerAdapter(LoggerAdapter):
         ):
             return
 
-        message = msg
-        if args:
-            message = message % tuple(_format_log_arg(arg) for arg in args)
-
-        stderr.write(f"DEBUG:{self.logger.name}:{message}\n")
-        stderr.flush()
+        message = _format_log_message(msg, args)
+        sys.stderr.write(f"DEBUG:{self.logger.name}:{message}\n")
+        sys.stderr.flush()
 
     def _logger_would_emit(self, level: int) -> bool:
         # If the logger itself would reject this level, don't bother walking handlers.

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cached_property
-from logging import DEBUG, getLogger
+from logging import DEBUG, NOTSET, Logger, LoggerAdapter, getLogger
 from os import environ
 from sys import stderr
 
@@ -23,40 +23,78 @@ from opentelemetry.util._importlib_metadata import (
     entry_points,
 )
 
-_logger = getLogger(__name__)
-
 SKIPPED_INSTRUMENTATIONS_WILDCARD = "*"
 OTEL_LOG_LEVEL = "OTEL_LOG_LEVEL"
 _DEBUG_LOG_LEVELS = frozenset(("trace", "debug"))
 
 
-def _diagnostic_debug_enabled() -> bool:
+def _otel_log_level_allows_debug() -> bool:
     log_level = environ.get(OTEL_LOG_LEVEL, "").strip().lower()
     return log_level in _DEBUG_LOG_LEVELS
 
 
-def _logger_handles_debug() -> bool:
-    return _logger.isEnabledFor(DEBUG) and _logger.hasHandlers()
-
-
-def _format_diagnostic_arg(arg: object) -> object:
+def _format_log_arg(arg: object) -> object:
     if isinstance(arg, str):
         return repr(arg)
 
     return arg
 
 
-def _debug(message: str, *args: object) -> None:
-    _logger.debug(message, *args)
+class _OtelLogLevelLoggerAdapter(LoggerAdapter):
+    """Write startup debug messages to stderr when logging would drop them.
 
-    if not _diagnostic_debug_enabled() or _logger_handles_debug():
-        return
+    Auto-instrumentation usually runs from sitecustomize before the
+    application configures logging, so normal logger.debug calls are often
+    not visible even when OTEL_LOG_LEVEL=debug. This adapter keeps normal
+    logging behavior, but also writes the same startup messages to stderr when
+    OTEL_LOG_LEVEL asks for debug output and Python logging would not emit them.
+    """
 
-    if args:
-        message = message % tuple(_format_diagnostic_arg(arg) for arg in args)
+    def __init__(self, logger, extra):
+        super().__init__(logger, extra)
+        # This adapter is built when this module is imported. That covers the
+        # sitecustomize path where auto-instrumentation runs before application
+        # logging setup, and the edge case where Python logging is set up and then
+        # auto_instrumentation.initialize() is invoked explicitly. If this adapter
+        # is used after application code can change logging, it should be modified
+        # to not use the cached value in the _logger_emits_debug field.
+        self._logger_emits_debug = self._logger_would_emit(DEBUG)
 
-    stderr.write(f"DEBUG:{__name__}:{message}\n")
-    stderr.flush()
+    def debug(self, msg: str, *args: object, **kwargs: object) -> None:
+        super().debug(msg, *args, **kwargs)
+
+        if not _otel_log_level_allows_debug() or self._logger_emits_debug:
+            return
+
+        message = msg
+        if args:
+            message = message % tuple(_format_log_arg(arg) for arg in args)
+
+        stderr.write(f"DEBUG:{self.logger.name}:{message}\n")
+        stderr.flush()
+
+    def _logger_would_emit(self, level: int) -> bool:
+        # If the logger itself would reject this level, don't bother walking handlers.
+        if not self.logger.isEnabledFor(level):
+            return False
+
+        logger: Logger | None = self.logger
+        while logger:
+            for handler in logger.handlers:
+                if handler.level == NOTSET or level >= handler.level:
+                    return True
+
+            # If we get here, this logger's handlers would not emit the record.
+            # If propagation is disabled, parent handlers will not see it either.
+            if not logger.propagate:
+                break
+
+            logger = logger.parent
+
+        return False
+
+
+_logger = _OtelLogLevelLoggerAdapter(getLogger(__name__), {})
 
 
 class _EntryPointDistFinder:
@@ -88,12 +126,14 @@ def _load_distro() -> BaseDistro:
             if distro_name is None or distro_name == entry_point.name:
                 distro = entry_point.load()()
                 if not isinstance(distro, BaseDistro):
-                    _debug(
+                    _logger.debug(
                         "%s is not an OpenTelemetry Distro. Skipping",
                         entry_point.name,
                     )
                     continue
-                _debug("Distribution %s will be configured", entry_point.name)
+                _logger.debug(
+                    "Distribution %s will be configured", entry_point.name
+                )
                 return distro
         except Exception as exc:  # pylint: disable=broad-except
             _logger.exception(
@@ -119,14 +159,16 @@ def _load_instrumentors(distro):
             break
 
         if entry_point.name in package_to_exclude:
-            _debug("Instrumentation skipped for library %s", entry_point.name)
+            _logger.debug(
+                "Instrumentation skipped for library %s", entry_point.name
+            )
             continue
 
         try:
             entry_point_dist = entry_point_finder.dist_for(entry_point)
             conflict = get_dist_dependency_conflicts(entry_point_dist)
             if conflict:
-                _debug(
+                _logger.debug(
                     "Skipping instrumentation %s: %s",
                     entry_point.name,
                     conflict,
@@ -135,13 +177,13 @@ def _load_instrumentors(distro):
 
             # tell instrumentation to not run dep checks again as we already did it above
             distro.load_instrumentor(entry_point, skip_dep_check=True)
-            _debug("Instrumented %s", entry_point.name)
+            _logger.debug("Instrumented %s", entry_point.name)
         except DependencyConflictError as exc:
             # Dependency conflicts are generally caught from get_dist_dependency_conflicts
             # returning a DependencyConflict. Keeping this error handling in case custom
             # distro and instrumentor behavior raises a DependencyConflictError later.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610
-            _debug(
+            _logger.debug(
                 "Skipping instrumentation %s: %s",
                 entry_point.name,
                 exc.conflict,
@@ -151,7 +193,7 @@ def _load_instrumentors(distro):
             # ModuleNotFoundError is raised when the library is not installed
             # and the instrumentation is not required to be loaded.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3421
-            _debug(
+            _logger.debug(
                 "Skipping instrumentation %s: %s", entry_point.name, exc.msg
             )
             continue

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -4,11 +4,15 @@
 import sys
 from functools import cached_property
 from logging import (
+    CRITICAL,
     DEBUG,
-    NOTSET,
+    ERROR,
+    INFO,
+    WARNING,
     Logger,
     LoggerAdapter,
     NullHandler,
+    getLevelName,
     getLogger,
 )
 from os import environ
@@ -32,71 +36,91 @@ from opentelemetry.util._importlib_metadata import (
 
 SKIPPED_INSTRUMENTATIONS_WILDCARD = "*"
 OTEL_LOG_LEVEL = "OTEL_LOG_LEVEL"
-_DEBUG_LOG_LEVELS = frozenset(("trace", "debug"))
+_OTEL_LOG_LEVELS = {
+    "trace": DEBUG,
+    "debug": DEBUG,
+    "info": INFO,
+    "warn": WARNING,
+    "warning": WARNING,
+    "error": ERROR,
+    "fatal": CRITICAL,
+    "critical": CRITICAL,
+}
 
 
-def _otel_log_level_allows_debug() -> bool:
+def _otel_log_level() -> int | None:
     log_level = environ.get(OTEL_LOG_LEVEL, "").strip().lower()
-    return log_level in _DEBUG_LOG_LEVELS
+    return _OTEL_LOG_LEVELS.get(log_level)
 
 
-def _format_log_arg(arg: object) -> object:
-    if isinstance(arg, str):
-        return repr(arg)
-
-    return arg
-
-
-def _format_log_message(msg: str, args: tuple[object, ...]) -> str:
+def _format_log_message(msg: object, args: tuple[object, ...]) -> str:
+    message = str(msg)
     if not args:
-        return msg
+        return message
 
     try:
-        return msg % tuple(_format_log_arg(arg) for arg in args)
+        return message % args
     except Exception:  # pylint: disable=broad-except
-        return msg
+        return message
 
 
 class _OtelLogLevelLoggerAdapter(LoggerAdapter):
-    """Write startup debug messages to stderr when logging would drop them.
+    """Write startup log messages to stderr before logging is configured.
 
     Auto-instrumentation usually runs from sitecustomize before the
-    application configures logging, so normal logger.debug calls are often
-    not visible even when OTEL_LOG_LEVEL=debug. This adapter keeps normal
-    logging behavior, but also writes the same startup messages to stderr when
-    OTEL_LOG_LEVEL asks for debug output and Python logging would not emit them.
+    application configures logging, so normal log calls are often not visible
+    even when OTEL_LOG_LEVEL requests them. This adapter keeps normal logging
+    behavior, but also writes startup messages to stderr when OTEL_LOG_LEVEL
+    asks for that level and no application logging configuration is detected on
+    the logger path. Once the application configures logging, its logger and
+    handler settings determine what gets emitted. Warning and higher records
+    are left to stdlib logging's lastResort handler so normal warning/error
+    output is not duplicated.
     """
 
-    def debug(self, msg: str, *args: object, **kwargs: object) -> None:
-        super().debug(msg, *args, **kwargs)
+    def log(
+        self, level: int, msg: object, *args: object, **kwargs: object
+    ) -> None:
+        # If application logging is already configured, make normal logging
+        # report the _logger caller instead of this helper. e.g.:
+        # DEBUG:_load.py:131:_load_instrumentors:Instrumented my_instrumentor
+        # instead of:
+        # DEBUG:_load.py:234:log:Instrumented my_instrumentor
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
 
-        if not _otel_log_level_allows_debug() or self._logger_would_emit(
-            DEBUG
-        ):
+        super().log(level, msg, *args, **kwargs)
+
+        otel_log_level = _otel_log_level()
+        if otel_log_level is None or level < otel_log_level:
+            return
+
+        if self._has_application_logging_configuration():
+            return
+
+        if self._handled_by_logging_last_resort(level):
             return
 
         message = _format_log_message(msg, args)
-        sys.stderr.write(f"DEBUG:{self.logger.name}:{message}\n")
+        sys.stderr.write(
+            f"{getLevelName(level)}:{self.logger.name}:{message}\n"
+        )
         sys.stderr.flush()
 
-    def _logger_would_emit(self, level: int) -> bool:
-        # If the logger itself would reject this level, don't bother walking handlers.
-        if not self.logger.isEnabledFor(level):
-            return False
+    @staticmethod
+    def _handled_by_logging_last_resort(level: int) -> bool:
+        return level >= WARNING
 
+    def _has_application_logging_configuration(self) -> bool:
         logger: Logger | None = self.logger
         while logger:
             for handler in logger.handlers:
-                if isinstance(handler, NullHandler):
-                    continue
-
-                if handler.level == NOTSET or level >= handler.level:
+                if not isinstance(handler, NullHandler):
                     return True
 
-            # If we get here, this logger's handlers would not emit the record.
-            # If propagation is disabled, parent handlers will not see it either.
+            # Respect application logging configuration even if it prevents this
+            # record from reaching a handler.
             if not logger.propagate:
-                break
+                return True
 
             logger = logger.parent
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -93,9 +93,7 @@ def _load_distro() -> BaseDistro:
                         entry_point.name,
                     )
                     continue
-                _debug(
-                    "Distribution %s will be configured", entry_point.name
-                )
+                _debug("Distribution %s will be configured", entry_point.name)
                 return distro
         except Exception as exc:  # pylint: disable=broad-except
             _logger.exception(
@@ -121,9 +119,7 @@ def _load_instrumentors(distro):
             break
 
         if entry_point.name in package_to_exclude:
-            _debug(
-                "Instrumentation skipped for library %s", entry_point.name
-            )
+            _debug("Instrumentation skipped for library %s", entry_point.name)
             continue
 
         try:

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from logging import DEBUG, INFO, NullHandler, getLogger
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -198,7 +199,7 @@ class TestLoad(TestCase):
             "Skipping instrumentation %s: %s", entry_point, dependency_conflict
         )
 
-    def test_writes_diagnostic_output_for_debug_levels(self):
+    def test_writes_otel_log_level_output_for_debug_levels(self):
         for log_level in ("debug", "trace"):
             with (
                 self.subTest(log_level=log_level),
@@ -206,19 +207,24 @@ class TestLoad(TestCase):
                     "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
                 ),
                 patch(
-                    "opentelemetry.instrumentation.auto_instrumentation._load._logger"
-                ) as logger_mock,
-                patch(
                     "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
                 ) as stderr_mock,
             ):
+                logger_mock = Mock()
                 logger_mock.isEnabledFor.return_value = True
-                logger_mock.hasHandlers.return_value = False
+                logger_mock.handlers = []
+                logger_mock.parent = None
+                logger_mock.propagate = True
+                logger_mock.name = (
+                    "opentelemetry.instrumentation."
+                    "auto_instrumentation._load"
+                )
+                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
 
-                _load._debug("Instrumented %s", "requests")
+                logger.debug("Instrumented %s", "requests")
 
-                logger_mock.debug.assert_called_once_with(
-                    "Instrumented %s", "requests"
+                logger_mock.log.assert_called_once_with(
+                    DEBUG, "Instrumented %s", "requests", extra={}
                 )
                 stderr_mock.write.assert_called_once_with(
                     "DEBUG:"
@@ -227,37 +233,115 @@ class TestLoad(TestCase):
                 )
                 stderr_mock.flush.assert_called_once()
 
-    def test_does_not_write_diagnostic_output(self):
+    def test_does_not_write_otel_log_level_output(self):
         cases = (
-            ("debug", True),
+            ("debug", DEBUG),
             ("info", False),
             ("debug2", False),
             ("debugger", False),
         )
 
-        for log_level, logger_has_handlers in cases:
+        for log_level, handler_level in cases:
             with (
                 self.subTest(log_level=log_level),
                 patch.dict(
                     "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
                 ),
                 patch(
-                    "opentelemetry.instrumentation.auto_instrumentation._load._logger"
-                ) as logger_mock,
-                patch(
                     "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
                 ) as stderr_mock,
             ):
+                logger_mock = Mock()
                 logger_mock.isEnabledFor.return_value = True
-                logger_mock.hasHandlers.return_value = logger_has_handlers
+                logger_mock.handlers = (
+                    [Mock(level=handler_level)] if handler_level else []
+                )
+                logger_mock.parent = None
+                logger_mock.propagate = True
+                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
 
-                _load._debug("Instrumented %s", "requests")
+                logger.debug("Instrumented %s", "requests")
 
-                logger_mock.debug.assert_called_once_with(
-                    "Instrumented %s", "requests"
+                logger_mock.log.assert_called_once_with(
+                    DEBUG, "Instrumented %s", "requests", extra={}
                 )
                 stderr_mock.write.assert_not_called()
                 stderr_mock.flush.assert_not_called()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    def test_otel_log_level_output_uses_logger_hierarchy_handlers(self):
+        parent_logger = getLogger("opentelemetry.test.auto_instrumentation")
+        logger = getLogger("opentelemetry.test.auto_instrumentation.loader")
+
+        original_parent_handlers = parent_logger.handlers[:]
+        original_parent_level = parent_logger.level
+        original_parent_propagate = parent_logger.propagate
+        original_logger_handlers = logger.handlers[:]
+        original_logger_level = logger.level
+        original_logger_propagate = logger.propagate
+
+        try:
+            parent_logger.handlers = []
+            parent_logger.setLevel(DEBUG)
+            parent_logger.propagate = False
+            logger.handlers = []
+            logger.setLevel(DEBUG)
+            logger.propagate = True
+
+            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
+                logger, {}
+            )
+
+            with patch(
+                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+            ) as stderr_mock:
+                otel_log_level_logger.debug("Instrumented %s", "requests")
+
+                stderr_mock.write.assert_called_once_with(
+                    "DEBUG:"
+                    "opentelemetry.test.auto_instrumentation.loader:"
+                    "Instrumented 'requests'\n"
+                )
+                stderr_mock.flush.assert_called_once()
+
+            handler = NullHandler()
+            handler.setLevel(INFO)
+            parent_logger.addHandler(handler)
+            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
+                logger, {}
+            )
+
+            with patch(
+                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+            ) as stderr_mock:
+                otel_log_level_logger.debug("Instrumented %s", "requests")
+
+                stderr_mock.write.assert_called_once_with(
+                    "DEBUG:"
+                    "opentelemetry.test.auto_instrumentation.loader:"
+                    "Instrumented 'requests'\n"
+                )
+                stderr_mock.flush.assert_called_once()
+
+            handler.setLevel(DEBUG)
+            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
+                logger, {}
+            )
+
+            with patch(
+                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+            ) as stderr_mock:
+                otel_log_level_logger.debug("Instrumented %s", "requests")
+
+                stderr_mock.write.assert_not_called()
+                stderr_mock.flush.assert_not_called()
+        finally:
+            parent_logger.handlers = original_parent_handlers
+            parent_logger.setLevel(original_parent_level)
+            parent_logger.propagate = original_parent_propagate
+            logger.handlers = original_logger_handlers
+            logger.setLevel(original_logger_level)
+            logger.propagate = original_logger_propagate
 
     @patch.dict(
         "os.environ",

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -198,104 +198,66 @@ class TestLoad(TestCase):
             "Skipping instrumentation %s: %s", entry_point, dependency_conflict
         )
 
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_writes_diagnostic_debug_output(
-        self, stderr_mock, logger_mock
-    ):
-        logger_mock.isEnabledFor.return_value = True
-        logger_mock.hasHandlers.return_value = False
+    def test_writes_diagnostic_output_for_debug_levels(self):
+        for log_level in ("debug", "trace"):
+            with (
+                self.subTest(log_level=log_level),
+                patch.dict(
+                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
+                ),
+                patch(
+                    "opentelemetry.instrumentation.auto_instrumentation._load._logger"
+                ) as logger_mock,
+                patch(
+                    "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+                ) as stderr_mock,
+            ):
+                logger_mock.isEnabledFor.return_value = True
+                logger_mock.hasHandlers.return_value = False
 
-        _load._debug("Instrumented %s", "requests")
+                _load._debug("Instrumented %s", "requests")
 
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
+                logger_mock.debug.assert_called_once_with(
+                    "Instrumented %s", "requests"
+                )
+                stderr_mock.write.assert_called_once_with(
+                    "DEBUG:"
+                    "opentelemetry.instrumentation.auto_instrumentation._load:"
+                    "Instrumented 'requests'\n"
+                )
+                stderr_mock.flush.assert_called_once()
+
+    def test_does_not_write_diagnostic_output(self):
+        cases = (
+            ("debug", True),
+            ("info", False),
+            ("debug2", False),
+            ("debugger", False),
         )
-        stderr_mock.write.assert_called_once_with(
-            "DEBUG:"
-            "opentelemetry.instrumentation.auto_instrumentation._load:"
-            "Instrumented 'requests'\n"
-        )
-        stderr_mock.flush.assert_called_once()
 
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "trace"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_writes_diagnostic_trace_output(self, stderr_mock, logger_mock):
-        logger_mock.isEnabledFor.return_value = True
-        logger_mock.hasHandlers.return_value = False
+        for log_level, logger_has_handlers in cases:
+            with (
+                self.subTest(log_level=log_level),
+                patch.dict(
+                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
+                ),
+                patch(
+                    "opentelemetry.instrumentation.auto_instrumentation._load._logger"
+                ) as logger_mock,
+                patch(
+                    "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+                ) as stderr_mock,
+            ):
+                logger_mock.isEnabledFor.return_value = True
+                logger_mock.hasHandlers.return_value = logger_has_handlers
 
-        _load._debug("Instrumented %s", "requests")
+                _load._debug("Instrumented %s", "requests")
 
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
-        )
-        stderr_mock.write.assert_called_once_with(
-            "DEBUG:"
-            "opentelemetry.instrumentation.auto_instrumentation._load:"
-            "Instrumented 'requests'\n"
-        )
-        stderr_mock.flush.assert_called_once()
-
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_does_not_write_diagnostic_when_logger_handles_debug(
-        self, stderr_mock, logger_mock
-    ):
-        logger_mock.isEnabledFor.return_value = True
-        logger_mock.hasHandlers.return_value = True
-
-        _load._debug("Instrumented %s", "requests")
-
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
-        )
-        stderr_mock.write.assert_not_called()
-        stderr_mock.flush.assert_not_called()
-
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "info"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_does_not_write_diagnostic_non_debug_output(
-        self, stderr_mock, logger_mock
-    ):
-        _load._debug("Instrumented %s", "requests")
-
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
-        )
-        stderr_mock.write.assert_not_called()
-        stderr_mock.flush.assert_not_called()
-
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug2"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_does_not_write_numbered_debug_output(
-        self, stderr_mock, logger_mock
-    ):
-        _load._debug("Instrumented %s", "requests")
-
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
-        )
-        stderr_mock.write.assert_not_called()
-        stderr_mock.flush.assert_not_called()
-
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debugger"}, clear=True)
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
-    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
-    def test_does_not_prefix_match_diagnostic_debug_output(
-        self, stderr_mock, logger_mock
-    ):
-        _load._debug("Instrumented %s", "requests")
-
-        logger_mock.debug.assert_called_once_with(
-            "Instrumented %s", "requests"
-        )
-        stderr_mock.write.assert_not_called()
-        stderr_mock.flush.assert_not_called()
+                logger_mock.debug.assert_called_once_with(
+                    "Instrumented %s", "requests"
+                )
+                stderr_mock.write.assert_not_called()
+                stderr_mock.flush.assert_not_called()
 
     @patch.dict(
         "os.environ",

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from contextlib import redirect_stderr
 from io import StringIO
-from logging import DEBUG, INFO, NullHandler, StreamHandler, getLogger
+from logging import DEBUG, INFO, NOTSET, NullHandler, StreamHandler, getLogger
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -18,6 +19,10 @@ from opentelemetry.instrumentation.environment_variables import (
 )
 from opentelemetry.instrumentation.version import __version__
 from opentelemetry.util._importlib_metadata import EntryPoint, entry_points
+
+_AUTO_INSTRUMENTATION_LOAD_LOGGER_NAME = (
+    "opentelemetry.instrumentation.auto_instrumentation._load"
+)
 
 
 class TestLoad(TestCase):
@@ -199,161 +204,6 @@ class TestLoad(TestCase):
         return call(
             "Skipping instrumentation %s: %s", entry_point, dependency_conflict
         )
-
-    def test_writes_otel_log_level_output_for_debug_levels(self):
-        for log_level in ("debug", "trace"):
-            with (
-                self.subTest(log_level=log_level),
-                patch.dict(
-                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
-                ),
-                patch(
-                    "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-                ) as stderr_mock,
-            ):
-                logger_mock = Mock()
-                logger_mock.isEnabledFor.return_value = True
-                logger_mock.handlers = []
-                logger_mock.parent = None
-                logger_mock.propagate = True
-                logger_mock.name = (
-                    "opentelemetry.instrumentation.auto_instrumentation._load"
-                )
-                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
-
-                logger.debug("Instrumented %s", "requests")
-
-                logger_mock.log.assert_called_once_with(
-                    DEBUG, "Instrumented %s", "requests", extra={}
-                )
-                stderr_mock.write.assert_called_once_with(
-                    "DEBUG:"
-                    "opentelemetry.instrumentation.auto_instrumentation._load:"
-                    "Instrumented 'requests'\n"
-                )
-                stderr_mock.flush.assert_called_once()
-
-    def test_does_not_write_otel_log_level_output(self):
-        cases = (
-            ("debug", DEBUG),
-            ("info", False),
-            ("debug2", False),
-            ("debugger", False),
-        )
-
-        for log_level, handler_level in cases:
-            with (
-                self.subTest(log_level=log_level),
-                patch.dict(
-                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
-                ),
-                patch(
-                    "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-                ) as stderr_mock,
-            ):
-                logger_mock = Mock()
-                logger_mock.isEnabledFor.return_value = True
-                logger_mock.handlers = (
-                    [Mock(level=handler_level)] if handler_level else []
-                )
-                logger_mock.parent = None
-                logger_mock.propagate = True
-                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
-
-                logger.debug("Instrumented %s", "requests")
-
-                logger_mock.log.assert_called_once_with(
-                    DEBUG, "Instrumented %s", "requests", extra={}
-                )
-                stderr_mock.write.assert_not_called()
-                stderr_mock.flush.assert_not_called()
-
-    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
-    def test_otel_log_level_output_uses_logger_hierarchy_handlers(
-        self,
-    ):  # pylint: disable=no-self-use
-        parent_logger = getLogger("opentelemetry.test.auto_instrumentation")
-        logger = getLogger("opentelemetry.test.auto_instrumentation.loader")
-
-        original_parent_handlers = parent_logger.handlers[:]
-        original_parent_level = parent_logger.level
-        original_parent_propagate = parent_logger.propagate
-        original_logger_handlers = logger.handlers[:]
-        original_logger_level = logger.level
-        original_logger_propagate = logger.propagate
-
-        try:
-            parent_logger.handlers = []
-            parent_logger.setLevel(DEBUG)
-            parent_logger.propagate = False
-            logger.handlers = []
-            logger.setLevel(DEBUG)
-            logger.propagate = True
-
-            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
-                logger, {}
-            )
-
-            with patch(
-                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-            ) as stderr_mock:
-                otel_log_level_logger.debug("Instrumented %s", "requests")
-
-                stderr_mock.write.assert_called_once_with(
-                    "DEBUG:"
-                    "opentelemetry.test.auto_instrumentation.loader:"
-                    "Instrumented 'requests'\n"
-                )
-                stderr_mock.flush.assert_called_once()
-
-            null_handler = NullHandler()
-            null_handler.setLevel(DEBUG)
-            parent_logger.addHandler(null_handler)
-
-            with patch(
-                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-            ) as stderr_mock:
-                otel_log_level_logger.debug("Instrumented %s", "requests")
-
-                stderr_mock.write.assert_called_once_with(
-                    "DEBUG:"
-                    "opentelemetry.test.auto_instrumentation.loader:"
-                    "Instrumented 'requests'\n"
-                )
-                stderr_mock.flush.assert_called_once()
-
-            stream_handler = StreamHandler(StringIO())
-            stream_handler.setLevel(INFO)
-            parent_logger.addHandler(stream_handler)
-
-            with patch(
-                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-            ) as stderr_mock:
-                otel_log_level_logger.debug("Instrumented %s", "requests")
-
-                stderr_mock.write.assert_called_once_with(
-                    "DEBUG:"
-                    "opentelemetry.test.auto_instrumentation.loader:"
-                    "Instrumented 'requests'\n"
-                )
-                stderr_mock.flush.assert_called_once()
-
-            stream_handler.setLevel(DEBUG)
-
-            with patch(
-                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
-            ) as stderr_mock:
-                otel_log_level_logger.debug("Instrumented %s", "requests")
-
-                stderr_mock.write.assert_not_called()
-                stderr_mock.flush.assert_not_called()
-        finally:
-            parent_logger.handlers = original_parent_handlers
-            parent_logger.setLevel(original_parent_level)
-            parent_logger.propagate = original_parent_propagate
-            logger.handlers = original_logger_handlers
-            logger.setLevel(original_logger_level)
-            logger.propagate = original_logger_propagate
 
     @patch.dict(
         "os.environ",
@@ -689,3 +539,246 @@ class TestLoad(TestCase):
 
         # All opentelemetry_post_instrument entry points should be loaded
         post_mock1.assert_called_once()
+
+
+class TestOtelLogLevelLogger(TestCase):
+    @staticmethod
+    def _logger_mock(name=_AUTO_INSTRUMENTATION_LOAD_LOGGER_NAME):
+        logger_mock = Mock()
+        logger_mock.isEnabledFor.return_value = True
+        logger_mock.handlers = []
+        logger_mock.parent = None
+        logger_mock.propagate = True
+        logger_mock.name = name
+        return logger_mock
+
+    @staticmethod
+    def _expected_message(
+        message, name=_AUTO_INSTRUMENTATION_LOAD_LOGGER_NAME
+    ):
+        return "DEBUG:" + name + ":" + message + "\n"
+
+    @staticmethod
+    def _stderr_from_debug(logger):
+        stderr = StringIO()
+        with redirect_stderr(stderr):
+            logger.debug("Instrumented %s", "requests")
+        return stderr.getvalue()
+
+    def _save_logger_state(self, logger):
+        state = (
+            logger.handlers[:],
+            logger.level,
+            logger.propagate,
+            logger.disabled,
+        )
+        self.addCleanup(self._restore_logger_state, logger, state)
+
+    @staticmethod
+    def _restore_logger_state(logger, state):
+        handlers, level, propagate, disabled = state
+        logger.handlers = handlers
+        logger.setLevel(level)
+        logger.propagate = propagate
+        logger.disabled = disabled
+
+    def test_writes_otel_log_level_output_for_debug_levels(self):
+        for log_level in ("debug", "trace"):
+            with (
+                self.subTest(log_level=log_level),
+                patch.dict(
+                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
+                ),
+            ):
+                logger_mock = self._logger_mock()
+                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
+
+                self.assertEqual(
+                    self._stderr_from_debug(logger),
+                    self._expected_message("Instrumented 'requests'"),
+                )
+
+                logger_mock.log.assert_called_once_with(
+                    DEBUG, "Instrumented %s", "requests", extra={}
+                )
+
+    def test_writes_otel_log_level_output_to_current_sys_stderr(self):
+        with patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True):
+            logger = _load._OtelLogLevelLoggerAdapter(self._logger_mock(), {})
+            stderr = StringIO()
+
+            with redirect_stderr(stderr):
+                logger.debug("Instrumented %s", "requests")
+
+            self.assertEqual(
+                stderr.getvalue(),
+                self._expected_message("Instrumented 'requests'"),
+            )
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    def test_otel_log_level_output_does_not_crash_on_format_error(self):
+        logger = _load._OtelLogLevelLoggerAdapter(self._logger_mock(), {})
+        msg = "Instrumented %s %s"
+        stderr = StringIO()
+
+        with redirect_stderr(stderr):
+            logger.debug(msg, "requests")
+
+        self.assertEqual(
+            stderr.getvalue(),
+            self._expected_message("Instrumented %s %s"),
+        )
+
+    def test_does_not_write_otel_log_level_output(self):
+        cases = (
+            ("debug", DEBUG),
+            ("info", False),
+            ("debug2", False),
+            ("debugger", False),
+        )
+
+        for log_level, handler_level in cases:
+            with (
+                self.subTest(log_level=log_level),
+                patch.dict(
+                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
+                ),
+            ):
+                logger_mock = self._logger_mock()
+                if handler_level:
+                    handler = StreamHandler(StringIO())
+                    handler.setLevel(handler_level)
+                    logger_mock.handlers = [handler]
+
+                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
+
+                self.assertEqual(self._stderr_from_debug(logger), "")
+
+                logger_mock.log.assert_called_once_with(
+                    DEBUG, "Instrumented %s", "requests", extra={}
+                )
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    def test_otel_log_level_output_uses_logger_hierarchy_handlers(self):
+        parent_logger = getLogger("opentelemetry.test.auto_instrumentation")
+        logger = getLogger("opentelemetry.test.auto_instrumentation.loader")
+        self._save_logger_state(parent_logger)
+        self._save_logger_state(logger)
+
+        parent_logger.handlers = []
+        parent_logger.setLevel(DEBUG)
+        parent_logger.propagate = False
+        logger.handlers = []
+        logger.setLevel(DEBUG)
+        logger.propagate = True
+
+        otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(logger, {})
+        expected_message = self._expected_message(
+            "Instrumented 'requests'", logger.name
+        )
+
+        self.assertEqual(
+            self._stderr_from_debug(otel_log_level_logger),
+            expected_message,
+        )
+
+        null_handler = NullHandler()
+        null_handler.setLevel(DEBUG)
+        parent_logger.addHandler(null_handler)
+
+        self.assertEqual(
+            self._stderr_from_debug(otel_log_level_logger),
+            expected_message,
+        )
+
+        stream_handler = StreamHandler(StringIO())
+        stream_handler.setLevel(INFO)
+        parent_logger.addHandler(stream_handler)
+
+        self.assertEqual(
+            self._stderr_from_debug(otel_log_level_logger),
+            expected_message,
+        )
+
+        stream_handler.setLevel(DEBUG)
+
+        self.assertEqual(self._stderr_from_debug(otel_log_level_logger), "")
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    def test_load_instrumentors_writes_debug_to_stderr_without_logging_handler(
+        self, iter_mock, mock_dep
+    ):
+        logger = _load._logger.logger
+        self._save_logger_state(logger)
+
+        logger.handlers = []
+        logger.setLevel(DEBUG)
+        logger.propagate = False
+        logger.disabled = False
+
+        ep_mock = Mock()
+        ep_mock.name = "requests"
+        distro_mock = Mock()
+        iter_mock.side_effect = [(), (ep_mock,), ()]
+        mock_dep.return_value = None
+        stderr = StringIO()
+
+        with redirect_stderr(stderr):
+            _load._load_instrumentors(distro_mock)
+
+        self.assertEqual(
+            stderr.getvalue(),
+            self._expected_message("Instrumented 'requests'"),
+        )
+        distro_mock.load_instrumentor.assert_called_once_with(
+            ep_mock, skip_dep_check=True
+        )
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts"
+    )
+    @patch(
+        "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
+    )
+    def test_load_instrumentors_uses_existing_root_logging_handler(
+        self, iter_mock, mock_dep
+    ):
+        logger = _load._logger.logger
+        current = logger
+        while current:
+            self._save_logger_state(current)
+            current.handlers = []
+            current.setLevel(NOTSET)
+            current.propagate = True
+            current.disabled = False
+            current = current.parent
+
+        log_output = StringIO()
+        handler = StreamHandler(log_output)
+        handler.setLevel(DEBUG)
+        root_logger = getLogger()
+        root_logger.handlers = [handler]
+        root_logger.setLevel(DEBUG)
+
+        ep_mock = Mock()
+        ep_mock.name = "requests"
+        distro_mock = Mock()
+        iter_mock.side_effect = [(), (ep_mock,), ()]
+        mock_dep.return_value = None
+        stderr = StringIO()
+
+        with redirect_stderr(stderr):
+            _load._load_instrumentors(distro_mock)
+
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(log_output.getvalue(), "Instrumented requests\n")
+        distro_mock.load_instrumentor.assert_called_once_with(
+            ep_mock, skip_dep_check=True
+        )

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -554,15 +554,15 @@ class TestOtelLogLevelLogger(TestCase):
 
     @staticmethod
     def _expected_message(
-        message, name=_AUTO_INSTRUMENTATION_LOAD_LOGGER_NAME
+        message, name=_AUTO_INSTRUMENTATION_LOAD_LOGGER_NAME, level="DEBUG"
     ):
-        return "DEBUG:" + name + ":" + message + "\n"
+        return level + ":" + name + ":" + message + "\n"
 
     @staticmethod
     def _stderr_from_debug(logger):
         stderr = StringIO()
         with redirect_stderr(stderr):
-            logger.debug("Instrumented %s", "requests")
+            logger.debug("Instrumented '%s'", "requests")
         return stderr.getvalue()
 
     def _save_logger_state(self, logger):
@@ -599,7 +599,41 @@ class TestOtelLogLevelLogger(TestCase):
                 )
 
                 logger_mock.log.assert_called_once_with(
-                    DEBUG, "Instrumented %s", "requests", extra={}
+                    DEBUG,
+                    "Instrumented '%s'",
+                    "requests",
+                    extra={},
+                    stacklevel=2,
+                )
+
+    def test_writes_otel_log_level_output_for_enabled_info_records(self):
+        for log_level in ("debug", "info"):
+            with (
+                self.subTest(log_level=log_level),
+                patch.dict(
+                    "os.environ", {"OTEL_LOG_LEVEL": log_level}, clear=True
+                ),
+            ):
+                logger_mock = self._logger_mock()
+                logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
+                stderr = StringIO()
+
+                with redirect_stderr(stderr):
+                    logger.info("Configured '%s'", "requests")
+
+                self.assertEqual(
+                    stderr.getvalue(),
+                    self._expected_message(
+                        "Configured 'requests'", level="INFO"
+                    ),
+                )
+
+                logger_mock.log.assert_called_once_with(
+                    INFO,
+                    "Configured '%s'",
+                    "requests",
+                    extra={},
+                    stacklevel=2,
                 )
 
     def test_writes_otel_log_level_output_to_current_sys_stderr(self):
@@ -608,7 +642,7 @@ class TestOtelLogLevelLogger(TestCase):
             stderr = StringIO()
 
             with redirect_stderr(stderr):
-                logger.debug("Instrumented %s", "requests")
+                logger.debug("Instrumented '%s'", "requests")
 
             self.assertEqual(
                 stderr.getvalue(),
@@ -618,7 +652,7 @@ class TestOtelLogLevelLogger(TestCase):
     @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
     def test_otel_log_level_output_does_not_crash_on_format_error(self):
         logger = _load._OtelLogLevelLoggerAdapter(self._logger_mock(), {})
-        msg = "Instrumented %s %s"
+        msg = "Instrumented '%s' '%s'"
         stderr = StringIO()
 
         with redirect_stderr(stderr):
@@ -626,10 +660,12 @@ class TestOtelLogLevelLogger(TestCase):
 
         self.assertEqual(
             stderr.getvalue(),
-            self._expected_message("Instrumented %s %s"),
+            self._expected_message("Instrumented '%s' '%s'"),
         )
 
-    def test_does_not_write_otel_log_level_output(self):
+    def test_does_not_write_fallback_when_level_disabled_or_logging_configured(
+        self,
+    ):
         cases = (
             ("debug", DEBUG),
             ("info", False),
@@ -655,22 +691,27 @@ class TestOtelLogLevelLogger(TestCase):
                 self.assertEqual(self._stderr_from_debug(logger), "")
 
                 logger_mock.log.assert_called_once_with(
-                    DEBUG, "Instrumented %s", "requests", extra={}
+                    DEBUG,
+                    "Instrumented '%s'",
+                    "requests",
+                    extra={},
+                    stacklevel=2,
                 )
 
     @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
-    def test_otel_log_level_output_uses_logger_hierarchy_handlers(self):
+    def test_otel_log_level_output_stops_after_application_logging_configured(
+        self,
+    ):
         parent_logger = getLogger("opentelemetry.test.auto_instrumentation")
         logger = getLogger("opentelemetry.test.auto_instrumentation.loader")
-        self._save_logger_state(parent_logger)
-        self._save_logger_state(logger)
-
-        parent_logger.handlers = []
-        parent_logger.setLevel(DEBUG)
-        parent_logger.propagate = False
-        logger.handlers = []
-        logger.setLevel(DEBUG)
-        logger.propagate = True
+        current = logger
+        while current:
+            self._save_logger_state(current)
+            current.handlers = []
+            current.setLevel(DEBUG)
+            current.propagate = True
+            current.disabled = False
+            current = current.parent
 
         otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(logger, {})
         expected_message = self._expected_message(
@@ -691,17 +732,19 @@ class TestOtelLogLevelLogger(TestCase):
             expected_message,
         )
 
+        parent_logger.propagate = False
+
+        # A propagation stop is application logging configuration even without a
+        # handler. Do not write fallback output over that configuration.
+        self.assertEqual(self._stderr_from_debug(otel_log_level_logger), "")
+
+        parent_logger.propagate = True
         stream_handler = StreamHandler(StringIO())
         stream_handler.setLevel(INFO)
         parent_logger.addHandler(stream_handler)
 
-        self.assertEqual(
-            self._stderr_from_debug(otel_log_level_logger),
-            expected_message,
-        )
-
-        stream_handler.setLevel(DEBUG)
-
+        # Any non-NullHandler means the application configured logging. Handler
+        # levels are then their output policy, so do not write fallback output.
         self.assertEqual(self._stderr_from_debug(otel_log_level_logger), "")
 
     @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
@@ -711,16 +754,18 @@ class TestOtelLogLevelLogger(TestCase):
     @patch(
         "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
-    def test_load_instrumentors_writes_debug_to_stderr_without_logging_handler(
+    def test_load_instrumentors_writes_debug_without_application_logging_config(
         self, iter_mock, mock_dep
     ):
         logger = _load._logger.logger
-        self._save_logger_state(logger)
-
-        logger.handlers = []
-        logger.setLevel(DEBUG)
-        logger.propagate = False
-        logger.disabled = False
+        current = logger
+        while current:
+            self._save_logger_state(current)
+            current.handlers = []
+            current.setLevel(DEBUG)
+            current.propagate = True
+            current.disabled = False
+            current = current.parent
 
         ep_mock = Mock()
         ep_mock.name = "requests"
@@ -734,7 +779,7 @@ class TestOtelLogLevelLogger(TestCase):
 
         self.assertEqual(
             stderr.getvalue(),
-            self._expected_message("Instrumented 'requests'"),
+            self._expected_message("Instrumented requests"),
         )
         distro_mock.load_instrumentor.assert_called_once_with(
             ep_mock, skip_dep_check=True
@@ -747,7 +792,7 @@ class TestOtelLogLevelLogger(TestCase):
     @patch(
         "opentelemetry.instrumentation.auto_instrumentation._load.entry_points"
     )
-    def test_load_instrumentors_uses_existing_root_logging_handler(
+    def test_load_instrumentors_defers_to_configured_root_logging_handler(
         self, iter_mock, mock_dep
     ):
         logger = _load._logger.logger

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -198,6 +198,105 @@ class TestLoad(TestCase):
             "Skipping instrumentation %s: %s", entry_point, dependency_conflict
         )
 
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_writes_diagnostic_debug_output(
+        self, stderr_mock, logger_mock
+    ):
+        logger_mock.isEnabledFor.return_value = True
+        logger_mock.hasHandlers.return_value = False
+
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_called_once_with(
+            "DEBUG:"
+            "opentelemetry.instrumentation.auto_instrumentation._load:"
+            "Instrumented 'requests'\n"
+        )
+        stderr_mock.flush.assert_called_once()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "trace"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_writes_diagnostic_trace_output(self, stderr_mock, logger_mock):
+        logger_mock.isEnabledFor.return_value = True
+        logger_mock.hasHandlers.return_value = False
+
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_called_once_with(
+            "DEBUG:"
+            "opentelemetry.instrumentation.auto_instrumentation._load:"
+            "Instrumented 'requests'\n"
+        )
+        stderr_mock.flush.assert_called_once()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_does_not_write_diagnostic_when_logger_handles_debug(
+        self, stderr_mock, logger_mock
+    ):
+        logger_mock.isEnabledFor.return_value = True
+        logger_mock.hasHandlers.return_value = True
+
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_not_called()
+        stderr_mock.flush.assert_not_called()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "info"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_does_not_write_diagnostic_non_debug_output(
+        self, stderr_mock, logger_mock
+    ):
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_not_called()
+        stderr_mock.flush.assert_not_called()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug2"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_does_not_write_numbered_debug_output(
+        self, stderr_mock, logger_mock
+    ):
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_not_called()
+        stderr_mock.flush.assert_not_called()
+
+    @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debugger"}, clear=True)
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.stderr")
+    def test_does_not_prefix_match_diagnostic_debug_output(
+        self, stderr_mock, logger_mock
+    ):
+        _load._debug("Instrumented %s", "requests")
+
+        logger_mock.debug.assert_called_once_with(
+            "Instrumented %s", "requests"
+        )
+        stderr_mock.write.assert_not_called()
+        stderr_mock.flush.assert_not_called()
+
     @patch.dict(
         "os.environ",
         {OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: " instr1 , instr3 "},

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
-from logging import DEBUG, INFO, NullHandler, getLogger
+from io import StringIO
+from logging import DEBUG, INFO, NullHandler, StreamHandler, getLogger
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -304,12 +305,9 @@ class TestLoad(TestCase):
                 )
                 stderr_mock.flush.assert_called_once()
 
-            handler = NullHandler()
-            handler.setLevel(INFO)
-            parent_logger.addHandler(handler)
-            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
-                logger, {}
-            )
+            null_handler = NullHandler()
+            null_handler.setLevel(DEBUG)
+            parent_logger.addHandler(null_handler)
 
             with patch(
                 "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
@@ -323,10 +321,23 @@ class TestLoad(TestCase):
                 )
                 stderr_mock.flush.assert_called_once()
 
-            handler.setLevel(DEBUG)
-            otel_log_level_logger = _load._OtelLogLevelLoggerAdapter(
-                logger, {}
-            )
+            stream_handler = StreamHandler(StringIO())
+            stream_handler.setLevel(INFO)
+            parent_logger.addHandler(stream_handler)
+
+            with patch(
+                "opentelemetry.instrumentation.auto_instrumentation._load.stderr"
+            ) as stderr_mock:
+                otel_log_level_logger.debug("Instrumented %s", "requests")
+
+                stderr_mock.write.assert_called_once_with(
+                    "DEBUG:"
+                    "opentelemetry.test.auto_instrumentation.loader:"
+                    "Instrumented 'requests'\n"
+                )
+                stderr_mock.flush.assert_called_once()
+
+            stream_handler.setLevel(DEBUG)
 
             with patch(
                 "opentelemetry.instrumentation.auto_instrumentation._load.stderr"

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -217,8 +217,7 @@ class TestLoad(TestCase):
                 logger_mock.parent = None
                 logger_mock.propagate = True
                 logger_mock.name = (
-                    "opentelemetry.instrumentation."
-                    "auto_instrumentation._load"
+                    "opentelemetry.instrumentation.auto_instrumentation._load"
                 )
                 logger = _load._OtelLogLevelLoggerAdapter(logger_mock, {})
 
@@ -270,7 +269,9 @@ class TestLoad(TestCase):
                 stderr_mock.flush.assert_not_called()
 
     @patch.dict("os.environ", {"OTEL_LOG_LEVEL": "debug"}, clear=True)
-    def test_otel_log_level_output_uses_logger_hierarchy_handlers(self):
+    def test_otel_log_level_output_uses_logger_hierarchy_handlers(
+        self,
+    ):  # pylint: disable=no-self-use
         parent_logger = getLogger("opentelemetry.test.auto_instrumentation")
         logger = getLogger("opentelemetry.test.auto_instrumentation.loader")
 


### PR DESCRIPTION
# Description

Writes auto-instrumentation startup debug messages to stderr when `OTEL_LOG_LEVEL=debug` or `OTEL_LOG_LEVEL=trace` is set. This makes it easier to see which distro and instrumentors were loaded during `opentelemetry-instrument` startup.

If Python logging is already configured, the new stderr output is suppressed to avoid double logging.

Fixes #4540

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran `python -m unittest opentelemetry-python-contrib/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py`
- [x] Ran `oteltest` with local packages and confirmed the expected stderr debug messages

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
