### PR TITLE
docs: document HTTP semantic convention opt-in

### DIFF
--- a/docs/_includes/http-semconv-stability.rst
+++ b/docs/_includes/http-semconv-stability.rst
@@ -1,0 +1,17 @@
+HTTP semantic convention stability opt-in
+-----------------------------------------
+
+HTTP instrumentations emit the old experimental HTTP semantic conventions by
+default. To emit only the stable HTTP and networking semantic conventions, set
+``OTEL_SEMCONV_STABILITY_OPT_IN=http`` before starting the instrumented
+process.
+
+To emit both the old and stable HTTP semantic conventions during migration, set
+``OTEL_SEMCONV_STABILITY_OPT_IN=http/dup``. The value can be combined with
+other signal opt-ins as a comma-separated list.
+
+For example:
+
+.. code-block:: sh
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http

--- a/docs/instrumentation/aiohttp_client/aiohttp_client.rst
+++ b/docs/instrumentation/aiohttp_client/aiohttp_client.rst
@@ -1,6 +1,8 @@
 OpenTelemetry aiohttp client Instrumentation
 ============================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.aiohttp_client
     :members:
     :undoc-members:

--- a/docs/instrumentation/aiohttp_server/aiohttp_server.rst
+++ b/docs/instrumentation/aiohttp_server/aiohttp_server.rst
@@ -1,6 +1,8 @@
 .. include:: ../../../instrumentation/opentelemetry-instrumentation-aiohttp-server/README.rst
     :end-before: References
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.aiohttp_server
     :members:
     :undoc-members:

--- a/docs/instrumentation/asgi/asgi.rst
+++ b/docs/instrumentation/asgi/asgi.rst
@@ -1,5 +1,7 @@
 .. include:: ../../../instrumentation/opentelemetry-instrumentation-asgi/README.rst
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 API
 ---
 

--- a/docs/instrumentation/django/django.rst
+++ b/docs/instrumentation/django/django.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Django Instrumentation
 ====================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.django
     :members:
     :undoc-members:

--- a/docs/instrumentation/falcon/falcon.rst
+++ b/docs/instrumentation/falcon/falcon.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Falcon Instrumentation
 ====================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.falcon
     :members:
     :undoc-members:

--- a/docs/instrumentation/fastapi/fastapi.rst
+++ b/docs/instrumentation/fastapi/fastapi.rst
@@ -1,5 +1,7 @@
 .. include:: ../../../instrumentation/opentelemetry-instrumentation-fastapi/README.rst
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 API
 ---
 

--- a/docs/instrumentation/flask/flask.rst
+++ b/docs/instrumentation/flask/flask.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Flask Instrumentation
 ===================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.flask
     :members:
     :undoc-members:

--- a/docs/instrumentation/httpx/httpx.rst
+++ b/docs/instrumentation/httpx/httpx.rst
@@ -1,6 +1,8 @@
 .. include:: ../../../instrumentation/opentelemetry-instrumentation-httpx/README.rst
     :end-before: References
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 API
 ---
 

--- a/docs/instrumentation/pyramid/pyramid.rst
+++ b/docs/instrumentation/pyramid/pyramid.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Pyramid Instrumentation
 =====================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.pyramid
     :members:
     :undoc-members:

--- a/docs/instrumentation/requests/requests.rst
+++ b/docs/instrumentation/requests/requests.rst
@@ -1,6 +1,8 @@
 OpenTelemetry requests Instrumentation
 ======================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.requests
     :members:
     :undoc-members:

--- a/docs/instrumentation/starlette/starlette.rst
+++ b/docs/instrumentation/starlette/starlette.rst
@@ -1,5 +1,7 @@
 .. include:: ../../../instrumentation/opentelemetry-instrumentation-starlette/README.rst
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 API
 ---
 

--- a/docs/instrumentation/tornado/tornado.rst
+++ b/docs/instrumentation/tornado/tornado.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Tornado Instrumentation
 ======================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.tornado
     :members:
     :undoc-members:

--- a/docs/instrumentation/urllib/urllib3.rst
+++ b/docs/instrumentation/urllib/urllib3.rst
@@ -1,6 +1,8 @@
 OpenTelemetry urllib Instrumentation
 ============================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.urllib
     :members:
     :undoc-members:

--- a/docs/instrumentation/urllib3/urllib3.rst
+++ b/docs/instrumentation/urllib3/urllib3.rst
@@ -1,6 +1,8 @@
 OpenTelemetry urllib3 Instrumentation
 ============================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.urllib3
     :members:
     :undoc-members:

--- a/docs/instrumentation/wsgi/wsgi.rst
+++ b/docs/instrumentation/wsgi/wsgi.rst
@@ -1,6 +1,8 @@
 OpenTelemetry WSGI Instrumentation
 ==================================
 
+.. include:: ../../_includes/http-semconv-stability.rst
+
 .. automodule:: opentelemetry.instrumentation.wsgi
     :members:
     :undoc-members:


### PR DESCRIPTION
## Summary
Fixes #4202.

Documents `OTEL_SEMCONV_STABILITY_OPT_IN` for HTTP instrumentations by adding a shared docs include and referencing it from each HTTP-related instrumentation page.

## Reproduction
Before this change, the HTTP instrumentation docs did not mention how to opt in to the stable HTTP semantic conventions with `OTEL_SEMCONV_STABILITY_OPT_IN=http` or how to emit both old and stable conventions with `http/dup`.

## Root cause
The instrumentations support the semantic convention stability opt-in, but the readthedocs pages did not expose the configuration behavior.

## Changes
- Add shared HTTP semantic convention stability opt-in documentation.
- Include it from aiohttp client/server, ASGI, Django, Falcon, FastAPI, Flask, HTTPX, Pyramid, Requests, Starlette, Tornado, urllib, urllib3, and WSGI instrumentation docs.

## Tests
- [x] `git diff --check`
- [x] `/tmp/otel-rstcheck-venv/bin/rstcheck --config .rstcheck.cfg docs/_includes/http-semconv-stability.rst docs/instrumentation/aiohttp_client/aiohttp_client.rst docs/instrumentation/aiohttp_server/aiohttp_server.rst docs/instrumentation/asgi/asgi.rst docs/instrumentation/django/django.rst docs/instrumentation/falcon/falcon.rst docs/instrumentation/fastapi/fastapi.rst docs/instrumentation/flask/flask.rst docs/instrumentation/httpx/httpx.rst docs/instrumentation/pyramid/pyramid.rst docs/instrumentation/requests/requests.rst docs/instrumentation/starlette/starlette.rst docs/instrumentation/tornado/tornado.rst docs/instrumentation/urllib/urllib3.rst docs/instrumentation/urllib3/urllib3.rst docs/instrumentation/wsgi/wsgi.rst`

## Screenshots / Logs
Not applicable; documentation only.
