### PR TITLE
fix(openai-agents-v2): default content capture to NO_CONTENT when env var is unset

### DIFF
--- a/.changelog/4757.fixed
+++ b/.changelog/4757.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-openai-agents-v2`: fix default content capture mode to NO_CONTENT when env var is unset

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
@@ -81,11 +81,11 @@ def _resolve_content_mode(value: Any) -> ContentCaptureMode:
         )
 
     if value is None:
-        return ContentCaptureMode.SPAN_AND_EVENT
+        return ContentCaptureMode.NO_CONTENT
 
     text = str(value).strip().lower()
     if not text:
-        return ContentCaptureMode.SPAN_AND_EVENT
+        return ContentCaptureMode.NO_CONTENT
 
     mapping = {
         "span_only": ContentCaptureMode.SPAN_ONLY,
@@ -108,7 +108,7 @@ def _resolve_content_mode(value: Any) -> ContentCaptureMode:
         "none": ContentCaptureMode.NO_CONTENT,
     }
 
-    return mapping.get(text, ContentCaptureMode.SPAN_AND_EVENT)
+    return mapping.get(text, ContentCaptureMode.NO_CONTENT)
 
 
 def _resolve_bool(value: Any, default: bool) -> bool:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_tracer.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_tracer.py
@@ -363,7 +363,9 @@ def test_agent_content_aggregation_appends_new_messages_once():
 
 
 def test_agent_span_collects_child_messages():
-    instrumentor, exporter = _instrument_with_provider()
+    instrumentor, exporter = _instrument_with_provider(
+        capture_message_content="span_only"
+    )
 
     try:
         provider = agents_tracing.get_trace_provider()
@@ -475,7 +477,9 @@ def test_capture_mode_can_be_disabled():
 
 
 def test_response_span_records_response_attributes():
-    instrumentor, exporter = _instrument_with_provider()
+    instrumentor, exporter = _instrument_with_provider(
+        capture_message_content="span_only"
+    )
 
     class _Usage:
         def __init__(self, input_tokens: int, output_tokens: int) -> None:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_zz_coverage_improvements.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_zz_coverage_improvements.py
@@ -181,12 +181,12 @@ class TestResolveContentMode:
     def test_resolve_content_mode_for_none(self):
         sp, init_module = _get_modules()
         result = init_module._resolve_content_mode(None)
-        assert result == sp.ContentCaptureMode.SPAN_AND_EVENT
+        assert result == sp.ContentCaptureMode.NO_CONTENT
 
     def test_resolve_content_mode_for_empty_string(self):
         sp, init_module = _get_modules()
         result = init_module._resolve_content_mode("")
-        assert result == sp.ContentCaptureMode.SPAN_AND_EVENT
+        assert result == sp.ContentCaptureMode.NO_CONTENT
 
     def test_resolve_content_mode_span_only_variants(self):
         sp, init_module = _get_modules()


### PR DESCRIPTION
## Description

Fixes #4756

When `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is not set,
`_resolve_content_mode` was returning `ContentCaptureMode.SPAN_AND_EVENT`,
causing prompts, system instructions, model responses, and tool arguments
to be captured in exported spans by default.

Per the GenAI semantic conventions, content capture should be **opt-in**.

### Root cause

Three return paths in `_resolve_content_mode` defaulted to `SPAN_AND_EVENT`:
- `value is None` — env var not set
- `value == ""` — env var set but empty
- `mapping.get(text, ...)` fallback — unrecognized value

All three now return `NO_CONTENT`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Updated two existing unit tests in `test_zz_coverage_improvements.py`
  that were asserting the old buggy behavior (`None` and `""` → `SPAN_AND_EVENT`),
  now correctly assert `NO_CONTENT`.
- Updated `test_agent_span_collects_child_messages` and
  `test_response_span_records_response_attributes` in `test_tracer.py` to
  explicitly pass `capture_message_content="span_only"` — these tests check
  content is captured when opted in, so they must opt in explicitly rather
  than relying on the default.
- Manually verified all code paths in `_resolve_content_mode` including:
  `None`, `""`, unknown string, `"true"`, `"false"`, `"span_only"`, `"event_only"`.
- Full test suite: **103 passed, 0 failed**.

## Does This PR Require a Core Repo Change?

- [x] No.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated