### PR TITLE
fix failing tests for docs and py312-asgi

### DIFF
--- a/docs/nitpick-exceptions.ini
+++ b/docs/nitpick-exceptions.ini
@@ -46,6 +46,7 @@ py-class=
     psycopg.AsyncConnection
     ObjectProxy
     wrapt.proxies.ObjectProxy
+    _wrappers.ObjectProxy
     fastapi.applications.FastAPI
     starlette.applications.Starlette
     _contextvars.Token

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -323,9 +323,12 @@ class TestAsgiApplication(AsyncAsgiTestBase):
 
         self.env_patch.start()
 
+    def tearDown(self):
+        self.env_patch.stop()
+        super().tearDown()
+
     def subTest(self, msg=..., **params):
         sub = super().subTest(msg, **params)
-        # Reinitialize test state to avoid state pollution
         self.setUp()
         return sub
 

--- a/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/tests/test_asgi_middleware.py
@@ -329,7 +329,7 @@ class TestAsgiApplication(AsyncAsgiTestBase):
 
     def subTest(self, msg=..., **params):
         sub = super().subTest(msg, **params)
-        self.setUp()
+        self.memory_exporter.clear()
         return sub
 
     # Helper to assert exemplars presence across specified histogram metric names.


### PR DESCRIPTION
I was not able to figure out the root cause, but CI started failing today for:
- [docs](https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/26258409202/job/77286272155?pr=4530)
- [py312-asgi](https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/26258409202/job/77286291818?pr=4530) (this test passes locally, but not in CI)

Fix #4619