### PR TITLE
opentelemetry-instrumentation-pyramid: avoid duplicate traversal subscribers

### DIFF
--- a/.changelog/4663.fixed
+++ b/.changelog/4663.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-pyramid`: avoid duplicate traversal subscribers

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -44,6 +44,9 @@ from opentelemetry.util.http import get_excluded_urls, redact_url
 
 TWEEN_NAME = "opentelemetry.instrumentation.pyramid.trace_tween_factory"
 SETTING_TRACE_ENABLED = "opentelemetry-pyramid.trace_enabled"
+_SETTING_BEFORE_TRAVERSAL_SUBSCRIBER_REGISTERED = (
+    "opentelemetry-pyramid.before_traversal_subscriber_registered"
+)
 
 _ENVIRON_STARTTIME_KEY = "opentelemetry-pyramid.starttime_key"
 _ENVIRON_SPAN_KEY = "opentelemetry-pyramid.span_key"
@@ -61,7 +64,10 @@ _sem_conv_opt_in_mode = _StabilityMode.DEFAULT
 def includeme(config):
     config.add_settings({SETTING_TRACE_ENABLED: True})
 
-    config.add_subscriber(_before_traversal, BeforeTraversal)
+    settings = config.get_settings()
+    if not settings.get(_SETTING_BEFORE_TRAVERSAL_SUBSCRIBER_REGISTERED):
+        settings[_SETTING_BEFORE_TRAVERSAL_SUBSCRIBER_REGISTERED] = True
+        config.add_subscriber(_before_traversal, BeforeTraversal)
     _insert_tween(config)
 
 

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from timeit import default_timer
+from unittest import TestCase
 from unittest.mock import patch
 
 from pyramid.config import Configurator
+from pyramid.config.adapters import AdaptersConfiguratorMixin
 
 from opentelemetry import trace
 from opentelemetry.instrumentation._semconv import (
@@ -15,6 +17,7 @@ from opentelemetry.instrumentation._semconv import (
     _StabilityMode,
 )
 from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+from opentelemetry.instrumentation.pyramid.callbacks import _before_traversal
 from opentelemetry.sdk.metrics.export import (
     HistogramDataPoint,
     NumberDataPoint,
@@ -82,6 +85,41 @@ _recommended_attrs = {
 }
 
 SCOPE = "opentelemetry.instrumentation.pyramid.callbacks"
+
+
+class TestAutomaticConfiguration(TestCase):
+    def tearDown(self):
+        PyramidInstrumentor().uninstrument()
+
+    def test_before_traversal_subscriber_registered_once_after_commit(self):
+        registrations = []
+        original_add_subscriber = AdaptersConfiguratorMixin.add_subscriber
+
+        def counting_add_subscriber(self, subscriber, iface=None, **kwargs):
+            if subscriber is _before_traversal:
+                registrations.append(subscriber)
+            return original_add_subscriber(
+                self, subscriber, iface=iface, **kwargs
+            )
+
+        def library_that_commits(config):
+            config.add_route("example", "/example")
+            config.commit()
+
+        def another_library(config):
+            pass
+
+        with patch.object(
+            AdaptersConfiguratorMixin,
+            "add_subscriber",
+            counting_add_subscriber,
+        ):
+            PyramidInstrumentor().instrument()
+            config = Configurator(settings={})
+            config.include(library_that_commits)
+            config.include(another_library)
+
+        self.assertEqual(len(registrations), 1)
 
 
 class TestAutomatic(InstrumentationTest, WsgiTestBase):


### PR DESCRIPTION
# Description

Fixes #4663.

## Summary

Prevent `opentelemetry-instrumentation-pyramid` from registering duplicate `BeforeTraversal` subscribers when Pyramid configuration includes run after `config.commit()`.

## Reproduction

A Pyramid include can call `config.commit()`, which resets Pyramid action state. A later `config.include(...)` creates another configurator and can run the OpenTelemetry callbacks include again. The new regression test simulates that flow and counts `_before_traversal` subscriber registrations.

## Root cause

The instrumentation relied on Pyramid include de-duplication to avoid re-running `callbacks.includeme`. After `config.commit()` resets action state, that de-duplication can no longer prevent the callbacks include from registering `_before_traversal` again for the same registry.

## Changes

- Add a registry settings sentinel so `callbacks.includeme` only registers the `BeforeTraversal` subscriber once.
- Keep `SETTING_TRACE_ENABLED` and tween insertion behavior on each include path.
- Add a regression test for an include that calls `config.commit()` before a later include.
- Add a changelog fragment.

## Tests

- [x] `/Users/liumin/Documents/OpenSourceContributions/opentelemetry-python-contrib-pika-consumer-wrap/.venv-tox/bin/tox -e py314-test-instrumentation-pyramid`
- [x] `/Users/liumin/Documents/OpenSourceContributions/opentelemetry-python-contrib-pika-consumer-wrap/.venv-tox/bin/tox -e lint-instrumentation-pyramid`
- [x] `.tox/lint-instrumentation-pyramid/bin/ruff check instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py`
- [x] `.tox/lint-instrumentation-pyramid/bin/ruff format --check instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py`
- [x] `git diff --check`

## Screenshots/Logs

N/A. This is a unit-level instrumentation fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
