### PR TITLE
opentelemetry-instrumentation-pika: avoid duplicate consumer wrapping

### DIFF
--- a/.changelog/4667.fixed
+++ b/.changelog/4667.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-pika`: avoid duplicate consumer span wrapping

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py
@@ -58,6 +58,10 @@ class PikaInstrumentor(BaseInstrumentor):  # type: ignore
             consumer_callback = getattr(consumer_info, callback_attr, None)
             if consumer_callback is None:
                 continue
+            if "_original_callback" in getattr(
+                consumer_callback, "__dict__", {}
+            ):
+                continue
             decorated_callback = utils._decorate_callback(
                 consumer_callback,
                 tracer,

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
@@ -155,6 +155,31 @@ class TestPika(TestCase):
             for callback in self.channel._consumers.values()
         )
 
+    def test_instrument_consumers_does_not_redecorate_callback(
+        self,
+    ) -> None:
+        tracer = mock.MagicMock(spec=Tracer)
+        callback_attr = PikaInstrumentor.CONSUMER_CALLBACK_ATTR
+        consumer_info = self.blocking_channel._consumer_infos["consumer-tag"]
+        original_callback = getattr(consumer_info, callback_attr)
+
+        PikaInstrumentor._instrument_channel_consumers(
+            self.blocking_channel, tracer
+        )
+        decorated_callback = getattr(consumer_info, callback_attr)
+
+        PikaInstrumentor._instrument_channel_consumers(
+            self.blocking_channel, tracer
+        )
+
+        self.assertIs(
+            getattr(consumer_info, callback_attr), decorated_callback
+        )
+        self.assertIs(
+            decorated_callback._original_callback,
+            original_callback,
+        )
+
     @mock.patch(
         "opentelemetry.instrumentation.pika.utils._decorate_basic_publish"
     )


### PR DESCRIPTION
# Description

Fixes #4667.

Replaces #4670. The original PR was closed when the fork branch was renamed.

## Summary

Avoid wrapping an already-instrumented pika consumer callback again when `_instrument_channel_consumers` runs more than once for the same channel.

## Reproduction

A `BlockingChannel` can call `basic_consume` multiple times. The instrumentation reruns `_instrument_channel_consumers` after each registration. The regression test calls `_instrument_channel_consumers` twice for the same channel and asserts the callback remains the first decorated function.

## Root cause

`_instrument_channel_consumers` decorated every callback in the channel consumer map each time it ran. Previously registered callbacks could therefore accumulate nested consumer span wrappers.

## Changes

- Skip callbacks that already carry `_original_callback` metadata.
- Add a regression test for repeated consumer instrumentation on the same `BlockingChannel`.
- Add a changelog fragment.

## Tests

- [x] `.venv-tox/bin/tox -e py314-test-instrumentation-sio-pika-1-wrapt2`
- [x] `.venv-tox/bin/tox -e py314-test-instrumentation-sio-pika-0-wrapt2`
- [x] `.venv-tox/bin/tox -e lint-instrumentation-sio-pika`
- [x] `.tox/lint-instrumentation-sio-pika/bin/ruff check instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py`
- [x] `.tox/lint-instrumentation-sio-pika/bin/ruff format --check instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py`
- [x] `git diff --check`

## Screenshots/Logs

N/A. This is a unit-level instrumentation fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
