### PR TITLE
fix(pymongo): support database semconv migration

### DIFF
--- a/.changelog/4682.fixed
+++ b/.changelog/4682.fixed
@@ -1,0 +1,1 @@
+Add database semantic convention migration support to PyMongo instrumentation.

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -68,6 +68,15 @@ from typing import Any, Callable, Collection, TypeVar
 
 from pymongo import monitoring
 
+from opentelemetry.instrumentation._semconv import (
+    _get_schema_url_for_signal_types,
+    _OpenTelemetrySemanticConventionStability,
+    _OpenTelemetryStabilitySignalType,
+    _set_db_name,
+    _set_db_statement,
+    _set_db_system,
+    _StabilityMode,
+)
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.pymongo.package import _instruments
 from opentelemetry.instrumentation.pymongo.utils import (
@@ -77,9 +86,6 @@ from opentelemetry.instrumentation.pymongo.version import __version__
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_MONGODB_COLLECTION,
-    DB_NAME,
-    DB_STATEMENT,
-    DB_SYSTEM,
 )
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
@@ -115,6 +121,7 @@ class CommandTracer(monitoring.CommandListener):
         response_hook: ResponseHookT = dummy_callback,
         failed_hook: FailedHookT = dummy_callback,
         capture_statement: bool = False,
+        sem_conv_opt_in_mode_db: _StabilityMode | None = None,
     ):
         self._tracer = tracer
         self._span_dict = {}
@@ -123,6 +130,12 @@ class CommandTracer(monitoring.CommandListener):
         self.success_hook = response_hook
         self.failed_hook = failed_hook
         self.capture_statement = capture_statement
+        if sem_conv_opt_in_mode_db is None:
+            _OpenTelemetrySemanticConventionStability._initialize()
+            sem_conv_opt_in_mode_db = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+                _OpenTelemetryStabilitySignalType.DATABASE
+            )
+        self._sem_conv_opt_in_mode_db = sem_conv_opt_in_mode_db
 
     def started(self, event: monitoring.CommandStartedEvent):
         """Method to handle a pymongo CommandStartedEvent"""
@@ -133,17 +146,32 @@ class CommandTracer(monitoring.CommandListener):
         statement = self._get_statement_by_command_name(command_name, event)
         collection = _get_command_collection_name(event)
 
+        span = None
         try:
             span = self._tracer.start_span(span_name, kind=SpanKind.CLIENT)
             if span.is_recording():
-                span.set_attribute(DB_SYSTEM, DbSystemValues.MONGODB.value)
-                span.set_attribute(DB_NAME, event.database_name)
-                span.set_attribute(DB_STATEMENT, statement)
+                span_attrs: dict[str, Any] = {}
+                _set_db_system(
+                    span_attrs,
+                    DbSystemValues.MONGODB.value,
+                    self._sem_conv_opt_in_mode_db,
+                )
+                _set_db_name(
+                    span_attrs,
+                    event.database_name,
+                    self._sem_conv_opt_in_mode_db,
+                )
+                _set_db_statement(
+                    span_attrs,
+                    statement,
+                    self._sem_conv_opt_in_mode_db,
+                )
                 if collection:
-                    span.set_attribute(DB_MONGODB_COLLECTION, collection)
+                    span_attrs[DB_MONGODB_COLLECTION] = collection
                 if event.connection_id is not None:
-                    span.set_attribute(NET_PEER_NAME, event.connection_id[0])
-                    span.set_attribute(NET_PEER_PORT, event.connection_id[1])
+                    span_attrs[NET_PEER_NAME] = event.connection_id[0]
+                    span_attrs[NET_PEER_PORT] = event.connection_id[1]
+                span.set_attributes(span_attrs)
             try:
                 self.start_hook(span, event)
             except (
@@ -254,11 +282,17 @@ class PymongoInstrumentor(BaseInstrumentor):
         capture_statement = kwargs.get("capture_statement")
         # Create and register a CommandTracer only the first time
         if self._commandtracer_instance is None:
+            _OpenTelemetrySemanticConventionStability._initialize()
+            sem_conv_opt_in_mode_db = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+                _OpenTelemetryStabilitySignalType.DATABASE
+            )
             tracer = get_tracer(
                 __name__,
                 __version__,
                 tracer_provider,
-                schema_url="https://opentelemetry.io/schemas/1.11.0",
+                schema_url=_get_schema_url_for_signal_types(
+                    [_OpenTelemetryStabilitySignalType.DATABASE]
+                ),
             )
 
             self._commandtracer_instance = CommandTracer(
@@ -267,6 +301,7 @@ class PymongoInstrumentor(BaseInstrumentor):
                 response_hook=response_hook,
                 failed_hook=failed_hook,
                 capture_statement=capture_statement,
+                sem_conv_opt_in_mode_db=sem_conv_opt_in_mode_db,
             )
             monitoring.register(self._commandtracer_instance)
         # If already created, just enable it

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -1,9 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=protected-access
+
 from unittest import mock
 
 from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
 from opentelemetry.instrumentation.pymongo import (
     CommandTracer,
     PymongoInstrumentor,
@@ -19,16 +25,32 @@ from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
 )
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+)
 from opentelemetry.test.test_base import TestBase
 
 
 class TestPymongo(TestBase):
     def setUp(self):
         super().setUp()
