### PR TITLE
tornado: make metrics tests less flaky on pypy

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -3,6 +3,7 @@
 
 
 import asyncio
+import platform
 from timeit import default_timer
 from unittest.mock import patch
 
@@ -238,13 +239,20 @@ class TestTornadoMetricsInstrumentation(TornadoTest):
         )
 
         # Server and client durations should be similar (adjusting for msecs vs secs)
+
+        # Give bigger delta for PyPy coarse timers
+        def metrics_delta(delta):
+            return (
+                0.05 if platform.python_implementation() == "PyPy" else delta
+            )
+
         self.assertAlmostEqual(
             abs(
                 req1_server_duration_data_point.sum / 1000.0
                 - req1_client_duration_data_point.sum
             ),
             0.0,
-            delta=0.01,
+            delta=metrics_delta(0.01),
         )
         self.assertAlmostEqual(
             abs(
@@ -252,20 +260,20 @@ class TestTornadoMetricsInstrumentation(TornadoTest):
                 - req2_client_duration_data_point.sum
             ),
             0.0,
-            delta=0.02,
+            delta=metrics_delta(0.02),
         )
 
         # Make sure duration is roughly equivalent to expected (req1/slow) should be around 1 second
         self.assertAlmostEqual(
             req1_server_duration_data_point.sum / 1000.0,
             1.0,
-            delta=0.1,
+            delta=metrics_delta(0.1),
             msg="Should have been about 1 second",
         )
         self.assertAlmostEqual(
             req2_server_duration_data_point.sum / 1000.0,
             0.0,
-            delta=0.1,
+            delta=metrics_delta(0.1),
             msg="Should have been really short",
         )
 


### PR DESCRIPTION
# Description

Give more room to PyPy when asserting metrics timings values to take into account its coarser timers.

Fixes #4664
Closes #4660

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
