### PR TITLE
fix(instrumentation-pika): update span attributes to current messaging semconv

### DIFF
--- a/.changelog/4654.fixed
+++ b/.changelog/4654.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-pika`: use current messaging semantic conventions

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -15,13 +15,21 @@ from wrapt import ObjectProxy
 from opentelemetry import context, propagate, trace
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.propagators.textmap import CarrierT, Getter
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_DESTINATION_TEMPORARY,
+    MESSAGING_MESSAGE_CONVERSATION_ID,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+    MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
 )
-from opentelemetry.semconv.trace import (
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.trace.span import Span
@@ -77,7 +85,9 @@ def _decorate_callback(
             ),
             span_kind=SpanKind.CONSUMER,
             task_name=task_name,
-            operation=MessagingOperationValues.RECEIVE,
+            operation=MessagingOperationTypeValues.RECEIVE,
+            routing_key=method.routing_key,
+            delivery_tag=method.delivery_tag,
         )
         try:
             with trace.use_span(span, end_on_exit=True):
@@ -119,6 +129,7 @@ def _decorate_basic_publish(
             span_kind=SpanKind.PRODUCER,
             task_name="(temporary)",
             operation=None,
+            routing_key=routing_key,
         )
         if not span:
             return original_function(
@@ -145,7 +156,9 @@ def _get_span(
     task_name: str,
     destination: str,
     span_kind: SpanKind,
-    operation: Optional[MessagingOperationValues] = None,
+    operation: Optional[MessagingOperationTypeValues] = None,
+    routing_key: Optional[str] = None,
+    delivery_tag: Optional[int] = None,
 ) -> Optional[Span]:
     if not is_instrumentation_enabled():
         return None
@@ -155,12 +168,20 @@ def _get_span(
         kind=span_kind,
     )
     if span.is_recording():
-        _enrich_span(span, channel, properties, destination, operation)
+        _enrich_span(
+            span,
+            channel,
+            properties,
+            destination,
+            operation,
+            routing_key,
+            delivery_tag,
+        )
     return span
 
 
 def _generate_span_name(
-    task_name: str, operation: Optional[MessagingOperationValues]
+    task_name: str, operation: Optional[MessagingOperationTypeValues]
 ) -> str:
     if not operation:
         return f"{task_name} send"
@@ -172,30 +193,40 @@ def _enrich_span(
     channel: Optional[Channel],
     properties: BasicProperties,
     task_destination: str,
-    operation: Optional[MessagingOperationValues] = None,
+    operation: Optional[MessagingOperationTypeValues] = None,
+    routing_key: Optional[str] = None,
+    delivery_tag: Optional[int] = None,
 ) -> None:
-    span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "rabbitmq")
+    span.set_attribute(MESSAGING_SYSTEM, MessagingSystemValues.RABBITMQ.value)
     if operation:
-        span.set_attribute(SpanAttributes.MESSAGING_OPERATION, operation.value)
+        span.set_attribute(MESSAGING_OPERATION_TYPE, operation.value)
     else:
-        span.set_attribute(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)
-    span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, task_destination)
-    if properties.message_id:
+        span.set_attribute(MESSAGING_DESTINATION_TEMPORARY, True)
+    span.set_attribute(MESSAGING_DESTINATION_NAME, task_destination)
+    if routing_key:
         span.set_attribute(
-            SpanAttributes.MESSAGING_MESSAGE_ID, properties.message_id
+            MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routing_key
         )
+    if properties.message_id:
+        span.set_attribute(MESSAGING_MESSAGE_ID, properties.message_id)
     if properties.correlation_id:
         span.set_attribute(
-            SpanAttributes.MESSAGING_CONVERSATION_ID, properties.correlation_id
+            MESSAGING_MESSAGE_CONVERSATION_ID, properties.correlation_id
+        )
+    if delivery_tag is not None:
+        span.set_attribute(
+            MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, delivery_tag
         )
     if not channel:
         return
     if not hasattr(channel.connection, "params"):
-        span.set_attribute(NET_PEER_NAME, channel.connection._impl.params.host)
-        span.set_attribute(NET_PEER_PORT, channel.connection._impl.params.port)
+        span.set_attribute(
+            SERVER_ADDRESS, channel.connection._impl.params.host
+        )
+        span.set_attribute(SERVER_PORT, channel.connection._impl.params.port)
     else:
-        span.set_attribute(NET_PEER_NAME, channel.connection.params.host)
-        span.set_attribute(NET_PEER_PORT, channel.connection.params.port)
+        span.set_attribute(SERVER_ADDRESS, channel.connection.params.host)
+        span.set_attribute(SERVER_PORT, channel.connection.params.port)
 
 
 # pylint:disable=abstract-method
@@ -249,7 +280,9 @@ class ReadyMessagesDequeProxy(ObjectProxy):
                     ),
                     span_kind=SpanKind.CONSUMER,
                     task_name=self._self_queue_consumer_generator.consumer_tag,
-                    operation=MessagingOperationValues.RECEIVE,
+                    operation=MessagingOperationTypeValues.RECEIVE,
+                    routing_key=method.routing_key,
+                    delivery_tag=method.delivery_tag,
                 )
                 try:
                     if message_ctx_token:

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
@@ -12,13 +12,21 @@ from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
 
 from opentelemetry.instrumentation.pika import utils
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_DESTINATION_TEMPORARY,
+    MESSAGING_MESSAGE_CONVERSATION_ID,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+    MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
 )
-from opentelemetry.semconv.trace import (
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.trace import Span, SpanKind, Tracer
 
@@ -52,6 +60,8 @@ class TestUtils(TestCase):
             channel,
             properties,
             destination,
+            None,
+            None,
             None,
         )
 
@@ -101,26 +111,18 @@ class TestUtils(TestCase):
         span.set_attribute.assert_has_calls(
             any_order=True,
             calls=[
-                mock.call(SpanAttributes.MESSAGING_SYSTEM, "rabbitmq"),
-                mock.call(SpanAttributes.MESSAGING_TEMP_DESTINATION, True),
                 mock.call(
-                    SpanAttributes.MESSAGING_DESTINATION, task_destination
+                    MESSAGING_SYSTEM, MessagingSystemValues.RABBITMQ.value
                 ),
+                mock.call(MESSAGING_DESTINATION_TEMPORARY, True),
+                mock.call(MESSAGING_DESTINATION_NAME, task_destination),
+                mock.call(MESSAGING_MESSAGE_ID, properties.message_id),
                 mock.call(
-                    SpanAttributes.MESSAGING_MESSAGE_ID, properties.message_id
-                ),
-                mock.call(
-                    SpanAttributes.MESSAGING_CONVERSATION_ID,
+                    MESSAGING_MESSAGE_CONVERSATION_ID,
                     properties.correlation_id,
                 ),
-                mock.call(
-                    NET_PEER_NAME,
-                    channel.connection.params.host,
-                ),
-                mock.call(
-                    NET_PEER_PORT,
-                    channel.connection.params.port,
-                ),
+                mock.call(SERVER_ADDRESS, channel.connection.params.host),
+                mock.call(SERVER_PORT, channel.connection.params.port),
             ],
         )
 
@@ -136,9 +138,7 @@ class TestUtils(TestCase):
         )
         span.set_attribute.assert_has_calls(
             any_order=True,
-            calls=[
-                mock.call(SpanAttributes.MESSAGING_OPERATION, operation.value)
-            ],
+            calls=[mock.call(MESSAGING_OPERATION_TYPE, operation.value)],
         )
 
     @staticmethod
@@ -150,7 +150,43 @@ class TestUtils(TestCase):
         utils._enrich_span(span, channel, properties, task_destination)
         span.set_attribute.assert_has_calls(
             any_order=True,
-            calls=[mock.call(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)],
+            calls=[mock.call(MESSAGING_DESTINATION_TEMPORARY, True)],
+        )
+
+    @staticmethod
+    def test_enrich_span_with_routing_key() -> None:
+        channel = mock.MagicMock()
+        properties = mock.MagicMock()
+        task_destination = "test.test"
+        routing_key = "my-routing-key"
+        span = mock.MagicMock(spec=Span)
+        utils._enrich_span(
+            span,
+            channel,
+            properties,
+            task_destination,
+            routing_key=routing_key,
+        )
+        span.set_attribute.assert_any_call(
+            MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routing_key
+        )
+
+    @staticmethod
+    def test_enrich_span_with_delivery_tag() -> None:
+        channel = mock.MagicMock()
+        properties = mock.MagicMock()
+        task_destination = "test.test"
+        delivery_tag = 42
+        span = mock.MagicMock(spec=Span)
+        utils._enrich_span(
+            span,
+            channel,
+            properties,
+            task_destination,
+            delivery_tag=delivery_tag,
+        )
+        span.set_attribute.assert_any_call(
+            MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, delivery_tag
         )
 
     @staticmethod
@@ -166,13 +202,9 @@ class TestUtils(TestCase):
             any_order=True,
             calls=[
                 mock.call(
-                    NET_PEER_NAME,
-                    channel.connection._impl.params.host,
+                    SERVER_ADDRESS, channel.connection._impl.params.host
                 ),
-                mock.call(
-                    NET_PEER_PORT,
-                    channel.connection._impl.params.port,
-                ),
+                mock.call(SERVER_PORT, channel.connection._impl.params.port),
             ],
         )
 
@@ -191,6 +223,8 @@ class TestUtils(TestCase):
         channel = mock.MagicMock(spec=Channel)
         method = mock.MagicMock(spec=Basic.Deliver)
         method.exchange = "test_exchange"
+        method.routing_key = "test-routing-key"
+        method.delivery_tag = 1
         properties = mock.MagicMock()
         mock_body = b"mock_body"
         decorated_callback = utils._decorate_callback(
@@ -207,7 +241,9 @@ class TestUtils(TestCase):
             destination=method.exchange,
             span_kind=SpanKind.CONSUMER,
             task_name=mock_task_name,
-            operation=MessagingOperationValues.RECEIVE,
+            operation=MessagingOperationTypeValues.RECEIVE,
+            routing_key=method.routing_key,
+            delivery_tag=method.delivery_tag,
         )
         use_span.assert_called_once_with(
             get_span.return_value, end_on_exit=True
@@ -232,6 +268,8 @@ class TestUtils(TestCase):
         channel = mock.MagicMock(spec=Channel)
         method = mock.MagicMock(spec=Basic.Deliver)
         method.exchange = "test_exchange"
+        method.routing_key = "test-routing-key"
+        method.delivery_tag = 1
         properties = mock.MagicMock()
         mock_body = b"mock_body"
         consume_hook = mock.MagicMock()
@@ -250,7 +288,9 @@ class TestUtils(TestCase):
             destination=method.exchange,
             span_kind=SpanKind.CONSUMER,
             task_name=mock_task_name,
-            operation=MessagingOperationValues.RECEIVE,
+            operation=MessagingOperationTypeValues.RECEIVE,
+            routing_key=method.routing_key,
+            delivery_tag=method.delivery_tag,
         )
         use_span.assert_called_once_with(
             get_span.return_value, end_on_exit=True
@@ -293,6 +333,7 @@ class TestUtils(TestCase):
             span_kind=SpanKind.PRODUCER,
             task_name="(temporary)",
             operation=None,
+            routing_key=routing_key,
         )
         use_span.assert_called_once_with(
             get_span.return_value, end_on_exit=True
@@ -358,6 +399,7 @@ class TestUtils(TestCase):
             span_kind=SpanKind.PRODUCER,
             task_name="(temporary)",
             operation=None,
+            routing_key=routing_key,
         )
 
     @mock.patch("opentelemetry.instrumentation.pika.utils._get_span")
@@ -392,6 +434,7 @@ class TestUtils(TestCase):
             span_kind=SpanKind.PRODUCER,
             task_name="(temporary)",
             operation=None,
+            routing_key=routing_key,
         )
         use_span.assert_called_once_with(
             get_span.return_value, end_on_exit=True
@@ -441,6 +484,7 @@ class TestUtils(TestCase):
             span_kind=SpanKind.PRODUCER,
             task_name="(temporary)",
             operation=None,
+            routing_key=routing_key,
         )
         use_span.assert_called_once_with(
             get_span.return_value, end_on_exit=True
@@ -479,6 +523,8 @@ class TestUtils(TestCase):
         )
         method = mock.MagicMock(spec=Basic.Deliver)
         method.exchange = "test_exchange"
+        method.routing_key = "test-routing-key"
+        method.delivery_tag = 1
         properties = mock.MagicMock()
         evt = _ConsumerDeliveryEvt(method, properties, b"mock_body")
         generator_info.pending_events.popleft.return_value = evt
@@ -503,7 +549,9 @@ class TestUtils(TestCase):
             destination=method.exchange,
             span_kind=SpanKind.CONSUMER,
             task_name=generator_info.consumer_tag,
-            operation=MessagingOperationValues.RECEIVE,
+            operation=MessagingOperationTypeValues.RECEIVE,
+            routing_key=method.routing_key,
+            delivery_tag=method.delivery_tag,
         )
         consume_hook.assert_called_once()
         returned_span.end.assert_called_once()
@@ -534,7 +582,9 @@ class TestUtils(TestCase):
             destination=method.exchange,
             span_kind=SpanKind.CONSUMER,
             task_name=generator_info.consumer_tag,
-            operation=MessagingOperationValues.RECEIVE,
+            operation=MessagingOperationTypeValues.RECEIVE,
+            routing_key=method.routing_key,
+            delivery_tag=method.delivery_tag,
         )
         consume_hook.assert_called_once()
         returned_span.end.assert_called_once()


### PR DESCRIPTION
# Description

Updates the pika instrumentation to use the current OpenTelemetry messaging semantic conventions, replacing deprecated constants throughout `utils.py`.

Fixes #1643

## Attribute mapping

| Old (deprecated) | New |
|---|---|
| `SpanAttributes.MESSAGING_SYSTEM` | `MESSAGING_SYSTEM` (messaging_attributes) |
| `SpanAttributes.MESSAGING_OPERATION` (`messaging.operation`) | `MESSAGING_OPERATION_TYPE` (`messaging.operation.type`) |
| `SpanAttributes.MESSAGING_TEMP_DESTINATION` | `MESSAGING_DESTINATION_TEMPORARY` |
| `SpanAttributes.MESSAGING_DESTINATION` | `MESSAGING_DESTINATION_NAME` |
| `SpanAttributes.MESSAGING_MESSAGE_ID` | `MESSAGING_MESSAGE_ID` |
| `SpanAttributes.MESSAGING_CONVERSATION_ID` | `MESSAGING_MESSAGE_CONVERSATION_ID` |
| `NET_PEER_NAME` (`net.peer.name`) | `SERVER_ADDRESS` (`server.address`) |
| `NET_PEER_PORT` (`net.peer.port`) | `SERVER_PORT` (`server.port`) |
| `MessagingOperationValues.RECEIVE` | `MessagingOperationTypeValues.RECEIVE` |

Also adds two RabbitMQ-specific attributes that were missing:
- `messaging.rabbitmq.destination.routing_key` — set on both producer and consumer spans when a routing key is present
- `messaging.rabbitmq.message.delivery_tag` — set on consumer spans from `method.delivery_tag`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- All 19 existing unit tests in `tests/test_utils.py` updated to assert the new attribute names and values; all pass.
- Two new tests added: `test_enrich_span_with_routing_key` and `test_enrich_span_with_delivery_tag`.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated