### PR TITLE
opentelemetry-docker-tests: bump requirements for being installable on Python 3.14

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -3,17 +3,14 @@ amqp==5.2.0
 asgiref==3.8.1
 async-timeout==4.0.3
 asyncpg==0.31.0
-bcrypt==5.0.0
 billiard==4.2.0
 celery==5.3.6
 certifi==2024.7.4
-cffi==2.0.0
 chardet==3.0.4
 click==8.1.7
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
-cryptography==46.0.7
 Django==4.2.30
 dnspython==2.6.1
 exceptiongroup==1.2.0
@@ -27,7 +24,6 @@ kombu==5.3.5
 mysql-connector-python==8.3.0
 mysqlclient==2.1.1
 packaging==24.0
-paramiko==4.0.0
 pluggy==1.6.0
 prometheus_client==0.20.0
 prompt-toolkit==3.0.43
@@ -37,10 +33,8 @@ prompt-toolkit==3.0.43
 psycopg==3.3.4
 psycopg2==2.9.12
 psycopg2-binary==2.9.12
-pycparser==3.0
 pymongo==4.6.3
 PyMySQL==1.1.1
-PyNaCl==1.6.2
 # prerequisite: install unixodbc
 pyodbc==5.3.0
 pytest==8.0.2

--- a/tests/opentelemetry-docker-tests/tests/test-requirements.txt
+++ b/tests/opentelemetry-docker-tests/tests/test-requirements.txt
@@ -2,7 +2,7 @@ aiopg==1.4.0
 amqp==5.2.0
 asgiref==3.8.1
 async-timeout==4.0.3
-asyncpg==0.29.0
+asyncpg==0.31.0
 bcrypt==5.0.0
 billiard==4.2.0
 celery==5.3.6
@@ -19,8 +19,8 @@ dnspython==2.6.1
 exceptiongroup==1.2.0
 flaky==3.7.0
 flask==3.1.3
-greenlet==3.0.3
-grpcio==1.63.2
+greenlet==3.3.1
+grpcio==1.81.1
 idna==3.7
 iniconfig==2.0.0
 kombu==5.3.5
@@ -28,21 +28,21 @@ mysql-connector-python==8.3.0
 mysqlclient==2.1.1
 packaging==24.0
 paramiko==4.0.0
-pluggy==1.4.0
+pluggy==1.6.0
 prometheus_client==0.20.0
 prompt-toolkit==3.0.43
 # prerequisite: install libpq-dev (debian) or postgresql-devel (rhel), postgresql (mac)
 # see https://www.psycopg.org/docs/install.html#build-prerequisites
 # you might have to install additional packages depending on your OS
-psycopg==3.1.18
-psycopg2==2.9.9
-psycopg2-binary==2.9.9
+psycopg==3.3.4
+psycopg2==2.9.12
+psycopg2-binary==2.9.12
 pycparser==3.0
 pymongo==4.6.3
 PyMySQL==1.1.1
 PyNaCl==1.6.2
 # prerequisite: install unixodbc
-pyodbc==5.0.1
+pyodbc==5.3.0
 pytest==8.0.2
 pytest-celery==0.0.0
 python-dateutil==2.9.0.post0
@@ -52,7 +52,7 @@ requests==2.33.1
 six==1.16.0
 SQLAlchemy==1.4.52
 tomli==2.0.1
-typing_extensions==4.12.2
+typing_extensions==4.13.2
 tzdata==2024.1
 urllib3==2.7.0
 vine==5.1.0


### PR DESCRIPTION
# Description

Bump requirements to be installable on Python 3.14 and while at it remove paramiko since it's not used.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated