### PR TITLE
fix(pika): skip already-decorated callbacks in _instrument_channel_consumers

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/pika_instrumentor.py
@@ -58,6 +58,8 @@ class PikaInstrumentor(BaseInstrumentor):  # type: ignore
             consumer_callback = getattr(consumer_info, callback_attr, None)
             if consumer_callback is None:
                 continue
+            if hasattr(consumer_callback, "_original_callback"):
+                continue
             decorated_callback = utils._decorate_callback(
                 consumer_callback,
                 tracer,

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_pika_instrumentation.py
@@ -28,10 +28,13 @@ class TestPika(TestCase):
         self.channel = mock.MagicMock(spec=Channel)
         consumer_info = mock.MagicMock()
         callback_attr = PikaInstrumentor.CONSUMER_CALLBACK_ATTR
-        setattr(consumer_info, callback_attr, mock.MagicMock())
+        setattr(consumer_info, callback_attr, self._consumer_callback)
         self.blocking_channel._consumer_infos = {"consumer-tag": consumer_info}
         self.channel._consumers = {"consumer-tag": consumer_info}
         self.mock_callback = mock.MagicMock()
+
+    def _consumer_callback(self) -> None:
+        pass
 
     def test_instrument_api(self) -> None:
         instrumentation = PikaInstrumentor()
@@ -153,6 +156,52 @@ class TestPika(TestCase):
         assert all(
             hasattr(callback, "_original_callback")
             for callback in self.channel._consumers.values()
+        )
+
+    @mock.patch("opentelemetry.instrumentation.pika.utils._decorate_callback")
+    def test_instrument_consumers_skips_already_decorated_callbacks(
+        self, decorate_callback: mock.MagicMock
+    ) -> None:
+        def consumer_callback_1() -> None:
+            pass
+
+        def consumer_callback_2() -> None:
+            pass
+
+        def decorate_callback_side_effect(
+            callback, tracer, consumer_tag, consume_hook
+        ):
+            def decorated_callback() -> None:
+                pass
+
+            return decorated_callback
+
+        tracer = mock.MagicMock(spec=Tracer)
+        callback_attr = PikaInstrumentor.CONSUMER_CALLBACK_ATTR
+        consumer_info_1 = mock.Mock()
+        consumer_info_2 = mock.Mock()
+        setattr(consumer_info_1, callback_attr, consumer_callback_1)
+        setattr(consumer_info_2, callback_attr, consumer_callback_2)
+        channel = mock.MagicMock(spec=BlockingChannel)
+        channel._consumer_infos = {
+            "consumer-tag-1": consumer_info_1,
+            "consumer-tag-2": consumer_info_2,
+        }
+        decorate_callback.side_effect = decorate_callback_side_effect
+
+        PikaInstrumentor._instrument_channel_consumers(channel, tracer)
+        wrapped_callback_1 = getattr(consumer_info_1, callback_attr)
+        wrapped_callback_2 = getattr(consumer_info_2, callback_attr)
+        PikaInstrumentor._instrument_channel_consumers(channel, tracer)
+
+        self.assertEqual(decorate_callback.call_count, 2)
+        self.assertIs(getattr(consumer_info_1, callback_attr), wrapped_callback_1)
+        self.assertIs(getattr(consumer_info_2, callback_attr), wrapped_callback_2)
+        self.assertIs(
+            wrapped_callback_1._original_callback, consumer_callback_1
+        )
+        self.assertIs(
+            wrapped_callback_2._original_callback, consumer_callback_2
         )
 
     @mock.patch(


### PR DESCRIPTION
# Description

When multiple `basic_consume()` calls are made on a single pika channel, each message produces duplicate (nested) CONSUMER spans -- N spans per message where N equals the number of consumers registered on the channel.

The root cause is that `_instrument_channel_consumers()` re-wraps every callback on each `basic_consume()` call without checking whether the callback is already decorated. The `_original_callback` attribute set on the decorated callback accumulates nested wrappers.

This adds a guard in `_instrument_channel_consumers()` to skip callbacks that already have an `_original_callback` attribute, indicating they were wrapped in a prior call.

Addresses #4667

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added a regression test `test_instrument_consumers_skips_already_decorated_callbacks` that:
1. Creates a channel with 2 consumer infos, each with a real callback function
2. Calls `_instrument_channel_consumers()` twice (simulating two `basic_consume()` calls)
3. Asserts `_decorate_callback` is called exactly 2 times (once per consumer, not 4)
4. Asserts each callback's `_original_callback` still points to the original function

- [x] Test added

# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated