### PR TITLE
Implement GenAI metrics for Anthropic and Groq instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `opentelemetry-instrumentation-groq`: New instrumentation package for the Groq Python SDK. Emits `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` histograms alongside traces for `chat.completions.create` (sync and async).
+  ([#4584](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4584))
+
 ### Breaking changes
 
 - Drop Python 3.9 support

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -54,6 +54,7 @@ packages=
     opentelemetry-sdk-extension-aws
     opentelemetry-propagator-aws-xray
     opentelemetry-instrumentation-anthropic
+    opentelemetry-instrumentation-groq
     opentelemetry-instrumentation-claude-agent-sdk
     opentelemetry-instrumentation-google-genai
     opentelemetry-instrumentation-vertexai

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/__init__.py
@@ -101,9 +101,9 @@ class AnthropicInstrumentor(BaseInstrumentor):
 
         # Patch Messages.create
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="Messages.create",
-            wrapper=messages_create(handler),
+            "anthropic.resources.messages",
+            "Messages.create",
+            messages_create(handler),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/messages_extractors.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/messages_extractors.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Sequence
 
-from anthropic.types import MessageDeltaUsage
-
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -53,7 +51,6 @@ if TYPE_CHECKING:
         ThinkingConfigParam,
         ToolChoiceParam,
         ToolUnionParam,
-        Usage,
     )
 
 
@@ -84,16 +81,33 @@ class UsageTokens:
     cache_read_input_tokens: int | None = None
 
 
-def extract_usage_tokens(
-    usage: Usage | MessageDeltaUsage | None,
-) -> UsageTokens:
+def _get_int_field(obj: object, field_name: str) -> int | None:
+    value = getattr(obj, field_name, None)
+
+    if value is None and isinstance(obj, dict):
+        value = obj.get(field_name)
+
+    model_extra = getattr(obj, "model_extra", None)
+    if value is None and isinstance(model_extra, dict):
+        value = model_extra.get(field_name)
+
+    obj_dict = getattr(obj, "__dict__", None)
+    if value is None and isinstance(obj_dict, dict):
+        value = obj_dict.get(field_name)
+
+    return value if isinstance(value, int) and value >= 0 else None
+
+
+def extract_usage_tokens(usage: object | None) -> UsageTokens:
     if usage is None:
         return UsageTokens()
 
-    input_tokens = usage.input_tokens
-    output_tokens = usage.output_tokens
-    cache_creation_input_tokens = usage.cache_creation_input_tokens
-    cache_read_input_tokens = usage.cache_read_input_tokens
+    input_tokens = _get_int_field(usage, "input_tokens")
+    output_tokens = _get_int_field(usage, "output_tokens")
+    cache_creation_input_tokens = _get_int_field(
+        usage, "cache_creation_input_tokens"
+    )
+    cache_read_input_tokens = _get_int_field(usage, "cache_read_input_tokens")
 
     if (
         input_tokens is None

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/patch.py
@@ -17,8 +17,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Union, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union, cast
 
+from anthropic._streaming import AsyncStream as AnthropicAsyncStream
 from anthropic._streaming import Stream as AnthropicStream
 from anthropic.types import Message as AnthropicMessage
 
@@ -32,23 +33,67 @@ from opentelemetry.util.genai.utils import (
 )
 
 from .messages_extractors import (
+    MessageRequestParams,
     extract_params,
     get_input_messages,
     get_llm_request_attributes,
     get_system_instruction,
 )
 from .wrappers import (
+    AsyncMessagesStreamManagerWrapper,
+    AsyncMessagesStreamWrapper,
+    MessagesStreamManagerWrapper,
     MessagesStreamWrapper,
     MessageWrapper,
 )
 
 if TYPE_CHECKING:
-    from anthropic.resources.messages import Messages
+    from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
+        AsyncMessageStreamManager,
+        MessageStreamManager,
+    )
+    from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import RawMessageStreamEvent
 
 
 _logger = logging.getLogger(__name__)
 ANTHROPIC = "anthropic"
+
+
+def _build_invocation(
+    params: MessageRequestParams,
+    instance: "Messages | AsyncMessages",
+    capture_content: bool,
+) -> LLMInvocation:
+    attributes = get_llm_request_attributes(params, instance)  # type: ignore[arg-type]
+    request_model_attribute = attributes.get(
+        GenAIAttributes.GEN_AI_REQUEST_MODEL
+    )
+    request_model = (
+        request_model_attribute
+        if isinstance(request_model_attribute, str)
+        else params.model
+    )
+
+    return LLMInvocation(
+        request_model=request_model,
+        provider=ANTHROPIC,
+        input_messages=get_input_messages(params.messages)
+        if capture_content
+        else [],
+        system_instruction=get_system_instruction(params.system)
+        if capture_content
+        else [],
+        attributes=attributes,
+    )
+
+
+def _fail_invocation(
+    handler: TelemetryHandler,
+    invocation: LLMInvocation,
+    exc: Exception,
+) -> None:
+    handler.fail_llm(invocation, Error(message=str(exc), type=type(exc)))
 
 
 def messages_create(
@@ -61,7 +106,7 @@ def messages_create(
         MessagesStreamWrapper[None],
     ],
 ]:
-    """Wrap the `create` method of the `Messages` class to trace it."""
+    """Wrap the sync ``Messages.create`` method to trace it."""
     capture_content = should_capture_content_on_spans_in_experimental_mode()
 
     def traced_method(
@@ -81,29 +126,8 @@ def messages_create(
         MessagesStreamWrapper[None],
     ]:
         params = extract_params(*args, **kwargs)
-        attributes = get_llm_request_attributes(params, instance)
-        request_model_attribute = attributes.get(
-            GenAIAttributes.GEN_AI_REQUEST_MODEL
-        )
-        request_model = (
-            request_model_attribute
-            if isinstance(request_model_attribute, str)
-            else params.model
-        )
+        invocation = _build_invocation(params, instance, capture_content)
 
-        invocation = LLMInvocation(
-            request_model=request_model,
-            provider=ANTHROPIC,
-            input_messages=get_input_messages(params.messages)
-            if capture_content
-            else [],
-            system_instruction=get_system_instruction(params.system)
-            if capture_content
-            else [],
-            attributes=attributes,
-        )
-
-        # Use manual lifecycle management for both streaming and non-streaming
         handler.start_llm(invocation)
         try:
             result = wrapped(*args, **kwargs)
@@ -117,12 +141,124 @@ def messages_create(
             handler.stop_llm(invocation)
             return wrapper.message
         except Exception as exc:
-            handler.fail_llm(
-                invocation, Error(message=str(exc), type=type(exc))
-            )
+            _fail_invocation(handler, invocation, exc)
             raise
 
     return cast(
         'Callable[..., Union["AnthropicMessage", "AnthropicStream[RawMessageStreamEvent]", MessagesStreamWrapper[None]]]',
         traced_method,
     )
+
+
+def async_messages_create(
+    handler: TelemetryHandler,
+) -> Callable[
+    ...,
+    Awaitable[
+        Union[
+            "AnthropicMessage",
+            "AnthropicAsyncStream[RawMessageStreamEvent]",
+            AsyncMessagesStreamWrapper[None],
+        ]
+    ],
+]:
+    """Wrap the async ``AsyncMessages.create`` method to trace it."""
+    capture_content = should_capture_content_on_spans_in_experimental_mode()
+
+    async def traced_method(
+        wrapped: Callable[
+            ...,
+            Awaitable[
+                Union[
+                    "AnthropicMessage",
+                    "AnthropicAsyncStream[RawMessageStreamEvent]",
+                ]
+            ],
+        ],
+        instance: "AsyncMessages",
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Union[
+        "AnthropicMessage",
+        "AnthropicAsyncStream[RawMessageStreamEvent]",
+        AsyncMessagesStreamWrapper[None],
+    ]:
+        params = extract_params(*args, **kwargs)
+        invocation = _build_invocation(params, instance, capture_content)
+
+        handler.start_llm(invocation)
+        try:
+            result = await wrapped(*args, **kwargs)
+            if isinstance(result, AnthropicAsyncStream):
+                return AsyncMessagesStreamWrapper(
+                    result, handler, invocation, capture_content
+                )
+
+            wrapper = MessageWrapper(result, capture_content)
+            wrapper.extract_into(invocation)
+            handler.stop_llm(invocation)
+            return wrapper.message
+        except Exception as exc:
+            _fail_invocation(handler, invocation, exc)
+            raise
+
+    return cast(
+        'Callable[..., Awaitable[Union["AnthropicMessage", "AnthropicAsyncStream[RawMessageStreamEvent]", AsyncMessagesStreamWrapper[None]]]]',
+        traced_method,
+    )
+
+
+def messages_stream(
+    handler: TelemetryHandler,
+) -> Callable[..., "MessagesStreamManagerWrapper[Any]"]:
+    """Wrap the sync ``Messages.stream`` method to trace message streams."""
+    capture_content = should_capture_content_on_spans_in_experimental_mode()
+
+    def traced_method(
+        wrapped: Callable[..., "MessageStreamManager[Any]"],
+        instance: "Messages",
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> "MessagesStreamManagerWrapper[Any]":
+        params = extract_params(*args, **kwargs)
+        invocation = _build_invocation(params, instance, capture_content)
+
+        handler.start_llm(invocation)
+        try:
+            manager = wrapped(*args, **kwargs)
+            return MessagesStreamManagerWrapper(
+                manager, handler, invocation, capture_content
+            )
+        except Exception as exc:
+            _fail_invocation(handler, invocation, exc)
+            raise
+
+    return traced_method
+
+
+def async_messages_stream(
+    handler: TelemetryHandler,
+) -> Callable[..., "AsyncMessagesStreamManagerWrapper[Any]"]:
+    """Wrap the async ``AsyncMessages.stream`` method to trace message streams."""
+    capture_content = should_capture_content_on_spans_in_experimental_mode()
+
+    def traced_method(
+        wrapped: Callable[..., "AsyncMessageStreamManager[Any]"],
+        instance: "AsyncMessages",
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> "AsyncMessagesStreamManagerWrapper[Any]":
+        params = extract_params(*args, **kwargs)
+        invocation = _build_invocation(params, instance, capture_content)
+
+        handler.start_llm(invocation)
+        try:
+            manager = wrapped(*args, **kwargs)
+            return AsyncMessagesStreamManagerWrapper(
+                manager, handler, invocation, capture_content
+            )
+        except Exception as exc:
+            _fail_invocation(handler, invocation, exc)
+            raise
+
+    return traced_method

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/wrappers.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/wrappers.py
@@ -34,7 +34,11 @@ from opentelemetry.util.genai.types import (
     LLMInvocation,
 )
 
-from .messages_extractors import set_invocation_response_attributes
+from .messages_extractors import (
+    GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    set_invocation_response_attributes,
+)
 
 try:
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
@@ -73,6 +77,27 @@ def _set_response_attributes(
     capture_content: bool,
 ) -> None:
     set_invocation_response_attributes(invocation, result, capture_content)
+
+
+def _get_usage_input_tokens(usage: object) -> int | None:
+    input_tokens = getattr(usage, "input_tokens", None)
+    cache_creation_input_tokens = getattr(
+        usage, "cache_creation_input_tokens", None
+    )
+    cache_read_input_tokens = getattr(usage, "cache_read_input_tokens", None)
+
+    if (
+        input_tokens is None
+        and cache_creation_input_tokens is None
+        and cache_read_input_tokens is None
+    ):
+        return None
+
+    return (
+        (input_tokens or 0)
+        + (cache_creation_input_tokens or 0)
+        + (cache_read_input_tokens or 0)
+    )
 
 
 class _ResponseProxy(Generic[ResponseT]):
@@ -145,6 +170,10 @@ class MessagesStreamWrapper(
         self._message: "Message | ParsedMessage[ResponseFormatT] | None" = None
         self._capture_content = capture_content
         self._finalized = False
+        self._stream_input_tokens: int | None = None
+        self._stream_output_tokens: int | None = None
+        self._stream_cache_creation_input_tokens: int | None = None
+        self._stream_cache_read_input_tokens: int | None = None
 
     def __enter__(self) -> "MessagesStreamWrapper[ResponseFormatT]":
         return self
@@ -202,6 +231,7 @@ class MessagesStreamWrapper(
             _set_response_attributes(
                 self.invocation, self._message, self._capture_content
             )
+            self._apply_stream_usage_attributes()
         with self._safe_instrumentation("stop_llm"):
             self.handler.stop_llm(self.invocation)
         self._finalized = True
@@ -229,11 +259,58 @@ class MessagesStreamWrapper(
                 exc_info=True,
             )
 
+    def _record_usage(self, usage: object | None) -> None:
+        if usage is None:
+            return
+
+        input_tokens = _get_usage_input_tokens(usage)
+        output_tokens = getattr(usage, "output_tokens", None)
+        cache_creation_input_tokens = getattr(
+            usage, "cache_creation_input_tokens", None
+        )
+        cache_read_input_tokens = getattr(
+            usage, "cache_read_input_tokens", None
+        )
+
+        if input_tokens is not None:
+            self._stream_input_tokens = input_tokens
+        if output_tokens is not None:
+            self._stream_output_tokens = output_tokens
+        if cache_creation_input_tokens is not None:
+            self._stream_cache_creation_input_tokens = (
+                cache_creation_input_tokens
+            )
+        if cache_read_input_tokens is not None:
+            self._stream_cache_read_input_tokens = cache_read_input_tokens
+
+    def _record_usage_from_chunk(
+        self,
+        chunk: "RawMessageStreamEvent | ParsedMessageStreamEvent[ResponseFormatT]",
+    ) -> None:
+        self._record_usage(getattr(chunk, "usage", None))
+        message = getattr(chunk, "message", None)
+        self._record_usage(getattr(message, "usage", None))
+
+    def _apply_stream_usage_attributes(self) -> None:
+        if self._stream_input_tokens is not None:
+            self.invocation.input_tokens = self._stream_input_tokens
+        if self._stream_output_tokens is not None:
+            self.invocation.output_tokens = self._stream_output_tokens
+        if self._stream_cache_creation_input_tokens is not None:
+            self.invocation.attributes[
+                GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+            ] = self._stream_cache_creation_input_tokens
+        if self._stream_cache_read_input_tokens is not None:
+            self.invocation.attributes[
+                GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            ] = self._stream_cache_read_input_tokens
+
     def _process_chunk(
         self,
         chunk: "RawMessageStreamEvent | ParsedMessageStreamEvent[ResponseFormatT]",
     ) -> None:
         """Accumulate a final message snapshot from a streaming chunk."""
+        self._record_usage_from_chunk(chunk)
         snapshot = cast(
             "ParsedMessage[ResponseFormatT] | None",
             getattr(self.stream, "current_message_snapshot", None),
@@ -267,6 +344,10 @@ class AsyncMessagesStreamWrapper(MessagesStreamWrapper[ResponseFormatT]):
         self._message: "Message | ParsedMessage[ResponseFormatT] | None" = None
         self._capture_content = capture_content
         self._finalized = False
+        self._stream_input_tokens: int | None = None
+        self._stream_output_tokens: int | None = None
+        self._stream_cache_creation_input_tokens: int | None = None
+        self._stream_cache_read_input_tokens: int | None = None
 
     async def __aenter__(
         self,

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/test_async_wrappers.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/test_async_wrappers.py
@@ -179,6 +179,45 @@ class _FakeAsyncResponse:
         self.aclose_calls += 1
 
 
+def test_sync_stream_wrapper_applies_usage_once_when_closed_twice():
+    usage = SimpleNamespace(
+        input_tokens=13,
+        output_tokens=5,
+        cache_creation_input_tokens=1,
+        cache_read_input_tokens=2,
+    )
+    event = SimpleNamespace(type="message_delta", usage=usage)
+    stream = _FakeSyncStream(events=[event])
+    invocation = _make_invocation()
+    stop_calls = []
+
+    def record_stop(invocation):
+        stop_calls.append(invocation)
+
+    handler = SimpleNamespace(
+        stop_llm=record_stop,
+        fail_llm=_noop_fail_llm,
+    )
+
+    wrapper = MessagesStreamWrapper(
+        stream=stream,
+        handler=handler,
+        invocation=invocation,
+        capture_content=False,
+    )
+
+    next(wrapper)
+
+    with pytest.raises(StopIteration):
+        next(wrapper)
+
+    wrapper.close()
+
+    assert len(stop_calls) == 1
+    assert invocation.input_tokens == 16
+    assert invocation.output_tokens == 5
+
+
 def test_sync_stream_wrapper_exit_closes_without_exception():
     stream = _FakeSyncStream()
     wrapper = _make_stream_wrapper(stream)
@@ -211,6 +250,36 @@ def test_sync_stream_wrapper_exit_fails_and_closes_on_exception():
     assert stream.close_calls == 1
     assert stopped == [True]
     assert failures == [("boom", ValueError)]
+
+
+def test_sync_stream_wrapper_extracts_usage_from_message_delta():
+    usage = SimpleNamespace(
+        input_tokens=13,
+        output_tokens=5,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    event = SimpleNamespace(type="message_delta", usage=usage)
+    stream = _FakeSyncStream(events=[event])
+    invocation = _make_invocation()
+    wrapper = MessagesStreamWrapper(
+        stream=stream,
+        handler=_make_handler(),
+        invocation=invocation,
+        capture_content=False,
+    )
+
+    next(wrapper)
+
+    with pytest.raises(StopIteration):
+        next(wrapper)
+
+    assert invocation.input_tokens == 13
+    assert invocation.output_tokens == 5
+    assert (
+        invocation.attributes["gen_ai.usage.cache_creation.input_tokens"] == 0
+    )
+    assert invocation.attributes["gen_ai.usage.cache_read.input_tokens"] == 0
 
 
 def test_sync_stream_wrapper_processes_events_and_stops_on_completion():
@@ -378,6 +447,37 @@ async def test_async_stream_wrapper_exit_fails_and_closes_on_exception():
     assert stream.close_calls == 1
     assert stopped == [True]
     assert failures == [("boom", ValueError)]
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_extracts_usage_from_message_delta():
+    usage = SimpleNamespace(
+        input_tokens=13,
+        output_tokens=5,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    event = SimpleNamespace(type="message_delta", usage=usage)
+    stream = _FakeAsyncStream(events=[event])
+    invocation = _make_invocation()
+    wrapper = AsyncMessagesStreamWrapper(
+        stream=stream,
+        handler=_make_handler(),
+        invocation=invocation,
+        capture_content=False,
+    )
+
+    await anext(wrapper)
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(wrapper)
+
+    assert invocation.input_tokens == 13
+    assert invocation.output_tokens == 5
+    assert (
+        invocation.attributes["gen_ai.usage.cache_creation.input_tokens"] == 0
+    )
+    assert invocation.attributes["gen_ai.usage.cache_read.input_tokens"] == 0
 
 
 @pytest.mark.asyncio

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/test_sync_messages.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/test_sync_messages.py
@@ -144,9 +144,31 @@ def _skip_if_cassette_missing_and_no_real_key(request):
         )
 
 
+GEN_AI_CLIENT_OPERATION_DURATION = "gen_ai.client.operation.duration"
+GEN_AI_CLIENT_TOKEN_USAGE = "gen_ai.client.token.usage"
+GEN_AI_TOKEN_TYPE = "gen_ai.token.type"
+
+
+def _metric_points(metric_reader, metric_name):
+    metrics_data = metric_reader.get_metrics_data()
+    assert metrics_data is not None
+    points = []
+    for resource_metrics in metrics_data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name == metric_name:
+                    points.extend(metric.data.data_points)
+    return points
+
+
+def _token_usage_points_by_type(metric_reader):
+    points = _metric_points(metric_reader, GEN_AI_CLIENT_TOKEN_USAGE)
+    return {point.attributes[GEN_AI_TOKEN_TYPE]: point for point in points}
+
+
 @pytest.mark.vcr()
 def test_sync_messages_create_basic(
-    span_exporter, anthropic_client, instrument_no_content
+    span_exporter, metric_reader, anthropic_client, instrument_no_content
 ):
     """Test basic sync message creation produces correct span."""
     model = "claude-sonnet-4-20250514"
@@ -169,6 +191,20 @@ def test_sync_messages_create_basic(
         input_tokens=expected_input_tokens(response.usage),
         output_tokens=response.usage.output_tokens,
         finish_reasons=[normalize_stop_reason(response.stop_reason)],
+    )
+    duration_points = _metric_points(
+        metric_reader, GEN_AI_CLIENT_OPERATION_DURATION
+    )
+    assert len(duration_points) == 1
+    assert duration_points[0].count == 1
+    assert duration_points[0].sum >= 0
+    assert (
+        duration_points[0].attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == GenAIAttributes.GenAiOperationNameValues.CHAT.value
+    )
+    assert (
+        duration_points[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == model
     )
 
 
@@ -236,21 +272,18 @@ def test_sync_messages_create_with_all_params(
 
 @pytest.mark.vcr()
 def test_sync_messages_create_token_usage(
-    span_exporter, anthropic_client, instrument_no_content
+    span_exporter, metric_reader, anthropic_client, instrument_no_content
 ):
     """Test that token usage is captured correctly."""
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "Count to 5."}]
-
     response = anthropic_client.messages.create(
         model=model,
         max_tokens=100,
         messages=messages,
     )
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-
     span = spans[0]
     assert GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS in span.attributes
     assert GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS in span.attributes
@@ -261,6 +294,20 @@ def test_sync_messages_create_token_usage(
         span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
         == response.usage.output_tokens
     )
+    token_points = _token_usage_points_by_type(metric_reader)
+    assert set(token_points) == {"input", "output"}
+    input_point = token_points["input"]
+    output_point = token_points["output"]
+    assert input_point.count == 1
+    assert output_point.count == 1
+    assert input_point.sum == expected_input_tokens(response.usage)
+    assert output_point.sum == response.usage.output_tokens
+    for point in (input_point, output_point):
+        assert (
+            point.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+            == GenAIAttributes.GenAiOperationNameValues.CHAT.value
+        )
+        assert point.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == model
 
 
 @pytest.mark.vcr()
@@ -392,12 +439,11 @@ def test_multiple_instrument_uninstrument_cycles(
 
 @pytest.mark.vcr()
 def test_sync_messages_create_streaming(  # pylint: disable=too-many-locals
-    span_exporter, anthropic_client, instrument_no_content
+    span_exporter, metric_reader, anthropic_client, instrument_no_content
 ):
     """Test streaming message creation produces correct span."""
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "Say hello in one word."}]
-
     # Collect response data from stream
     response_text = ""
     response_id = None
@@ -405,7 +451,6 @@ def test_sync_messages_create_streaming(  # pylint: disable=too-many-locals
     stop_reason = None
     input_tokens = None
     output_tokens = None
-
     with anthropic_client.messages.create(
         model=model,
         max_tokens=100,
@@ -433,10 +478,8 @@ def test_sync_messages_create_streaming(  # pylint: disable=too-many-locals
                 usage = getattr(chunk, "usage", None)
                 if usage:
                     output_tokens = getattr(usage, "output_tokens", None)
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-
     assert_span_attributes(
         spans[0],
         request_model=model,
@@ -448,6 +491,34 @@ def test_sync_messages_create_streaming(  # pylint: disable=too-many-locals
         if stop_reason
         else None,
     )
+    duration_points = _metric_points(
+        metric_reader, GEN_AI_CLIENT_OPERATION_DURATION
+    )
+    assert len(duration_points) == 1
+    assert duration_points[0].count == 1
+    assert duration_points[0].sum >= 0
+    assert (
+        duration_points[0].attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == GenAIAttributes.GenAiOperationNameValues.CHAT.value
+    )
+    assert (
+        duration_points[0].attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == model
+    )
+    token_points = _token_usage_points_by_type(metric_reader)
+    assert set(token_points) == {"input", "output"}
+    input_point = token_points["input"]
+    output_point = token_points["output"]
+    assert input_point.count == 1
+    assert output_point.count == 1
+    assert input_point.sum == input_tokens
+    assert output_point.sum == output_tokens
+    for point in (input_point, output_point):
+        assert (
+            point.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+            == GenAIAttributes.GenAiOperationNameValues.CHAT.value
+        )
+        assert point.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == model
 
 
 @pytest.mark.vcr()
@@ -489,7 +560,6 @@ def test_sync_messages_create_streaming_iteration(
     """Test streaming with direct iteration (without context manager)."""
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "Say hi."}]
-
     stream = anthropic_client.messages.create(
         model=model,
         max_tokens=100,
@@ -500,10 +570,8 @@ def test_sync_messages_create_streaming_iteration(
     # Consume the stream by iterating
     chunks = list(stream)
     assert len(chunks) > 0
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == model
     # Verify span has response attributes from streaming
@@ -541,7 +609,6 @@ def test_sync_messages_create_streaming_connection_error(
 
     # Create client with invalid endpoint
     client = Anthropic(base_url="http://localhost:9999")
-
     with pytest.raises(APIConnectionError):
         client.messages.create(
             model=model,
@@ -553,7 +620,6 @@ def test_sync_messages_create_streaming_connection_error(
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == model
     assert ErrorAttributes.ERROR_TYPE in span.attributes
@@ -572,7 +638,6 @@ def test_sync_messages_create_captures_tool_use_content(
     _skip_if_cassette_missing_and_no_real_key(request)
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "What is the weather in SF?"}]
-
     anthropic_client.messages.create(
         model=model,
         max_tokens=256,
@@ -590,14 +655,12 @@ def test_sync_messages_create_captures_tool_use_content(
         ],
         tool_choice={"type": "tool", "name": "get_weather"},
     )
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
     output_messages = _load_span_messages(
         span, GenAIAttributes.GEN_AI_OUTPUT_MESSAGES
     )
-
     assert any(
         part.get("type") == "tool_call"
         for message in output_messages
@@ -624,14 +687,12 @@ def test_sync_messages_create_captures_thinking_content(
         messages=messages,
         thinking={"type": "enabled", "budget_tokens": 10000},
     )
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
     output_messages = _load_span_messages(
         span, GenAIAttributes.GEN_AI_OUTPUT_MESSAGES
     )
-
     assert any(
         part.get("type") == "reasoning"
         for message in output_messages
@@ -680,7 +741,6 @@ def test_stream_wrapper_finalize_idempotent(  # pylint: disable=too-many-locals
             if usage:
                 output_tokens = getattr(usage, "output_tokens", None)
                 input_tokens = expected_input_tokens(usage)
-
     stream.close()
 
     spans = span_exporter.get_finished_spans()
@@ -892,7 +952,6 @@ def test_sync_messages_create_instrumentation_error_swallowed(
         chunks = list(stream)
 
     assert len(chunks) > 0
-
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/README.rst
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/README.rst
@@ -1,0 +1,42 @@
+OpenTelemetry Groq Instrumentation
+====================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-groq.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-groq/
+
+Instrumentation for `Groq <https://groq.com/>`_ Python SDK.
+
+Records distributed traces, operation duration histograms, and token usage
+histograms for every ``chat.completions.create`` call.
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install opentelemetry-instrumentation-groq
+
+Usage
+-----
+
+.. code-block:: python
+
+    from groq import Groq
+    from opentelemetry.instrumentation.groq import GroqInstrumentor
+
+    GroqInstrumentor().instrument()
+
+    client = Groq()
+    response = client.chat.completions.create(
+        model="llama-3.3-70b-versatile",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI Semantic Conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `Groq API Documentation <https://console.groq.com/docs/api>`_

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-groq"
+dynamic = ["version"]
+description = "OpenTelemetry Groq instrumentation"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.37",
+  "opentelemetry-instrumentation ~= 0.58b0",
+  "opentelemetry-semantic-conventions ~= 0.58b0",
+  "opentelemetry-util-genai >= 0.2b0, <0.4b0",
+]
+
+[project.optional-dependencies]
+instruments = [
+  "groq >= 0.9.0",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+groq = "opentelemetry.instrumentation.groq:GroqInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-groq"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/groq/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/__init__.py
@@ -1,0 +1,112 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+OpenTelemetry Groq Instrumentation
+====================================
+
+Instrumentation for the Groq Python SDK.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.groq import GroqInstrumentor
+    import groq
+
+    # Enable instrumentation
+    GroqInstrumentor().instrument()
+
+    # Use Groq client normally
+    client = groq.Groq()
+    response = client.chat.completions.create(
+        model="llama-3.3-70b-versatile",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+
+Configuration
+-------------
+
+Message content capture can be enabled by setting the environment variable:
+``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true``
+
+API
+---
+"""
+
+from typing import Any, Collection
+
+from wrapt import (
+    wrap_function_wrapper,  # pyright: ignore[reportUnknownVariableType]
+)
+
+from opentelemetry.instrumentation.groq.package import _instruments
+from opentelemetry.instrumentation.groq.patch import (
+    async_chat_completions_create,
+    chat_completions_create,
+)
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.util.genai.handler import TelemetryHandler
+
+
+class GroqInstrumentor(BaseInstrumentor):
+    """An instrumentor for the Groq Python SDK.
+
+    Automatically traces Groq API calls and records operation duration and
+    token usage metrics. Optionally captures message content as span attributes.
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs: Any) -> None:
+        """Enable Groq instrumentation.
+
+        Args:
+            **kwargs: Optional arguments
+                - tracer_provider: TracerProvider instance
+                - meter_provider: MeterProvider instance
+                - logger_provider: LoggerProvider instance
+        """
+        handler = TelemetryHandler(
+            tracer_provider=kwargs.get("tracer_provider"),
+            meter_provider=kwargs.get("meter_provider"),
+            logger_provider=kwargs.get("logger_provider"),
+        )
+
+        wrap_function_wrapper(
+            module="groq.resources.chat.completions",
+            name="Completions.create",
+            wrapper=chat_completions_create(handler),
+        )
+        wrap_function_wrapper(
+            module="groq.resources.chat.completions",
+            name="AsyncCompletions.create",
+            wrapper=async_chat_completions_create(handler),
+        )
+
+    def _uninstrument(self, **kwargs: Any) -> None:
+        """Disable Groq instrumentation."""
+        import groq  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+
+        unwrap(
+            groq.resources.chat.completions.Completions,  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownArgumentType]
+            "create",
+        )
+        unwrap(
+            groq.resources.chat.completions.AsyncCompletions,  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownArgumentType]
+            "create",
+        )

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/package.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/package.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_instruments = ("groq >= 0.9.0",)

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/patch.py
@@ -1,0 +1,283 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patching functions for Groq instrumentation."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    server_attributes as ServerAttributes,
+)
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.types import (
+    Error,
+    InputMessage,
+    LLMInvocation,
+    OutputMessage,
+    Text,
+)
+from opentelemetry.util.genai.utils import (
+    should_capture_content_on_spans_in_experimental_mode,
+)
+
+if TYPE_CHECKING:
+    from groq.resources.chat.completions import AsyncCompletions, Completions
+
+_logger = logging.getLogger(__name__)
+GROQ = "groq"
+
+
+@dataclass
+class ChatCompletionParams:
+    model: str | None = None
+    messages: list[Any] | None = None
+    max_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    stop: str | list[str] | None = None
+    stream: bool | None = None
+
+
+def extract_params(
+    *,
+    model: str | None = None,
+    messages: list[Any] | None = None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    stop: str | list[str] | None = None,
+    stream: bool | None = None,
+    **_kwargs: object,
+) -> ChatCompletionParams:
+    return ChatCompletionParams(
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        stop=stop,
+        stream=stream,
+    )
+
+
+def _get_server_address_and_port(
+    instance: Any,
+    attributes: dict[str, Any],
+) -> None:
+    try:
+        base_url = instance._client.base_url
+        host = base_url.host
+        if host:
+            attributes[ServerAttributes.SERVER_ADDRESS] = host
+        port = base_url.port
+        if port and port != 443 and port > 0:
+            attributes[ServerAttributes.SERVER_PORT] = port
+    except AttributeError:
+        pass
+
+
+def get_llm_request_attributes(
+    params: ChatCompletionParams,
+    instance: Any,
+) -> dict[str, Any]:
+    stop_sequences: tuple[str, ...] | None = None
+    if isinstance(params.stop, str):
+        stop_sequences = (params.stop,)
+    elif isinstance(params.stop, list):
+        stop_sequences = tuple(params.stop)
+
+    attributes: dict[str, Any] = {
+        GenAIAttributes.GEN_AI_OPERATION_NAME: GenAIAttributes.GenAiOperationNameValues.CHAT.value,
+        GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.GROQ.value,
+        GenAIAttributes.GEN_AI_REQUEST_MODEL: params.model,
+    }
+    if params.max_tokens is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] = (
+            params.max_tokens
+        )
+    if params.temperature is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] = (
+            params.temperature
+        )
+    if params.top_p is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] = params.top_p
+    if stop_sequences is not None:
+        attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] = (
+            stop_sequences
+        )
+
+    _get_server_address_and_port(instance, attributes)
+    return attributes
+
+
+def get_input_messages(messages: list[Any] | None) -> list[InputMessage]:
+    if not messages:
+        return []
+    result: list[InputMessage] = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+        else:
+            role = getattr(msg, "role", "user")
+            content = getattr(msg, "content", "")
+        parts = (
+            [Text(content=content)]
+            if isinstance(content, str) and content
+            else []
+        )
+        result.append(InputMessage(role=role, parts=parts))
+    return result
+
+
+def _extract_response(
+    result: Any,
+    invocation: LLMInvocation,
+    capture_content: bool,
+) -> None:
+    if getattr(result, "model", None):
+        invocation.response_model_name = result.model
+    if getattr(result, "id", None):
+        invocation.response_id = result.id
+
+    choices = getattr(result, "choices", None) or []
+    finish_reason: str | None = None
+    if choices:
+        finish_reason = getattr(choices[0], "finish_reason", None)
+        if finish_reason:
+            invocation.finish_reasons = [finish_reason]
+
+        if capture_content:
+            message = getattr(choices[0], "message", None)
+            if message:
+                content = getattr(message, "content", None)
+                role = getattr(message, "role", "assistant") or "assistant"
+                if content:
+                    invocation.output_messages = [
+                        OutputMessage(
+                            role=role,
+                            parts=[Text(content=content)],
+                            finish_reason=finish_reason or "",
+                        )
+                    ]
+
+    usage = getattr(result, "usage", None)
+    if usage:
+        prompt_tokens = getattr(usage, "prompt_tokens", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        if prompt_tokens is not None:
+            invocation.input_tokens = prompt_tokens
+        if completion_tokens is not None:
+            invocation.output_tokens = completion_tokens
+
+
+def chat_completions_create(
+    handler: TelemetryHandler,
+) -> Callable[..., Any]:
+    """Wrap ``Completions.create`` to emit traces and metrics."""
+    capture_content = should_capture_content_on_spans_in_experimental_mode()
+
+    def traced_method(
+        wrapped: Callable[..., Any],
+        instance: "Completions",
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        params = extract_params(**kwargs)
+        attributes = get_llm_request_attributes(params, instance)
+        request_model_attr = attributes.get(
+            GenAIAttributes.GEN_AI_REQUEST_MODEL
+        )
+        request_model = (
+            request_model_attr
+            if isinstance(request_model_attr, str)
+            else params.model
+        )
+
+        invocation = LLMInvocation(
+            request_model=request_model,
+            provider=GROQ,
+            input_messages=get_input_messages(params.messages)
+            if capture_content
+            else [],
+            attributes=attributes,
+        )
+
+        handler.start_llm(invocation)
+        try:
+            result = wrapped(*args, **kwargs)
+            _extract_response(result, invocation, capture_content)
+            handler.stop_llm(invocation)
+            return result
+        except Exception as exc:
+            handler.fail_llm(
+                invocation, Error(message=str(exc), type=type(exc))
+            )
+            raise
+
+    return cast(Callable[..., Any], traced_method)
+
+
+def async_chat_completions_create(
+    handler: TelemetryHandler,
+) -> Callable[..., Any]:
+    """Wrap ``AsyncCompletions.create`` to emit traces and metrics."""
+    capture_content = should_capture_content_on_spans_in_experimental_mode()
+
+    async def traced_method(
+        wrapped: Callable[..., Any],
+        instance: "AsyncCompletions",
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        params = extract_params(**kwargs)
+        attributes = get_llm_request_attributes(params, instance)
+        request_model_attr = attributes.get(
+            GenAIAttributes.GEN_AI_REQUEST_MODEL
+        )
+        request_model = (
+            request_model_attr
+            if isinstance(request_model_attr, str)
+            else params.model
+        )
+
+        invocation = LLMInvocation(
+            request_model=request_model,
+            provider=GROQ,
+            input_messages=get_input_messages(params.messages)
+            if capture_content
+            else [],
+            attributes=attributes,
+        )
+
+        handler.start_llm(invocation)
+        try:
+            result = await wrapped(*args, **kwargs)
+            _extract_response(result, invocation, capture_content)
+            handler.stop_llm(invocation)
+            return result
+        except Exception as exc:
+            handler.fail_llm(
+                invocation, Error(message=str(exc), type=type(exc))
+            )
+            raise
+
+    return cast(Callable[..., Any], traced_method)

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/version.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/src/opentelemetry/instrumentation/groq/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1b0.dev"

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_api_error.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_api_error.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 100,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say hello in one word."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile"
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "error": {
+            "message": "Invalid API Key. Please refer to https://console.groq.com for more details.",
+            "type": "invalid_request_error",
+            "code": "invalid_api_key"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:05 GMT
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_basic.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_basic.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 100,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say hello in one word."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile"
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-f8a3b2c1d4e5f6a7b8c9d0e1",
+          "object": "chat.completion",
+          "created": 1748909400,
+          "model": "llama-3.3-70b-versatile",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello!"
+              },
+              "finish_reason": "stop",
+              "logprobs": null
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 3,
+            "total_tokens": 16,
+            "prompt_time": 0.001234567,
+            "completion_time": 0.002345678,
+            "total_time": 0.003580245
+          },
+          "system_fingerprint": "fp_a1b2c3d4e5",
+          "x_groq": {
+            "id": "req_01abcdef1234567890abcdef"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:00 GMT
+      x-ratelimit-limit-requests:
+      - '30'
+      x-ratelimit-limit-tokens:
+      - '15000'
+      x-ratelimit-remaining-requests:
+      - '29'
+      x-ratelimit-remaining-tokens:
+      - '14984'
+      x-ratelimit-reset-requests:
+      - 2s
+      x-ratelimit-reset-tokens:
+      - 64ms
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_metrics.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_metrics.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 100,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Count to 5."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile"
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-d4e5f6a7b8c9d0e1f2a3b4c5",
+          "object": "chat.completion",
+          "created": 1748909404,
+          "model": "llama-3.3-70b-versatile",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "1, 2, 3, 4, 5"
+              },
+              "finish_reason": "stop",
+              "logprobs": null
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 17,
+            "total_tokens": 29,
+            "prompt_time": 0.001234567,
+            "completion_time": 0.005678901,
+            "total_time": 0.006913468
+          },
+          "system_fingerprint": "fp_a1b2c3d4e5",
+          "x_groq": {
+            "id": "req_05abcdef1234567890abcdef"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:04 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_stop_reason.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_stop_reason.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 100,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say hi."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile"
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-b2c3d4e5f6a7b8c9d0e1f2a3",
+          "object": "chat.completion",
+          "created": 1748909402,
+          "model": "llama-3.3-70b-versatile",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hi! How can I help you today?"
+              },
+              "finish_reason": "stop",
+              "logprobs": null
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 9,
+            "total_tokens": 20,
+            "prompt_time": 0.001234567,
+            "completion_time": 0.003456789,
+            "total_time": 0.004691356
+          },
+          "system_fingerprint": "fp_a1b2c3d4e5",
+          "x_groq": {
+            "id": "req_03abcdef1234567890abcdef"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:02 GMT
+      x-ratelimit-limit-requests:
+      - '30'
+      x-ratelimit-remaining-requests:
+      - '29'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_token_usage.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_token_usage.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 100,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Count to 5."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile"
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-a1b2c3d4e5f6a7b8c9d0e1f2",
+          "object": "chat.completion",
+          "created": 1748909401,
+          "model": "llama-3.3-70b-versatile",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "1, 2, 3, 4, 5"
+              },
+              "finish_reason": "stop",
+              "logprobs": null
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 17,
+            "total_tokens": 29,
+            "prompt_time": 0.001234567,
+            "completion_time": 0.005678901,
+            "total_time": 0.006913468
+          },
+          "system_fingerprint": "fp_a1b2c3d4e5",
+          "x_groq": {
+            "id": "req_02abcdef1234567890abcdef"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:01 GMT
+      x-ratelimit-limit-requests:
+      - '30'
+      x-ratelimit-limit-tokens:
+      - '15000'
+      x-ratelimit-remaining-requests:
+      - '29'
+      x-ratelimit-remaining-tokens:
+      - '14971'
+      x-ratelimit-reset-requests:
+      - 2s
+      x-ratelimit-reset-tokens:
+      - 116ms
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_with_all_params.yaml
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/cassettes/test_chat_completion_with_all_params.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: |-
+      {
+        "max_tokens": 50,
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say hello in one word."
+          }
+        ],
+        "model": "llama-3.3-70b-versatile",
+        "stop": [
+          "STOP"
+        ],
+        "temperature": 0.7,
+        "top_p": 0.9
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_groq_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+      user-agent:
+      - Groq/Python 0.18.0
+    method: POST
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-c3d4e5f6a7b8c9d0e1f2a3b4",
+          "object": "chat.completion",
+          "created": 1748909403,
+          "model": "llama-3.3-70b-versatile",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello!"
+              },
+              "finish_reason": "stop",
+              "logprobs": null
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 3,
+            "total_tokens": 16,
+            "prompt_time": 0.001234567,
+            "completion_time": 0.002345678,
+            "total_time": 0.003580245
+          },
+          "system_fingerprint": "fp_a1b2c3d4e5",
+          "x_groq": {
+            "id": "req_04abcdef1234567890abcdef"
+          }
+        }
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 22 May 2026 10:00:03 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/conftest.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/conftest.py
@@ -1,0 +1,251 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test configuration and fixtures for Groq instrumentation tests."""
+# pylint: disable=redefined-outer-name
+
+import json
+import os
+
+import pytest
+import yaml
+from groq import Groq
+
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
+from opentelemetry.instrumentation.groq import GroqInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
+
+
+@pytest.fixture
+def span_exporter():
+    exporter = InMemorySpanExporter()
+    yield exporter
+    exporter.clear()
+
+
+@pytest.fixture
+def log_exporter():
+    exporter = InMemoryLogExporter()
+    yield exporter
+    exporter.clear()
+
+
+@pytest.fixture
+def metric_reader():
+    reader = InMemoryMetricReader()
+    yield reader
+
+
+@pytest.fixture
+def tracer_provider(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    return provider
+
+
+@pytest.fixture
+def logger_provider(log_exporter):
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    yield provider
+
+
+@pytest.fixture
+def meter_provider(metric_reader):
+    provider = MeterProvider(metric_readers=[metric_reader])
+    yield provider
+
+
+@pytest.fixture(autouse=True)
+def environment():
+    if not os.getenv("GROQ_API_KEY"):
+        os.environ["GROQ_API_KEY"] = "test_groq_api_key"
+
+
+@pytest.fixture
+def groq_client():
+    return Groq()
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            ("authorization", "Bearer test_groq_api_key"),
+        ],
+        "decode_compressed_response": True,
+        "before_record_response": scrub_response_headers,
+    }
+
+
+@pytest.fixture(scope="function")
+def instrument_no_content(tracer_provider, logger_provider, meter_provider):
+    """Instrument Groq without content capture."""
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    os.environ.update(
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "stable",
+            OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "NO_CONTENT",
+        }
+    )
+
+    instrumentor = GroqInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+
+    try:
+        yield instrumentor
+    finally:
+        os.environ.pop(
+            OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None
+        )
+        os.environ.pop(OTEL_SEMCONV_STABILITY_OPT_IN, None)
+        instrumentor.uninstrument()
+        _OpenTelemetrySemanticConventionStability._initialized = False
+
+
+@pytest.fixture(scope="function")
+def instrument_with_content(tracer_provider, logger_provider, meter_provider):
+    """Instrument Groq with content capture enabled."""
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    os.environ.update(
+        {
+            OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental",
+            OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "SPAN_ONLY",
+        }
+    )
+
+    instrumentor = GroqInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+
+    try:
+        yield instrumentor
+    finally:
+        os.environ.pop(
+            OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None
+        )
+        os.environ.pop(OTEL_SEMCONV_STABILITY_OPT_IN, None)
+        instrumentor.uninstrument()
+        _OpenTelemetrySemanticConventionStability._initialized = False
+
+
+@pytest.fixture
+def instrument_groq(tracer_provider, logger_provider, meter_provider):
+    instrumentor = GroqInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+    yield instrumentor
+    instrumentor.uninstrument()
+
+
+@pytest.fixture
+def uninstrument_groq():
+    yield
+    GroqInstrumentor().uninstrument()
+
+
+class LiteralBlockScalar(str):
+    """Formats the string as a literal block scalar."""
+
+
+def literal_block_scalar_presenter(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+yaml.add_representer(LiteralBlockScalar, literal_block_scalar_presenter)
+
+
+def process_string_value(string_value):
+    try:
+        json_data = json.loads(string_value)
+        return LiteralBlockScalar(json.dumps(json_data, indent=2))
+    except (ValueError, TypeError):
+        if len(string_value) > 80:
+            return LiteralBlockScalar(string_value)
+    return string_value
+
+
+def convert_body_to_literal(data):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key == "body" and isinstance(value, dict) and "string" in value:
+                value["string"] = process_string_value(value["string"])
+            elif key == "body" and isinstance(value, str):
+                data[key] = process_string_value(value)
+            else:
+                convert_body_to_literal(value)
+    elif isinstance(data, list):
+        for idx, choice in enumerate(data):
+            data[idx] = convert_body_to_literal(choice)
+    return data
+
+
+class PrettyPrintJSONBody:
+    @staticmethod
+    def serialize(cassette_dict):
+        cassette_dict = convert_body_to_literal(cassette_dict)
+        return yaml.dump(
+            cassette_dict, default_flow_style=False, allow_unicode=True
+        )
+
+    @staticmethod
+    def deserialize(cassette_string):
+        return yaml.load(cassette_string, Loader=yaml.Loader)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def fixture_vcr(vcr):
+    vcr.register_serializer("yaml", PrettyPrintJSONBody)
+    return vcr
+
+
+_SCRUBBED_RESPONSE_HEADERS = frozenset(
+    {
+        "x-groq-org-id",
+    }
+)
+
+
+def scrub_response_headers(response):
+    headers = response.get("headers", {})
+    for header in _SCRUBBED_RESPONSE_HEADERS:
+        headers.pop(header, None)
+    return response

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.latest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.latest.txt
@@ -1,0 +1,23 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groq
+pytest==7.4.4
+pytest-vcr==1.0.2
+pytest-asyncio==0.21.0
+wrapt==1.16.0
+
+-e opentelemetry-instrumentation
+-e util/opentelemetry-util-genai
+-e instrumentation-genai/opentelemetry-instrumentation-groq

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.oldest.txt
@@ -1,0 +1,25 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+-e util/opentelemetry-util-genai
+groq==0.9.0
+pytest==7.4.4
+pytest-vcr==1.0.2
+pytest-asyncio==0.21.0
+wrapt==1.16.0
+opentelemetry-api==1.37  # when updating, also update in pyproject.toml
+opentelemetry-sdk==1.37  # when updating, also update in pyproject.toml
+opentelemetry-semantic-conventions==0.58b0  # when updating, also update in pyproject.toml
+
+-e instrumentation-genai/opentelemetry-instrumentation-groq

--- a/instrumentation-genai/opentelemetry-instrumentation-groq/tests/test_chat_completions.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-groq/tests/test_chat_completions.py
@@ -1,0 +1,365 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Groq chat.completions.create instrumentation."""
+
+import pytest
+from groq import APIConnectionError, AuthenticationError, Groq
+
+from opentelemetry.instrumentation.groq import GroqInstrumentor
+from opentelemetry.semconv._incubating.attributes import (
+    error_attributes as ErrorAttributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    server_attributes as ServerAttributes,
+)
+from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
+
+DEFAULT_MODEL = "llama-3.3-70b-versatile"
+USER_ONLY_PROMPT = [{"role": "user", "content": "Say hello in one word."}]
+
+
+def assert_span_attributes(
+    span,
+    request_model,
+    response_id=None,
+    response_model=None,
+    input_tokens=None,
+    output_tokens=None,
+    finish_reasons=None,
+    operation_name="chat",
+    server_address="api.groq.com",
+):
+    assert span.name == f"{operation_name} {request_model}"
+    assert (
+        operation_name
+        == span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+    )
+    assert (
+        GenAIAttributes.GenAiSystemValues.GROQ.value
+        == span.attributes[GenAIAttributes.GEN_AI_SYSTEM]
+    )
+    assert (
+        request_model == span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+    )
+    assert server_address == span.attributes[ServerAttributes.SERVER_ADDRESS]
+
+    if response_id is not None:
+        assert (
+            response_id == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_ID]
+        )
+    if response_model is not None:
+        assert (
+            response_model
+            == span.attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL]
+        )
+    if input_tokens is not None:
+        assert (
+            input_tokens
+            == span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
+        )
+    if output_tokens is not None:
+        assert (
+            output_tokens
+            == span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
+        )
+    if finish_reasons is not None:
+        assert finish_reasons == tuple(
+            span.attributes[GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Span tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.vcr()
+def test_chat_completion_basic(
+    span_exporter, groq_client, instrument_no_content
+):
+    """Span created with correct provider and model attributes."""
+    response = groq_client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        max_tokens=100,
+        messages=USER_ONLY_PROMPT,
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    assert_span_attributes(
+        spans[0],
+        request_model=DEFAULT_MODEL,
+        response_id=response.id,
+        response_model=response.model,
+    )
+
+
+@pytest.mark.vcr()
+def test_chat_completion_token_usage(
+    span_exporter, groq_client, instrument_no_content
+):
+    """Token counts appear as span attributes."""
+    response = groq_client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        max_tokens=100,
+        messages=[{"role": "user", "content": "Count to 5."}],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS in span.attributes
+    assert GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS in span.attributes
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
+        == response.usage.prompt_tokens
+    )
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
+        == response.usage.completion_tokens
+    )
+
+
+@pytest.mark.vcr()
+def test_chat_completion_stop_reason(
+    span_exporter, groq_client, instrument_no_content
+):
+    """Finish reason captured on span."""
+    response = groq_client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        max_tokens=100,
+        messages=[{"role": "user", "content": "Say hi."}],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert span.attributes[GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS] == (
+        response.choices[0].finish_reason,
+    )
+
+
+@pytest.mark.vcr()
+def test_chat_completion_with_all_params(
+    span_exporter, groq_client, instrument_no_content
+):
+    """All request parameters appear as span attributes."""
+    groq_client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        max_tokens=50,
+        messages=USER_ONLY_PROMPT,
+        temperature=0.7,
+        top_p=0.9,
+        stop=["STOP"],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
+        "STOP",
+    )
+
+
+def test_chat_completion_connection_error(
+    span_exporter, instrument_no_content
+):
+    """Connection errors are recorded on the span with error.type."""
+    client = Groq(base_url="http://localhost:9999")
+
+    with pytest.raises(APIConnectionError):
+        client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            max_tokens=100,
+            messages=USER_ONLY_PROMPT,
+            timeout=0.1,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == DEFAULT_MODEL
+    )
+    assert ErrorAttributes.ERROR_TYPE in span.attributes
+    assert "APIConnectionError" in span.attributes[ErrorAttributes.ERROR_TYPE]
+
+
+@pytest.mark.vcr()
+def test_chat_completion_api_error(
+    span_exporter, groq_client, instrument_no_content
+):
+    """API errors (4xx) are recorded with error.type on the span."""
+    with pytest.raises(AuthenticationError):
+        groq_client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            max_tokens=100,
+            messages=USER_ONLY_PROMPT,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert ErrorAttributes.ERROR_TYPE in span.attributes
+
+
+# ---------------------------------------------------------------------------
+# Instrumentor lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_instrumentor_instrument_uninstrument(uninstrument_groq):
+    """Instrumentor can be applied and removed cleanly."""
+    instrumentor = GroqInstrumentor()
+    assert not instrumentor.is_instrumented_by_opentelemetry
+    instrumentor.instrument()
+    assert instrumentor.is_instrumented_by_opentelemetry
+    instrumentor.uninstrument()
+    assert not instrumentor.is_instrumented_by_opentelemetry
+
+
+# ---------------------------------------------------------------------------
+# Metrics tests
+# ---------------------------------------------------------------------------
+
+_DURATION_BUCKETS = (
+    0.01,
+    0.02,
+    0.04,
+    0.08,
+    0.16,
+    0.32,
+    0.64,
+    1.28,
+    2.56,
+    5.12,
+    10.24,
+    20.48,
+    40.96,
+    81.92,
+)
+_TOKEN_USAGE_BUCKETS = (
+    1,
+    4,
+    16,
+    64,
+    256,
+    1024,
+    4096,
+    16384,
+    65536,
+    262144,
+    1048576,
+    4194304,
+    16777216,
+    67108864,
+)
+
+
+def assert_metric_attributes(data_point, request_model):
+    assert (
+        data_point.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == GenAIAttributes.GenAiOperationNameValues.CHAT.value
+    )
+    assert GenAIAttributes.GEN_AI_PROVIDER_NAME in data_point.attributes
+    assert (
+        data_point.attributes[GenAIAttributes.GEN_AI_PROVIDER_NAME]
+        == GenAIAttributes.GenAiSystemValues.GROQ.value
+    )
+    assert (
+        data_point.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == request_model
+    )
+
+
+@pytest.mark.vcr()
+def test_chat_completion_metrics(
+    metric_reader, groq_client, instrument_no_content
+):
+    """Operation duration and token usage histograms are recorded."""
+    groq_client.chat.completions.create(
+        model=DEFAULT_MODEL,
+        max_tokens=100,
+        messages=[{"role": "user", "content": "Count to 5."}],
+    )
+
+    metrics = metric_reader.get_metrics_data().resource_metrics
+    assert len(metrics) == 1
+
+    metric_data = metrics[0].scope_metrics[0].metrics
+    assert len(metric_data) == 2
+
+    duration_metric = next(
+        (
+            m
+            for m in metric_data
+            if m.name == gen_ai_metrics.GEN_AI_CLIENT_OPERATION_DURATION
+        ),
+        None,
+    )
+    assert duration_metric is not None
+    duration_point = duration_metric.data.data_points[0]
+    assert duration_point.sum > 0
+    assert duration_point.explicit_bounds == _DURATION_BUCKETS
+    assert_metric_attributes(duration_point, DEFAULT_MODEL)
+
+    token_usage_metric = next(
+        (
+            m
+            for m in metric_data
+            if m.name == gen_ai_metrics.GEN_AI_CLIENT_TOKEN_USAGE
+        ),
+        None,
+    )
+    assert token_usage_metric is not None
+
+    input_token_point = next(
+        (
+            d
+            for d in token_usage_metric.data.data_points
+            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+            == GenAIAttributes.GenAiTokenTypeValues.INPUT.value
+        ),
+        None,
+    )
+    assert input_token_point is not None
+    assert input_token_point.sum == 12
+    assert input_token_point.explicit_bounds == _TOKEN_USAGE_BUCKETS
+    assert_metric_attributes(input_token_point, DEFAULT_MODEL)
+
+    output_token_point = next(
+        (
+            d
+            for d in token_usage_metric.data.data_points
+            if d.attributes[GenAIAttributes.GEN_AI_TOKEN_TYPE]
+            == GenAIAttributes.GenAiTokenTypeValues.OUTPUT.value
+        ),
+        None,
+    )
+    assert output_token_point is not None
+    assert output_token_point.sum == 17
+    assert_metric_attributes(output_token_point, DEFAULT_MODEL)

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,11 @@ envlist =
     # pypy3-test-instrumentation-anthropic-{oldest,latest}
     lint-instrumentation-anthropic
 
+    ; instrumentation-groq
+    py3{10,11,12,13,14}-test-instrumentation-groq-{oldest,latest}
+    pypy3-test-instrumentation-groq-{oldest,latest}
+    lint-instrumentation-groq
+
     ; instrumentation-claude-agent-sdk
     py3{10,11,12,13}-test-instrumentation-claude-agent-sdk-{oldest,latest}
     # Disabling pypy3 as jiter (anthropic dep) requires PyPy 3.11+
@@ -502,6 +507,11 @@ deps =
   anthropic-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.latest.txt
   lint-instrumentation-anthropic: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests/requirements.oldest.txt
 
+  groq-oldest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.oldest.txt
+  groq-latest: {[testenv]test_deps}
+  groq-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.latest.txt
+  lint-instrumentation-groq: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-groq/tests/requirements.oldest.txt
+
   claude-agent-sdk-oldest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/tests/requirements.oldest.txt
   claude-agent-sdk-latest: {[testenv]test_deps}
   claude-agent-sdk-latest: -r {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/tests/requirements.latest.txt
@@ -917,6 +927,9 @@ commands =
   test-instrumentation-anthropic: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-anthropic/tests --vcr-record=none {posargs}
   lint-instrumentation-anthropic: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-anthropic"
 
+  test-instrumentation-groq: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-groq/tests --vcr-record=none {posargs}
+  lint-instrumentation-groq: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-groq"
+
   test-instrumentation-claude-agent-sdk: pytest {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk/tests --vcr-record=none {posargs}
   lint-instrumentation-claude-agent-sdk: sh -c "cd instrumentation-genai && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-claude-agent-sdk"
 
@@ -1144,6 +1157,7 @@ deps =
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-vertexai[instruments]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-google-genai[instruments]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-anthropic[instruments]
+  {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-groq[instruments]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-langchain[instruments]
   {toxinidir}/instrumentation-genai/opentelemetry-instrumentation-claude-agent-sdk[instruments]
   {toxinidir}/instrumentation/opentelemetry-instrumentation-aiokafka[instruments]

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ members = [
     "opentelemetry-instrumentation-fastapi",
     "opentelemetry-instrumentation-flask",
     "opentelemetry-instrumentation-google-genai",
+    "opentelemetry-instrumentation-groq",
     "opentelemetry-instrumentation-grpc",
     "opentelemetry-instrumentation-httpx",
     "opentelemetry-instrumentation-jinja2",
@@ -1767,6 +1768,23 @@ wheels = [
 ]
 
 [[package]]
+name = "groq"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/51/4728c13611849ff6cf8536740ae78ba3ee5e665d67b572a47c9ead0f9788/groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3", size = 155609, upload-time = "2026-04-18T10:43:50.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/748639c95c60ad8846c65b167ca611c815d06d5f67a9e73b23486dce4fdf/groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84", size = 142334, upload-time = "2026-04-18T10:43:49.125Z" },
+]
+
+[[package]]
 name = "grpc-google-iam-v1"
 version = "0.14.3"
 source = { registry = "https://pypi.org/simple/" }
@@ -3418,6 +3436,31 @@ instruments = [
 [package.metadata]
 requires-dist = [
     { name = "google-genai", marker = "extra == 'instruments'", specifier = ">=1.32.0" },
+    { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
+    { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
+    { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
+]
+provides-extras = ["instruments"]
+
+[[package]]
+name = "opentelemetry-instrumentation-groq"
+source = { editable = "instrumentation-genai/opentelemetry-instrumentation-groq" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+
+[package.optional-dependencies]
+instruments = [
+    { name = "groq" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "groq", marker = "extra == 'instruments'", specifier = ">=0.9.0" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
     { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },


### PR DESCRIPTION
# Description

Adds GenAI client metrics support for Anthropic and Groq instrumentations.

For Anthropic, token usage is extracted from normal message responses and streaming events, then populated on `LLMInvocation` so the existing `TelemetryHandler` can emit metrics automatically.

For Groq, this PR adds a new `opentelemetry-instrumentation-groq` package with sync and async Chat Completions instrumentation.

The emitted metrics are:

- `gen_ai.client.operation.duration`
- `gen_ai.client.token.usage`

The changes are additive and preserve existing span and error behavior.

## Main Changes

### Anthropic

- Extract input and output token counts from Anthropic `Message.usage`.
- Preserve cache creation and cache read token fields.
- Preserve zero-valued cache token fields instead of treating them as missing.
- Aggregate semantic input tokens from base input tokens plus cache tokens.
- Collect usage from streaming `message_delta` events.
- Apply streamed usage before `TelemetryHandler.stop_llm()`.
- Keep stream finalization idempotent.
- Continue relying on the shared GenAI telemetry flow to record metrics.

### Groq

- Add the new `opentelemetry-instrumentation-groq` package.
- Add `GroqInstrumentor`.
- Instrument sync and async Chat Completions calls.
- Extract request attributes such as model, max tokens, temperature, top-p,
  stop sequences, and server address.
- Extract response id, response model, finish reasons, prompt tokens, and
  completion tokens.
- Record errors through `handler.fail_llm()`.
- Register the package in test and release-related configuration.

Closes open-telemetry/opentelemetry-python-genai#98

## Contributors

- João Galvão (@JMGalvao): Groq instrumentation.
- David Santos (@davidgss04): Anthropic metrics support.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

## Anthropic

### Changes to existing cassette-backed tests

- `test_sync_messages_create_basic` verifies non-streaming span creation and
  `gen_ai.client.operation.duration`.

- `test_sync_messages_create_token_usage` verifies non-streaming input/output
  token usage on spans and `gen_ai.client.token.usage` metrics.

- `test_sync_messages_create_streaming` verifies streaming spans and GenAI
  metrics after the stream is fully consumed.

- `test_sync_messages_create_aggregates_cache_tokens` verifies non-streaming
  cache token preservation and input token aggregation.

- `test_sync_messages_create_streaming_aggregates_cache_tokens` verifies
  streaming cache token extraction, preservation, and aggregation.

- `test_sync_messages_create_event_only_no_content_in_span` verifies EVENT_ONLY
  mode keeps content out of spans while preserving metadata and token usage.

### Added wrapper tests

- `test_sync_stream_wrapper_extracts_usage_from_message_delta` verifies sync
  stream usage extraction from `message_delta` events.

- `test_async_stream_wrapper_extracts_usage_from_message_delta` verifies async
  stream usage extraction and zero-valued cache token preservation.

- `test_sync_stream_wrapper_applies_usage_once_when_closed_twice` verifies
  idempotent stream finalization.

## Groq

- `test_chat_completion_basic` verifies Groq span creation with provider,
  model, operation, and server attributes.

- `test_chat_completion_token_usage` verifies input/output token extraction
  from `usage.prompt_tokens` and `usage.completion_tokens`.

- `test_chat_completion_stop_reason` verifies response finish reason capture.

- `test_chat_completion_with_all_params` verifies request parameter attributes.

- `test_chat_completion_connection_error` verifies connection errors are
  recorded with `error.type`.

- `test_chat_completion_api_error` verifies API errors are recorded with
  `error.type`.

- `test_instrumentor_instrument_uninstrument` verifies instrumentor lifecycle.

- `test_chat_completion_metrics` verifies duration and token usage histograms.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
