### PR TITLE
fix(instrumentation-logging): promote otel.event.name to LogRecord.event_name in _translate

### DIFF
--- a/.changelog/4717.added
+++ b/.changelog/4717.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-tortoiseorm`: Implement semantic convention stability migration support for `OTEL_SEMCONV_STABILITY_OPT_IN` mode `database` and `database/dup`.

--- a/.changelog/4717.added
+++ b/.changelog/4717.added
@@ -1,1 +1,0 @@
-`opentelemetry-instrumentation-tortoiseorm`: Implement semantic convention stability migration support for `OTEL_SEMCONV_STABILITY_OPT_IN` mode `database` and `database/dup`.

--- a/.changelog/4750.fixed
+++ b/.changelog/4750.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-logging`: promote `otel.event.name` to `LogRecord.event_name` in logging bridge

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -47,7 +47,7 @@
 | [opentelemetry-instrumentation-system-metrics](./opentelemetry-instrumentation-system-metrics) | psutil >= 5 | No | development
 | [opentelemetry-instrumentation-threading](./opentelemetry-instrumentation-threading) | threading | No | development
 | [opentelemetry-instrumentation-tornado](./opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | Yes | migration
-| [opentelemetry-instrumentation-tortoiseorm](./opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | No | development
+| [opentelemetry-instrumentation-tortoiseorm](./opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | No | migration
 | [opentelemetry-instrumentation-urllib](./opentelemetry-instrumentation-urllib) | urllib | Yes | migration
 | [opentelemetry-instrumentation-urllib3](./opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 3.0.0 | Yes | migration
 | [opentelemetry-instrumentation-wsgi](./opentelemetry-instrumentation-wsgi) | wsgi | Yes | migration

--- a/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/src/opentelemetry/instrumentation/logging/handler.py
@@ -9,7 +9,7 @@ import threading
 import traceback
 from contextvars import ContextVar
 from time import time_ns
-from typing import Callable, Mapping
+from typing import Callable
 
 from opentelemetry._logs import (
     LoggerProvider,
@@ -20,8 +20,14 @@ from opentelemetry._logs import (
     get_logger_provider,
 )
 from opentelemetry.context import get_current
-from opentelemetry.semconv._incubating.attributes import code_attributes
-from opentelemetry.semconv.attributes import exception_attributes
+from opentelemetry.semconv._incubating.attributes import (
+    code_attributes,
+    event_attributes,
+)
+from opentelemetry.semconv.attributes import (
+    exception_attributes,
+    otel_attributes,
+)
 from opentelemetry.util.types import AnyValue
 
 _internal_logger = logging.getLogger(__name__ + ".internal")
@@ -132,10 +138,24 @@ class LoggingHandler(logging.Handler):
 
     def _get_attributes(
         self, record: logging.LogRecord
-    ) -> Mapping[str, AnyValue]:
+    ) -> tuple[dict[str, AnyValue], str | None]:
         attributes = {
             k: v for k, v in vars(record).items() if k not in _RESERVED_ATTRS
         }
+
+        # Promote otel.event.name (stable) or event.name (deprecated) to the
+        # first-class LogRecord.event_name field instead of leaving it as a
+        # plain attribute.  otel.event.name takes precedence; event.name is a
+        # deprecated fallback per the OTel semantic conventions.
+        # Both keys are always popped so neither leaks into attributes.
+        event_name: str | None = attributes.pop(
+            otel_attributes.OTEL_EVENT_NAME, None
+        )
+        deprecated_event_name: str | None = attributes.pop(
+            event_attributes.EVENT_NAME, None
+        )
+        if event_name is None:
+            event_name = deprecated_event_name
 
         if self._log_code_attributes:
             # Add standard code attributes for logs.
@@ -158,12 +178,12 @@ class LoggingHandler(logging.Handler):
                 attributes[exception_attributes.EXCEPTION_STACKTRACE] = (
                     "".join(traceback.format_exception(*record.exc_info))
                 )
-        return attributes
+        return attributes, event_name
 
     def _translate(self, record: logging.LogRecord) -> LogRecord:
         timestamp = int(record.created * 1e9)
         observered_timestamp = time_ns()
-        attributes = self._get_attributes(record)
+        attributes, event_name = self._get_attributes(record)
         severity_number = std_to_otel(record.levelno)
         if self.formatter:
             body = self.format(record)
@@ -188,6 +208,7 @@ class LoggingHandler(logging.Handler):
             severity_number=severity_number,
             body=body,
             attributes=attributes,
+            event_name=event_name,
         )
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_handler.py
@@ -601,6 +601,92 @@ class TestLoggingHandler(unittest.TestCase):
             f"Should have 22 dropped attributes, got {record.dropped_attributes}",
         )
 
+    # --- event_name promotion tests (issue #4743) ---
+
+    def test_otel_event_name_promoted_to_event_name_field(self):
+        """otel.event.name in extra is promoted to LogRecord.event_name, not left as an attribute."""
+        processor, logger, handler = set_up_test_logging(logging.WARNING)
+
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning(
+                "something happened",
+                extra={"otel.event.name": "my.event"},
+            )
+
+        record = processor.get_log_record(0)
+        self.assertEqual(record.log_record.event_name, "my.event")
+        self.assertNotIn("otel.event.name", record.log_record.attributes)
+
+        logger.removeHandler(handler)
+
+    def test_deprecated_event_name_promoted_as_fallback(self):
+        """event.name (deprecated) is promoted to LogRecord.event_name when otel.event.name is absent."""
+        processor, logger, handler = set_up_test_logging(logging.WARNING)
+
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning(
+                "something happened",
+                extra={"event.name": "legacy.event"},
+            )
+
+        record = processor.get_log_record(0)
+        self.assertEqual(record.log_record.event_name, "legacy.event")
+        self.assertNotIn("event.name", record.log_record.attributes)
+
+        logger.removeHandler(handler)
+
+    def test_otel_event_name_takes_precedence_over_deprecated_event_name(self):
+        """otel.event.name wins over event.name when both are present."""
+        processor, logger, handler = set_up_test_logging(logging.WARNING)
+
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning(
+                "something happened",
+                extra={
+                    "otel.event.name": "stable.event",
+                    "event.name": "legacy.event",
+                },
+            )
+
+        record = processor.get_log_record(0)
+        self.assertEqual(record.log_record.event_name, "stable.event")
+        self.assertNotIn("otel.event.name", record.log_record.attributes)
+        self.assertNotIn("event.name", record.log_record.attributes)
+
+        logger.removeHandler(handler)
+
+    def test_event_name_is_none_when_not_provided(self):
+        """event_name is None when neither otel.event.name nor event.name is passed."""
+        processor, logger, handler = set_up_test_logging(logging.WARNING)
+
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("plain log, no event name")
+
+        record = processor.get_log_record(0)
+        self.assertIsNone(record.log_record.event_name)
+
+        logger.removeHandler(handler)
+
+    def test_other_extra_attributes_unaffected_by_event_name_promotion(self):
+        """Unrelated extra attributes still land in the attributes dict normally."""
+        processor, logger, handler = set_up_test_logging(logging.WARNING)
+
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning(
+                "something happened",
+                extra={
+                    "otel.event.name": "my.event",
+                    "http.status_code": 200,
+                },
+            )
+
+        record = processor.get_log_record(0)
+        self.assertEqual(record.log_record.event_name, "my.event")
+        self.assertEqual(record.log_record.attributes["http.status_code"], 200)
+        self.assertNotIn("otel.event.name", record.log_record.attributes)
+
+        logger.removeHandler(handler)
+
 
 # pylint: disable=invalid-name
 class SetupLoggingHandlerTestCase(unittest.TestCase):

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/__init__.py
@@ -34,6 +34,17 @@ from typing import Collection
 import wrapt
 
 from opentelemetry import trace
+from opentelemetry.instrumentation._semconv import (
+    _get_schema_url_for_signal_types,
+    _OpenTelemetrySemanticConventionStability,
+    _OpenTelemetryStabilitySignalType,
+    _set_db_name,
+    _set_db_statement,
+    _set_db_system,
+    _set_db_user,
+    _set_http_net_peer_name_client,
+    _set_http_peer_port_client,
+)
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.tortoiseorm.package import _instruments
 from opentelemetry.instrumentation.tortoiseorm.version import __version__
@@ -42,15 +53,7 @@ from opentelemetry.instrumentation.utils import (
     unwrap,
 )
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
-    DB_NAME,
-    DB_STATEMENT,
-    DB_SYSTEM,
-    DB_USER,
     DbSystemValues,
-)
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
 )
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
@@ -96,12 +99,18 @@ class TortoiseORMInstrumentor(BaseInstrumentor):
         Returns:
             None
         """
+        _OpenTelemetrySemanticConventionStability._initialize()
+        self._sem_conv_opt_in_mode = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+            _OpenTelemetryStabilitySignalType.DATABASE
+        )
         tracer_provider = kwargs.get("tracer_provider")
         self._tracer = trace.get_tracer(
             __name__,
             __version__,
             tracer_provider,
-            schema_url="https://opentelemetry.io/schemas/1.11.0",
+            schema_url=_get_schema_url_for_signal_types(
+                [_OpenTelemetryStabilitySignalType.DATABASE]
+            ),
         )
         self.capture_parameters = kwargs.get("capture_parameters", False)
         if TORTOISE_SQLITE_SUPPORT:
@@ -228,31 +237,44 @@ class TortoiseORMInstrumentor(BaseInstrumentor):
     def _hydrate_span_from_args(self, connection, query, parameters) -> dict:
         """Get network and database attributes from connection."""
         span_attributes = {}
+        mode = self._sem_conv_opt_in_mode
+
         capabilities = getattr(connection, "capabilities", None)
         if capabilities is not None:
             if capabilities.dialect == "sqlite":
-                span_attributes[DB_SYSTEM] = DbSystemValues.SQLITE.value
+                _set_db_system(
+                    span_attributes, DbSystemValues.SQLITE.value, mode
+                )
             elif capabilities.dialect == "postgres":
-                span_attributes[DB_SYSTEM] = DbSystemValues.POSTGRESQL.value
+                _set_db_system(
+                    span_attributes, DbSystemValues.POSTGRESQL.value, mode
+                )
             elif capabilities.dialect == "mysql":
-                span_attributes[DB_SYSTEM] = DbSystemValues.MYSQL.value
+                _set_db_system(
+                    span_attributes, DbSystemValues.MYSQL.value, mode
+                )
+
         dbname = getattr(connection, "filename", None)
         if dbname:
-            span_attributes[DB_NAME] = dbname
+            _set_db_name(span_attributes, dbname, mode)
         dbname = getattr(connection, "database", None)
         if dbname:
-            span_attributes[DB_NAME] = dbname
+            _set_db_name(span_attributes, dbname, mode)
+
         if query is not None:
-            span_attributes[DB_STATEMENT] = query
+            _set_db_statement(span_attributes, query, mode)
+
         user = getattr(connection, "user", None)
         if user:
-            span_attributes[DB_USER] = user
+            _set_db_user(span_attributes, user, mode)
+
         host = getattr(connection, "host", None)
         if host:
-            span_attributes[NET_PEER_NAME] = host
+            _set_http_net_peer_name_client(span_attributes, host, mode)
+
         port = getattr(connection, "port", None)
         if port:
-            span_attributes[NET_PEER_PORT] = port
+            _set_http_peer_port_client(span_attributes, port, mode)
 
         if self.capture_parameters:
             if parameters is not None and len(parameters) > 0:

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/package.py
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/src/opentelemetry/instrumentation/tortoiseorm/package.py
@@ -3,3 +3,5 @@
 
 
 _instruments = ("tortoise-orm >= 0.17.0",)
+
+_semconv_status = "migration"

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/tests/test_tortoiseorm_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/tests/test_tortoiseorm_instrumentation.py
@@ -2,16 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextlib
+from unittest import mock
 
 from tortoise import Tortoise, fields, models
 
 from opentelemetry import trace
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
 from opentelemetry.instrumentation.tortoiseorm import TortoiseORMInstrumentor
 from opentelemetry.instrumentation.utils import suppress_instrumentation
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_NAME,
     DB_STATEMENT,
     DB_SYSTEM,
+)
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
 )
 from opentelemetry.test.test_base import TestBase
 
@@ -24,15 +35,34 @@ class MockModel(models.Model):
         return self.name
 
 
+@contextlib.contextmanager
+def use_semconv_opt_in(sem_conv_mode):
+    """Context manager to set OTEL_SEMCONV_STABILITY_OPT_IN and reset state."""
+    env_patch = mock.patch.dict(
+        "os.environ",
+        {OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode},
+    )
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    env_patch.start()
+    try:
+        yield
+    finally:
+        env_patch.stop()
+        _OpenTelemetrySemanticConventionStability._initialized = False
+
+
 class TestTortoiseORMInstrumentor(TestBase):
     def setUp(self):
         super().setUp()
+        _OpenTelemetrySemanticConventionStability._initialized = False
         TortoiseORMInstrumentor().instrument()
 
     def tearDown(self):
         super().tearDown()
         TortoiseORMInstrumentor().uninstrument()
-        self._async_call(Tortoise._drop_databases())
+        _OpenTelemetrySemanticConventionStability._initialized = False
+        if Tortoise._inited:
+            self._async_call(Tortoise._drop_databases())
 
     # pylint: disable-next=no-self-use
     def _async_call(self, coro):
@@ -47,6 +77,8 @@ class TestTortoiseORMInstrumentor(TestBase):
         await Tortoise.generate_schemas()
 
     def test_trace_integration(self):
+        """Default mode (no opt-in): old semconv attributes only."""
+
         async def run():
             await self._init_tortoise()
             await MockModel.create(name="Test 1")
@@ -60,15 +92,83 @@ class TestTortoiseORMInstrumentor(TestBase):
 
         insert_span = next(s for s in crud_spans if s.name == "INSERT")
         self.assertEqual(insert_span.kind, trace.SpanKind.CLIENT)
+        # Old attrs present
         self.assertEqual(insert_span.attributes[DB_SYSTEM], "sqlite")
         self.assertEqual(insert_span.attributes[DB_NAME], ":memory:")
         self.assertIn("INSERT", insert_span.attributes[DB_STATEMENT])
+        # New attrs must NOT be present in default mode
+        self.assertNotIn(DB_SYSTEM_NAME, insert_span.attributes)
+        self.assertNotIn(DB_NAMESPACE, insert_span.attributes)
+        self.assertNotIn(DB_QUERY_TEXT, insert_span.attributes)
 
         select_span = next(s for s in crud_spans if s.name == "SELECT")
         self.assertEqual(select_span.kind, trace.SpanKind.CLIENT)
         self.assertEqual(select_span.attributes[DB_SYSTEM], "sqlite")
         self.assertEqual(select_span.attributes[DB_NAME], ":memory:")
         self.assertIn("SELECT", select_span.attributes[DB_STATEMENT])
+
+    def test_trace_integration_new_semconv(self):
+        """database opt-in mode: new stable semconv attributes only."""
+        TortoiseORMInstrumentor().uninstrument()
+
+        with use_semconv_opt_in("database"):
+            TortoiseORMInstrumentor().instrument()
+
+            async def run():
+                await self._init_tortoise()
+                await MockModel.create(name="Test New Semconv")
+                await MockModel.filter(name="Test New Semconv").first()
+
+            self._async_call(run())
+
+        spans = self.memory_exporter.get_finished_spans()
+        crud_spans = [s for s in spans if s.name in ("INSERT", "SELECT")]
+        self.assertGreaterEqual(len(crud_spans), 2)
+
+        insert_span = next(s for s in crud_spans if s.name == "INSERT")
+        # New attrs present
+        self.assertEqual(insert_span.attributes[DB_SYSTEM_NAME], "sqlite")
+        self.assertEqual(insert_span.attributes[DB_NAMESPACE], ":memory:")
+        self.assertIn("INSERT", insert_span.attributes[DB_QUERY_TEXT])
+        # Old attrs must NOT be present
+        self.assertNotIn(DB_SYSTEM, insert_span.attributes)
+        self.assertNotIn(DB_NAME, insert_span.attributes)
+        self.assertNotIn(DB_STATEMENT, insert_span.attributes)
+
+        select_span = next(s for s in crud_spans if s.name == "SELECT")
+        self.assertEqual(select_span.attributes[DB_SYSTEM_NAME], "sqlite")
+        self.assertIn("SELECT", select_span.attributes[DB_QUERY_TEXT])
+
+    def test_trace_integration_dup_semconv(self):
+        """database/dup mode: both old and new semconv attributes present."""
+        TortoiseORMInstrumentor().uninstrument()
+
+        with use_semconv_opt_in("database/dup"):
+            TortoiseORMInstrumentor().instrument()
+
+            async def run():
+                await self._init_tortoise()
+                await MockModel.create(name="Test Dup Semconv")
+
+            self._async_call(run())
+
+        spans = self.memory_exporter.get_finished_spans()
+        insert_span = next((s for s in spans if s.name == "INSERT"), None)
+        self.assertIsNotNone(insert_span)
+
+        # Old attrs present
+        self.assertIn(DB_SYSTEM, insert_span.attributes)
+        self.assertIn(DB_NAME, insert_span.attributes)
+        self.assertIn(DB_STATEMENT, insert_span.attributes)
+        # New attrs also present
+        self.assertIn(DB_SYSTEM_NAME, insert_span.attributes)
+        self.assertIn(DB_NAMESPACE, insert_span.attributes)
+        self.assertIn(DB_QUERY_TEXT, insert_span.attributes)
+        # Values are consistent
+        self.assertEqual(insert_span.attributes[DB_SYSTEM], "sqlite")
+        self.assertEqual(insert_span.attributes[DB_SYSTEM_NAME], "sqlite")
+        self.assertEqual(insert_span.attributes[DB_NAME], ":memory:")
+        self.assertEqual(insert_span.attributes[DB_NAMESPACE], ":memory:")
 
     def test_capture_parameters(self):
         TortoiseORMInstrumentor().uninstrument()


### PR DESCRIPTION
## Description

`LoggingHandler._translate` never set the first-class `event_name` field on
`LogRecord`. When a user passed `otel.event.name` (or the deprecated `event.name`)
via `extra={...}`, it silently landed in `attributes` as a plain key and was
exported as a regular OTLP attribute instead of the dedicated `event_name` field.

This fix updates `_get_attributes` to pop both keys from the attributes dict and
return the resolved event name alongside the attributes. `_translate` then passes
it as `event_name=` to `LogRecord(...)`.

- `otel.event.name` (stable) takes precedence
- `event.name` (deprecated) is used only as a fallback
- Both keys are always popped so neither leaks into attributes

Fixes #4743

Part of open-telemetry/community#1751

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Five new unit tests added to `TestLoggingHandler` in `tests/test_handler.py`:

- `test_otel_event_name_promoted_to_event_name_field` — stable key is promoted to `event_name`, removed from attributes
- `test_deprecated_event_name_promoted_as_fallback` — deprecated `event.name` works when stable key is absent
- `test_otel_event_name_takes_precedence_over_deprecated_event_name` — stable key wins when both are present, both popped from attributes
- `test_event_name_is_none_when_not_provided` — `event_name` is `None` when neither key is passed (no regression)
- `test_other_extra_attributes_unaffected_by_event_name_promotion` — unrelated `extra` fields still land in attributes normally

All 36 existing tests continue to pass (41 total).

To reproduce:
python3 -m pytest instrumentation/opentelemetry-instrumentation-logging/tests/test_handler.py -v

## Does This PR Require a Core Repo Change?

- [x] No.

## Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated