### PR TITLE
opentelemetry-instrumentation-django: remove duplicate calls

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/benchmark-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-django/benchmark-requirements.txt
@@ -1,0 +1,6 @@
+django>=2.0
+pytest-benchmark==4.0.0
+-e opentelemetry-instrumentation
+-e util/opentelemetry-util-http
+-e instrumentation/opentelemetry-instrumentation-wsgi
+-e instrumentation/opentelemetry-instrumentation-django

--- a/instrumentation/opentelemetry-instrumentation-django/benchmarks/test_benchmark_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/benchmarks/test_benchmark_middleware.py
@@ -1,0 +1,54 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.http import HttpResponse
+
+if not settings.configured:
+    settings.configure(
+        ROOT_URLCONF=__name__,
+        DATABASES={"default": {}},
+        MIDDLEWARE=[],
+        ALLOWED_HOSTS=["testserver"],
+    )
+
+from django.urls import re_path  # noqa: E402
+
+from opentelemetry.instrumentation.django import DjangoInstrumentor  # noqa: E402
+from opentelemetry.sdk.metrics import MeterProvider  # noqa: E402
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
+    InMemorySpanExporter,
+)
+
+
+def _simple_view(request):
+    return HttpResponse("OK")
+
+
+urlpatterns = [re_path(r"^traced/", _simple_view)]
+
+
+@pytest.fixture(name="django_client")
+def _django_client_fixture():
+    from django.test.client import Client
+
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter_provider = MeterProvider()
+    DjangoInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+    )
+    client = Client()
+    yield client
+    DjangoInstrumentor().uninstrument()
+
+
+def test_middleware_full_request(benchmark, django_client):
+    benchmark(django_client.get, "/traced/")

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -120,6 +120,9 @@ class _DjangoMiddleware:
         "opentelemetry-instrumentor-django.duration_attr_key"
     )
     _environ_timer_key = "opentelemetry-instrumentor-django.timer_key"
+    _environ_url_disabled_key = (
+        "opentelemetry-instrumentor-django.url_disabled_key"
+    )
     _traced_request_attrs = get_traced_request_attrs("DJANGO")
     _excluded_urls = get_excluded_urls("DJANGO")
     _tracer = None
@@ -171,7 +174,11 @@ class _DjangoMiddleware:
         # Read more about request.META here:
         # https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.META
 
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        is_url_disabled = self._excluded_urls.url_disabled(
+            request.build_absolute_uri("?")
+        )
+        request.META[self._environ_url_disabled_key] = is_url_disabled
+        if is_url_disabled:
             return
 
         is_asgi_request = _is_asgi_request(request)
@@ -282,7 +289,7 @@ class _DjangoMiddleware:
     def process_view(self, request, view_func, *args, **kwargs):
         # Process view is executed before the view function, here we get the
         # route template from request.resolver_match.  It is not set yet in process_request
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if request.META.get(self._environ_url_disabled_key, False):
             return
 
         if (
@@ -307,7 +314,7 @@ class _DjangoMiddleware:
                         duration_attrs[HTTP_ROUTE] = route
 
     def process_exception(self, request, exception):
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if request.META.get(self._environ_url_disabled_key, False):
             return
 
         if self._environ_activation_key in request.META.keys():
@@ -317,7 +324,7 @@ class _DjangoMiddleware:
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
     def process_response(self, request, response):
-        if self._excluded_urls.url_disabled(request.build_absolute_uri("?")):
+        if request.META.get(self._environ_url_disabled_key, False):
             return response
 
         is_asgi_request = _is_asgi_request(request)

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,7 @@ envlist =
     py3{13,14}-test-instrumentation-django-3
     pypy3-test-instrumentation-django-{0,1,2,3}
     lint-instrumentation-django
+    benchmark-instrumentation-django
 
     ; opentelemetry-instrumentation-dbapi
     py3{10,11,12,13,14}-test-instrumentation-dbapi-{wrapt1,wrapt2}
@@ -618,6 +619,7 @@ deps =
   django-2: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-django/test-requirements-2.txt
   django-3: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-django/test-requirements-3.txt
   lint-instrumentation-django: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-django/test-requirements-3.txt
+  benchmark-instrumentation-django: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-django/benchmark-requirements.txt
 
   fastapi: {[testenv]test_deps}
   fastapi-oldest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-fastapi/test-requirements.oldest.txt
@@ -860,6 +862,7 @@ commands =
 
   test-instrumentation-django: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-django/tests {posargs}
   lint-instrumentation-django: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-django"
+  benchmark-instrumentation-django: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-django/benchmarks {posargs} --benchmark-json=instrumentation-django-benchmark.json
 
   test-instrumentation-falcon: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-falcon/tests {posargs}
   lint-instrumentation-falcon: sh -c "cd instrumentation && pylint --rcfile ../.pylintrc opentelemetry-instrumentation-falcon"


### PR DESCRIPTION
# Description

The django instrumentation made multiple calls to the same method, storing the results on the first call instead.

## Type of change

Please delete options that are not relevant.

- [x] Small improvement (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added benchmark test

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Benchmark test has been added
- [ ] Documentation has been updated
