### PR TITLE
opentelemetry-instrumentation: add config_dataclass opt-in to BaseInstrumentor

### DIFF
--- a/.changelog/4766.added
+++ b/.changelog/4766.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation`: add `configuration` opt-in attribute on `BaseInstrumentor` for declarative-config validation, and set it on `URLLib3Instrumentor` via `URLLib3InstrumentorConfig`

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -242,6 +242,22 @@ _excluded_urls_from_env = get_excluded_urls("URLLIB3")
 
 
 @dataclass
+class URLLib3InstrumentorConfig:
+    """Declarative configuration schema for :class:`URLLib3Instrumentor`.
+
+    Fields map directly to the ``instrument()`` keyword arguments that are
+    expressible as plain YAML values.  Callable options (``request_hook``,
+    ``response_hook``, ``url_filter``) and SDK provider objects are not
+    included because they cannot be represented in a configuration file.
+    """
+
+    excluded_urls: str | None = None
+    captured_request_headers: list[str] | None = None
+    captured_response_headers: list[str] | None = None
+    sensitive_headers: list[str] | None = None
+
+
+@dataclass
 class RequestInfo:
     """Arguments that were passed to the ``urlopen()`` call."""
 
@@ -280,6 +296,8 @@ _ResponseHookT = typing.Optional[
 
 
 class URLLib3Instrumentor(BaseInstrumentor):
+    config_dataclass = URLLib3InstrumentorConfig
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -296,7 +296,7 @@ _ResponseHookT = typing.Optional[
 
 
 class URLLib3Instrumentor(BaseInstrumentor):
-    config_dataclass = URLLib3InstrumentorConfig
+    configuration = URLLib3InstrumentorConfig
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -298,7 +298,7 @@ _ResponseHookT = (
 
 
 class URLLib3Instrumentor(BaseInstrumentor):
-    config_dataclass = URLLib3InstrumentorConfig
+    configuration = URLLib3InstrumentorConfig
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -244,6 +244,22 @@ _excluded_urls_from_env = get_excluded_urls("URLLIB3")
 
 
 @dataclass
+class URLLib3InstrumentorConfig:
+    """Declarative configuration schema for :class:`URLLib3Instrumentor`.
+
+    Fields map directly to the ``instrument()`` keyword arguments that are
+    expressible as plain YAML values.  Callable options (``request_hook``,
+    ``response_hook``, ``url_filter``) and SDK provider objects are not
+    included because they cannot be represented in a configuration file.
+    """
+
+    excluded_urls: str | None = None
+    captured_request_headers: list[str] | None = None
+    captured_response_headers: list[str] | None = None
+    sensitive_headers: list[str] | None = None
+
+
+@dataclass
 class RequestInfo:
     """Arguments that were passed to the ``urlopen()`` call."""
 
@@ -282,6 +298,8 @@ _ResponseHookT = (
 
 
 class URLLib3Instrumentor(BaseInstrumentor):
+    config_dataclass = URLLib3InstrumentorConfig
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -750,9 +750,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_span(num_spans=0)
 
         # The remaining fields are honored on a captured request.
-        self.perform_request(
-            captured_url, headers={"X-Request": "secret"}
-        )
+        self.perform_request(captured_url, headers={"X-Request": "secret"})
         span = self.assert_span(num_spans=1)
         # captured_request_headers captured the request header, and
         # sensitive_headers redacted its value.

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -3,6 +3,7 @@
 
 import json
 import typing
+import unittest
 from unittest import mock
 
 import urllib3
@@ -19,6 +20,7 @@ from opentelemetry.instrumentation._semconv import (
 from opentelemetry.instrumentation.urllib3 import (
     RequestInfo,
     URLLib3Instrumentor,
+    URLLib3InstrumentorConfig,
 )
 from opentelemetry.instrumentation.utils import (
     suppress_http_instrumentation,
@@ -1022,3 +1024,29 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(
             span.attributes["http.request.header.x_test"], ("Value",)
         )
+
+
+class TestURLLib3InstrumentorConfig(unittest.TestCase):
+    def test_configuration_attribute_is_config_dataclass(self):
+        self.assertIs(
+            URLLib3Instrumentor.configuration, URLLib3InstrumentorConfig
+        )
+
+    def test_default_fields_are_none(self):
+        config = URLLib3InstrumentorConfig()
+        self.assertIsNone(config.excluded_urls)
+        self.assertIsNone(config.captured_request_headers)
+        self.assertIsNone(config.captured_response_headers)
+        self.assertIsNone(config.sensitive_headers)
+
+    def test_fields_accept_declared_values(self):
+        config = URLLib3InstrumentorConfig(
+            excluded_urls="/healthz",
+            captured_request_headers=["X-Test"],
+            captured_response_headers=["X-Response"],
+            sensitive_headers=["Authorization"],
+        )
+        self.assertEqual(config.excluded_urls, "/healthz")
+        self.assertEqual(config.captured_request_headers, ["X-Test"])
+        self.assertEqual(config.captured_response_headers, ["X-Response"])
+        self.assertEqual(config.sensitive_headers, ["Authorization"])

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import json
 import typing
 import unittest
@@ -711,6 +712,58 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(
             span.attributes["http.response.header.x_secret"],
             ("[REDACTED]",),
+        )
+
+    def test_config_dataclass_fields_match_instrument_kwargs(self):
+        """The config dataclass field names must match the ``instrument()``
+        keyword arguments.
+
+        Declarative configuration forwards the config as
+        ``instrument(**dataclasses.asdict(config))``, and ``_instrument`` reads
+        each option with ``kwargs.get("<name>")``. A field whose name did not
+        match its kwarg would be silently ignored, so exercise every field end
+        to end and assert it actually takes effect.
+        """
+        excluded_url = "http://mock/status/201"
+        Entry.single_register(Entry.GET, excluded_url, status=201)
+
+        captured_url = "http://mock/capture_headers"
+        Entry.single_register(
+            Entry.GET,
+            captured_url,
+            body="Hello!",
+            headers={"X-Response": "response-value"},
+        )
+
+        config = URLLib3InstrumentorConfig(
+            excluded_urls=".*/201",
+            captured_request_headers=["X-Request"],
+            captured_response_headers=["X-Response"],
+            sensitive_headers=["X-Request"],
+        )
+
+        URLLib3Instrumentor().uninstrument()
+        URLLib3Instrumentor().instrument(**dataclasses.asdict(config))
+
+        # excluded_urls is honored: the excluded URL produces no span.
+        self.perform_request(excluded_url)
+        self.assert_span(num_spans=0)
+
+        # The remaining fields are honored on a captured request.
+        self.perform_request(
+            captured_url, headers={"X-Request": "secret"}
+        )
+        span = self.assert_span(num_spans=1)
+        # captured_request_headers captured the request header, and
+        # sensitive_headers redacted its value.
+        self.assertEqual(
+            span.attributes["http.request.header.x_request"],
+            ("[REDACTED]",),
+        )
+        # captured_response_headers captured the response header.
+        self.assertEqual(
+            span.attributes["http.response.header.x_response"],
+            ("response-value",),
         )
 
     def test_custom_headers_with_regex(self):

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -1017,9 +1017,7 @@ class TestURLLib3Instrumentor(TestBase):
 
 class TestURLLib3InstrumentorConfig(unittest.TestCase):
     def test_configuration_attribute_is_config_dataclass(self):
-        self.assertIs(
-            URLLib3Instrumentor.configuration, URLLib3InstrumentorConfig
-        )
+        self.assertIs(URLLib3Instrumentor.configuration, URLLib3InstrumentorConfig)
 
     def test_default_fields_are_none(self):
         config = URLLib3InstrumentorConfig()

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import json
 import typing
 import unittest
@@ -663,6 +664,58 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(
             span.attributes["http.response.header.x_secret"],
             ("[REDACTED]",),
+        )
+
+    def test_config_dataclass_fields_match_instrument_kwargs(self):
+        """The config dataclass field names must match the ``instrument()``
+        keyword arguments.
+
+        Declarative configuration forwards the config as
+        ``instrument(**dataclasses.asdict(config))``, and ``_instrument`` reads
+        each option with ``kwargs.get("<name>")``. A field whose name did not
+        match its kwarg would be silently ignored, so exercise every field end
+        to end and assert it actually takes effect.
+        """
+        excluded_url = "http://mock/status/201"
+        Entry.single_register(Entry.GET, excluded_url, status=201)
+
+        captured_url = "http://mock/capture_headers"
+        Entry.single_register(
+            Entry.GET,
+            captured_url,
+            body="Hello!",
+            headers={"X-Response": "response-value"},
+        )
+
+        config = URLLib3InstrumentorConfig(
+            excluded_urls=".*/201",
+            captured_request_headers=["X-Request"],
+            captured_response_headers=["X-Response"],
+            sensitive_headers=["X-Request"],
+        )
+
+        URLLib3Instrumentor().uninstrument()
+        URLLib3Instrumentor().instrument(**dataclasses.asdict(config))
+
+        # excluded_urls is honored: the excluded URL produces no span.
+        self.perform_request(excluded_url)
+        self.assert_span(num_spans=0)
+
+        # The remaining fields are honored on a captured request.
+        self.perform_request(
+            captured_url, headers={"X-Request": "secret"}
+        )
+        span = self.assert_span(num_spans=1)
+        # captured_request_headers captured the request header, and
+        # sensitive_headers redacted its value.
+        self.assertEqual(
+            span.attributes["http.request.header.x_request"],
+            ("[REDACTED]",),
+        )
+        # captured_response_headers captured the response header.
+        self.assertEqual(
+            span.attributes["http.response.header.x_response"],
+            ("response-value",),
         )
 
     def test_custom_headers_with_regex(self):

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -3,6 +3,7 @@
 
 import json
 import typing
+import unittest
 from unittest import mock
 
 import urllib3
@@ -19,6 +20,7 @@ from opentelemetry.instrumentation._semconv import (
 from opentelemetry.instrumentation.urllib3 import (
     RequestInfo,
     URLLib3Instrumentor,
+    URLLib3InstrumentorConfig,
 )
 from opentelemetry.instrumentation.utils import (
     suppress_http_instrumentation,
@@ -960,3 +962,29 @@ class TestURLLib3Instrumentor(TestBase):
         self.assertEqual(b"Hello!", response.data)
         span = self.assert_span()
         self.assertEqual(span.attributes["http.request.header.x_test"], ("Value",))
+
+
+class TestURLLib3InstrumentorConfig(unittest.TestCase):
+    def test_configuration_attribute_is_config_dataclass(self):
+        self.assertIs(
+            URLLib3Instrumentor.configuration, URLLib3InstrumentorConfig
+        )
+
+    def test_default_fields_are_none(self):
+        config = URLLib3InstrumentorConfig()
+        self.assertIsNone(config.excluded_urls)
+        self.assertIsNone(config.captured_request_headers)
+        self.assertIsNone(config.captured_response_headers)
+        self.assertIsNone(config.sensitive_headers)
+
+    def test_fields_accept_declared_values(self):
+        config = URLLib3InstrumentorConfig(
+            excluded_urls="/healthz",
+            captured_request_headers=["X-Test"],
+            captured_response_headers=["X-Response"],
+            sensitive_headers=["Authorization"],
+        )
+        self.assertEqual(config.excluded_urls, "/healthz")
+        self.assertEqual(config.captured_request_headers, ["X-Test"])
+        self.assertEqual(config.captured_response_headers, ["X-Response"])
+        self.assertEqual(config.sensitive_headers, ["Authorization"])

--- a/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/tests/test_urllib3_integration.py
@@ -702,9 +702,7 @@ class TestURLLib3Instrumentor(TestBase):
         self.assert_span(num_spans=0)
 
         # The remaining fields are honored on a captured request.
-        self.perform_request(
-            captured_url, headers={"X-Request": "secret"}
-        )
+        self.perform_request(captured_url, headers={"X-Request": "secret"})
         span = self.assert_span(num_spans=1)
         # captured_request_headers captured the request header, and
         # sensitive_headers redacted its value.

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -37,7 +37,7 @@ class BaseInstrumentor(ABC):
     needed to provide practical instrumentation to the end user.
 
     To enable schema-based validation of declarative configuration options,
-    set ``config_dataclass`` to a dataclass type whose fields declare the
+    set ``configuration`` to a dataclass type whose fields declare the
     accepted options and their types.  The SDK declarative configuration
     pipeline will run the raw YAML options through ``_dict_to_dataclass``
     before forwarding them to ``instrument()``, applying the same type
@@ -47,7 +47,7 @@ class BaseInstrumentor(ABC):
 
     _instance = None
     _is_instrumented_by_opentelemetry = False
-    config_dataclass: type | None = None
+    configuration: type | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -35,10 +35,19 @@ class BaseInstrumentor(ABC):
     Since every third party library or framework is different and has different
     instrumentation needs, more methods can be added to the child classes as
     needed to provide practical instrumentation to the end user.
+
+    To enable schema-based validation of declarative configuration options,
+    set ``config_dataclass`` to a dataclass type whose fields declare the
+    accepted options and their types.  The SDK declarative configuration
+    pipeline will run the raw YAML options through ``_dict_to_dataclass``
+    before forwarding them to ``instrument()``, applying the same type
+    coercion used for SDK component configuration.  Omit the attribute (or
+    set it to ``None``) to pass options through without validation.
     """
 
     _instance = None
     _is_instrumented_by_opentelemetry = False
+    config_dataclass: type | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -38,7 +38,7 @@ class BaseInstrumentor(ABC):
     needed to provide practical instrumentation to the end user.
 
     To enable schema-based validation of declarative configuration options,
-    set ``config_dataclass`` to a dataclass type whose fields declare the
+    set ``configuration`` to a dataclass type whose fields declare the
     accepted options and their types.  The SDK declarative configuration
     pipeline will run the raw YAML options through ``_dict_to_dataclass``
     before forwarding them to ``instrument()``, applying the same type
@@ -48,7 +48,7 @@ class BaseInstrumentor(ABC):
 
     _instance = None
     _is_instrumented_by_opentelemetry = False
-    config_dataclass: type | None = None
+    configuration: type | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -36,10 +36,19 @@ class BaseInstrumentor(ABC):
     Since every third party library or framework is different and has different
     instrumentation needs, more methods can be added to the child classes as
     needed to provide practical instrumentation to the end user.
+
+    To enable schema-based validation of declarative configuration options,
+    set ``config_dataclass`` to a dataclass type whose fields declare the
+    accepted options and their types.  The SDK declarative configuration
+    pipeline will run the raw YAML options through ``_dict_to_dataclass``
+    before forwarding them to ``instrument()``, applying the same type
+    coercion used for SDK component configuration.  Omit the attribute (or
+    set it to ``None``) to pass options through without validation.
     """
 
     _instance = None
     _is_instrumented_by_opentelemetry = False
+    config_dataclass: type | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -52,13 +52,13 @@ class TestInstrumentor(TestCase):
 
     def test_configuration_can_be_overridden(self):
         @dataclass
-        class FooConfig:
-            bar: str | None = None
+        class SampleConfig:
+            excluded_urls: str | None = None
 
         class ConfiguredInstrumentor(self.Instrumentor):
-            configuration = FooConfig
+            configuration = SampleConfig
 
-        self.assertIs(ConfiguredInstrumentor.configuration, FooConfig)
+        self.assertIs(ConfiguredInstrumentor.configuration, SampleConfig)
         self.assertIsNone(self.Instrumentor.configuration)
 
     @patch("opentelemetry.instrumentation.instrumentor._LOG")

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from logging import WARNING
 from unittest import TestCase
 from unittest.mock import patch
@@ -42,6 +45,21 @@ class TestInstrumentor(TestCase):
 
     def test_singleton(self):
         self.assertIs(self.Instrumentor(), self.Instrumentor())
+
+    def test_configuration_defaults_to_none(self):
+        self.assertIsNone(BaseInstrumentor.configuration)
+        self.assertIsNone(self.Instrumentor().configuration)
+
+    def test_configuration_can_be_overridden(self):
+        @dataclass
+        class FooConfig:
+            bar: str | None = None
+
+        class ConfiguredInstrumentor(self.Instrumentor):
+            configuration = FooConfig
+
+        self.assertIs(ConfiguredInstrumentor.configuration, FooConfig)
+        self.assertIsNone(self.Instrumentor.configuration)
 
     @patch("opentelemetry.instrumentation.instrumentor._LOG")
     @patch(

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from logging import WARNING
 from unittest import TestCase
 from unittest.mock import patch
@@ -42,6 +45,21 @@ class TestInstrumentor(TestCase):
 
     def test_singleton(self):
         self.assertIs(self.Instrumentor(), self.Instrumentor())
+
+    def test_configuration_defaults_to_none(self):
+        self.assertIsNone(BaseInstrumentor.configuration)
+        self.assertIsNone(self.Instrumentor().configuration)
+
+    def test_configuration_can_be_overridden(self):
+        @dataclass
+        class FooConfig:
+            bar: str | None = None
+
+        class ConfiguredInstrumentor(self.Instrumentor):
+            configuration = FooConfig
+
+        self.assertIs(ConfiguredInstrumentor.configuration, FooConfig)
+        self.assertIsNone(self.Instrumentor.configuration)
 
     @patch("opentelemetry.instrumentation.instrumentor._LOG")
     @patch("opentelemetry.instrumentation.instrumentor.BaseInstrumentor._check_dependency_conflicts")


### PR DESCRIPTION
Fixes #4765

## Summary

- Adds `configuration: type | None = None` to `BaseInstrumentor`; default `None` leaves all existing instrumentors unaffected
- Adds `URLLib3InstrumentorConfig` as the reference implementation — a typed dataclass covering the four YAML-representable options (`excluded_urls`, `captured_request_headers`, `captured_response_headers`, `sensitive_headers`); callable and SDK provider options are intentionally excluded
- Sets `configuration = URLLib3InstrumentorConfig` on `URLLib3Instrumentor`

The SDK side that reads `configuration` and runs options through `_dict_to_dataclass` is in open-telemetry/opentelemetry-python#5372.

## Test plan

- [ ] Existing urllib3 instrumentation tests continue to pass
- [ ] New tests cover `BaseInstrumentor.configuration` defaulting to `None`/being overridable, and `URLLib3Instrumentor.configuration` wiring `URLLib3InstrumentorConfig`
- [ ] End-to-end: run the demo at https://github.com/ocelotl/instrumentation_configuration_demo with `docker compose up`; verify spans appear in `output/traces.jsonl` with captured headers and that `/healthz` requests are excluded