### PR TITLE
docs(dbapi): fix pyodbc connect method example

### DIFF
--- a/.changelog/4657.fixed
+++ b/.changelog/4657.fixed
@@ -1,1 +1,1 @@
-Fix pyodbc DB-API instrumentation examples to wrap `connect`.
+`opentelemetry-instrumentation-dbapi`: Fix pyodbc DB-API instrumentation examples to wrap `connect`.

--- a/.changelog/4657.fixed
+++ b/.changelog/4657.fixed
@@ -1,0 +1,1 @@
+Fix pyodbc DB-API instrumentation examples to wrap `connect`.

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -35,11 +35,11 @@ be used directly as follows.
     # Example: mysql.connector
     trace_integration(mysql.connector, "connect", "mysql")
     # Example: pyodbc
-    trace_integration(pyodbc, "Connection", "odbc")
+    trace_integration(pyodbc, "connect", "odbc")
 
     # Or, directly call wrap_connect for more configurability.
     wrap_connect(__name__, mysql.connector, "connect", "mysql")
-    wrap_connect(__name__, pyodbc, "Connection", "odbc")
+    wrap_connect(__name__, pyodbc, "connect", "odbc")
 
 
 Configuration


### PR DESCRIPTION
# Description

Fixes #707.

## Summary

Updates the DBAPI documentation example for pyodbc to wrap the module-level `connect` function instead of `Connection`.

## Reproduction

The issue report shows `trace_integration(pyodbc, "Connection", "odbc")` does not produce DB spans for pyodbc, while changing the connect method name to `"connect"` makes instrumentation work.

## Root cause

The documented pyodbc example uses the wrong connect method name. `trace_integration` and `wrap_connect` both expect the DBAPI module function used to create connections.

## Changes

- Changes the pyodbc `trace_integration` example from `"Connection"` to `"connect"`.
- Changes the pyodbc `wrap_connect` example from `"Connection"` to `"connect"`.

## Tests

- `git diff --check`
- `/tmp/otel-rstcheck-venv/bin/rstcheck docs/instrumentation/dbapi/dbapi.rst`
- `python3 -m compileall -q instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py`

## Screenshots/Logs

Not applicable; docs-only change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not applicable; docs-only example change)
- [ ] Unit tests have been added (not applicable; docs-only example change)
- [x] Documentation has been updated