### PR TITLE
opentelemetry-instrumentation-django: fix spans ending prematurely for StreamingHttpResponse

### DIFF
--- a/.changelog/4723.fixed
+++ b/.changelog/4723.fixed
@@ -1,0 +1,1 @@
+﻿`opentelemetry-instrumentation-django`: fix spans ending prematurely for StreamingHttpResponse

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -419,7 +419,17 @@ class _DjangoMiddleware:
         self._active_request_counter.add(-1, active_requests_count_attrs)
 
         if activation and span:
-            if exception:
+            if response.streaming and not exception:
+                original_close = response.close
+
+                def _end_span_on_close(*args, **kwargs):
+                    try:
+                        original_close(*args, **kwargs)
+                    finally:
+                        activation.__exit__(None, None, None)
+
+                response.close = _end_span_on_close
+            elif exception:
                 activation.__exit__(
                     type(exception),
                     exception,

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -58,6 +58,7 @@ from .views import (
     excluded_noarg2,
     response_with_custom_header,
     route_span_name,
+    streaming_view,
     traced,
     traced_template,
 )
@@ -1136,3 +1137,70 @@ class TestMiddlewareSpanActivationTiming(WsgiTestBase):
             for metric in sm.metrics
         )
         self.assertTrue(histogram_found)
+
+
+class TestMiddlewareStreamingResponse(WsgiTestBase):
+    """Test span end timing relative to StreamingHttpResponse consumption."""
+
+    @classmethod
+    def setUpClass(cls):
+        conf.settings.configure(ROOT_URLCONF=modules[__name__])
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        setup_test_environment()
+        _django_instrumentor.instrument()
+
+    def tearDown(self):
+        super().tearDown()
+        teardown_test_environment()
+        _django_instrumentor.uninstrument()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        conf.settings = conf.LazySettings()
+
+    def test_span_ends_before_streaming_content_consumed(self):
+        """Reproduces the bug: span ends before the stream is actually sent."""
+        events = []
+
+        def view(request):
+            return streaming_view(request, events)
+
+        route = re_path(r"^streaming/", view)
+        urlpatterns.append(route)
+        self.addCleanup(urlpatterns.remove, route)
+
+        original_end = Span.end
+
+        def patched_end(self, *args, **kwargs):
+            events.append("span_closed")
+            return original_end(self, *args, **kwargs)
+
+        with patch.object(Span, "end", patched_end):
+            response = Client().get("/streaming/")
+            spans_before_consumption = (
+                self.memory_exporter.get_finished_spans()
+            )
+            # Now actually consume the stream, simulating a real WSGI server
+            list(response.streaming_content)
+
+        self.assertEqual(
+            len(spans_before_consumption),
+            0,
+            "Span should not be finished yet: stream not yet consumed",
+        )
+        self.assertIn("span_closed", events)
+        self.assertIn("generator_started", events)
+
+        # THIS is the assertion that proves the bug:
+        # the generator should start BEFORE the span closes.
+        self.assertLess(
+            events.index("generator_started"),
+            events.index("span_closed"),
+            "Span ended before streaming content was consumed: "
+            f"event order was {events}",
+        )
+

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -1203,4 +1203,3 @@ class TestMiddlewareStreamingResponse(WsgiTestBase):
             "Span ended before streaming content was consumed: "
             f"event order was {events}",
         )
-

--- a/instrumentation/opentelemetry-instrumentation-django/tests/views.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/views.py
@@ -80,6 +80,7 @@ async def async_with_custom_header(request):
     response.headers["custom-test-header-2"] = "test-header-value-2"
     return response
 
+
 def streaming_view(request, events):  # pylint: disable=unused-argument
     def stream_generator():
         events.append("generator_started")

--- a/instrumentation/opentelemetry-instrumentation-django/tests/views.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/views.py
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 
 
 def traced(request):  # pylint: disable=unused-argument
@@ -79,3 +79,12 @@ async def async_with_custom_header(request):
     response.headers["custom-test-header-1"] = "test-header-value-1"
     response.headers["custom-test-header-2"] = "test-header-value-2"
     return response
+
+def streaming_view(request, events):  # pylint: disable=unused-argument
+    def stream_generator():
+        events.append("generator_started")
+        yield b"chunk1"
+        yield b"chunk2"
+        events.append("generator_finished")
+
+    return StreamingHttpResponse(stream_generator())


### PR DESCRIPTION
# Description

Fixes #4681

The Django instrumentation middleware ends the request span synchronously inside `process_response()`, right after `get_response()` returns. For a normal `HttpResponse` this is correct, since the body is fully rendered by that point.

For `StreamingHttpResponse`, however, `get_response()` returns before the stream is actually consumed. Django (and WSGI servers) only iterate `response.streaming_content` afterward, once the response is being sent to the client. As a result, the span's `end_time` is set before the streamed content has finished sending, producing inaccurate span durations for streaming endpoints.

For streaming responses (`response.streaming`), span completion is now deferred until `response.close()` is called, which occurs after the stream has been consumed. Existing behavior for non-streaming responses and exception paths is preserved.

Scope: this change covers the synchronous (WSGI) path only. Async/ASGI behavior remains unchanged.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added `TestMiddlewareStreamingResponse` in `tests/test_middleware.py`.

The test records the order of:

* streaming content consumption
* span completion (`Span.end`)

and verifies that the span is not completed before the streaming response is consumed.

Tested locally with:

`tox -e py313-test-instrumentation-django-3`

Result:

`78 passed`

# Does This PR Require a Core Repo Change?

* [x] No.

# Checklist:

* [x] Followed the style guidelines of this project
* [x] Changelogs have been updated
* [x] Unit tests have been added
* [ ] Documentation has been updated

