### PR TITLE
requirements: bump urllib3 2.x to latest

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/test-requirements.txt
@@ -14,7 +14,7 @@ python-snappy==0.7.1
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e exporter/opentelemetry-exporter-prometheus-remote-write

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
@@ -23,7 +23,7 @@ pytest==7.4.4
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 Werkzeug==3.0.6
 wrapt==1.16.0
 yarl==1.9.4

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/test-requirements-2.txt
@@ -12,7 +12,7 @@ python-dateutil==2.8.2
 six==1.16.0
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation

--- a/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements.txt
@@ -22,7 +22,7 @@ sniffio==1.3.0
 starlette==0.46.1
 tomli==2.0.1
 typing_extensions==4.14.1
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation

--- a/instrumentation/opentelemetry-instrumentation-requests/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-requests/test-requirements.txt
@@ -12,7 +12,7 @@ pytest==7.4.4
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation

--- a/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
+++ b/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
@@ -1,6 +1,7 @@
 # Used to generate test-requirements.{oldest,latest}.txt with uv pip compile
 pytest~=7.4
-requests~=2.32
+requests~=2.33.1
+urllib3~=2.7.0
 httpx~=0.28
 -e opentelemetry-instrumentation
 -e instrumentation/opentelemetry-instrumentation-asgi

--- a/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.latest.txt
@@ -76,8 +76,10 @@ typing-extensions==4.12.2
     #   asgiref
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-urllib3==2.3.0
-    # via requests
+urllib3==2.7.0
+    # via
+    #   -r instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
+    #   requests
 wrapt==1.14.1
     # via opentelemetry-instrumentation
 zipp==3.21.0

--- a/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-starlette/test-requirements.oldest.txt
@@ -74,8 +74,10 @@ typing-extensions==4.12.2
     #   asgiref
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-urllib3==2.3.0
-    # via requests
+urllib3==2.7.0
+    # via
+    #   -r instrumentation/opentelemetry-instrumentation-starlette/test-requirements.in
+    #   requests
 wrapt==1.16.0
     # via opentelemetry-instrumentation
 zipp==3.21.0

--- a/instrumentation/opentelemetry-instrumentation-tornado/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-tornado/test-requirements.txt
@@ -14,7 +14,7 @@ requests==2.33.1
 tomli==2.0.1
 tornado==6.4.2
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation

--- a/instrumentation/opentelemetry-instrumentation-urllib3/test-requirements-1.txt
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/test-requirements-1.txt
@@ -8,7 +8,7 @@ py-cpuinfo==9.0.0
 pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 -e opentelemetry-instrumentation

--- a/opamp/opentelemetry-opamp-client/test-requirements.in
+++ b/opamp/opentelemetry-opamp-client/test-requirements.in
@@ -4,12 +4,12 @@ packaging>=24.0
 pluggy>=1.5.0
 protobuf>=5.29.5
 pytest>=7.4.4
-pytest-vcr>=1.0.2 ; python_version > '3.9' and platform_python_implementation !='PyPy'
+pytest-vcr>=1.0.2 ; platform_python_implementation !='PyPy'
 pyyaml>=6.0.2
-vcrpy>=7.0.0 ; python_version > '3.9' and platform_python_implementation !='PyPy'
+vcrpy>=7.0.0 ; platform_python_implementation !='PyPy'
 yarl>=1.20.1
-requests>=2.32.2
-urllib3>=2.5.0
+requests>=2.33.1
+urllib3>=2.7.0
 uuid-utils>=0.11.0
 wrapt>=1.16.0
 -e opamp/opentelemetry-opamp-client

--- a/opamp/opentelemetry-opamp-client/test-requirements.latest.txt
+++ b/opamp/opentelemetry-opamp-client/test-requirements.latest.txt
@@ -62,7 +62,7 @@ typing-extensions==4.14.0
     #   exceptiongroup
     #   multidict
     #   opentelemetry-api
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r opamp/opentelemetry-opamp-client/test-requirements.in
     #   requests

--- a/opamp/opentelemetry-opamp-client/test-requirements.lowest.txt
+++ b/opamp/opentelemetry-opamp-client/test-requirements.lowest.txt
@@ -59,7 +59,7 @@ tomli==1.1.0
     # via
     #   -r opamp/opentelemetry-opamp-client/test-requirements.in
     #   pytest
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r opamp/opentelemetry-opamp-client/test-requirements.in
     #   requests

--- a/propagator/opentelemetry-propagator-aws-xray/test-requirements-0.txt
+++ b/propagator/opentelemetry-propagator-aws-xray/test-requirements-0.txt
@@ -12,7 +12,7 @@ pytest-benchmark==4.0.0
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 opentelemetry-api==1.16  # when updating, also update in pyproject.toml

--- a/propagator/opentelemetry-propagator-aws-xray/test-requirements-1.txt
+++ b/propagator/opentelemetry-propagator-aws-xray/test-requirements-1.txt
@@ -12,7 +12,7 @@ pytest-benchmark==4.0.0
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
-urllib3==2.2.2
+urllib3==2.7.0
 wrapt==1.16.0
 zipp==3.19.2
 # test with the latest version of opentelemetry-api, sdk, and semantic conventions


### PR DESCRIPTION
# Description

This bumps urllib3 2.x entries in test requirements to latest 2.7.0. urllib3 1.x users are skipped because need to check if they can be upgraded to 2.x.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
