### PR TITLE
docs(dbapi): fix pyodbc connect method example

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -35,11 +35,11 @@ be used directly as follows.
     # Example: mysql.connector
     trace_integration(mysql.connector, "connect", "mysql")
     # Example: pyodbc
-    trace_integration(pyodbc, "Connection", "odbc")
+    trace_integration(pyodbc, "connect", "odbc")
 
     # Or, directly call wrap_connect for more configurability.
     wrap_connect(__name__, mysql.connector, "connect", "mysql")
-    wrap_connect(__name__, pyodbc, "Connection", "odbc")
+    wrap_connect(__name__, pyodbc, "connect", "odbc")
 
 
 Configuration


### PR DESCRIPTION
# Description

Summary
- Updates the DBAPI instrumentation examples for `pyodbc` to wrap the module-level `connect` callable instead of `Connection`.

Reproduction
- In #707, the reporter used `trace_integration(pyodbc, "Connection", "odbc")` from the docs and did not see DBAPI spans.
- Another user confirmed that switching the wrapped method name to `"connect"` made instrumentation work.

Root cause
- `trace_integration` / `wrap_connect` wrap the DBAPI module function that creates connections. For `pyodbc`, that function is `pyodbc.connect`; using `Connection` in the example can lead users to wrap the wrong target.

Changes
- Replace the `pyodbc` examples in the DBAPI instrumentation docs from `"Connection"` to `"connect"`.

Tests
- `python3 -m compileall -q instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi`
- `git diff --check`
- Not run: `tox` / `uv` based test environments, because neither `tox` nor `uv` is available in this local environment.

Screenshots/Logs
- Not applicable.

Fixes #707

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `python3 -m compileall -q instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi`
- [x] `git diff --check`

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated