### PR TITLE
opentelemetry-instrumentation-mysql: add semconv stability opt-in test coverage

### DIFF
--- a/.changelog/4810.added
+++ b/.changelog/4810.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-mysql`: add semantic convention stability opt-in mode tests

--- a/instrumentation/opentelemetry-instrumentation-mysql/tests/test_mysql_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/tests/test_mysql_integration.py
@@ -1,18 +1,38 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 from unittest import mock
 
 import mysql.connector
 
 import opentelemetry.instrumentation.mysql
 from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
 from opentelemetry.instrumentation.mysql import MySQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
     DB_STATEMENT,
 )
 from opentelemetry.test.test_base import TestBase
+
+
+@contextlib.contextmanager
+def use_semconv_opt_in(sem_conv_mode):
+    env_patch = mock.patch.dict(
+        "os.environ",
+        {OTEL_SEMCONV_STABILITY_OPT_IN: sem_conv_mode},
+    )
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    env_patch.start()
+    try:
+        yield
+    finally:
+        env_patch.stop()
+        _OpenTelemetrySemanticConventionStability._initialized = False
 
 
 def connect_and_execute_query():
@@ -29,6 +49,7 @@ def make_mysql_connection_mock():
     cnx.database = "test"
     cnx.server_host = "localhost"
     cnx.server_port = 3306
+    cnx.user = "testuser"
 
     cursor = mock.MagicMock()
     cursor._cnx = cnx
@@ -441,3 +462,59 @@ class TestMysqlIntegration(TestBase):
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
+
+    @mock.patch("mysql.connector.connect")
+    def test_semconv_stable(self, mock_connect):
+        """database,http opt-in emits only stable attributes."""
+        with use_semconv_opt_in("database,http"):
+            mock_connect.return_value = make_mysql_connection_mock()
+            MySQLInstrumentor().instrument()
+
+            connect_and_execute_query()
+
+            spans_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans_list), 1)
+            span = spans_list[0]
+
+            self.assertEqual(span.attributes["db.system.name"], "mysql")
+            self.assertEqual(span.attributes["db.namespace"], "test")
+            self.assertEqual(
+                span.attributes["db.query.text"], "SELECT * FROM test"
+            )
+            self.assertEqual(span.attributes["server.address"], "localhost")
+            self.assertEqual(span.attributes["server.port"], 3306)
+            self.assertNotIn("db.system", span.attributes)
+            self.assertNotIn("db.name", span.attributes)
+            self.assertNotIn("db.statement", span.attributes)
+            self.assertNotIn("db.user", span.attributes)
+            self.assertNotIn("net.peer.name", span.attributes)
+            self.assertNotIn("net.peer.port", span.attributes)
+
+    @mock.patch("mysql.connector.connect")
+    def test_semconv_dup(self, mock_connect):
+        """database/dup,http/dup opt-in emits both legacy and stable attributes."""
+        with use_semconv_opt_in("database/dup,http/dup"):
+            mock_connect.return_value = make_mysql_connection_mock()
+            MySQLInstrumentor().instrument()
+
+            connect_and_execute_query()
+
+            spans_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans_list), 1)
+            span = spans_list[0]
+
+            self.assertEqual(span.attributes["db.system"], "mysql")
+            self.assertEqual(span.attributes["db.system.name"], "mysql")
+            self.assertEqual(span.attributes["db.name"], "test")
+            self.assertEqual(span.attributes["db.namespace"], "test")
+            self.assertEqual(
+                span.attributes["db.statement"], "SELECT * FROM test"
+            )
+            self.assertEqual(
+                span.attributes["db.query.text"], "SELECT * FROM test"
+            )
+            self.assertEqual(span.attributes["db.user"], "testuser")
+            self.assertEqual(span.attributes["net.peer.name"], "localhost")
+            self.assertEqual(span.attributes["net.peer.port"], 3306)
+            self.assertEqual(span.attributes["server.address"], "localhost")
+            self.assertEqual(span.attributes["server.port"], 3306)

--- a/instrumentation/opentelemetry-instrumentation-mysql/tests/test_mysql_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/tests/test_mysql_integration.py
@@ -15,7 +15,23 @@ from opentelemetry.instrumentation._semconv import (
 from opentelemetry.instrumentation.mysql import MySQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.semconv._incubating.attributes.db_attributes import (
+    DB_NAME,
     DB_STATEMENT,
+    DB_SYSTEM,
+    DB_USER,
+)
+from opentelemetry.semconv._incubating.attributes.net_attributes import (
+    NET_PEER_NAME,
+    NET_PEER_PORT,
+)
+from opentelemetry.semconv.attributes.db_attributes import (
+    DB_NAMESPACE,
+    DB_QUERY_TEXT,
+    DB_SYSTEM_NAME,
+)
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.test.test_base import TestBase
 
@@ -476,19 +492,19 @@ class TestMysqlIntegration(TestBase):
             self.assertEqual(len(spans_list), 1)
             span = spans_list[0]
 
-            self.assertEqual(span.attributes["db.system.name"], "mysql")
-            self.assertEqual(span.attributes["db.namespace"], "test")
+            self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mysql")
+            self.assertEqual(span.attributes[DB_NAMESPACE], "test")
             self.assertEqual(
-                span.attributes["db.query.text"], "SELECT * FROM test"
+                span.attributes[DB_QUERY_TEXT], "SELECT * FROM test"
             )
-            self.assertEqual(span.attributes["server.address"], "localhost")
-            self.assertEqual(span.attributes["server.port"], 3306)
-            self.assertNotIn("db.system", span.attributes)
-            self.assertNotIn("db.name", span.attributes)
-            self.assertNotIn("db.statement", span.attributes)
-            self.assertNotIn("db.user", span.attributes)
-            self.assertNotIn("net.peer.name", span.attributes)
-            self.assertNotIn("net.peer.port", span.attributes)
+            self.assertEqual(span.attributes[SERVER_ADDRESS], "localhost")
+            self.assertEqual(span.attributes[SERVER_PORT], 3306)
+            self.assertNotIn(DB_SYSTEM, span.attributes)
+            self.assertNotIn(DB_NAME, span.attributes)
+            self.assertNotIn(DB_STATEMENT, span.attributes)
+            self.assertNotIn(DB_USER, span.attributes)
+            self.assertNotIn(NET_PEER_NAME, span.attributes)
+            self.assertNotIn(NET_PEER_PORT, span.attributes)
 
     @mock.patch("mysql.connector.connect")
     def test_semconv_dup(self, mock_connect):
@@ -503,18 +519,18 @@ class TestMysqlIntegration(TestBase):
             self.assertEqual(len(spans_list), 1)
             span = spans_list[0]
 
-            self.assertEqual(span.attributes["db.system"], "mysql")
-            self.assertEqual(span.attributes["db.system.name"], "mysql")
-            self.assertEqual(span.attributes["db.name"], "test")
-            self.assertEqual(span.attributes["db.namespace"], "test")
+            self.assertEqual(span.attributes[DB_SYSTEM], "mysql")
+            self.assertEqual(span.attributes[DB_SYSTEM_NAME], "mysql")
+            self.assertEqual(span.attributes[DB_NAME], "test")
+            self.assertEqual(span.attributes[DB_NAMESPACE], "test")
             self.assertEqual(
-                span.attributes["db.statement"], "SELECT * FROM test"
+                span.attributes[DB_STATEMENT], "SELECT * FROM test"
             )
             self.assertEqual(
-                span.attributes["db.query.text"], "SELECT * FROM test"
+                span.attributes[DB_QUERY_TEXT], "SELECT * FROM test"
             )
-            self.assertEqual(span.attributes["db.user"], "testuser")
-            self.assertEqual(span.attributes["net.peer.name"], "localhost")
-            self.assertEqual(span.attributes["net.peer.port"], 3306)
-            self.assertEqual(span.attributes["server.address"], "localhost")
-            self.assertEqual(span.attributes["server.port"], 3306)
+            self.assertEqual(span.attributes[DB_USER], "testuser")
+            self.assertEqual(span.attributes[NET_PEER_NAME], "localhost")
+            self.assertEqual(span.attributes[NET_PEER_PORT], 3306)
+            self.assertEqual(span.attributes[SERVER_ADDRESS], "localhost")
+            self.assertEqual(span.attributes[SERVER_PORT], 3306)


### PR DESCRIPTION
# Description

The mysql instrumentation delegates span creation to the shared dbapi layer, which already handles the database semconv stability migration (#4109). However, unlike pymssql (#4592), the mysql test suite had no coverage of the `OTEL_SEMCONV_STABILITY_OPT_IN` modes, so regressions in what the instrumentation emits per mode would go unnoticed.

This adds two tests mirroring the merged pymssql pattern:

- `test_semconv_stable` (`database,http`): asserts only stable attributes are emitted (`db.system.name`, `db.namespace`, `db.query.text`, `server.address`, `server.port`) and legacy ones (`db.system`, `db.name`, `db.statement`, `db.user`, `net.peer.*`) are absent
- `test_semconv_dup` (`database/dup,http/dup`): asserts both legacy and stable attributes are emitted

Verified locally that the current dbapi-based behavior matches the [database semconv spec](https://opentelemetry.io/docs/specs/semconv/database/database-spans/) in default, stable and dup modes.

Fixes #1632

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `pytest instrumentation/opentelemetry-instrumentation-mysql/tests/` — 17 passed (15 existing + 2 new)
- [x] `ruff check` / `ruff format --check` (ruff 0.14.1) — clean

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated (not required: test-only change, no behavior impact)
- [x] Unit tests have been added
- [x] Documentation has been updated (not required)

<!-- oss-radar:idempotency=auto-20260713-151841.w4.open-telemetry_opentelemetry-python-contrib.1632 -->
