### PR TITLE
docs(aws): document EKS resource detector prerequisites

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/README.rst
@@ -74,6 +74,64 @@ populate `resource` attributes by creating a `TraceProvider` using the `AwsEc2Re
 Refer to each detectors' docstring to determine any possible requirements for that
 detector.
 
+AWS EKS resource detector prerequisites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``AwsEksResourceDetector`` is intended to run inside an EKS workload. It
+checks the mounted Kubernetes service account token to confirm that the workload
+is running on EKS, then reads the ``cluster-info`` ConfigMap from the
+``amazon-cloudwatch`` namespace to populate ``k8s.cluster.name``.
+
+Make sure the workload has a mounted service account token and CA certificate.
+For example, do not disable ``automountServiceAccountToken`` for the Pod or its
+service account.
+
+The detector needs read access to the ``cluster-info`` ConfigMap:
+
+.. code-block:: yaml
+
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: otel-awseksresourcedetector
+      namespace: amazon-cloudwatch
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        resourceNames:
+          - cluster-info
+        verbs:
+          - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: otel-awseksresourcedetector
+      namespace: amazon-cloudwatch
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: otel-awseksresourcedetector
+    subjects:
+      - kind: ServiceAccount
+        name: your-service-account
+        namespace: your-application-namespace
+
+The ConfigMap must exist in the ``amazon-cloudwatch`` namespace. The detector
+uses ``data.cluster.name``:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cluster-info
+      namespace: amazon-cloudwatch
+    data:
+      cluster.name: your-cluster-name
+
 
 Usage (AWS X-Ray Remote Sampler)
 --------------------------------


### PR DESCRIPTION
# Description

Fixes #1384.

## Summary

Adds AWS EKS resource detector prerequisite documentation to the AWS SDK extension README.

## Reproduction

Users currently need to inspect `AwsEksResourceDetector` source to learn that it uses the mounted Kubernetes service account token and reads the `cluster-info` ConfigMap in the `amazon-cloudwatch` namespace.

## Root cause

The README described AWS resource detectors generically but did not document the EKS detector's Kubernetes token, CA, RBAC, or ConfigMap requirements.

## Changes

- Documents the mounted service account token/CA requirement.
- Adds minimal RBAC for reading the `amazon-cloudwatch/cluster-info` ConfigMap.
- Shows the required `cluster-info` ConfigMap field used by the detector.

## Tests

- `git diff --check`
- `/tmp/otel-rstcheck-venv/bin/rstcheck sdk-extension/opentelemetry-sdk-extension-aws/README.rst`

## Screenshots/Logs

Not applicable; docs-only change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not applicable; docs-only README change)
- [ ] Unit tests have been added (not applicable; docs-only README change)
- [x] Documentation has been updated