### PR TITLE
botocore: Don't emit errors on 3xx responses

### DIFF
--- a/.changelog/4634.fixed
+++ b/.changelog/4634.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-botocore`: don't emit error status on 3xx ClientError responses

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -157,6 +157,7 @@ from opentelemetry.semconv._incubating.attributes.rpc_attributes import (
     RPC_SYSTEM,
 )
 from opentelemetry.trace.span import Span
+from opentelemetry.trace.status import StatusCode
 
 logger = logging.getLogger(__name__)
 
@@ -279,6 +280,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
             # tracing streaming services require to close the span manually
             # at a later time after the stream has been consumed
             end_on_exit=end_span_on_exit,
+            set_status_on_exception=False,
         ) as span:
             _safe_invoke(extension.before_service_call, span, instrumentor_ctx)
             self._call_request_hook(span, call_context)
@@ -291,9 +293,25 @@ class BotocoreInstrumentor(BaseInstrumentor):
                     except ClientError as error:
                         result = getattr(error, "response", None)
                         _apply_response_attributes(span, result)
-                        _safe_invoke(
-                            extension.on_error, span, error, instrumentor_ctx
-                        )
+                        if _is_http_error(result):
+                            span.set_status(StatusCode.ERROR, str(error))
+                            _safe_invoke(
+                                extension.on_error,
+                                span,
+                                error,
+                                instrumentor_ctx,
+                            )
+                        else:
+                            span.set_status(StatusCode.OK)
+                            _safe_invoke(
+                                extension.on_success,
+                                span,
+                                result,
+                                instrumentor_ctx,
+                            )
+                        raise
+                    except Exception as error:
+                        span.set_status(StatusCode.ERROR, str(error))
                         raise
                     _apply_response_attributes(span, result)
                     _safe_invoke(
@@ -439,6 +457,7 @@ class AiobotocoreInstrumentor(BaseInstrumentor):
             # tracing streaming services require to close the span manually
             # at a later time after the stream has been consumed
             end_on_exit=end_span_on_exit,
+            set_status_on_exception=False,
         ) as span:
             _safe_invoke(extension.before_service_call, span, instrumentor_ctx)
             self._call_request_hook(span, call_context)
@@ -451,9 +470,25 @@ class AiobotocoreInstrumentor(BaseInstrumentor):
                     except ClientError as error:
                         result = getattr(error, "response", None)
                         _apply_response_attributes(span, result)
-                        _safe_invoke(
-                            extension.on_error, span, error, instrumentor_ctx
-                        )
+                        if _is_http_error(result):
+                            span.set_status(StatusCode.ERROR, str(error))
+                            _safe_invoke(
+                                extension.on_error,
+                                span,
+                                error,
+                                instrumentor_ctx,
+                            )
+                        else:
+                            span.set_status(StatusCode.OK)
+                            _safe_invoke(
+                                extension.on_success,
+                                span,
+                                result,
+                                instrumentor_ctx,
+                            )
+                        raise
+                    except Exception as error:
+                        span.set_status(StatusCode.ERROR, str(error))
                         raise
                     _apply_response_attributes(span, result)
                     _safe_invoke(
@@ -483,6 +518,16 @@ class AiobotocoreInstrumentor(BaseInstrumentor):
         self.response_hook(
             span, call_context.service, call_context.operation, result
         )
+
+
+def _is_http_error(result: Optional[Dict[str, Any]]) -> bool:
+    """Return True if the ClientError response represents a genuine HTTP error (>= 400)."""
+    if result is None:
+        return True
+    status_code = result.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    if status_code is None:
+        return True
+    return status_code >= 400
 
 
 def _apply_response_attributes(span: Span, result):

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -6,7 +6,7 @@ from importlib.metadata import EntryPoint
 from unittest.mock import ANY, Mock, call, patch
 
 import botocore.session
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import ClientError, ParamValidationError
 from moto import mock_aws  # pylint: disable=import-error
 
 from opentelemetry import trace as trace_api
@@ -165,6 +165,44 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertIn(EXCEPTION_STACKTRACE, event.attributes)
         self.assertIn(EXCEPTION_TYPE, event.attributes)
         self.assertIn(EXCEPTION_MESSAGE, event.attributes)
+
+    @mock_aws
+    def test_client_error_with_http_error_status(self):
+        """ClientError with HTTP 4xx sets span status to ERROR."""
+        s3 = self._make_client("s3")
+
+        with self.assertRaises(ClientError):
+            s3.get_object(Bucket="non-existent-bucket", Key="non-existent-key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+        self.assertIs(span.status.status_code, trace_api.StatusCode.ERROR)
+
+    @mock_aws
+    def test_client_error_304_not_modified(self):
+        """S3 IfNoneMatch returning 304 sets span status to OK."""
+        s3 = self._make_client("s3")
+        s3.create_bucket(
+            Bucket="test-bucket",
+            CreateBucketConfiguration={"LocationConstraint": self.region},
+        )
+        etag = s3.put_object(Bucket="test-bucket", Key="key", Body=b"data")[
+            "ETag"
+        ]
+
+        with self.assertRaises(ClientError):
+            s3.get_object(
+                Bucket="test-bucket", Key="key", IfNoneMatch=etag
+            )
+
+        spans = self.memory_exporter.get_finished_spans()
+        # Filter to the GetObject span
+        get_spans = [s for s in spans if s.name == "S3.GetObject"]
+        self.assertEqual(1, len(get_spans))
+        self.assertIs(
+            get_spans[0].status.status_code, trace_api.StatusCode.OK
+        )
 
     @mock_aws
     def test_s3_client(self):


### PR DESCRIPTION
# Description

When making conditional requests to S3 `get_object` (e.g. using the `IfNoneMatch` or `IfModifiedSince` parameters) a `304 Not Modified` response is returned wrapped in a `ClientError` exception. This causes `S3.GetObject` traces to be spuriously marked as error.

Fixes #4633 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) 

# How Has This Been Tested?

- [x] Added unit test coverage
  - [x] `tox -f test-instrumentation-botocore`
- [x] `uvx tox -e lint-instrumentation-botocore`
- [x] `uvx ruff check instrumentation/opentelemetry-instrumentation-botocore/`


# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

