### PR TITLE
gen-ai: Specify oldest version of genai util for tests

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.40",
   "opentelemetry-instrumentation ~= 0.61b0",
   "opentelemetry-semantic-conventions ~= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0.dev, <0.5b0",
+  "opentelemetry-util-genai >= 0.4b0, <0.5b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
@@ -15,7 +15,6 @@
 # This variant of the requirements aims to test the system using
 # the oldest supported version of external dependencies.
 
--e util/opentelemetry-util-genai # todo: update to 0.4b0 when it's released
 anthropic==0.51.0
 pytest==7.4.4
 pytest-vcr==1.0.2
@@ -24,5 +23,5 @@ wrapt==1.16.0
 opentelemetry-api==1.40  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
-
+opentelemetry-util-genai==0.4b0
 -e instrumentation-genai/opentelemetry-instrumentation-anthropic

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
@@ -22,6 +22,6 @@ pytest-asyncio==0.21.0
 wrapt==1.16.0
 opentelemetry-api==1.40  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
-opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
-opentelemetry-util-genai==0.4b0
+opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml 
+opentelemetry-util-genai==0.4b0  # when updating, also update in pyproject.toml
 -e instrumentation-genai/opentelemetry-instrumentation-anthropic

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~=1.40",
   "opentelemetry-instrumentation >=0.61b0, <2",
   "opentelemetry-semantic-conventions >=0.61b0, <2",
-  "opentelemetry-util-genai >= 0.4b0.dev, <0.5b0",
+  "opentelemetry-util-genai >= 0.4b0, <0.5b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
@@ -25,7 +25,7 @@ opentelemetry-api==1.40.0
 opentelemetry-sdk==1.40.0
 opentelemetry-semantic-conventions==0.61b0
 opentelemetry-instrumentation==0.61b0
-util/opentelemetry-util-genai[upload]==0.4b.0
+opentelemetry-util-genai[upload]==0.4b.0
 
 fsspec==2025.9.0
 

--- a/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
@@ -25,7 +25,7 @@ opentelemetry-api==1.40.0
 opentelemetry-sdk==1.40.0
 opentelemetry-semantic-conventions==0.61b0
 opentelemetry-instrumentation==0.61b0
--e util/opentelemetry-util-genai[upload]
+util/opentelemetry-util-genai[upload]==0.4b.0
 
 fsspec==2025.9.0
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api >= 1.40",
   "opentelemetry-instrumentation >= 0.61b0",
   "opentelemetry-semantic-conventions >= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0.dev"
+  "opentelemetry-util-genai >= 0.4b0"
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
@@ -31,6 +31,5 @@ opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
 grpcio>=1.60.0; implementation_name != "pypy"
 grpcio<1.60.0; implementation_name == "pypy"
-
--e util/opentelemetry-util-genai
+opentelemetry-util-genai=="0.4b.0"
 -e instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
@@ -29,7 +29,8 @@ opentelemetry-exporter-otlp-proto-http~=1.30
 opentelemetry-api==1.40  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
+opentelemetry-util-genai==0.4b.0  # when updating, also update in pyproject.toml
 grpcio>=1.60.0; implementation_name != "pypy"
 grpcio<1.60.0; implementation_name == "pypy"
-opentelemetry-util-genai=="0.4b.0"
+
 -e instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.40",
   "opentelemetry-instrumentation ~= 0.61b0",
   "opentelemetry-semantic-conventions ~= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0.dev",
+  "opentelemetry-util-genai >= 0.4b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/tests/requirements.oldest.txt
@@ -32,6 +32,6 @@ opentelemetry-exporter-otlp-proto-http~=1.30
 opentelemetry-api==1.40  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
+opentelemetry-util-genai==0.4b0  #  when updating, also update in pyproject.toml
 
 -e instrumentation-genai/opentelemetry-instrumentation-openai-v2
--e util/opentelemetry-util-genai

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.40",
   "opentelemetry-instrumentation ~= 0.61b0",
   "opentelemetry-semantic-conventions ~= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0.dev, <0.5b0",
+  "opentelemetry-util-genai >= 0.4b0, <0.5b0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
@@ -69,7 +69,7 @@ opentelemetry-api==1.40
 opentelemetry-sdk==1.40
 opentelemetry-semantic-conventions==0.61b0
 opentelemetry-instrumentation==0.61b0
-opentelemetry-util-genai[upload]==0.2b0
+opentelemetry-util-genai[upload]==0.4b0
 
 fsspec==2025.9.0
 

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/tests/requirements.oldest.txt
@@ -69,8 +69,8 @@ opentelemetry-api==1.40
 opentelemetry-sdk==1.40
 opentelemetry-semantic-conventions==0.61b0
 opentelemetry-instrumentation==0.61b0
-# opentelemetry-util-genai[upload]==0.2b0
--e util/opentelemetry-util-genai[upload]
+opentelemetry-util-genai[upload]==0.2b0
+
 fsspec==2025.9.0
 
 -e instrumentation-genai/opentelemetry-instrumentation-vertexai[instruments]


### PR DESCRIPTION
Preparing to repo separation - minimize needs to install current version of genai utils in instrumentations.
Specify the oldest supported version in tests.