### PR TITLE
fix(instrumentation-logging): prevent _uninstrument from corrupting log-record-factory chain

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/__init__.py
@@ -135,6 +135,7 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
     """
 
     _old_factory = None
+    _our_factory = None
     _log_hook = None
     _logging_handler = None
 
@@ -214,6 +215,7 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
 
             return record
 
+        LoggingInstrumentor._our_factory = record_factory
         logging.setLogRecordFactory(record_factory)
 
         # Here we need to handle 3 scenarios:
@@ -262,9 +264,22 @@ class LoggingInstrumentor(BaseInstrumentor):  # pylint: disable=empty-docstring
             LoggingInstrumentor._logging_handler = handler
 
     def _uninstrument(self, **kwargs):
-        if LoggingInstrumentor._old_factory:
-            logging.setLogRecordFactory(LoggingInstrumentor._old_factory)
-            LoggingInstrumentor._old_factory = None
+        if LoggingInstrumentor._our_factory is not None:
+            current = logging.getLogRecordFactory()
+            if current is LoggingInstrumentor._our_factory:
+                # We are still at the head of the factory chain — safe to
+                # restore the previous factory without dropping any other
+                # custom factories that may have been registered before us.
+                logging.setLogRecordFactory(LoggingInstrumentor._old_factory)
+            # If current is NOT our factory another library installed its own
+            # factory on top of ours after we instrumented.  Blindly restoring
+            # _old_factory would cut that library's factory out of the chain
+            # (the bug described in #3808).  In that case we leave the chain
+            # intact and accept that our factory remains in it; removing a
+            # node from the middle of the linked list is not safely possible
+            # without cooperation from the other factories.
+        LoggingInstrumentor._old_factory = None
+        LoggingInstrumentor._our_factory = None
 
         if LoggingInstrumentor._logging_handler:
             logging.getLogger().removeHandler(


### PR DESCRIPTION
## Description

Fixes #3808

`LoggingInstrumentor._uninstrument()` unconditionally restored `_old_factory` (the factory active before instrumentation), silently dropping any log-record factories installed by other libraries **after** OTel's factory was added.

Example:
```
Before uninstrument:  APP_FACTORY → OTEL_FACTORY → ORIGINAL
After old behaviour:  (APP_FACTORY orphaned)   ORIGINAL
```

**Fix:** store a reference to our own factory closure (`_our_factory`). In `_uninstrument`, compare the current factory against `_our_factory` by identity. Only restore `_old_factory` when we are still at the head of the chain. If another factory was installed on top of ours, skip the restore — our factory remains in the chain, but no data is lost.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Logic reviewed against the described failure scenario. Existing test suite passes.

## Does This PR Require a Core Repo Change?

- [x] No.