### PR TITLE
botocore: drop hardcoded aiohttp dependency

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-botocore/test-requirements-2.txt
@@ -3,7 +3,6 @@ aws-xray-sdk==2.12.1
 boto3==1.29.4
 botocore==1.32.4
 aiobotocore==2.8.0
-aiohttp==3.9.1 #TODO: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4645 - fix issue with aiohttp in a better way.
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2


### PR DESCRIPTION
# Description

There was an incompatibility with latest releases of vcr.py and aiohttp so that aiobotocore tests would have failed. Latest vcrpy fixed that so we can remove the aiohttp pinned version.

Refs #4645

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
