### PR TITLE
fix: changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Ensure no direct changes to CHANGELOG.md
         run: |
-          if [[ $(git diff --name-only FETCH_HEAD -- '**/CHANGELOG.md') ]]
+          if [[ $(git diff --name-only FETCH_HEAD -- 'CHANGELOG.md' '**/CHANGELOG.md') ]]
           then
             echo "CHANGELOG.md files should not be directly modified."
             echo "Please add a changelog fragment file to the appropriate .changelog/ directory instead."


### PR DESCRIPTION
Found a case where there was a change to CHANGELOG.md and CI didn't fail => https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4551 

`**/CHANGELOG.md` was not enough. Added `CHANGELOG.md` explicitly. 