### PR TITLE
Fix duplicate Pyramid traversal subscribers

### DIFF
--- a/.changelog/4741.fixed
+++ b/.changelog/4741.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-pyramid`: avoid duplicate traversal subscribers

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/callbacks.py
@@ -44,6 +44,7 @@ from opentelemetry.util.http import get_excluded_urls, redact_url
 
 TWEEN_NAME = "opentelemetry.instrumentation.pyramid.trace_tween_factory"
 SETTING_TRACE_ENABLED = "opentelemetry-pyramid.trace_enabled"
+_SETTING_CALLBACKS_REGISTERED = "opentelemetry-pyramid.callbacks_registered"
 
 _ENVIRON_STARTTIME_KEY = "opentelemetry-pyramid.starttime_key"
 _ENVIRON_SPAN_KEY = "opentelemetry-pyramid.span_key"
@@ -61,6 +62,10 @@ _sem_conv_opt_in_mode = _StabilityMode.DEFAULT
 def includeme(config):
     config.add_settings({SETTING_TRACE_ENABLED: True})
 
+    if config.get_settings().get(_SETTING_CALLBACKS_REGISTERED):
+        return
+
+    config.add_settings({_SETTING_CALLBACKS_REGISTERED: True})
     config.add_subscriber(_before_traversal, BeforeTraversal)
     _insert_tween(config)
 

--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -5,6 +5,7 @@ from timeit import default_timer
 from unittest.mock import patch
 
 from pyramid.config import Configurator
+from pyramid.config.adapters import AdaptersConfiguratorMixin
 
 from opentelemetry import trace
 from opentelemetry.instrumentation._semconv import (
@@ -145,6 +146,37 @@ class TestAutomatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual(
             config.registry.__name__, __name__.rsplit(".", maxsplit=1)[0]
         )
+
+    def test_before_traversal_subscriber_not_duplicated_after_commit(self):
+        registrations = []
+
+        def library_that_commits(config):
+            config.add_route("example", "/example")
+            config.commit()
+
+        def another_library(config):
+            pass
+
+        original_add_subscriber = AdaptersConfiguratorMixin.add_subscriber
+
+        def counting_add_subscriber(config, subscriber, iface=None, **kwargs):
+            if getattr(subscriber, "__name__", "") == "_before_traversal":
+                registrations.append(subscriber)
+
+            return original_add_subscriber(
+                config, subscriber, iface=iface, **kwargs
+            )
+
+        with patch.object(
+            AdaptersConfiguratorMixin,
+            "add_subscriber",
+            counting_add_subscriber,
+        ):
+            config = Configurator()
+            config.include(library_that_commits)
+            config.include(another_library)
+
+        self.assertEqual(len(registrations), 1)
 
     def test_redirect_response_is_not_an_error(self):
         tween_list = "pyramid.tweens.excview_tween_factory"


### PR DESCRIPTION
# Description

Fixes #4663.

`opentelemetry-instrumentation-pyramid` can register duplicate `_before_traversal` subscribers when a Pyramid include calls `config.commit()` and a later include creates another child configurator. This change records that the callbacks have already been registered in Pyramid settings, so later includes re-enable tracing without adding a duplicate subscriber or tween.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `uvx --from tox --with tox-uv tox -e py314-test-instrumentation-pyramid`
- [x] `uvx --from tox --with tox-uv tox -e lint-instrumentation-pyramid`
- [x] `uvx --from tox --with tox-uv tox -e ruff`

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
