### PR TITLE
opentelemetry-instrumentation-pymongo: semantic convention stability migration

### DIFF
--- a/.changelog/4772.added
+++ b/.changelog/4772.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-pymongo`: add database semantic convention stability support through `OTEL_SEMCONV_STABILITY_OPT_IN`

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -34,7 +34,7 @@
 | [opentelemetry-instrumentation-psycopg](./opentelemetry-instrumentation-psycopg) | psycopg >= 3.1.0 | No | migration
 | [opentelemetry-instrumentation-psycopg2](./opentelemetry-instrumentation-psycopg2) | psycopg2 >= 2.7.3.1,psycopg2-binary >= 2.7.3.1 | No | migration
 | [opentelemetry-instrumentation-pymemcache](./opentelemetry-instrumentation-pymemcache) | pymemcache >= 1.3.5, < 5 | No | migration
-| [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 | No | development
+| [opentelemetry-instrumentation-pymongo](./opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 | No | migration
 | [opentelemetry-instrumentation-pymssql](./opentelemetry-instrumentation-pymssql) | pymssql >= 2.1.5, < 3 | No | migration
 | [opentelemetry-instrumentation-pymysql](./opentelemetry-instrumentation-pymysql) | PyMySQL < 2 | No | migration
 | [opentelemetry-instrumentation-pyramid](./opentelemetry-instrumentation-pyramid) | pyramid >= 1.7 | Yes | migration

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -192,6 +192,8 @@ class CommandTracer(monitoring.CommandListener):
         except Exception as ex:  # noqa pylint: disable=broad-except
             if span is not None and span.is_recording():
                 span.set_status(Status(StatusCode.ERROR, str(ex)))
+                if _report_new(self._semconv_opt_in_mode):
+                    span.set_attribute(ERROR_TYPE, type(ex).__qualname__)
                 span.end()
                 self._pop_span(event)
 
@@ -226,11 +228,9 @@ class CommandTracer(monitoring.CommandListener):
                 )
             )
             if _report_new(self._semconv_opt_in_mode):
-                error_type = (
-                    event.failure.get("codeName") if event.failure else None
+                span.set_attribute(
+                    ERROR_TYPE, event.failure.get("codeName", "UnknownError")
                 )
-                if error_type:
-                    span.set_attribute(ERROR_TYPE, error_type)
             try:
                 self.failed_hook(span, event)
             except (

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -68,6 +68,19 @@ from typing import Any, Callable, Collection, TypeVar
 
 from pymongo import monitoring
 
+from opentelemetry.instrumentation._semconv import (
+    _get_schema_url_for_signal_types,
+    _OpenTelemetrySemanticConventionStability,
+    _OpenTelemetryStabilitySignalType,
+    _report_new,
+    _report_old,
+    _set_db_name,
+    _set_db_statement,
+    _set_db_system,
+    _set_http_net_peer_name_client,
+    _set_http_peer_port_client,
+    _StabilityMode,
+)
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.pymongo.package import _instruments
 from opentelemetry.instrumentation.pymongo.utils import (
@@ -77,15 +90,10 @@ from opentelemetry.instrumentation.pymongo.version import __version__
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_MONGODB_COLLECTION,
-    DB_NAME,
-    DB_STATEMENT,
-    DB_SYSTEM,
+    DbSystemValues,
 )
-from opentelemetry.semconv._incubating.attributes.net_attributes import (
-    NET_PEER_NAME,
-    NET_PEER_PORT,
-)
-from opentelemetry.semconv.trace import DbSystemValues
+from opentelemetry.semconv.attributes.db_attributes import DB_COLLECTION_NAME
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.trace import SpanKind, Tracer, get_tracer
 from opentelemetry.trace.span import Span
 from opentelemetry.trace.status import Status, StatusCode
@@ -115,6 +123,7 @@ class CommandTracer(monitoring.CommandListener):
         response_hook: ResponseHookT = dummy_callback,
         failed_hook: FailedHookT = dummy_callback,
         capture_statement: bool = False,
+        semconv_opt_in_mode: _StabilityMode = _StabilityMode.DEFAULT,
     ):
         self._tracer = tracer
         self._span_dict = {}
@@ -123,6 +132,7 @@ class CommandTracer(monitoring.CommandListener):
         self.success_hook = response_hook
         self.failed_hook = failed_hook
         self.capture_statement = capture_statement
+        self._semconv_opt_in_mode = semconv_opt_in_mode
 
     def started(self, event: monitoring.CommandStartedEvent):
         """Method to handle a pymongo CommandStartedEvent"""
@@ -136,14 +146,40 @@ class CommandTracer(monitoring.CommandListener):
         try:
             span = self._tracer.start_span(span_name, kind=SpanKind.CLIENT)
             if span.is_recording():
-                span.set_attribute(DB_SYSTEM, DbSystemValues.MONGODB.value)
-                span.set_attribute(DB_NAME, event.database_name)
-                span.set_attribute(DB_STATEMENT, statement)
+                span_attributes: dict = {}
+                _set_db_system(
+                    span_attributes,
+                    DbSystemValues.MONGODB.value,
+                    self._semconv_opt_in_mode,
+                )
+                _set_db_name(
+                    span_attributes,
+                    event.database_name,
+                    self._semconv_opt_in_mode,
+                )
+                _set_db_statement(
+                    span_attributes,
+                    statement,
+                    self._semconv_opt_in_mode,
+                )
                 if collection:
-                    span.set_attribute(DB_MONGODB_COLLECTION, collection)
+                    if _report_old(self._semconv_opt_in_mode):
+                        span_attributes[DB_MONGODB_COLLECTION] = collection
+                    if _report_new(self._semconv_opt_in_mode):
+                        span_attributes[DB_COLLECTION_NAME] = collection
                 if event.connection_id is not None:
-                    span.set_attribute(NET_PEER_NAME, event.connection_id[0])
-                    span.set_attribute(NET_PEER_PORT, event.connection_id[1])
+                    _set_http_net_peer_name_client(
+                        span_attributes,
+                        event.connection_id[0],
+                        self._semconv_opt_in_mode,
+                    )
+                    _set_http_peer_port_client(
+                        span_attributes,
+                        event.connection_id[1],
+                        self._semconv_opt_in_mode,
+                    )
+                for k, v in span_attributes.items():
+                    span.set_attribute(k, v)
             try:
                 self.start_hook(span, event)
             except (
@@ -189,6 +225,12 @@ class CommandTracer(monitoring.CommandListener):
                     event.failure.get("errmsg", "Unknown error"),
                 )
             )
+            if _report_new(self._semconv_opt_in_mode):
+                error_type = (
+                    event.failure.get("codeName") if event.failure else None
+                )
+                if error_type:
+                    span.set_attribute(ERROR_TYPE, error_type)
             try:
                 self.failed_hook(span, event)
             except (
@@ -254,11 +296,17 @@ class PymongoInstrumentor(BaseInstrumentor):
         capture_statement = kwargs.get("capture_statement")
         # Create and register a CommandTracer only the first time
         if self._commandtracer_instance is None:
+            _OpenTelemetrySemanticConventionStability._initialize()
+            semconv_opt_in_mode = _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
+                _OpenTelemetryStabilitySignalType.DATABASE,
+            )
             tracer = get_tracer(
                 __name__,
                 __version__,
                 tracer_provider,
-                schema_url="https://opentelemetry.io/schemas/1.11.0",
+                schema_url=_get_schema_url_for_signal_types(
+                    [_OpenTelemetryStabilitySignalType.DATABASE]
+                ),
             )
 
             self._commandtracer_instance = CommandTracer(
@@ -267,6 +315,7 @@ class PymongoInstrumentor(BaseInstrumentor):
                 response_hook=response_hook,
                 failed_hook=failed_hook,
                 capture_statement=capture_statement,
+                semconv_opt_in_mode=semconv_opt_in_mode,
             )
             monitoring.register(self._commandtracer_instance)
         # If already created, just enable it

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -178,8 +178,7 @@ class CommandTracer(monitoring.CommandListener):
                         event.connection_id[1],
                         self._semconv_opt_in_mode,
                     )
-                for key, val in span_attributes.items():
-                    span.set_attribute(key, val)
+                span.set_attributes(span_attributes)
             try:
                 self.start_hook(span, event)
             except (

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -178,8 +178,8 @@ class CommandTracer(monitoring.CommandListener):
                         event.connection_id[1],
                         self._semconv_opt_in_mode,
                     )
-                for k, v in span_attributes.items():
-                    span.set_attribute(k, v)
+                for key, val in span_attributes.items():
+                    span.set_attribute(key, val)
             try:
                 self.start_hook(span, event)
             except (

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/package.py
@@ -3,3 +3,5 @@
 
 
 _instruments = ("pymongo >= 3.1, < 5.0",)
+
+_semconv_status = "migration"

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -1,9 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 from unittest import mock
 
 from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+    _StabilityMode,
+)
 from opentelemetry.instrumentation.pymongo import (
     CommandTracer,
     PymongoInstrumentor,
@@ -19,7 +25,33 @@ from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
 )
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_COLLECTION_NAME,
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+)
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
+)
 from opentelemetry.test.test_base import TestBase
+
+
+@contextlib.contextmanager
+def use_semconv_opt_in(sem_conv_mode):
+    env_patch = mock.patch.dict(
+        "os.environ",
+        {OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode},
+    )
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    env_patch.start()
+    try:
+        yield
+    finally:
+        env_patch.stop()
+        _OpenTelemetrySemanticConventionStability._initialized = False
 
 
 class TestPymongo(TestBase):
@@ -29,6 +61,15 @@ class TestPymongo(TestBase):
         self.start_callback = mock.MagicMock()
         self.success_callback = mock.MagicMock()
         self.failed_callback = mock.MagicMock()
+        PymongoInstrumentor._instance = None
+        PymongoInstrumentor._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
+
+    def tearDown(self):
+        super().tearDown()
+        PymongoInstrumentor._instance = None
+        PymongoInstrumentor._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
 
     def test_pymongo_instrumentor(self):
         mock_register = mock.Mock()
@@ -60,7 +101,7 @@ class TestPymongo(TestBase):
         self.assertEqual(span.attributes[DB_NAME], "database_name")
         self.assertEqual(span.attributes[DB_STATEMENT], "find")
         self.assertEqual(span.attributes[NET_PEER_NAME], "test.com")
-        self.assertEqual(span.attributes[NET_PEER_PORT], "1234")
+        self.assertEqual(span.attributes[NET_PEER_PORT], 1234)
         self.start_callback.assert_called_once_with(span, mock_event)
 
     def test_succeeded(self):
@@ -300,6 +341,139 @@ class TestPymongo(TestBase):
                     expected,
                 )
                 self.memory_exporter.clear()
+
+    def test_schema_url_default(self):
+        with mock.patch("pymongo.monitoring.register"):
+            instrumentor = PymongoInstrumentor()
+            instrumentor.instrument(tracer_provider=self.tracer_provider)
+        self.assertEqual(
+            instrumentor._commandtracer_instance._tracer._instrumentation_scope.schema_url,
+            "https://opentelemetry.io/schemas/1.11.0",
+        )
+
+    def test_schema_url_new_semconv(self):
+        with use_semconv_opt_in("database"):
+            with mock.patch("pymongo.monitoring.register"):
+                instrumentor = PymongoInstrumentor()
+                instrumentor.instrument(tracer_provider=self.tracer_provider)
+        self.assertEqual(
+            instrumentor._commandtracer_instance._tracer._instrumentation_scope.schema_url,
+            "https://opentelemetry.io/schemas/1.25.0",
+        )
+
+    def test_started_new_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE
+        )
+        mock_event = MockEvent({"command_name": "find"}, ("testhost", 1234))
+        command_tracer.started(event=mock_event)
+        span = command_tracer._pop_span(mock_event)  # pylint: disable=protected-access
+        self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mongodb")
+        self.assertEqual(span.attributes[DB_NAMESPACE], "database_name")
+        self.assertEqual(span.attributes[DB_QUERY_TEXT], "find")
+        self.assertEqual(span.attributes[SERVER_ADDRESS], "testhost")
+        self.assertEqual(span.attributes[SERVER_PORT], 1234)
+
+    def test_started_both_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE_DUP
+        )
+        mock_event = MockEvent({"command_name": "find"}, ("testhost", 1234))
+        command_tracer.started(event=mock_event)
+        span = command_tracer._pop_span(mock_event)  # pylint: disable=protected-access
+        self.assertEqual(span.attributes[DB_SYSTEM], "mongodb")
+        self.assertEqual(span.attributes[DB_NAME], "database_name")
+        self.assertEqual(span.attributes[DB_STATEMENT], "find")
+        self.assertEqual(span.attributes[NET_PEER_NAME], "testhost")
+        self.assertEqual(span.attributes[NET_PEER_PORT], 1234)
+        self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mongodb")
+        self.assertEqual(span.attributes[DB_NAMESPACE], "database_name")
+        self.assertEqual(span.attributes[DB_QUERY_TEXT], "find")
+        self.assertEqual(span.attributes[SERVER_ADDRESS], "testhost")
+        self.assertEqual(span.attributes[SERVER_PORT], 1234)
+
+    def test_collection_name_default_semconv(self):
+        command_tracer = CommandTracer(self.tracer)
+        mock_event = MockEvent({"command_name": "find", "find": "test_coll"})
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.attributes[DB_MONGODB_COLLECTION], "test_coll")
+        self.assertNotIn(DB_COLLECTION_NAME, span.attributes)
+
+    def test_collection_name_new_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE
+        )
+        mock_event = MockEvent({"command_name": "find", "find": "test_coll"})
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.attributes[DB_COLLECTION_NAME], "test_coll")
+        self.assertNotIn(DB_MONGODB_COLLECTION, span.attributes)
+
+    def test_collection_name_both_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE_DUP
+        )
+        mock_event = MockEvent({"command_name": "find", "find": "test_coll"})
+        command_tracer.started(event=mock_event)
+        command_tracer.succeeded(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.attributes[DB_MONGODB_COLLECTION], "test_coll")
+        self.assertEqual(span.attributes[DB_COLLECTION_NAME], "test_coll")
+
+    def test_failed_error_type_not_set_on_default(self):
+        command_tracer = CommandTracer(self.tracer)
+        mock_event = MockEvent({})
+        command_tracer.started(event=mock_event)
+        mock_event.mark_as_failed()
+        command_tracer.failed(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertFalse(span.status.is_ok)
+        self.assertNotIn(ERROR_TYPE, span.attributes)
+
+    def test_failed_error_type_set_on_new_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE
+        )
+        mock_event = MockEvent({})
+        command_tracer.started(event=mock_event)
+        mock_event.failure = {
+            "errmsg": "operation failed",
+            "codeName": "OperationFailed",
+        }
+        command_tracer.failed(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertFalse(span.status.is_ok)
+        self.assertEqual(span.attributes[ERROR_TYPE], "OperationFailed")
+
+    def test_failed_error_type_set_on_both_semconv(self):
+        command_tracer = CommandTracer(
+            self.tracer, semconv_opt_in_mode=_StabilityMode.DATABASE_DUP
+        )
+        mock_event = MockEvent({})
+        command_tracer.started(event=mock_event)
+        mock_event.failure = {
+            "errmsg": "operation failed",
+            "codeName": "OperationFailed",
+        }
+        command_tracer.failed(event=mock_event)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertFalse(span.status.is_ok)
+        self.assertEqual(span.attributes[ERROR_TYPE], "OperationFailed")
 
 
 class MockCommand:

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -54,6 +54,7 @@ def use_semconv_opt_in(sem_conv_mode):
         _OpenTelemetrySemanticConventionStability._initialized = False
 
 
+# pylint: disable=too-many-public-methods
 class TestPymongo(TestBase):
     def setUp(self):
         super().setUp()

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -6,6 +6,7 @@ import os
 from unittest import mock
 
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation._semconv import (
@@ -17,7 +18,6 @@ from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_MONGODB_COLLECTION,
     DB_NAME,
     DB_STATEMENT,
-    DB_SYSTEM,
 )
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
@@ -29,6 +29,7 @@ from opentelemetry.semconv.attributes.db_attributes import (
     DB_QUERY_TEXT,
     DB_SYSTEM_NAME,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.attributes.server_attributes import (
     SERVER_ADDRESS,
     SERVER_PORT,
@@ -189,8 +190,12 @@ class TestFunctionalPymongo(TestBase):
             self.instrumentor.instrument()
             self.instrumentor._commandtracer_instance._tracer = self._tracer
             self.instrumentor._commandtracer_instance.capture_statement = True
+            client = MongoClient(
+                MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
+            )
+            collection = client[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME]
             with self._tracer.start_as_current_span("rootSpan"):
-                self._collection.find_one({"name": "testName"})
+                collection.find_one({"name": "testName"})
 
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
@@ -209,9 +214,30 @@ class TestFunctionalPymongo(TestBase):
             pymongo_span.attributes[DB_COLLECTION_NAME],
             MONGODB_COLLECTION_NAME,
         )
-        self.assertNotIn(DB_SYSTEM, pymongo_span.attributes)
-        self.assertNotIn(DB_NAME, pymongo_span.attributes)
-        self.assertNotIn(DB_STATEMENT, pymongo_span.attributes)
-        self.assertNotIn(NET_PEER_NAME, pymongo_span.attributes)
-        self.assertNotIn(NET_PEER_PORT, pymongo_span.attributes)
-        self.assertNotIn(DB_MONGODB_COLLECTION, pymongo_span.attributes)
+
+    def test_failed_command_stable_semconv_records_error_type(self):
+        with use_semconv_opt_in("database"):
+            self.instrumentor.uninstrument()
+            self.instrumentor._commandtracer_instance = None
+            self.instrumentor.instrument()
+            self.instrumentor._commandtracer_instance._tracer = self._tracer
+            client = MongoClient(
+                MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
+            )
+            db = client[MONGODB_DB_NAME]
+
+            with self._tracer.start_as_current_span("rootSpan"):
+                with self.assertRaises(OperationFailure):
+                    db.command({"FakeCommand": 1})
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        pymongo_span = next(s for s in spans if s.name != "rootSpan")
+        self.assertEqual(
+            pymongo_span.status.status_code,
+            trace_api.StatusCode.ERROR,
+        )
+        self.assertEqual(
+            pymongo_span.attributes[ERROR_TYPE],
+            "FakeCommand",
+        )

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -228,7 +228,7 @@ class TestFunctionalPymongo(TestBase):
 
             with self._tracer.start_as_current_span("rootSpan"):
                 with self.assertRaises(OperationFailure):
-                    db.command({"FakeCommand": 1})
+                    db.command({"fakeCommand": 1})
 
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
@@ -238,6 +238,9 @@ class TestFunctionalPymongo(TestBase):
             trace_api.StatusCode.ERROR,
         )
         self.assertEqual(
+            pymongo_span.status.description, "no such command: 'fakeCommand'"
+        )
+        self.assertEqual(
             pymongo_span.attributes[ERROR_TYPE],
-            "FakeCommand",
+            "CommandNotFound",
         )

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -1,20 +1,37 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import os
+from unittest import mock
 
 from pymongo import MongoClient
 
 from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
 from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_MONGODB_COLLECTION,
     DB_NAME,
     DB_STATEMENT,
+    DB_SYSTEM,
 )
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
+)
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_COLLECTION_NAME,
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+)
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.test.test_base import TestBase
 
@@ -24,10 +41,28 @@ MONGODB_DB_NAME = os.getenv("MONGODB_DB_NAME", "opentelemetry-tests")
 MONGODB_COLLECTION_NAME = "test"
 
 
+@contextlib.contextmanager
+def use_semconv_opt_in(sem_conv_mode):
+    env_patch = mock.patch.dict(
+        "os.environ",
+        {OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode},
+    )
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    env_patch.start()
+    try:
+        yield
+    finally:
+        env_patch.stop()
+        _OpenTelemetrySemanticConventionStability._initialized = False
+
+
 class TestFunctionalPymongo(TestBase):
     def setUp(self):
         super().setUp()
         self._tracer = self.tracer_provider.get_tracer(__name__)
+        PymongoInstrumentor._instance = None
+        PymongoInstrumentor._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
         self.instrumentor = PymongoInstrumentor()
         self.instrumentor.instrument()
         self.instrumentor._commandtracer_instance._tracer = self._tracer
@@ -40,6 +75,9 @@ class TestFunctionalPymongo(TestBase):
 
     def tearDown(self):
         self.instrumentor.uninstrument()
+        PymongoInstrumentor._instance = None
+        PymongoInstrumentor._commandtracer_instance = None
+        _OpenTelemetrySemanticConventionStability._initialized = False
         super().tearDown()
 
     def validate_spans(self, expected_db_statement):
@@ -143,3 +181,37 @@ class TestFunctionalPymongo(TestBase):
         self._collection.find_one()
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
+
+    def test_find_stable_semconv(self):
+        with use_semconv_opt_in("database"):
+            self.instrumentor.uninstrument()
+            self.instrumentor._commandtracer_instance = None
+            self.instrumentor.instrument()
+            self.instrumentor._commandtracer_instance._tracer = self._tracer
+            self.instrumentor._commandtracer_instance.capture_statement = True
+            with self._tracer.start_as_current_span("rootSpan"):
+                self._collection.find_one({"name": "testName"})
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        pymongo_span = next(s for s in spans if s.name != "rootSpan")
+        self.assertEqual(pymongo_span.attributes[DB_SYSTEM_NAME], "mongodb")
+        self.assertEqual(
+            pymongo_span.attributes[DB_NAMESPACE], MONGODB_DB_NAME
+        )
+        self.assertEqual(
+            pymongo_span.attributes[DB_QUERY_TEXT],
+            "find {'name': 'testName'}",
+        )
+        self.assertEqual(pymongo_span.attributes[SERVER_ADDRESS], MONGODB_HOST)
+        self.assertEqual(pymongo_span.attributes[SERVER_PORT], MONGODB_PORT)
+        self.assertEqual(
+            pymongo_span.attributes[DB_COLLECTION_NAME],
+            MONGODB_COLLECTION_NAME,
+        )
+        self.assertNotIn(DB_SYSTEM, pymongo_span.attributes)
+        self.assertNotIn(DB_NAME, pymongo_span.attributes)
+        self.assertNotIn(DB_STATEMENT, pymongo_span.attributes)
+        self.assertNotIn(NET_PEER_NAME, pymongo_span.attributes)
+        self.assertNotIn(NET_PEER_PORT, pymongo_span.attributes)
+        self.assertNotIn(DB_MONGODB_COLLECTION, pymongo_span.attributes)


### PR DESCRIPTION
# Description

Add pymongo instrumentor support for when `OTEL_SEMCONV_STABILITY_OPT_IN` includes: ("database" or "database/dup") and ("http" or "http/dup")

Fixes #4713
Fixes #1629 
Refs #2453

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new tests for old semconv, stable semconv and when using both semconv (dup mode)

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
