### PR TITLE
Add optional http.client.response.body.size span attribute & metric to Aiohttp-client instrumentation.

### DIFF
--- a/.changelog/4572.added
+++ b/.changelog/4572.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-aiohttp-client`: add optional `http.client.response.body.size` span attribute & metric to the aiohttp client instrumentation

--- a/.changelog/4572.added
+++ b/.changelog/4572.added
@@ -1,1 +1,1 @@
-`opentelemetry-instrumentation-aiohttp-client`: add optional `http.client.response.body.size` span attribute & metric to the aiohttp client instrumentation
+`opentelemetry-instrumentation-aiohttp-client`: add the `http.response.body.size` span attribute and the `http.client.response.body.size` metric, derived from the `Content-Length` response header, when the new HTTP semantic conventions are enabled

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -189,6 +189,25 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Capturing response body size
+****************************
+To capture the ``http.response.body.size`` span attribute and record the
+``http.client.response.body.size`` metric histogram, set the environment variable
+``OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE`` to ``"true"``.
+
+This is an opt-in attribute per the semantic conventions specification. It is
+only emitted when the new HTTP semantic conventions are active
+(``OTEL_SEMCONV_STABILITY_OPT_IN`` includes ``http`` or ``http/dup``).
+
+::
+
+    export OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE="true"
+    export OTEL_SEMCONV_STABILITY_OPT_IN="http"
+
+The body size is derived from the ``Content-Length`` response header. For
+chunked responses that lack a ``Content-Length`` header, the attribute and
+metric are not recorded.
+
 API
 ---
 """
@@ -243,6 +262,12 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.metrics import MeterProvider, get_meter
 from opentelemetry.propagate import inject
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_RESPONSE_BODY_SIZE,
+)
+from opentelemetry.semconv._incubating.metrics.http_metrics import (
+    create_http_client_response_body_size,
+)
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.metrics import (
     MetricInstruments,  # type: ignore[reportDeprecated]
@@ -259,6 +284,7 @@ from opentelemetry.util.http import (
     get_custom_header_attributes,
     get_custom_headers,
     get_excluded_urls,
+    is_capture_response_body_size_enabled,
     normalise_request_header_name,
     normalise_response_header_name,
     redact_url,
@@ -424,6 +450,14 @@ def create_trace_config(
             explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
         )
 
+    capture_response_body_size = is_capture_response_body_size_enabled()
+
+    response_body_size_histogram = None
+    if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
+        response_body_size_histogram = create_http_client_response_body_size(
+            meter
+        )
+
     excluded_urls = get_excluded_urls("AIOHTTP_CLIENT")
 
     def _end_trace(trace_config_ctx: types.SimpleNamespace):
@@ -432,6 +466,24 @@ def create_trace_config(
             context_api.detach(trace_config_ctx.token)
         if trace_config_ctx.span:
             trace_config_ctx.span.end()
+
+        if (
+            trace_config_ctx.response_body_size_histogram is not None
+            and trace_config_ctx.response_body_size is not None
+        ):
+            body_size_attrs = cast(
+                dict[str, Any],
+                _filter_semconv_duration_attrs(
+                    trace_config_ctx.metric_attributes,
+                    _client_duration_attrs_old,
+                    _client_duration_attrs_new,
+                    _StabilityMode.HTTP,
+                ),
+            )
+            trace_config_ctx.response_body_size_histogram.record(
+                trace_config_ctx.response_body_size,
+                attributes=body_size_attrs,
+            )
 
         if trace_config_ctx.duration_histogram_old is not None:
             duration_attrs_old = cast(
@@ -586,6 +638,15 @@ def create_trace_config(
             )
         )
 
+        if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
+            content_length = params.response.content_length
+            if content_length is not None:
+                if trace_config_ctx.span.is_recording():
+                    trace_config_ctx.span.set_attribute(
+                        HTTP_RESPONSE_BODY_SIZE, content_length
+                    )
+                trace_config_ctx.response_body_size = content_length
+
         _end_trace(trace_config_ctx)
 
     async def on_request_exception(
@@ -620,6 +681,8 @@ def create_trace_config(
             token=None,
             duration_histogram_old=duration_histogram_old,
             duration_histogram_new=duration_histogram_new,
+            response_body_size_histogram=response_body_size_histogram,
+            response_body_size=None,
             metric_attributes={},
             url_filter=url_filter,
             excluded_urls=excluded_urls,

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -183,19 +183,15 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
-Capturing response body size
-****************************
-To capture the ``http.response.body.size`` span attribute and record the
-``http.client.response.body.size`` metric histogram, set the environment variable
-``OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE`` to ``"true"``.
-
-This is an opt-in attribute per the semantic conventions specification. It is
-only emitted when the new HTTP semantic conventions are active
-(``OTEL_SEMCONV_STABILITY_OPT_IN`` includes ``http`` or ``http/dup``).
+Response body size
+******************
+The ``http.response.body.size`` span attribute and the
+``http.client.response.body.size`` metric histogram are emitted when the new
+HTTP semantic conventions are active, i.e. when
+``OTEL_SEMCONV_STABILITY_OPT_IN`` includes ``http`` or ``http/dup``.
 
 ::
 
-    export OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE="true"
     export OTEL_SEMCONV_STABILITY_OPT_IN="http"
 
 The body size is derived from the ``Content-Length`` response header. For
@@ -276,7 +272,6 @@ from opentelemetry.util.http import (
     get_custom_header_attributes,
     get_custom_headers,
     get_excluded_urls,
-    is_capture_response_body_size_enabled,
     normalise_request_header_name,
     normalise_response_header_name,
     redact_url,
@@ -438,13 +433,9 @@ def create_trace_config(
             explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
         )
 
-    capture_response_body_size = is_capture_response_body_size_enabled()
-
     response_body_size_histogram = None
-    if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
-        response_body_size_histogram = create_http_client_response_body_size(
-            meter
-        )
+    if _report_new(sem_conv_opt_in_mode):
+        response_body_size_histogram = create_http_client_response_body_size(meter)
 
     excluded_urls = get_excluded_urls("AIOHTTP_CLIENT")
 
@@ -607,13 +598,11 @@ def create_trace_config(
             )
         )
 
-        if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
+        if _report_new(sem_conv_opt_in_mode):
             content_length = params.response.content_length
             if content_length is not None:
                 if trace_config_ctx.span.is_recording():
-                    trace_config_ctx.span.set_attribute(
-                        HTTP_RESPONSE_BODY_SIZE, content_length
-                    )
+                    trace_config_ctx.span.set_attribute(HTTP_RESPONSE_BODY_SIZE, content_length)
                 trace_config_ctx.response_body_size = content_length
 
         _end_trace(trace_config_ctx)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -183,6 +183,25 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Capturing response body size
+****************************
+To capture the ``http.response.body.size`` span attribute and record the
+``http.client.response.body.size`` metric histogram, set the environment variable
+``OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE`` to ``"true"``.
+
+This is an opt-in attribute per the semantic conventions specification. It is
+only emitted when the new HTTP semantic conventions are active
+(``OTEL_SEMCONV_STABILITY_OPT_IN`` includes ``http`` or ``http/dup``).
+
+::
+
+    export OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE="true"
+    export OTEL_SEMCONV_STABILITY_OPT_IN="http"
+
+The body size is derived from the ``Content-Length`` response header. For
+chunked responses that lack a ``Content-Length`` header, the attribute and
+metric are not recorded.
+
 API
 ---
 """
@@ -235,6 +254,12 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.metrics import MeterProvider, get_meter
 from opentelemetry.propagate import inject
+from opentelemetry.semconv._incubating.attributes.http_attributes import (
+    HTTP_RESPONSE_BODY_SIZE,
+)
+from opentelemetry.semconv._incubating.metrics.http_metrics import (
+    create_http_client_response_body_size,
+)
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.metrics import (
     MetricInstruments,  # type: ignore[reportDeprecated]
@@ -251,6 +276,7 @@ from opentelemetry.util.http import (
     get_custom_header_attributes,
     get_custom_headers,
     get_excluded_urls,
+    is_capture_response_body_size_enabled,
     normalise_request_header_name,
     normalise_response_header_name,
     redact_url,
@@ -412,6 +438,14 @@ def create_trace_config(
             explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
         )
 
+    capture_response_body_size = is_capture_response_body_size_enabled()
+
+    response_body_size_histogram = None
+    if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
+        response_body_size_histogram = create_http_client_response_body_size(
+            meter
+        )
+
     excluded_urls = get_excluded_urls("AIOHTTP_CLIENT")
 
     def _end_trace(trace_config_ctx: types.SimpleNamespace):
@@ -420,6 +454,24 @@ def create_trace_config(
             context_api.detach(trace_config_ctx.token)
         if trace_config_ctx.span:
             trace_config_ctx.span.end()
+
+        if (
+            trace_config_ctx.response_body_size_histogram is not None
+            and trace_config_ctx.response_body_size is not None
+        ):
+            body_size_attrs = cast(
+                dict[str, Any],
+                _filter_semconv_duration_attrs(
+                    trace_config_ctx.metric_attributes,
+                    _client_duration_attrs_old,
+                    _client_duration_attrs_new,
+                    _StabilityMode.HTTP,
+                ),
+            )
+            trace_config_ctx.response_body_size_histogram.record(
+                trace_config_ctx.response_body_size,
+                attributes=body_size_attrs,
+            )
 
         if trace_config_ctx.duration_histogram_old is not None:
             duration_attrs_old = cast(
@@ -555,6 +607,15 @@ def create_trace_config(
             )
         )
 
+        if capture_response_body_size and _report_new(sem_conv_opt_in_mode):
+            content_length = params.response.content_length
+            if content_length is not None:
+                if trace_config_ctx.span.is_recording():
+                    trace_config_ctx.span.set_attribute(
+                        HTTP_RESPONSE_BODY_SIZE, content_length
+                    )
+                trace_config_ctx.response_body_size = content_length
+
         _end_trace(trace_config_ctx)
 
     async def on_request_exception(
@@ -587,6 +648,8 @@ def create_trace_config(
             token=None,
             duration_histogram_old=duration_histogram_old,
             duration_histogram_new=duration_histogram_new,
+            response_body_size_histogram=response_body_size_histogram,
+            response_body_size=None,
             metric_attributes={},
             url_filter=url_filter,
             excluded_urls=excluded_urls,

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1621,9 +1621,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         self._assert_spans(0)
         self._assert_metrics(0)
 
-    @mock.patch.dict(
-        os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"}
-    )
+    @mock.patch.dict(os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"})
     def test_response_body_size_not_set_by_default(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
@@ -1649,9 +1647,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         )
         span = self._assert_spans(1)
         self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
-        self.assertIsInstance(
-            span.attributes[HTTP_RESPONSE_BODY_SIZE], int
-        )
+        self.assertIsInstance(span.attributes[HTTP_RESPONSE_BODY_SIZE], int)
 
     @mock.patch.dict(
         "os.environ",
@@ -1668,13 +1664,9 @@ class TestAioHttpClientInstrumentor(TestBase):
         )
         metrics = self._assert_metrics(2)
         metric_names = {m.name for m in metrics}
-        self.assertIn(
-            "http.client.response.body.size", metric_names
-        )
+        self.assertIn("http.client.response.body.size", metric_names)
         body_size_metric = next(
-            m
-            for m in metrics
-            if m.name == "http.client.response.body.size"
+            m for m in metrics if m.name == "http.client.response.body.size"
         )
         data_point = body_size_metric.data.data_points[0]
         self.assertEqual(data_point.count, 1)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1286,6 +1286,10 @@ class TestAioHttpClientInstrumentor(TestBase):
         return aiohttp.web.Response(status=int(200))
 
     @staticmethod
+    async def handler_with_body(request):
+        return aiohttp.web.Response(status=200, body=b"hello")
+
+    @staticmethod
     def get_default_request(url: str = URL):
         async def default_request(server: aiohttp.test_utils.TestServer):
             async with aiohttp.test_utils.TestClient(server) as session:
@@ -1627,7 +1631,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().instrument()
 
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
@@ -1643,7 +1647,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
@@ -1659,8 +1663,9 @@ class TestAioHttpClientInstrumentor(TestBase):
     def test_response_body_size_metric_recorded(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
+
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         metrics = self._assert_metrics(2)
         metric_names = {m.name for m in metrics}
@@ -1682,7 +1687,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -36,6 +36,7 @@ from opentelemetry.instrumentation.utils import (
 from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_HOST,
     HTTP_METHOD,
+    HTTP_RESPONSE_BODY_SIZE,
     HTTP_STATUS_CODE,
     HTTP_URL,
 )
@@ -57,6 +58,9 @@ from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import Span, StatusCode
 from opentelemetry.util._importlib_metadata import entry_points
+from opentelemetry.util.http import (
+    OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE,
+)
 
 
 def run_with_test_server(
@@ -1616,6 +1620,80 @@ class TestAioHttpClientInstrumentor(TestBase):
         )
         self._assert_spans(0)
         self._assert_metrics(0)
+
+    @mock.patch.dict(
+        os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"}
+    )
+    def test_response_body_size_not_set_by_default(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_set_on_span(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+        self.assertIsInstance(
+            span.attributes[HTTP_RESPONSE_BODY_SIZE], int
+        )
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_metric_recorded(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        metrics = self._assert_metrics(2)
+        metric_names = {m.name for m in metrics}
+        self.assertIn(
+            "http.client.response.body.size", metric_names
+        )
+        body_size_metric = next(
+            m
+            for m in metrics
+            if m.name == "http.client.response.body.size"
+        )
+        data_point = body_size_metric.data.data_points[0]
+        self.assertEqual(data_point.count, 1)
+        self.assertTrue(data_point.sum > 0)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_not_set_without_new_semconv(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
 
 
 class TestLoadingAioHttpInstrumentor(unittest.TestCase):

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1217,6 +1217,10 @@ class TestAioHttpClientInstrumentor(TestBase):
         return aiohttp.web.Response(status=200)
 
     @staticmethod
+    async def handler_with_body(request):
+        return aiohttp.web.Response(status=200, body=b"hello")
+
+    @staticmethod
     def get_default_request(url: str = URL):
         async def default_request(server: aiohttp.test_utils.TestServer):
             async with aiohttp.test_utils.TestClient(server) as session:
@@ -1519,7 +1523,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().instrument()
 
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
@@ -1535,7 +1539,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
@@ -1551,8 +1555,9 @@ class TestAioHttpClientInstrumentor(TestBase):
     def test_response_body_size_metric_recorded(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
+
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         metrics = self._assert_metrics(2)
         metric_names = {m.name for m in metrics}
@@ -1574,7 +1579,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
         run_with_test_server(
-            self.get_default_request(), self.URL, self.default_handler
+            self.get_default_request(), self.URL, self.handler_with_body
         )
         span = self._assert_spans(1)
         self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -48,6 +48,9 @@ from opentelemetry.semconv._incubating.attributes.server_attributes import (
     SERVER_ADDRESS,
     SERVER_PORT,
 )
+from opentelemetry.semconv._incubating.metrics.http_metrics import (
+    HTTP_CLIENT_RESPONSE_BODY_SIZE,
+)
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.attributes.http_attributes import (
     HTTP_REQUEST_METHOD,
@@ -58,9 +61,6 @@ from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import Span, StatusCode
 from opentelemetry.util._importlib_metadata import entry_points
-from opentelemetry.util.http import (
-    OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE,
-)
 
 
 def run_with_test_server(runnable: typing.Callable, url: str, handler: typing.Callable) -> tuple[str, int]:
@@ -202,13 +202,14 @@ class TestAioHttpIntegration(TestBase):
                     HTTP_RESPONSE_STATUS_CODE: status_code,
                     SERVER_ADDRESS: host,
                     SERVER_PORT: port,
+                    HTTP_RESPONSE_BODY_SIZE: 0,
                 }
                 if status_code >= 400:
                     attributes[ERROR_TYPE] = str(status_code.value)
                 spans = [("GET", (span_status, None), attributes)]
                 self._assert_spans(spans)
                 self.memory_exporter.clear()
-                metrics = self._assert_metrics(1)
+                metrics = self._assert_metrics(2)
                 duration_data_point = metrics[0].data.data_points[index]
                 self.assertEqual(
                     duration_data_point.attributes.get(HTTP_RESPONSE_STATUS_CODE),
@@ -251,6 +252,7 @@ class TestAioHttpIntegration(TestBase):
                     SERVER_ADDRESS: host,
                     SERVER_PORT: port,
                     NET_PEER_PORT: port,
+                    HTTP_RESPONSE_BODY_SIZE: 0,
                 }
 
                 if status_code >= 400:
@@ -259,7 +261,7 @@ class TestAioHttpIntegration(TestBase):
                 spans = [("GET", (span_status, None), attributes)]
                 self._assert_spans(spans, 1)
                 self.memory_exporter.clear()
-                metrics = self._assert_metrics(2)
+                metrics = self._assert_metrics(3)
                 duration_data_point = metrics[0].data.data_points[index]
                 self.assertEqual(
                     duration_data_point.attributes.get(HTTP_STATUS_CODE),
@@ -726,6 +728,7 @@ class TestAioHttpIntegration(TestBase):
                         ERROR_TYPE: "405",
                         SERVER_ADDRESS: "localhost",
                         SERVER_PORT: 5000,
+                        HTTP_RESPONSE_BODY_SIZE: 0,
                     },
                 )
             ]
@@ -1201,6 +1204,7 @@ class TestAioHttpIntegration(TestBase):
 
 class TestAioHttpClientInstrumentor(TestBase):
     URL = "/test-path"
+    RESPONSE_BODY = b"hello"
 
     def setUp(self):
         super().setUp()
@@ -1218,7 +1222,16 @@ class TestAioHttpClientInstrumentor(TestBase):
 
     @staticmethod
     async def handler_with_body(request):
-        return aiohttp.web.Response(status=200, body=b"hello")
+        return aiohttp.web.Response(status=200, body=TestAioHttpClientInstrumentor.RESPONSE_BODY)
+
+    @staticmethod
+    async def chunked_handler(request):
+        response = aiohttp.web.StreamResponse(status=200)
+        response.enable_chunked_encoding()
+        await response.prepare(request)
+        await response.write(TestAioHttpClientInstrumentor.RESPONSE_BODY)
+        await response.write_eof()
+        return response
 
     @staticmethod
     def get_default_request(url: str = URL):
@@ -1279,7 +1292,8 @@ class TestAioHttpClientInstrumentor(TestBase):
                 span.attributes[URL_FULL],
             )
             self.assertEqual(200, span.attributes[HTTP_RESPONSE_STATUS_CODE])
-            metrics = self._assert_metrics(1)
+            self.assertEqual(0, span.attributes[HTTP_RESPONSE_BODY_SIZE])
+            metrics = self._assert_metrics(2)
             duration_data_point = metrics[0].data.data_points[0]
             self.assertEqual(duration_data_point.count, 1)
             self.assertEqual(
@@ -1313,9 +1327,10 @@ class TestAioHttpClientInstrumentor(TestBase):
                     SERVER_ADDRESS: host,
                     SERVER_PORT: port,
                     NET_PEER_PORT: port,
+                    HTTP_RESPONSE_BODY_SIZE: 0,
                 },
             )
-            metrics = self._assert_metrics(2)
+            metrics = self._assert_metrics(3)
             duration_data_point = metrics[0].data.data_points[0]
             self.assertEqual(duration_data_point.count, 1)
             self.assertEqual(
@@ -1518,71 +1533,55 @@ class TestAioHttpClientInstrumentor(TestBase):
         self._assert_metrics(0)
 
     @mock.patch.dict(os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"})
-    def test_response_body_size_not_set_by_default(self):
-        AioHttpClientInstrumentor().uninstrument()
-        AioHttpClientInstrumentor().instrument()
-
-        run_with_test_server(
-            self.get_default_request(), self.URL, self.handler_with_body
-        )
-        span = self._assert_spans(1)
-        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
-
-    @mock.patch.dict(
-        os.environ,
-        {
-            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
-            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
-        },
-    )
     def test_response_body_size_set_on_span(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
-        run_with_test_server(
-            self.get_default_request(), self.URL, self.handler_with_body
-        )
+        run_with_test_server(self.get_default_request(), self.URL, self.handler_with_body)
         span = self._assert_spans(1)
-        self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+        self.assertEqual(len(self.RESPONSE_BODY), span.attributes[HTTP_RESPONSE_BODY_SIZE])
         self.assertIsInstance(span.attributes[HTTP_RESPONSE_BODY_SIZE], int)
 
-    @mock.patch.dict(
-        "os.environ",
-        {
-            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
-            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
-        },
-    )
+    @mock.patch.dict(os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"})
     def test_response_body_size_metric_recorded(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
 
-        run_with_test_server(
-            self.get_default_request(), self.URL, self.handler_with_body
-        )
+        host, port = run_with_test_server(self.get_default_request(), self.URL, self.handler_with_body)
         metrics = self._assert_metrics(2)
-        metric_names = {m.name for m in metrics}
-        self.assertIn("http.client.response.body.size", metric_names)
-        body_size_metric = next(
-            m for m in metrics if m.name == "http.client.response.body.size"
-        )
+        body_size_metric = next(m for m in metrics if m.name == HTTP_CLIENT_RESPONSE_BODY_SIZE)
+        self.assertEqual("By", body_size_metric.unit)
         data_point = body_size_metric.data.data_points[0]
-        self.assertEqual(data_point.count, 1)
-        self.assertTrue(data_point.sum > 0)
+        self.assertEqual(1, data_point.count)
+        self.assertEqual(len(self.RESPONSE_BODY), data_point.sum)
+        self.assertEqual(
+            dict(data_point.attributes),
+            {
+                HTTP_RESPONSE_STATUS_CODE: 200,
+                HTTP_REQUEST_METHOD: "GET",
+                SERVER_ADDRESS: host,
+                SERVER_PORT: port,
+            },
+        )
 
-    @mock.patch.dict(
-        "os.environ",
-        {
-            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
-        },
-    )
     def test_response_body_size_not_set_without_new_semconv(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
-        run_with_test_server(
-            self.get_default_request(), self.URL, self.handler_with_body
-        )
+        run_with_test_server(self.get_default_request(), self.URL, self.handler_with_body)
         span = self._assert_spans(1)
         self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+        metrics = self._assert_metrics(1)
+        self.assertNotIn(HTTP_CLIENT_RESPONSE_BODY_SIZE, {m.name for m in metrics})
+
+    @mock.patch.dict(os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"})
+    def test_response_body_size_not_set_for_chunked_response(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(self.get_default_request(), self.URL, self.chunked_handler)
+        span = self._assert_spans(1)
+        # chunked responses carry no Content-Length, so the size is unknown
+        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+        metrics = self._assert_metrics(1)
+        self.assertNotIn(HTTP_CLIENT_RESPONSE_BODY_SIZE, {m.name for m in metrics})
 
 
 class TestLoadingAioHttpInstrumentor(unittest.TestCase):

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -36,6 +36,7 @@ from opentelemetry.instrumentation.utils import (
 from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_HOST,
     HTTP_METHOD,
+    HTTP_RESPONSE_BODY_SIZE,
     HTTP_STATUS_CODE,
     HTTP_URL,
 )
@@ -57,6 +58,9 @@ from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import Span, StatusCode
 from opentelemetry.util._importlib_metadata import entry_points
+from opentelemetry.util.http import (
+    OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE,
+)
 
 
 def run_with_test_server(runnable: typing.Callable, url: str, handler: typing.Callable) -> tuple[str, int]:
@@ -1508,6 +1512,80 @@ class TestAioHttpClientInstrumentor(TestBase):
         run_with_test_server(self.get_default_request(url), url, self.default_handler)
         self._assert_spans(0)
         self._assert_metrics(0)
+
+    @mock.patch.dict(
+        os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"}
+    )
+    def test_response_body_size_not_set_by_default(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_set_on_span(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
+        self.assertIsInstance(
+            span.attributes[HTTP_RESPONSE_BODY_SIZE], int
+        )
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "http",
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_metric_recorded(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        metrics = self._assert_metrics(2)
+        metric_names = {m.name for m in metrics}
+        self.assertIn(
+            "http.client.response.body.size", metric_names
+        )
+        body_size_metric = next(
+            m
+            for m in metrics
+            if m.name == "http.client.response.body.size"
+        )
+        data_point = body_size_metric.data.data_points[0]
+        self.assertEqual(data_point.count, 1)
+        self.assertTrue(data_point.sum > 0)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE: "true",
+        },
+    )
+    def test_response_body_size_not_set_without_new_semconv(self):
+        AioHttpClientInstrumentor().uninstrument()
+        AioHttpClientInstrumentor().instrument()
+        run_with_test_server(
+            self.get_default_request(), self.URL, self.default_handler
+        )
+        span = self._assert_spans(1)
+        self.assertNotIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
 
 
 class TestLoadingAioHttpInstrumentor(unittest.TestCase):

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1513,9 +1513,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         self._assert_spans(0)
         self._assert_metrics(0)
 
-    @mock.patch.dict(
-        os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"}
-    )
+    @mock.patch.dict(os.environ, {OTEL_SEMCONV_STABILITY_OPT_IN: "http"})
     def test_response_body_size_not_set_by_default(self):
         AioHttpClientInstrumentor().uninstrument()
         AioHttpClientInstrumentor().instrument()
@@ -1541,9 +1539,7 @@ class TestAioHttpClientInstrumentor(TestBase):
         )
         span = self._assert_spans(1)
         self.assertIn(HTTP_RESPONSE_BODY_SIZE, span.attributes)
-        self.assertIsInstance(
-            span.attributes[HTTP_RESPONSE_BODY_SIZE], int
-        )
+        self.assertIsInstance(span.attributes[HTTP_RESPONSE_BODY_SIZE], int)
 
     @mock.patch.dict(
         "os.environ",
@@ -1560,13 +1556,9 @@ class TestAioHttpClientInstrumentor(TestBase):
         )
         metrics = self._assert_metrics(2)
         metric_names = {m.name for m in metrics}
-        self.assertIn(
-            "http.client.response.body.size", metric_names
-        )
+        self.assertIn("http.client.response.body.size", metric_names)
         body_size_metric = next(
-            m
-            for m in metrics
-            if m.name == "http.client.response.body.size"
+            m for m in metrics if m.name == "http.client.response.body.size"
         )
         data_point = body_size_metric.data.data_points[0]
         self.assertEqual(data_point.count, 1)

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -36,10 +36,6 @@ OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_CLIENT_RESPONSE = "OTEL_INSTRUMENTATIO
 
 OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS = "OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS"
 
-OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE = (
-    "OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE"
-)
-
 # List of recommended metrics attributes
 _duration_attrs = {
     HTTP_METHOD,
@@ -244,15 +240,6 @@ def get_custom_header_attributes(
         return {}
     sanitize: SanitizeValue = SanitizeValue(sensitive_headers or ())
     return sanitize.sanitize_header_values(headers, captured_headers, normalize_function)
-
-
-def is_capture_response_body_size_enabled() -> bool:
-    return (
-        environ.get(
-            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE, ""
-        ).lower()
-        == "true"
-    )
 
 
 def _parse_active_request_count_attrs(req_attrs):

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -48,6 +48,10 @@ OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS = (
     "OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS"
 )
 
+OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE = (
+    "OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE"
+)
+
 # List of recommended metrics attributes
 _duration_attrs = {
     HTTP_METHOD,
@@ -276,6 +280,13 @@ def get_custom_header_attributes(
         headers, captured_headers, normalize_function
     )
 
+def is_capture_response_body_size_enabled() -> bool:
+    return (
+        environ.get(
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE, ""
+        ).lower()
+        == "true"
+    )
 
 def _parse_active_request_count_attrs(req_attrs):
     active_requests_count_attrs = {

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -280,6 +280,7 @@ def get_custom_header_attributes(
         headers, captured_headers, normalize_function
     )
 
+
 def is_capture_response_body_size_enabled() -> bool:
     return (
         environ.get(
@@ -287,6 +288,7 @@ def is_capture_response_body_size_enabled() -> bool:
         ).lower()
         == "true"
     )
+
 
 def _parse_active_request_count_attrs(req_attrs):
     active_requests_count_attrs = {

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -245,6 +245,7 @@ def get_custom_header_attributes(
     sanitize: SanitizeValue = SanitizeValue(sensitive_headers or ())
     return sanitize.sanitize_header_values(headers, captured_headers, normalize_function)
 
+
 def is_capture_response_body_size_enabled() -> bool:
     return (
         environ.get(
@@ -252,6 +253,7 @@ def is_capture_response_body_size_enabled() -> bool:
         ).lower()
         == "true"
     )
+
 
 def _parse_active_request_count_attrs(req_attrs):
     active_requests_count_attrs = {

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -36,6 +36,10 @@ OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_CLIENT_RESPONSE = "OTEL_INSTRUMENTATIO
 
 OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS = "OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS"
 
+OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE = (
+    "OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE"
+)
+
 # List of recommended metrics attributes
 _duration_attrs = {
     HTTP_METHOD,
@@ -241,6 +245,13 @@ def get_custom_header_attributes(
     sanitize: SanitizeValue = SanitizeValue(sensitive_headers or ())
     return sanitize.sanitize_header_values(headers, captured_headers, normalize_function)
 
+def is_capture_response_body_size_enabled() -> bool:
+    return (
+        environ.get(
+            OTEL_PYTHON_INSTRUMENTATION_HTTP_RESPONSE_BODY_SIZE, ""
+        ).lower()
+        == "true"
+    )
 
 def _parse_active_request_count_attrs(req_attrs):
     active_requests_count_attrs = {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3623 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added unit tests.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
