### PR TITLE
fix(redis): poll FT.INFO to avoid flaky test_redis_query race condition

### DIFF
--- a/.changelog/4767.fixed
+++ b/.changelog/4767.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-redis`: fix flaky `test_redis_query` by polling `FT.INFO` until RediSearch backfill completes after index creation

--- a/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import time
 from time import time_ns
 
 import redis
@@ -628,6 +629,27 @@ class TestRedisearchInstrument(TestBase):
             fields=schema, definition=definition
         )
         assert "OK" in str(res)
+
+        # Wait for RediSearch to finish indexing existing documents.
+        # FT.CREATE returns "OK" once the index is registered, but the
+        # backfill scan of pre-existing keys happens asynchronously.
+        # Querying before it completes intermittently returns total=0.
+        timeout = 5.0
+        interval = 0.05
+        elapsed = 0.0
+        while elapsed < timeout:
+            info = self.redis_client.ft("idx:test_vss").info()
+            if (
+                not int(info.get("indexing", 1))
+                and float(info.get("percent_indexed", 0)) >= 1.0
+            ):
+                break
+            time.sleep(interval)
+            elapsed += interval
+        else:
+            raise RuntimeError(
+                "RediSearch index did not finish indexing within timeout"
+            )
 
     def test_redis_create_index(self):
         spans = self.memory_exporter.get_finished_spans()


### PR DESCRIPTION
## Description

Fixes #4589

`FT.CREATE` returns `OK` once the index is registered, but the backfill
scan of pre-existing keys happens asynchronously in the background.
In `TestRedisearchInstrument.setUp`, `prepare_data()` writes a JSON
document (`test:001`) and then `create_index()` immediately creates an
index over the `test:` prefix. If `test_redis_query` issues `FT.SEARCH`
before the backfill completes, RediSearch returns `total=0` instead of
`1`, causing an intermittent assertion failure in CI.

Fix by polling `FT.INFO` after `create_index()` returns until
`indexing=0` and `percent_indexed=1`, with a 5s timeout and 50ms
interval. On fast machines the poll exits on the first iteration with
zero overhead; on slower CI machines under load it waits as needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran `TestRedisearchInstrument::test_redis_query` in a 30-iteration
loop locally against the `redis/redis-stack:7.2.0-v12` Docker image
(same image used in CI via `docker-compose.yml`). All 30 runs passed.

Also verified the poll logic by temporarily adding debug prints showing
`indexing` and `percent_indexed` values from `FT.INFO` — confirmed the
fields are read correctly and the loop exits as expected.

To reproduce locally:
1. `docker compose up -d otredis` (from `tests/opentelemetry-docker-tests/tests/`)
2. `pip install -e instrumentation/opentelemetry-instrumentation-redis/`
3. `for i in $(seq 1 30); do python -m pytest tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py::TestRedisearchInstrument::test_redis_query -x -q; done`

## Does This PR Require a Core Repo Change?

- [x] No.

## Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated