### PR TITLE
opentelemetry-instrumentation-asyncpg: migrate to stable database and server semantic conventions

### DIFF
--- a/.changelog/4725.fixed
+++ b/.changelog/4725.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-asyncpg`: migrate to stable database and server semantic conventions

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -50,18 +50,15 @@ from opentelemetry.instrumentation.asyncpg.package import _instruments
 from opentelemetry.instrumentation.asyncpg.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.semconv._incubating.attributes.db_attributes import (
-    DB_NAME,
-    DB_STATEMENT,
-    DB_SYSTEM,
-    DB_USER,
-    DbSystemValues,
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+    DbSystemNameValues,
 )
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
-    NET_TRANSPORT,
-    NetTransportValues,
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
@@ -77,7 +74,7 @@ _PREPARED_STMT_METHODS = (
 
 def _hydrate_span_from_args(connection, query, parameters) -> dict:
     """Get network and database attributes from connection."""
-    span_attributes = {DB_SYSTEM: DbSystemValues.POSTGRESQL.value}
+    span_attributes = {DB_SYSTEM_NAME: DbSystemNameValues.POSTGRESQL.value}
 
     # connection contains _params attribute which is a namedtuple ConnectionParameters.
     # https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connection.py#L68
@@ -85,24 +82,19 @@ def _hydrate_span_from_args(connection, query, parameters) -> dict:
     params = getattr(connection, "_params", None)
     dbname = getattr(params, "database", None)
     if dbname:
-        span_attributes[DB_NAME] = dbname
-    user = getattr(params, "user", None)
-    if user:
-        span_attributes[DB_USER] = user
+        span_attributes[DB_NAMESPACE] = dbname
 
     # connection contains _addr attribute which is either a host/port tuple, or unix socket string
     # https://magicstack.github.io/asyncpg/current/_modules/asyncpg/connection.html
     addr = getattr(connection, "_addr", None)
     if isinstance(addr, tuple):
-        span_attributes[NET_PEER_NAME] = addr[0]
-        span_attributes[NET_PEER_PORT] = addr[1]
-        span_attributes[NET_TRANSPORT] = NetTransportValues.IP_TCP.value
+        span_attributes[SERVER_ADDRESS] = addr[0]
+        span_attributes[SERVER_PORT] = addr[1]
     elif isinstance(addr, str):
-        span_attributes[NET_PEER_NAME] = addr
-        span_attributes[NET_TRANSPORT] = NetTransportValues.OTHER.value
+        span_attributes[SERVER_ADDRESS] = addr
 
     if query is not None:
-        span_attributes[DB_STATEMENT] = query
+        span_attributes[DB_QUERY_TEXT] = query
 
     if parameters is not None and len(parameters) > 0:
         span_attributes["db.statement.parameters"] = str(parameters)
@@ -127,7 +119,7 @@ class AsyncPGInstrumentor(BaseInstrumentor):
             __name__,
             __version__,
             tracer_provider,
-            schema_url="https://opentelemetry.io/schemas/1.11.0",
+            schema_url="https://opentelemetry.io/schemas/1.29.0",
         )
 
         for method in [

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/tests/test_asyncpg_wrapper.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/tests/test_asyncpg_wrapper.py
@@ -19,6 +19,11 @@ from opentelemetry.instrumentation.asyncpg import (
     _PREPARED_STMT_METHODS,
     AsyncPGInstrumentor,
 )
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+    DbSystemNameValues,
+)
 from opentelemetry.test.test_base import TestBase
 
 
@@ -243,10 +248,11 @@ class TestAsyncPGInstrumentation(TestBase):
                 self.assertEqual(spans[0].name, expected_name)
                 self.assertTrue(spans[0].status.is_ok)
                 self.assertEqual(
-                    spans[0].attributes.get("db.statement"), query
+                    spans[0].attributes.get(DB_QUERY_TEXT), query
                 )
                 self.assertEqual(
-                    spans[0].attributes.get("db.system"), "postgresql"
+                    spans[0].attributes.get(DB_SYSTEM_NAME),
+                    DbSystemNameValues.POSTGRESQL.value,
                 )
 
                 apg.uninstrument()


### PR DESCRIPTION
Fixes #1635

## Description
Migrates the asyncpg instrumentation from incubating semantic conventions to the latest stable database and server semantic conventions.

## Changes
- `DB_NAME`, `DB_STATEMENT`, `DB_SYSTEM`, `DB_USER`, `NET_PEER_NAME`, `NET_PEER_PORT`, `NET_TRANSPORT` (incubating) replaced with stable `DB_NAMESPACE`, `DB_QUERY_TEXT`, `DB_SYSTEM_NAME`, `SERVER_ADDRESS`, `SERVER_PORT`
- Bumped schema_url from 1.11.0 to 1.29.0
- Updated tests to assert against the new stable attribute constants
- `DB_USER` and `NET_TRANSPORT` were dropped as there's no direct stable equivalent in the current semconv spec

## Testing
All existing asyncpg tests pass locally (py312, default/wrapt1/wrapt2 variants). ruff lint passes on modified files.