### PR TITLE
docs: document OTEL_SEMCONV_STABILITY_OPT_IN for HTTP instrumentation migration

### DIFF
--- a/.changelog/4698.fixed
+++ b/.changelog/4698.fixed
@@ -1,0 +1,1 @@
+`instrumentation`: document `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable for HTTP instrumentation migration

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -1,3 +1,23 @@
+## HTTP Semantic Convention Migration
+
+Several HTTP instrumentations (those with `migration` in the Semconv status
+column) support the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to
+control which HTTP semantic conventions are emitted during the transition period.
+
+Set `OTEL_SEMCONV_STABILITY_OPT_IN` to one of the following values:
+
+- `http` — emit the new, stable HTTP and networking conventions and stop emitting
+  the old experimental conventions that the instrumentation emitted previously.
+- `http/dup` — emit both the old experimental and the new stable HTTP and
+  networking conventions simultaneously, allowing for a seamless transition.
+
+By default (when the variable is unset), the old experimental HTTP and networking
+conventions are emitted to preserve backward compatibility.
+
+For more information, see the
+[HTTP semantic conventions stability migration guide](https://opentelemetry.io/docs/specs/semconv/http/migration-guide/).
+
+## Instrumentations
 
 | Instrumentation | Supported Packages | Metrics support | Semconv status |
 | --------------- | ------------------ | --------------- | -------------- |


### PR DESCRIPTION
## Description
Adds a section to `instrumentation/README.md` documenting the
`OTEL_SEMCONV_STABILITY_OPT_IN` environment variable supported
by HTTP instrumentations with `migration` semconv status.

This follows the approach suggested by @lzchen in PR #4640 —
a single excerpt in the instrumentation README rather than
individual per-instrumentation documentation.

## Changes
- `instrumentation/README.md`: added "HTTP Semantic Convention
  Migration" section above the instrumentation table explaining
  the three modes of OTEL_SEMCONV_STABILITY_OPT_IN with a link
  to the migration guide

## Related
Fixes #4202