### PR TITLE
tornado: reduce cardinality with old semconv metrics attributes

### DIFF
--- a/.changelog/4666.fixed
+++ b/.changelog/4666.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-tornado`: reduce cardinality of `http.target` metrics attribute with old semantic conventions

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -929,8 +929,7 @@ def _create_active_requests_attributes_old(handler):
         HTTP_HOST: request.host,
     }
 
-    rule = find_matched_rule(handler)
-    if rule:
+    if rule := find_matched_rule(handler):
         route = route_from_rule(rule, handler)
 
         if route is not None:

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -838,7 +838,7 @@ def _record_prepare_metrics(server_histograms, handler, sem_conv_opt_in_mode):
             request_size, attributes=metric_attributes_old
         )
         active_requests_attributes_old = (
-            _create_active_requests_attributes_old(handler.request)
+            _create_active_requests_attributes_old(handler)
         )
         server_histograms["active_requests"].add(
             1, attributes=active_requests_attributes_old
@@ -890,7 +890,7 @@ def _record_on_finish_metrics(
         )
 
         active_requests_attributes_old = (
-            _create_active_requests_attributes_old(handler.request)
+            _create_active_requests_attributes_old(handler)
         )
         server_histograms["active_requests"].add(
             -1, attributes=active_requests_attributes_old
@@ -919,15 +919,22 @@ def _record_on_finish_metrics(
             )
 
 
-def _create_active_requests_attributes_old(request):
+def _create_active_requests_attributes_old(handler):
     """Create metric attributes for active requests using old semconv."""
+    request = handler.request
     metric_attributes = {
         HTTP_METHOD: request.method,
         HTTP_SCHEME: request.protocol,
         HTTP_FLAVOR: request.version,
         HTTP_HOST: request.host,
     }
-    metric_attributes[HTTP_TARGET] = request.path
+
+    rule = find_matched_rule(handler)
+    if rule:
+        route = route_from_rule(rule, handler)
+
+        if route is not None:
+            metric_attributes[HTTP_TARGET] = route
     return metric_attributes
 
 
@@ -944,7 +951,7 @@ def _create_active_requests_attributes_new(request):
 
 def _create_metric_attributes_old(handler):
     """Create metric attributes using old semconv."""
-    metric_attributes = _create_active_requests_attributes_old(handler.request)
+    metric_attributes = _create_active_requests_attributes_old(handler)
     metric_attributes[HTTP_STATUS_CODE] = handler.get_status()
     return metric_attributes
 

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -373,8 +373,8 @@ class TestTornadoSemconvDefault(TornadoSemconvTestBase):
 
     def test_server_metrics_old_semconv(self):
         """Test that server metrics use old semantic conventions by default."""
-        response = self.fetch("/")
-        self.assertEqual(response.code, 201)
+        response = self.fetch("/parametrized/hello/?foo=bar")
+        self.assertEqual(response.code, 200)
         metrics = self.get_sorted_metrics(SCOPE)
 
         # Find old semconv metrics
@@ -390,6 +390,15 @@ class TestTornadoSemconvDefault(TornadoSemconvTestBase):
                 self.assertEqual(metric.unit, "ms")
             elif metric.name == "http.server.request.duration":
                 new_duration_found = True
+
+            for data_point in metric.data.data_points:
+                attributes = dict(data_point.attributes)
+
+                self.assertIn(HTTP_TARGET, attributes)
+                self.assertEqual(
+                    attributes[HTTP_TARGET], "/parametrized/{message}/"
+                )
+
         self.assertTrue(old_duration_found, "Old semconv metric not found")
         self.assertFalse(
             new_duration_found, "New semconv metric should not be present"


### PR DESCRIPTION
# Description

Reduce the `http.target` cardinality in metrics when the old semantic conventions are configured.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
