### PR TITLE
ci: Enable GitHub Merge Queue support

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read
@@ -17,6 +18,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     if: |
+      github.event_name != 'merge_group' &&
       !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
       && github.actor != 'otelbot[bot]'
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,6 +13,12 @@ on:
       - '**/*.rst'
       - '.github/workflows/check-links.yml'
       - '.github/workflows/check_links_config.json'
+  merge_group:
+    paths:
+      - '**/*.md'
+      - '**/*.rst'
+      - '.github/workflows/check-links.yml'
+      - '.github/workflows/check_links_config.json'
 
 permissions:
   contents: read
@@ -20,6 +26,9 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
+
+env:
+  DIFF_RANGE: ${{ github.event_name == 'merge_group' && format('{0}...{1}', github.event.merge_group.base_sha, github.event.merge_group.head_sha) || format('origin/{0}...HEAD', github.base_ref) }}
 
 jobs:
   check-links:
@@ -53,14 +62,14 @@ jobs:
             ${{ steps.changed-files.outputs.all_changed_files }} \
             || { echo "Check that anchor links are lowercase"; exit 1; }
 
-      - name: Check new links only on pull requests
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+      - name: Check new links
+        if: steps.changed-files.outputs.any_changed == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         run: |
           # Extract URLs only from added lines in the diff to avoid
           # rate limiting when checking all links in large files like
           # CHANGELOG.md. Only new/changed links are checked on PRs;
           # pushes to main still check all links in changed files.
-          git diff "origin/${{ github.base_ref }}...HEAD" -- \
+          git diff "$DIFF_RANGE" -- \
             ${{ steps.changed-files.outputs.all_changed_files }} \
             | grep '^+' | grep -v '^+++' \
             | grep -oP 'https?://[^\s\)\]\"'"'"'`>]+' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/ci.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/ci.yml.j2
@@ -8,6 +8,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -41,7 +41,9 @@ jobs:
     {%- endif %}
     {%- if job_data == "docs" %}
     if: |
-      github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'otelbot[bot]')
     {%- endif %}
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -70,7 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: |
-      github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'otelbot[bot]')
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Part of open-telemetry/community#3436

For merge queues, we need to trigger github actions on merge_group events as mentioned in the docs. This updates workflows so they will trigger.

Equivalent core PR: https://github.com/open-telemetry/opentelemetry-python/pull/5209

## Type of change

Please delete options that are not relevant.

- [x] CI

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Working in Core repo. Tested with nektos/act as well.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
