### PR TITLE
`opentelemetry-util-genai`, `instrumentation-genai/*`: ignore now deprecated genai enums

### DIFF
--- a/.changelog/4814.fixed
+++ b/.changelog/4814.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-util-genai`, `instrumentation-genai/*`: ignore now deprecated GenAI enums

--- a/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/messages_extractors.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-anthropic/src/opentelemetry/instrumentation/anthropic/messages_extractors.py
@@ -224,7 +224,7 @@ def get_llm_request_attributes(
     params: MessageRequestParams, client_instance: "Messages"
 ) -> dict[str, AttributeValue]:
     attributes: dict[str, AttributeValue | None] = {
-        GenAIAttributes.GEN_AI_OPERATION_NAME: GenAIAttributes.GenAiOperationNameValues.CHAT.value,
+        GenAIAttributes.GEN_AI_OPERATION_NAME: GenAIAttributes.GenAiOperationNameValues.CHAT.value,  # pyright: ignore[reportDeprecated]
         GenAIAttributes.GEN_AI_SYSTEM: GenAIAttributes.GenAiSystemValues.ANTHROPIC.value,  # pyright: ignore[reportDeprecated]
         GenAIAttributes.GEN_AI_REQUEST_MODEL: params.model,
         GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS: params.max_tokens,

--- a/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/span_manager.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/span_manager.py
@@ -68,12 +68,12 @@ class _SpanManager:
         span = self._create_span(
             run_id=run_id,
             parent_run_id=parent_run_id,
-            span_name=f"{GenAI.GenAiOperationNameValues.CHAT.value} {request_model}",
+            span_name=f"{GenAI.GenAiOperationNameValues.CHAT.value} {request_model}",  # pyright: ignore[reportDeprecated]
             kind=SpanKind.CLIENT,
         )
         span.set_attribute(
             GenAI.GEN_AI_OPERATION_NAME,
-            GenAI.GenAiOperationNameValues.CHAT.value,
+            GenAI.GenAiOperationNameValues.CHAT.value,  # pyright: ignore[reportDeprecated]
         )
         if request_model:
             span.set_attribute(GenAI.GEN_AI_REQUEST_MODEL, request_model)

--- a/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/patch.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-vertexai/src/opentelemetry/instrumentation/vertexai/patch.py
@@ -152,7 +152,7 @@ class MethodWrappers:
         params = _extract_params(*args, **kwargs)
         request_attributes = get_genai_request_attributes(True, params)
         with self.tracer.start_as_current_span(
-            name=f"{GenAI.GenAiOperationNameValues.CHAT.value} {request_attributes.get(GenAI.GEN_AI_REQUEST_MODEL, '')}".strip(),
+            name=f"{GenAI.GenAiOperationNameValues.CHAT.value} {request_attributes.get(GenAI.GEN_AI_REQUEST_MODEL, '')}".strip(),  # pyright: ignore[reportDeprecated]
             kind=SpanKind.CLIENT,
         ) as span:
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -60,7 +60,7 @@ class AgentInvocation(GenAIInvocation):
         agent_name: str | None = None,
     ) -> None:
         """Use handler.start_invoke_local_agent() or handler.start_invoke_remote_agent() instead of calling this directly."""
-        _operation_name = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value
+        _operation_name = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value  # pyright: ignore[reportDeprecated]
         super().__init__(
             tracer,
             metrics_recorder,
@@ -201,9 +201,9 @@ class AgentInvocation(GenAIInvocation):
     def _get_metric_token_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
         if self.input_tokens is not None:
-            counts[GenAI.GenAiTokenTypeValues.INPUT.value] = self.input_tokens
+            counts[GenAI.GenAiTokenTypeValues.INPUT.value] = self.input_tokens  # pyright: ignore[reportDeprecated]
         if self.output_tokens is not None:
-            counts[GenAI.GenAiTokenTypeValues.OUTPUT.value] = (
+            counts[GenAI.GenAiTokenTypeValues.OUTPUT.value] = (  # pyright: ignore[reportDeprecated]
                 self.output_tokens
             )
         return counts

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
@@ -37,7 +37,7 @@ class EmbeddingInvocation(GenAIInvocation):
         server_port: int | None = None,
     ) -> None:
         """Use handler.start_embedding(provider) or handler.embedding(provider) instead of calling this directly."""
-        _operation_name = GenAI.GenAiOperationNameValues.EMBEDDINGS.value
+        _operation_name = GenAI.GenAiOperationNameValues.EMBEDDINGS.value  # pyright: ignore[reportDeprecated]
         super().__init__(
             tracer,
             metrics_recorder,
@@ -91,7 +91,7 @@ class EmbeddingInvocation(GenAIInvocation):
 
     def _get_metric_token_counts(self) -> dict[str, int]:
         if self.input_tokens is not None:
-            return {GenAI.GenAiTokenTypeValues.INPUT.value: self.input_tokens}
+            return {GenAI.GenAiTokenTypeValues.INPUT.value: self.input_tokens}  # pyright: ignore[reportDeprecated]
         return {}
 
     def _apply_finish(self, error: Error | None = None) -> None:

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -55,7 +55,7 @@ class InferenceInvocation(GenAIInvocation):
         operation_name: str | None = None,
     ) -> None:
         operation_name = (
-            operation_name or GenAI.GenAiOperationNameValues.CHAT.value
+            operation_name or GenAI.GenAiOperationNameValues.CHAT.value  # pyright: ignore[reportDeprecated]
         )
         """Use handler.start_inference(provider) or handler.inference(provider) instead of calling this directly."""
         super().__init__(
@@ -176,9 +176,9 @@ class InferenceInvocation(GenAIInvocation):
     def _get_metric_token_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
         if self.input_tokens is not None:
-            counts[GenAI.GenAiTokenTypeValues.INPUT.value] = self.input_tokens
+            counts[GenAI.GenAiTokenTypeValues.INPUT.value] = self.input_tokens  # pyright: ignore[reportDeprecated]
         if self.output_tokens is not None:
-            counts[GenAI.GenAiTokenTypeValues.OUTPUT.value] = (
+            counts[GenAI.GenAiTokenTypeValues.OUTPUT.value] = (  # pyright: ignore[reportDeprecated]
                 self.output_tokens
             )
         return counts

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
@@ -49,7 +49,7 @@ class ToolInvocation(GenAIInvocation):
         tool_description: str | None = None,
     ) -> None:
         """Use handler.start_tool(name) or handler.tool(name) instead of calling this directly."""
-        _operation_name = GenAI.GenAiOperationNameValues.EXECUTE_TOOL.value
+        _operation_name = GenAI.GenAiOperationNameValues.EXECUTE_TOOL.value  # pyright: ignore[reportDeprecated]
         super().__init__(
             tracer,
             metrics_recorder,


### PR DESCRIPTION
# Description

Semantic conventions 1.42.0 deprecated all the GenAI stuff in favor of a separate specific semconv.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
