### PR TITLE
Fix broken botocore tests, minor change to HTTPX instrumentation test, remove `_ExtendedAttributes` import from logging instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
@@ -3,6 +3,7 @@ aws-xray-sdk==2.12.1
 boto3==1.29.4
 botocore==1.32.4
 aiobotocore==2.8.0
+aiohttp<3.9.0
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
@@ -3,7 +3,7 @@ aws-xray-sdk==2.12.1
 boto3==1.29.4
 botocore==1.32.4
 aiobotocore==2.8.0
-aiohttp<3.9.0
+aiohttp<3.10.0
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
@@ -3,7 +3,7 @@ aws-xray-sdk==2.12.1
 boto3==1.29.4
 botocore==1.32.4
 aiobotocore==2.8.0
-aiohttp<3.10.0
+aiohttp==3.9.1 #TODO: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4645 - fix issue with aiohttp in a better way.
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-3.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-3.txt
@@ -3,7 +3,7 @@ aws-xray-sdk==2.12.1
 boto3==1.35.16
 botocore==1.35.16
 aiobotocore==2.15.0
-aiohttp<3.10.0
+aiohttp==3.9.3 #TODO: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4645 - fix issue with aiohttp in a better way.
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-3.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-3.txt
@@ -3,6 +3,7 @@ aws-xray-sdk==2.12.1
 boto3==1.35.16
 botocore==1.35.16
 aiobotocore==2.15.0
+aiohttp<3.10.0
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/tests/test_httpx_integration.py
@@ -99,7 +99,7 @@ def _response_hook(span, request: "RequestInfo", response: "ResponseInfo"):
     assert _is_url_tuple(request) or isinstance(request.url, httpx.URL)
     span.set_attribute(
         HTTP_RESPONSE_BODY,
-        b"".join(response[2]),
+        "".join([part.decode() for part in response[2]]),
     )
 
 
@@ -109,7 +109,7 @@ async def _async_response_hook(
     assert _is_url_tuple(request) or isinstance(request.url, httpx.URL)
     span.set_attribute(
         HTTP_RESPONSE_BODY,
-        b"".join([part async for part in response[2]]),
+        "".join([part.decode() async for part in response[2]]),
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
@@ -9,7 +9,7 @@ import threading
 import traceback
 from contextvars import ContextVar
 from time import time_ns
-from typing import Callable
+from typing import Callable, Mapping
 
 from opentelemetry._logs import (
     LoggerProvider,
@@ -132,7 +132,7 @@ class LoggingHandler(logging.Handler):
 
     def _get_attributes(
         self, record: logging.LogRecord
-    ) ->  Mapping[str, AnyValue]:
+    ) -> Mapping[str, AnyValue]:
         attributes = {
             k: v for k, v in vars(record).items() if k not in _RESERVED_ATTRS
         }

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
@@ -22,7 +22,7 @@ from opentelemetry._logs import (
 from opentelemetry.context import get_current
 from opentelemetry.semconv._incubating.attributes import code_attributes
 from opentelemetry.semconv.attributes import exception_attributes
-from opentelemetry.util.types import _ExtendedAttributes
+from opentelemetry.util.types import AnyValue
 
 _internal_logger = logging.getLogger(__name__ + ".internal")
 _internal_logger.propagate = False
@@ -132,7 +132,7 @@ class LoggingHandler(logging.Handler):
 
     def _get_attributes(
         self, record: logging.LogRecord
-    ) -> _ExtendedAttributes:
+    ) ->  Mapping[str, AnyValue]:
         attributes = {
             k: v for k, v in vars(record).items() if k not in _RESERVED_ATTRS
         }


### PR DESCRIPTION
# Description

This fixes the botocore tests broken at head by pinning test requirements (see https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4645 for details)

It also removes  `_ExtendedAttributes` import from the logging instrumentation so I can remove that private type (https://github.com/open-telemetry/opentelemetry-python/pull/5266).

Also decode HTTPX byte response to a string in it's unit tests to fix some unit tests that'll be broken by (https://github.com/open-telemetry/opentelemetry-python/pull/5266).


## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Does This PR Require a Core Repo Change?

- [x ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x ] Followed the style guidelines of this project
- [x ] Changelogs have been updated
- [x ] Unit tests have been added
- [x ] Documentation has been updated
