### PR TITLE
opentelemetry-instrumentation-tornado: sanitize the http method

### DIFF
--- a/.changelog/4735.fixed
+++ b/.changelog/4735.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-tornado`: sanitize the request http method in server and client spans and metrics

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=too-many-lines
+
 """
 This library uses OpenTelemetry to track web requests in Tornado applications.
 

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -849,10 +849,9 @@ def _record_prepare_metrics(server_histograms, handler, sem_conv_opt_in_mode):
             active_requests_attributes_new = (
                 _create_active_requests_attributes_new(handler.request)
             )
-            active_requests_attributes_old_or_dup = {
-                **active_requests_attributes_old,
-                **active_requests_attributes_new,
-            }
+            active_requests_attributes_old_or_dup = (
+                active_requests_attributes_old | active_requests_attributes_new
+            )
         else:
             active_requests_attributes_old_or_dup = (
                 active_requests_attributes_old
@@ -914,10 +913,9 @@ def _record_on_finish_metrics(
             active_requests_attributes_new = (
                 _create_active_requests_attributes_new(handler.request)
             )
-            active_requests_attributes_old_or_dup = {
-                **active_requests_attributes_old,
-                **active_requests_attributes_new,
-            }
+            active_requests_attributes_old_or_dup = (
+                active_requests_attributes_old | active_requests_attributes_new
+            )
         else:
             active_requests_attributes_old_or_dup = (
                 active_requests_attributes_old

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -732,7 +732,9 @@ def _get_default_span_name(handler):
         Default span name.
     """
 
-    method = handler.request.method
+    method = sanitize_method(handler.request.method)
+    if method == "_OTHER":
+        method = "HTTP"
     rule = find_matched_rule(handler)
     # if there's no rule, like for 404 just return the method
     route = route_from_rule(rule, handler) if rule else None
@@ -791,7 +793,7 @@ def _finish_span(tracer, handler, error, sem_conv_opt_in_mode):
     if error:
         if isinstance(error, tornado.web.HTTPError):
             status_code = error.status_code
-            if not ctx and status_code == 404:
+            if not ctx and status_code in (404, 405):
                 ctx = _start_span(tracer, handler, sem_conv_opt_in_mode)
         else:
             status_code = 500
@@ -840,8 +842,21 @@ def _record_prepare_metrics(server_histograms, handler, sem_conv_opt_in_mode):
         active_requests_attributes_old = (
             _create_active_requests_attributes_old(handler)
         )
+        # in case of http/dup send both old and new attributes since we will add one entry
+        if _report_new(sem_conv_opt_in_mode):
+            active_requests_attributes_new = (
+                _create_active_requests_attributes_new(handler.request)
+            )
+            active_requests_attributes_old_or_dup = {
+                **active_requests_attributes_old,
+                **active_requests_attributes_new,
+            }
+        else:
+            active_requests_attributes_old_or_dup = (
+                active_requests_attributes_old
+            )
         server_histograms["active_requests"].add(
-            1, attributes=active_requests_attributes_old
+            1, attributes=active_requests_attributes_old_or_dup
         )
 
     # Record new semconv metrics
@@ -892,8 +907,22 @@ def _record_on_finish_metrics(
         active_requests_attributes_old = (
             _create_active_requests_attributes_old(handler)
         )
+        # in case of http/dup send both old and new attributes since we will add one entry
+        if _report_new(sem_conv_opt_in_mode):
+            active_requests_attributes_new = (
+                _create_active_requests_attributes_new(handler.request)
+            )
+            active_requests_attributes_old_or_dup = {
+                **active_requests_attributes_old,
+                **active_requests_attributes_new,
+            }
+        else:
+            active_requests_attributes_old_or_dup = (
+                active_requests_attributes_old
+            )
+
         server_histograms["active_requests"].add(
-            -1, attributes=active_requests_attributes_old
+            -1, attributes=active_requests_attributes_old_or_dup
         )
 
     # Record new semconv metrics
@@ -923,7 +952,7 @@ def _create_active_requests_attributes_old(handler):
     """Create metric attributes for active requests using old semconv."""
     request = handler.request
     metric_attributes = {
-        HTTP_METHOD: request.method,
+        HTTP_METHOD: sanitize_method(request.method),
         HTTP_SCHEME: request.protocol,
         HTTP_FLAVOR: request.version,
         HTTP_HOST: request.host,
@@ -940,7 +969,7 @@ def _create_active_requests_attributes_old(handler):
 def _create_active_requests_attributes_new(request):
     """Create metric attributes for active requests using new semconv."""
     metric_attributes = {
-        HTTP_REQUEST_METHOD: request.method,
+        HTTP_REQUEST_METHOD: sanitize_method(request.method),
         URL_SCHEME: request.protocol,
     }
     if request.version:

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/client.py
@@ -76,8 +76,11 @@ def fetch_async(  # pylint: disable=too-many-locals
     args, kwargs = _normalize_request(args, kwargs)
     request = args[0]
 
+    span_name = sanitize_method(request.method)
+    if span_name == "_OTHER":
+        span_name = "HTTP"
     span = tracer.start_span(
-        request.method,
+        span_name,
         kind=trace.SpanKind.CLIENT,
         start_time=start_time,
     )
@@ -209,7 +212,7 @@ def _create_metric_attributes_old(response):
     metric_attributes = {
         HTTP_STATUS_CODE: response.code,
         HTTP_URL: redact_url(response.request.url),
-        HTTP_METHOD: response.request.method,
+        HTTP_METHOD: sanitize_method(response.request.method),
     }
     return metric_attributes
 
@@ -219,7 +222,7 @@ def _create_metric_attributes_new(response):
     metric_attributes = {
         HTTP_RESPONSE_STATUS_CODE: response.code,
         URL_FULL: redact_url(response.request.url),
-        HTTP_REQUEST_METHOD: response.request.method,
+        HTTP_REQUEST_METHOD: sanitize_method(response.request.method),
     }
 
     # Add server address and port if available

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -180,6 +180,35 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
 
         self.memory_exporter.clear()
 
+    def test_unknown_method_span_name(self):
+        response = self.fetch(
+            "/", method="UNKNOWN", allow_nonstandard_methods=True
+        )
+        self.assertEqual(response.code, 405)
+        spans = self.memory_exporter.get_finished_spans()
+
+        self.assertEqual(len(spans), 2)
+
+        server, client = self.sorted_spans(spans)
+
+        self.assertEqual(server.name, "HTTP /")
+        self.assertSpanHasAttributes(
+            server,
+            {
+                HTTP_METHOD: "_OTHER",
+            },
+        )
+
+        self.assertEqual(client.name, "HTTP")
+        self.assertSpanHasAttributes(
+            client,
+            {
+                HTTP_METHOD: "_OTHER",
+            },
+        )
+
+        self.memory_exporter.clear()
+
     def test_not_recording(self):
         mock_tracer = Mock()
         mock_span = Mock()

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -636,7 +636,7 @@ class TestTornadoSemconvHttpDup(TornadoSemconvTestBase):
 
     def test_server_metrics_method_is_sanitized(self):
         response = self.fetch(
-            "/", method="UKNOWN", allow_nonstandard_methods=True
+            "/", method="UNKNOWN", allow_nonstandard_methods=True
         )
         self.assertEqual(response.code, 405)
         metrics = self.get_sorted_metrics(SCOPE)

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -634,6 +634,66 @@ class TestTornadoSemconvHttpDup(TornadoSemconvTestBase):
         self.assertTrue(old_duration_found, "Old semconv metric not found")
         self.assertTrue(new_duration_found, "New semconv metric not found")
 
+    def test_server_metrics_method_is_sanitized(self):
+        response = self.fetch(
+            "/", method="UKNOWN", allow_nonstandard_methods=True
+        )
+        self.assertEqual(response.code, 405)
+        metrics = self.get_sorted_metrics(SCOPE)
+
+        old_server_found = False
+        new_server_found = False
+        old_client_found = False
+        new_client_found = False
+        for metric in metrics:
+            if metric.name not in (
+                "http.server.active_requests",
+                "http.client.duration",
+                "http.client.request.duration",
+            ):
+                continue
+
+            for data_point in metric.data.data_points:
+                attributes = dict(data_point.attributes)
+                print(metric.name, attributes)
+                if old_attribute := attributes.get("http.method"):
+                    self.assertEqual(old_attribute, "_OTHER")
+                    old_server_found = (
+                        True
+                        if metric.name == "http.server.active_requests"
+                        else old_server_found
+                    )
+                    old_client_found = (
+                        True
+                        if metric.name == "http.client.duration"
+                        else old_client_found
+                    )
+                if new_attribute := attributes.get("http.request.method"):
+                    self.assertEqual(new_attribute, "_OTHER")
+                    new_server_found = (
+                        True
+                        if metric.name == "http.server.active_requests"
+                        else new_server_found
+                    )
+                    new_client_found = (
+                        True
+                        if metric.name == "http.client.request.duration"
+                        else new_client_found
+                    )
+
+        self.assertTrue(
+            old_server_found, "Old semconv server metric not found"
+        )
+        self.assertTrue(
+            new_server_found, "New semconv server metric not found"
+        )
+        self.assertTrue(
+            old_client_found, "Old semconv client metric not found"
+        )
+        self.assertTrue(
+            new_client_found, "New semconv client metric not found"
+        )
+
     def test_url_query_attribute_both_semconv(self):
         """Test that URL_QUERY is set in dup mode when request has query string."""
         response = self.fetch("/?test=value&another=param")

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py
@@ -655,7 +655,6 @@ class TestTornadoSemconvHttpDup(TornadoSemconvTestBase):
 
             for data_point in metric.data.data_points:
                 attributes = dict(data_point.attributes)
-                print(metric.name, attributes)
                 if old_attribute := attributes.get("http.method"):
                     self.assertEqual(old_attribute, "_OTHER")
                     old_server_found = (


### PR DESCRIPTION
# Description

Sanitize all http method users.
This also changed the instrumentation to create spans also for 405 http status code and fixed server active requests metrics attributes to have both old and stable semconv attributes when configured to emit http/dup.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
