### PR TITLE
opentelemetry-instrumentation-redis: gracefully handle hook exceptions

### DIFF
--- a/.changelog/4696.added
+++ b/.changelog/4696.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-redis`: gracefully handle hook exceptions

--- a/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/src/opentelemetry/instrumentation/redis/__init__.py
@@ -210,6 +210,14 @@ if _CLIENT_ASYNCIO_SUPPORT:
 _INSTRUMENTATION_ATTR = "_is_instrumented_by_opentelemetry"
 
 
+def _execute_hook(hook: Callable[..., None], *args: Any) -> None:
+    try:
+        hook(*args)
+    # pylint: disable-next=broad-exception-caught
+    except Exception:
+        _logger.warning("Exception raised by hook %r", hook, exc_info=True)
+
+
 def _traced_execute_factory(
     tracer: Tracer,
     request_hook: RequestHook | None = None,
@@ -260,13 +268,13 @@ def _traced_execute_factory(
                 if span.name == "redis.create_index":
                     _add_create_attributes(span, args)
             if callable(request_hook):
-                request_hook(span, instance, args, kwargs)
+                _execute_hook(request_hook, span, instance, args, kwargs)
             response = func(*args, **kwargs)
             if span.is_recording():
                 if span.name == "redis.search":
                     _add_search_attributes(span, response, args)
             if callable(response_hook):
-                response_hook(span, instance, response)
+                _execute_hook(response_hook, span, instance, response)
             return response
 
     return _traced_execute_command
@@ -334,7 +342,7 @@ def _traced_execute_pipeline_factory(
                 exception = watch_exception
 
             if callable(response_hook):
-                response_hook(span, instance, response)
+                _execute_hook(response_hook, span, instance, response)
 
         if exception:
             raise exception
@@ -393,10 +401,10 @@ def _async_traced_execute_factory(
                     http_sem_conv_opt_in_mode,
                 )
             if callable(request_hook):
-                request_hook(span, instance, args, kwargs)
+                _execute_hook(request_hook, span, instance, args, kwargs)
             response = await func(*args, **kwargs)
             if callable(response_hook):
-                response_hook(span, instance, response)
+                _execute_hook(response_hook, span, instance, response)
             return response
 
     return _async_traced_execute_command
@@ -466,7 +474,7 @@ def _async_traced_execute_pipeline_factory(
                 exception = watch_exception
 
             if callable(response_hook):
-                response_hook(span, instance, response)
+                _execute_hook(response_hook, span, instance, response)
 
         if exception:
             raise exception

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -230,6 +230,58 @@ class TestRedis(TestBase):
         span = spans[0]
         self.assertEqual(span.attributes.get(custom_attribute_name), "GET")
 
+    def test_request_hook_exception(self):
+        def request_hook(_span, _conn, _args, _kwargs):
+            raise ValueError("hook error")
+
+        redis_client = redis.Redis()
+        connection = redis.connection.Connection()
+        redis_client.connection = connection
+
+        RedisInstrumentor().uninstrument()
+        RedisInstrumentor().instrument(
+            tracer_provider=self.tracer_provider, request_hook=request_hook
+        )
+
+        with self.assertLogs(
+            "opentelemetry.instrumentation.redis", level="WARNING"
+        ) as log_ctx:
+            with mock.patch.object(connection, "send_command"):
+                with mock.patch.object(
+                    redis_client, "parse_response", return_value="ok"
+                ):
+                    redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertTrue(any("request_hook" in msg for msg in log_ctx.output))
+
+    def test_response_hook_exception(self):
+        def response_hook(_span, _conn, _response):
+            raise ValueError("hook error")
+
+        redis_client = redis.Redis()
+        connection = redis.connection.Connection()
+        redis_client.connection = connection
+
+        RedisInstrumentor().uninstrument()
+        RedisInstrumentor().instrument(
+            tracer_provider=self.tracer_provider, response_hook=response_hook
+        )
+
+        with self.assertLogs(
+            "opentelemetry.instrumentation.redis", level="WARNING"
+        ) as log_ctx:
+            with mock.patch.object(connection, "send_command"):
+                with mock.patch.object(
+                    redis_client, "parse_response", return_value="ok"
+                ):
+                    redis_client.get("key")
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertTrue(any("response_hook" in msg for msg in log_ctx.output))
+
     def test_query_sanitizer_enabled(self):
         redis_client = redis.Redis()
         connection = redis.connection.Connection()
@@ -647,6 +699,42 @@ class TestRedisAsync(TestBase, IsolatedAsyncioTestCase):
         # after un-instrumenting the query should not be recorder
         await self.client.set("key", "value")
         spans = self.assert_span_count(0)
+
+    @pytest.mark.asyncio
+    async def test_request_hook_exception(self):
+        def request_hook(_span, _conn, _args, _kwargs):
+            raise ValueError("hook error")
+
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider, request_hook=request_hook
+        )
+
+        with self.assertLogs(
+            "opentelemetry.instrumentation.redis", level="WARNING"
+        ) as log_ctx:
+            await self.client.set("key", "value")
+
+        self.assert_span_count(1)
+        self.assertTrue(any("request_hook" in msg for msg in log_ctx.output))
+        self.instrumentor.uninstrument()
+
+    @pytest.mark.asyncio
+    async def test_response_hook_exception(self):
+        def response_hook(_span, _conn, _response):
+            raise ValueError("hook error")
+
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider, response_hook=response_hook
+        )
+
+        with self.assertLogs(
+            "opentelemetry.instrumentation.redis", level="WARNING"
+        ) as log_ctx:
+            await self.client.set("key", "value")
+
+        self.assert_span_count(1)
+        self.assertTrue(any("response_hook" in msg for msg in log_ctx.output))
+        self.instrumentor.uninstrument()
 
     @pytest.mark.asyncio
     async def test_span_name_empty_pipeline(self):


### PR DESCRIPTION
# Description

Adds functionality to `opentelemetry-instrumentation-redis` to gracefully handle hook exceptions.

Fixes #4695

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
uv run tox -e py314-test-instrumentation-redis
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
