### PR TITLE
docs: document OTEL_SEMCONV_STABILITY_OPT_IN across HTTP instrumentations

### DIFF
--- a/.changelog/4202.added
+++ b/.changelog/4202.added
@@ -1,0 +1,4 @@
+Document ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable in all HTTP
+instrumentations (aiohttp-client, ASGI, Django, FastAPI, Flask, HTTPX, Requests,
+WSGI), explaining the ``http``, ``http/dup``, and default (old experimental)
+behaviour.

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -178,6 +178,23 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -193,6 +193,23 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -283,6 +283,23 @@ We can configure the tags to be appended to the sqlquery log by adding below var
 | ``SQLCOMMENTER_WITH_DB_DRIVER``     | Database driver name used by Django.                      | ``db_driver='django.db.backends.postgresql'``                             |
 +-------------------------------------+-----------------------------------------------------------+---------------------------------------------------------------------------+
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -165,6 +165,23 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -239,6 +239,23 @@ The following sqlcomment key-values can be opted out of through ``commenter_opti
 | ``controller``    | Flask controller/endpoint name.                    | ``controller='home_view'``             |
 +-------------------+----------------------------------------------------+----------------------------------------+
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -297,6 +297,23 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -166,6 +166,23 @@ For example,
 
 will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -200,6 +200,23 @@ In order to prevent unbound cardinality for HTTP methods by default nonstandard 
 To record all of the names set the environment variable  ``OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS``
 to a value that evaluates to true, e.g. ``1``.
 
+Semantic Convention Stability
+*****************************
+
+This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
+variable, which controls which version of the HTTP semantic conventions is emitted:
+
+* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
+  emitting the old experimental HTTP and networking conventions that the
+  instrumentation emitted previously.
+* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
+  allowing for a seamless transition.
+* Default (unset) — emit only the old experimental HTTP and networking conventions.
+
+For example, to opt in to the stable conventions::
+
+    export OTEL_SEMCONV_STABILITY_OPT_IN=http
+
 API
 ---
 """


### PR DESCRIPTION
## Summary

All eight HTTP instrumentations already support the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable but it is not mentioned in any of their user-facing documentation. This PR adds a **Semantic Convention Stability** subsection to the module docstring of each affected instrumentation (which is what gets rendered on readthedocs via `automodule`).

**Instrumentations updated:** aiohttp-client, ASGI, Django, FastAPI, Flask, HTTPX, Requests, WSGI

## What was added

Each instrumentation's `__init__.py` module docstring now includes:

```
Semantic Convention Stability
*****************************

This instrumentation supports the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment
variable, which controls which version of the HTTP semantic conventions is emitted:

* ``http`` — emit the new, stable HTTP and networking conventions only, and stop
  emitting the old experimental HTTP and networking conventions that the
  instrumentation emitted previously.
* ``http/dup`` — emit both the old and the stable HTTP and networking conventions,
  allowing for a seamless transition.
* Default (unset) — emit only the old experimental HTTP and networking conventions.
```

## Rationale for placing docs in module docstrings

The `docs/instrumentation/*/instrumentation.rst` files use `.. automodule::` to render documentation from the module's docstring. All other configuration environment variables (e.g. `OTEL_PYTHON_FLASK_EXCLUDED_URLS`, `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_*`) are already documented in the module docstrings, so this section follows the same pattern and appears naturally in the readthedocs output.

## Changes

- `instrumentation/opentelemetry-instrumentation-{aiohttp-client,asgi,django,fastapi,flask,httpx,requests,wsgi}/src/.../__ init__.py` — add "Semantic Convention Stability" subsection before the closing `API` section
- `.changelog/4202.added` — towncrier fragment

Fixes #4202

Made with [Cursor](https://cursor.com)