### PR TITLE
fix(dbapi): add missing instrumentation enabled check

### DIFF
--- a/.changelog/4781.fixed
+++ b/.changelog/4781.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-dbapi`: fix suppression for async queries

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -950,6 +950,9 @@ class CursorTracer(Generic[CursorT]):
         *args: tuple[Any, ...],
         **kwargs: dict[Any, Any],
     ):
+        if not is_instrumentation_enabled():
+            return await query_method(*args, **kwargs)
+
         operation_name = self.get_operation_name(cursor, args)
         name = operation_name
         if not name:

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -124,6 +124,24 @@ class TestDBApiIntegration(TestBase):
         self.assertEqual(span.attributes[NET_PEER_PORT], 123)
         self.assertIs(span.status.status_code, trace_api.StatusCode.UNSET)
 
+    def test_suppress_instrumentation_async(self):
+        execute = mock.AsyncMock(return_value="result")
+        db_integration = dbapi.DatabaseApiIntegration(
+            "instrumenting_module_test_name",
+            "testcomponent",
+        )
+
+        with suppress_instrumentation():
+            result = asyncio.run(
+                dbapi.CursorTracer(db_integration).traced_execution_async(
+                    MockCursor(), execute, "SELECT 1"
+                )
+            )
+
+        self.assertEqual(result, "result")
+        execute.assert_awaited_once_with("SELECT 1")
+        self.assertEqual(len(self.memory_exporter.get_finished_spans()), 0)
+
     def test_span_succeeded_new_semconv(self):
         with use_semconv_opt_in("database,http"):
             connection_props = _get_default_connection_props()


### PR DESCRIPTION
# Description

This change adds a missing check to the `traced_execution_async` function. Its synchronous counterpart already performs the check. This discrepancy became apparent because of a change I am working on locally, which needs this check to prevent infinite recursion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added `test_suppress_instrumentation_async`.

Run:

```console tox -e py310-test-instrumentation-dbapi-wrapt2 ```

Result:

```text 59 passed, 2 skipped ```

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project 
- [ ] Changelogs have been updated 
- [x] Unit tests have been added
- [ ] Documentation has been updated