### PR TITLE
opentelemetry-instrumentation-dbapi: suppress async cursor spans

### DIFF
--- a/.changelog/4622.fixed
+++ b/.changelog/4622.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-dbapi`: suppress async cursor spans when instrumentation is disabled

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -909,6 +909,9 @@ class CursorTracer(Generic[CursorT]):
         *args: tuple[Any, ...],
         **kwargs: dict[Any, Any],
     ):
+        if not is_instrumentation_enabled():
+            return await query_method(*args, **kwargs)
+
         operation_name = self.get_operation_name(cursor, args)
         name = operation_name
         if not name:

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -525,6 +525,33 @@ class TestDBApiIntegration(TestBase):
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 0)
 
+    def test_suppress_instrumentation_async(self):
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name",
+            "testcomponent",
+        )
+        cursor_tracer = dbapi.CursorTracer(db_integration)
+        mock_cursor = MockCursor()
+        called = False
+
+        async def async_execute(_query, *_args):
+            nonlocal called
+            called = True
+
+        with suppress_instrumentation():
+            asyncio.run(
+                cursor_tracer.traced_execution_async(
+                    mock_cursor,
+                    async_execute,
+                    "Test query",
+                    ("param1Value", False),
+                )
+            )
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+        self.assertTrue(called)
+
     def _get_metric(self, name):
         return next(
             (


### PR DESCRIPTION
Honor `suppress_instrumentation()` in `CursorTracer.traced_execution_async`, matching the sync traced_execution path of `CursorTracer.traced_execution`.

# Description

Fixes async DBAPI cursor execution not honoring `suppress_instrumentation()`.

The sync `CursorTracer.traced_execution()` path already checks `is_instrumentation_enabled()` before creating spans, but `CursorTracer.traced_execution_async()` did not. This meant async DBAPI instrumentations that use this shared tracer could still emit spans while instrumentation was suppressed.

This change adds the same suppression guard to the async execution path and adds a regression test to verify the async query method still runs while no span is exported.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran the DBAPI package tests and lint locally:

- [x] `uvx tox -e py314-test-instrumentation-dbapi-wrapt2 -- instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py::TestDBApiIntegration::test_suppress_instrumentation_async`
- [x] `uvx tox -e lint-instrumentation-dbapi`
- [x] `uvx ruff check instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py`

Test configuration: macOS, Python 3.14.3.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated