### PR TITLE
opentelemetry-instrumentation-requests: remove multiple calls to sanitize_method

### DIFF
--- a/.changelog/4719.changed
+++ b/.changelog/4719.changed
@@ -1,0 +1,1 @@
+opentelemetry-instrumentation-requests: remove multiple calls to sanitize_method

--- a/instrumentation/opentelemetry-instrumentation-requests/benchmark-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-requests/benchmark-requirements.txt
@@ -1,0 +1,4 @@
+pytest-benchmark==4.0.0
+-e opentelemetry-instrumentation
+-e util/opentelemetry-util-http
+-e instrumentation/opentelemetry-instrumentation-requests

--- a/instrumentation/opentelemetry-instrumentation-requests/benchmarks/test_benchmark_sanitize_method.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/benchmarks/test_benchmark_sanitize_method.py
@@ -30,8 +30,8 @@ class _FakeAdapter(BaseAdapter):
         pass
 
 
-@pytest.fixture
-def instrumented_session():
+@pytest.fixture(name="http_session")
+def _http_session_fixture():
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -42,5 +42,5 @@ def instrumented_session():
     RequestsInstrumentor().uninstrument()
 
 
-def test_instrumented_send(benchmark, instrumented_session):
-    benchmark(instrumented_session.get, _URL)
+def test_instrumented_send(benchmark, http_session: requests.Session):
+    benchmark(http_session.get, _URL)

--- a/instrumentation/opentelemetry-instrumentation-requests/benchmarks/test_benchmark_sanitize_method.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/benchmarks/test_benchmark_sanitize_method.py
@@ -1,0 +1,46 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import requests
+from requests.adapters import BaseAdapter
+from requests.models import Response
+
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+_URL = "http://mock/status/200"
+
+
+class _FakeAdapter(BaseAdapter):
+    def __init__(self):
+        super().__init__()
+        resp = Response()
+        resp.status_code = 200
+        self._response = resp
+
+    def send(self, *args, **kwargs):
+        return self._response
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def instrumented_session():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    RequestsInstrumentor().instrument(tracer_provider=provider)
+    session = requests.Session()
+    session.mount("http://", _FakeAdapter())
+    yield session
+    RequestsInstrumentor().uninstrument()
+
+
+def test_instrumented_send(benchmark, instrumented_session):
+    benchmark(instrumented_session.get, _URL)

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -328,7 +328,8 @@ def _instrument(
         # See
         # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-client
         method = request.method
-        span_name = get_default_span_name(method)
+        sanitized_method = sanitize_method(method.strip())
+        span_name = get_default_span_name(sanitized_method)
 
         url = redact_url(request.url)
 
@@ -336,7 +337,7 @@ def _instrument(
         _set_http_method(
             span_attributes,
             method,
-            sanitize_method(method),
+            sanitized_method,
             sem_conv_opt_in_mode,
         )
         _set_http_url(span_attributes, url, sem_conv_opt_in_mode)
@@ -363,7 +364,7 @@ def _instrument(
         _set_http_method(
             metric_labels,
             method,
-            sanitize_method(method),
+            sanitized_method,
             sem_conv_opt_in_mode,
         )
 
@@ -532,7 +533,6 @@ def get_default_span_name(method: str) -> str:
     Returns:
         span name
     """
-    method = sanitize_method(method.strip())
     if method == "_OTHER":
         return "HTTP"
     return method

--- a/tox.ini
+++ b/tox.ini
@@ -202,6 +202,7 @@ envlist =
     pypy3-test-instrumentation-logging
     lint-instrumentation-logging
     benchmark-instrumentation-logging
+    benchmark-instrumentation-requests
 
     ; opentelemetry-exporter-richconsole
     py3{10,11,12,13,14}-test-exporter-richconsole
@@ -691,6 +692,7 @@ deps =
   logging: {[testenv]test_deps}
   logging: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-logging/test-requirements.txt
   benchmark-instrumentation-logging: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-logging/benchmark-requirements.txt
+  benchmark-instrumentation-requests: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-requests/benchmark-requirements.txt
 
   aiohttp-client: {[testenv]test_deps}
   aiohttp-client: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-aiohttp-client/test-requirements.txt
@@ -893,6 +895,7 @@ commands =
   test-instrumentation-logging: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-logging/tests {posargs}
   lint-instrumentation-logging: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-logging"
   benchmark-instrumentation-logging: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-logging/benchmarks {posargs} --benchmark-json=instrumentation-logging-benchmark.json
+  benchmark-instrumentation-requests: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-requests/benchmarks {posargs} --benchmark-json=instrumentation-requests-benchmark.json
 
   test-instrumentation-mysql: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/tests {posargs}
   lint-instrumentation-mysql: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-mysql"


### PR DESCRIPTION

# Description

Instead call the method once and pass the results in where needed

## Type of change

Please delete options that are not relevant.

- [x] Small improvement

# How Has This Been Tested?

Benchmarks with similar results to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4718

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
