### PR TITLE
openai: pass tool definitions to genai utils

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Pass tool definitions from `tools` kwarg to `InferenceInvocation.tool_definitions`
+  so `gen_ai.tool.definitions` span attribute is populated on chat completion spans
+  ([#4554](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4554))
+
 ## Version 2.4b0 (2026-05-01)
 
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -497,7 +497,7 @@ def _prepare_tool_definitions(tools) -> list[ToolDefinition] | None:
                         parameters=get_property_value(func, "parameters"),
                     )
                 )
-    return definitions or None
+    return definitions
 
 
 def _prepare_output_messages(choices) -> List[OutputMessage]:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -32,11 +32,13 @@ from opentelemetry.util.genai.environment_variables import (
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import InferenceInvocation
 from opentelemetry.util.genai.types import (
+    FunctionToolDefinition,
     InputMessage,
     OutputMessage,
     Text,
     ToolCallRequest,
     ToolCallResponse,
+    ToolDefinition,
 )
 
 _OpenAIOmit = getattr(openai, "Omit", None)
@@ -397,6 +399,9 @@ def create_chat_invocation(
         invocation.input_messages = _prepare_input_messages(
             kwargs.get("messages", [])
         )
+        invocation.tool_definitions = _prepare_tool_definitions(
+            kwargs.get("tools")
+        )
     return invocation
 
 
@@ -473,6 +478,26 @@ def extract_tool_calls_new(tool_calls) -> list[ToolCallRequest]:
             ToolCallRequest(id=call_id, name=func_name, arguments=arguments)
         )
     return parts
+
+
+def _prepare_tool_definitions(tools) -> list[ToolDefinition] | None:
+    if not tools:
+        return None
+
+    definitions: list[ToolDefinition] = []
+    for tool in tools:
+        tool_type = get_property_value(tool, "type")
+        if tool_type == "function":
+            func = get_property_value(tool, "function")
+            if func:
+                definitions.append(
+                    FunctionToolDefinition(
+                        name=get_property_value(func, "name") or "",
+                        description=get_property_value(func, "description"),
+                        parameters=get_property_value(func, "parameters"),
+                    )
+                )
+    return definitions or None
 
 
 def _prepare_output_messages(choices) -> List[OutputMessage]:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_async_chat_completions.py
@@ -22,6 +22,7 @@ from opentelemetry.util.genai.utils import is_experimental_mode
 
 from .test_utils import (
     DEFAULT_MODEL,
+    EXPECTED_TOOL_DEFINITIONS,
     USER_ONLY_EXPECTED_INPUT_MESSAGES,
     USER_ONLY_PROMPT,
     WEATHER_TOOL_EXPECTED_INPUT_MESSAGES,
@@ -615,6 +616,12 @@ async def chat_completion_tool_call(
             assert_messages_attribute(
                 spans[0].attributes["gen_ai.output.messages"], first_output
             )
+
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.tool.definitions"],
+                EXPECTED_TOOL_DEFINITIONS,
+            )
+            assert "gen_ai.tool.definitions" not in spans[1].attributes
 
             # second call
             del first_output[0]["finish_reason"]
@@ -1270,6 +1277,10 @@ async def async_chat_completion_multiple_tools_streaming(
             ]
             assert_messages_attribute(
                 spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.tool.definitions"],
+                EXPECTED_TOOL_DEFINITIONS,
             )
     else:
         assert len(logs) == 3

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_chat_completions.py
@@ -36,6 +36,7 @@ from opentelemetry.util.genai.utils import is_experimental_mode
 
 from .test_utils import (
     DEFAULT_MODEL,
+    EXPECTED_TOOL_DEFINITIONS,
     USER_ONLY_EXPECTED_INPUT_MESSAGES,
     USER_ONLY_PROMPT,
     WEATHER_TOOL_EXPECTED_INPUT_MESSAGES,
@@ -747,6 +748,12 @@ def chat_completion_tool_call(
                 spans[0].attributes["gen_ai.output.messages"], first_output
             )
 
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.tool.definitions"],
+                EXPECTED_TOOL_DEFINITIONS,
+            )
+            assert "gen_ai.tool.definitions" not in spans[1].attributes
+
             # second call
             del first_output[0]["finish_reason"]
             second_input = []
@@ -1415,6 +1422,10 @@ def chat_completion_multiple_tools_streaming(
             ]
             assert_messages_attribute(
                 spans[0].attributes["gen_ai.output.messages"], first_output
+            )
+            assert_messages_attribute(
+                spans[0].attributes["gen_ai.tool.definitions"],
+                EXPECTED_TOOL_DEFINITIONS,
             )
     else:
         assert len(logs) == 3

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_utils.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/test_utils.py
@@ -173,6 +173,26 @@ def get_current_weather_tool_definition():
     }
 
 
+EXPECTED_TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. Boston, MA",
+                },
+            },
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    }
+]
+
+
 def remove_none_values(body):
     """Remove None values from a dictionary recursively"""
     result = {}


### PR DESCRIPTION
# Description

Pass tool definitions from the OpenAI `tools` kwarg through to `InferenceInvocation.tool_definitions` so they are serialized into `gen_ai.tool.definitions` span/event attributes and forwarded to the completion hook.

The utils layer already supports tool definitions (PR #4181), but the OpenAI v2 instrumentation was not extracting them from request kwargs.

Fixes #4511

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added assertions for `gen_ai.tool.definitions` in existing sync and async tool call tests (both non-streaming and streaming variants)
- [x] Verified second span (no tools passed) does not contain the attribute

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated