### PR TITLE
feat(instrumentation-anthropic): instrument AsyncMessages.create and AsyncMessages.stream

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/__init__.py
@@ -48,6 +48,8 @@ from opentelemetry.util.genai.handler import TelemetryHandler
 
 from .package import _instruments
 from .patch import (
+    async_messages_create,
+    async_messages_stream,
     messages_create,
     messages_stream,
 )
@@ -90,7 +92,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
             logger_provider=logger_provider,
         )
 
-        # Patch Messages.create and Messages.stream
+        # Patch sync Messages.create / Messages.stream
         wrap_function_wrapper(
             "anthropic.resources.messages",
             "Messages.create",
@@ -100,6 +102,17 @@ class AnthropicInstrumentor(BaseInstrumentor):
             "anthropic.resources.messages",
             "Messages.stream",
             messages_stream(handler),
+        )
+        # Patch async AsyncMessages.create / AsyncMessages.stream
+        wrap_function_wrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.create",
+            async_messages_create(handler),
+        )
+        wrap_function_wrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.stream",
+            async_messages_stream(handler),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
@@ -115,5 +128,13 @@ class AnthropicInstrumentor(BaseInstrumentor):
         )
         unwrap(
             anthropic.resources.messages.Messages,  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownArgumentType]
+            "stream",
+        )
+        unwrap(
+            anthropic.resources.messages.AsyncMessages,  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownArgumentType]
+            "create",
+        )
+        unwrap(
+            anthropic.resources.messages.AsyncMessages,  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownArgumentType]
             "stream",
         )

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/patch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Union, cast
 
+from anthropic._streaming import AsyncStream as AnthropicAsyncStream
 from anthropic._streaming import Stream as AnthropicStream
 from anthropic.types import Message as AnthropicMessage
 
@@ -25,6 +26,8 @@ from .messages_extractors import (
     get_system_instruction,
 )
 from .wrappers import (
+    AsyncMessagesStreamManagerWrapper,
+    AsyncMessagesStreamWrapper,
     MessagesStreamManagerWrapper,
     MessagesStreamWrapper,
     MessageWrapper,
@@ -32,9 +35,10 @@ from .wrappers import (
 
 if TYPE_CHECKING:
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
+        AsyncMessageStreamManager,
         MessageStreamManager,
     )
-    from anthropic.resources.messages import Messages
+    from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import RawMessageStreamEvent
 
 
@@ -152,4 +156,62 @@ def messages_stream(
 
     return cast(
         "Callable[..., MessagesStreamManagerWrapper[Any]]", traced_method
+    )
+
+
+def async_messages_create(
+    handler: TelemetryHandler,
+) -> Callable[..., Any]:
+    """Wrap the async ``create`` method of ``AsyncMessages`` to trace it."""
+    capture_content = handler.should_capture_content()
+
+    async def traced_method(
+        wrapped: Callable[..., Any],
+        instance: AsyncMessages,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        invocation = _create_invocation(
+            handler, instance, args, kwargs, capture_content
+        )
+        try:
+            result = await wrapped(*args, **kwargs)
+            if isinstance(result, AnthropicAsyncStream):
+                return AsyncMessagesStreamWrapper(
+                    result, invocation, capture_content
+                )
+
+            wrapper = MessageWrapper(result, capture_content)
+            wrapper.extract_into(invocation)
+            invocation.stop()
+            return wrapper.message
+        except Exception as exc:
+            invocation.fail(exc)
+            raise
+
+    return cast("Callable[..., Any]", traced_method)
+
+
+def async_messages_stream(
+    handler: TelemetryHandler,
+) -> Callable[..., AsyncMessagesStreamManagerWrapper[Any]]:
+    """Wrap the async ``stream`` method of ``AsyncMessages`` to trace it."""
+    capture_content = handler.should_capture_content()
+
+    def traced_method(
+        wrapped: Callable[..., AsyncMessageStreamManager],
+        instance: AsyncMessages,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> AsyncMessagesStreamManagerWrapper[Any]:
+        return AsyncMessagesStreamManagerWrapper(
+            wrapped(*args, **kwargs),
+            lambda: _create_invocation(
+                handler, instance, args, kwargs, capture_content
+            ),
+            capture_content,
+        )
+
+    return cast(
+        "Callable[..., AsyncMessagesStreamManagerWrapper[Any]]", traced_method
     )


### PR DESCRIPTION
## Description

Fixes #4497

`AnthropicInstrumentor` only patched the synchronous `Messages.create` and `Messages.stream` methods. `AsyncAnthropic` clients use `AsyncMessages`, so async calls produced **no spans** at all.

Add two new patch functions mirroring the sync variants:

- **`async_messages_create`** — `async def` wrapper that `await`s the wrapped call, detects `AsyncStream` responses and wraps them in the existing `AsyncMessagesStreamWrapper`
- **`async_messages_stream`** — wraps the async stream manager in the existing `AsyncMessagesStreamManagerWrapper`

Both are wired into `_instrument()` targeting `AsyncMessages.create` and `AsyncMessages.stream`, with matching `unwrap()` calls in `_uninstrument()`.

`AsyncMessagesStreamWrapper` and `AsyncMessagesStreamManagerWrapper` were already present in `wrappers.py` but unused — this PR connects them.

## Type of change

- [x] Bug fix / feature (adds missing async coverage)

## How Has This Been Tested?

Code review against existing sync wrapper structure and async wrapper infrastructure in `wrappers.py`. VCR-based tests for the async path would be a follow-up.

## Does This PR Require a Core Repo Change?

- [x] No.