+        with self.disable_logging():
+            PymongoInstrumentor().uninstrument()
+        PymongoInstrumentor()._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
         self.tracer = self.tracer_provider.get_tracer(__name__)
         self.start_callback = mock.MagicMock()
         self.success_callback = mock.MagicMock()
         self.failed_callback = mock.MagicMock()
+
+    def tearDown(self):
+        with self.disable_logging():
+            PymongoInstrumentor().uninstrument()
+        PymongoInstrumentor()._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
+        super().tearDown()
 
     def test_pymongo_instrumentor(self):
         mock_register = mock.Mock()
@@ -62,6 +84,74 @@ class TestPymongo(TestBase):
         self.assertEqual(span.attributes[NET_PEER_NAME], "test.com")
         self.assertEqual(span.attributes[NET_PEER_PORT], "1234")
         self.start_callback.assert_called_once_with(span, mock_event)
+
+    def test_started_new_database_semconv(self):
+        command_attrs = {
+            "command_name": "find",
+        }
+        with mock.patch.dict(
+            "os.environ", {OTEL_SEMCONV_STABILITY_OPT_IN: "database"}
+        ):
+            _OpenTelemetrySemanticConventionStability._initialized = False
+            command_tracer = CommandTracer(
+                self.tracer, request_hook=self.start_callback
+            )
+        mock_event = MockEvent(
+            command_attrs, ("test.com", "1234"), "test_request_id"
+        )
+        command_tracer.started(event=mock_event)
+        # pylint: disable=protected-access
+        span = command_tracer._pop_span(mock_event)
+        self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mongodb")
+        self.assertEqual(span.attributes[DB_NAMESPACE], "database_name")
+        self.assertEqual(span.attributes[DB_QUERY_TEXT], "find")
+        self.assertFalse(DB_SYSTEM in span.attributes)
+        self.assertFalse(DB_NAME in span.attributes)
+        self.assertFalse(DB_STATEMENT in span.attributes)
+        self.assertEqual(span.attributes[NET_PEER_NAME], "test.com")
+        self.assertEqual(span.attributes[NET_PEER_PORT], "1234")
+
+    def test_started_dup_database_semconv(self):
+        command_attrs = {
+            "command_name": "find",
+        }
+        with mock.patch.dict(
+            "os.environ", {OTEL_SEMCONV_STABILITY_OPT_IN: "database/dup"}
+        ):
+            _OpenTelemetrySemanticConventionStability._initialized = False
+            command_tracer = CommandTracer(
+                self.tracer, request_hook=self.start_callback
+            )
+        mock_event = MockEvent(
+            command_attrs, ("test.com", "1234"), "test_request_id"
+        )
+        command_tracer.started(event=mock_event)
+        # pylint: disable=protected-access
+        span = command_tracer._pop_span(mock_event)
+        self.assertEqual(span.attributes[DB_SYSTEM], "mongodb")
+        self.assertEqual(span.attributes[DB_NAME], "database_name")
+        self.assertEqual(span.attributes[DB_STATEMENT], "find")
+        self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mongodb")
+        self.assertEqual(span.attributes[DB_NAMESPACE], "database_name")
+        self.assertEqual(span.attributes[DB_QUERY_TEXT], "find")
+
+    def test_instrumentor_uses_database_semconv_schema_url(self):
+        with (
+            mock.patch("pymongo.monitoring.register"),
+            mock.patch(
+                "opentelemetry.instrumentation.pymongo.get_tracer"
+            ) as mock_get_tracer,
+            mock.patch.dict(
+                "os.environ", {OTEL_SEMCONV_STABILITY_OPT_IN: "database"}
+            ),
+        ):
+            _OpenTelemetrySemanticConventionStability._initialized = False
+            PymongoInstrumentor().instrument()
+
+        self.assertEqual(
+            mock_get_tracer.call_args.kwargs["schema_url"],
+            "https://opentelemetry.io/schemas/1.25.0",
+        )
 
     def test_succeeded(self):
         mock_event = MockEvent({})


### PR DESCRIPTION
# Description

Fixes #1629

## Summary

Adds database semantic convention migration support to the PyMongo instrumentation.

## Reproduction

With `OTEL_SEMCONV_STABILITY_OPT_IN=database`, PyMongo spans still emitted the legacy database span attributes such as `db.system`, `db.name`, and `db.statement`, and the tracer schema URL stayed at `1.11.0`.

## Root cause

The PyMongo instrumentation set legacy database attributes directly and used a hard-coded legacy schema URL instead of the shared semantic convention migration helpers.

## Changes

- Initialize the database semconv opt-in mode for PyMongo command tracing.
- Use the shared database semconv helpers for `db.system`, database name, and statement attributes.
- Set the tracer schema URL from the database semconv opt-in mode.
- Add tests for default, `database`, and `database/dup` modes.

## Tests

- [x] `.venv/bin/python -m tox -e py314-test-instrumentation-pymongo`
- [x] `.venv/bin/python -m tox -e lint-instrumentation-pymongo`
- [x] `.tox/lint-instrumentation-pymongo/bin/ruff check instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py`

## Screenshots/Logs

Not applicable; this is a tracing attribute behavior change covered by unit tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
