### PR TITLE
test(aiohttp-server): make non-global tracer provider test deterministic

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/tests/test_aiohttp_server_integration.py
@@ -28,7 +28,7 @@ from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 from opentelemetry.sdk.metrics.export import (
     HistogramDataPoint,
 )
-from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.semconv._incubating.attributes.http_attributes import (
     HTTP_FLAVOR,
     HTTP_METHOD,
@@ -64,7 +64,7 @@ from opentelemetry.semconv.attributes.user_agent_attributes import (
     USER_AGENT_ORIGINAL,
 )
 from opentelemetry.test.test_base import TestBase
-from opentelemetry.trace import StatusCode
+from opentelemetry.trace import SpanKind, StatusCode
 from opentelemetry.util._importlib_metadata import entry_points
 from opentelemetry.util.http import (
     OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS,
@@ -419,40 +419,30 @@ async def test_excluded_urls(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "tracer",
-    [
-        TestBase().create_tracer_provider(
-            sampler=ParentBased(TraceIdRatioBased(0.05))
-        )
-    ],
+    [TestBase().create_tracer_provider(sampler=ALWAYS_ON)],
 )
 async def test_non_global_tracer_provider(
     tracer,
     server_fixture,
     aiohttp_client,
 ):
-    n_requests = 1000
-    collection_ratio = 0.05
-    n_expected_trace_ids = n_requests * collection_ratio
-
     _, memory_exporter = tracer
     server, _ = server_fixture
 
     assert len(memory_exporter.get_finished_spans()) == 0
 
     client = await aiohttp_client(server)
-    for _ in range(n_requests):
-        await client.get("/test-path")
+    await client.get("/test-path")
 
-    trace_ids = {
-        span.context.trace_id
-        for span in memory_exporter.get_finished_spans()
-        if span.context is not None
-    }
-    assert (
-        0.5 * n_expected_trace_ids
-        <= len(trace_ids)
-        <= 1.5 * n_expected_trace_ids
-    )
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+    assert span.name == "GET /test-path"
+    assert span.kind == SpanKind.SERVER
+    assert span.attributes[HTTP_METHOD] == "GET"
+    assert span.attributes[HTTP_STATUS_CODE] == HTTPStatus.OK
+    assert span.attributes[HTTP_TARGET] == "/test-path"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Make `test_non_global_tracer_provider` deterministic by using the always-on sampler and a single request. The test now verifies that exactly one server span is exported through the supplied provider and checks its expected name, kind, method, status, and target.

This removes the statistical sampling bounds without weakening coverage of the non-global provider path.

Fixes #4811

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Focused test passed 10 consecutive runs
- [x] aiohttp-server test suite: 34 passed
- [x] Ruff and pre-commit checks
- [x] aiohttp-server Pylint checks
- [x] Pyright type checking

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated
- [x] Changelog not required because this is a test-only change
- [x] Documentation not required