### PR TITLE
opentelemetry-instrumentation-aiopg: fix manual connection attributes

### DIFF
--- a/.changelog/4821.fixed
+++ b/.changelog/4821.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-aiopg`: fix connection metadata for manual instrumentation

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/aiopg_integration.py
@@ -107,9 +107,7 @@ class AsyncCursorTracer(CursorTracer):
         *args: typing.Tuple[typing.Any, typing.Any],
         **kwargs: typing.Dict[typing.Any, typing.Any],
     ):
-        name = ""
-        if args:
-            name = self.get_operation_name(cursor, args)
+        name = self.get_operation_name(cursor, args)
 
         if not name:
             name = (

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/wrappers.py
@@ -153,7 +153,9 @@ def instrument_connection(
         version=version,
         tracer_provider=tracer_provider,
     )
-    db_integration.get_connection_attributes(connection)
+    db_integration.get_connection_attributes(
+        getattr(connection, "_conn", connection)
+    )
     return get_traced_connection_proxy(connection, db_integration)
 
 

--- a/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/tests/test_aiopg_integration.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -188,7 +189,14 @@ class TestAiopgInstrumentor(TestBase):
         self.assertIs(span.resource, resource)
 
     def test_instrument_connection(self):
-        cnx = async_call(aiopg.connect(database="test"))
+        cnx = async_call(
+            aiopg.connect(
+                database="testdatabase",
+                server_host="testhost",
+                server_port=123,
+                user="testuser",
+            )
+        )
         query = "SELECT * FROM test"
         cursor = async_call(cnx.cursor())
         async_call(cursor.execute(query))
@@ -202,6 +210,11 @@ class TestAiopgInstrumentor(TestBase):
 
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+        self.assertEqual(span.attributes[DB_NAME], "testdatabase")
+        self.assertEqual(span.attributes[DB_USER], "testuser")
+        self.assertEqual(span.attributes[NET_PEER_NAME], "testhost")
+        self.assertEqual(span.attributes[NET_PEER_PORT], 123)
 
     def test_instrument_connection_after_instrument(self):
         cnx = async_call(aiopg.connect(database="test"))
@@ -458,6 +471,7 @@ class TestAiopgIntegration(TestBase):
         connection = mock.Mock()
         # Avoid get_attributes failing because can't concatenate mock
         connection.database = "-"
+        connection._conn = connection
         connection2 = wrappers.instrument_connection(
             self.tracer, connection, "-"
         )
@@ -468,6 +482,7 @@ class TestAiopgIntegration(TestBase):
         # Set connection.database to avoid a failure because mock can't
         # be concatenated
         connection.database = "-"
+        connection._conn = connection
         connection2 = wrappers.instrument_connection(
             self.tracer, connection, "-"
         )
@@ -534,6 +549,12 @@ class MockPsycopg2Connection:
         self.server_port = server_port
         self.server_host = server_host
         self.user = user
+        self.info = SimpleNamespace(
+            dbname=database,
+            port=server_port,
+            host=server_host,
+            user=user,
+        )
 
 
 class MockConnection:

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
@@ -103,6 +103,46 @@ class TestFunctionalAiopgConnect(TestBase):
             self.validate_spans("test")
 
 
+class TestFunctionalAiopgInstrumentConnection(TestBase):
+    def setUp(self):
+        super().setUp()
+
+        async def connect():
+            connection = await aiopg.connect(
+                dbname=POSTGRES_DB_NAME,
+                user=POSTGRES_USER,
+                password=POSTGRES_PASSWORD,
+                host=POSTGRES_HOST,
+                port=POSTGRES_PORT,
+            )
+            return AiopgInstrumentor().instrument_connection(
+                connection, tracer_provider=self.tracer_provider
+            )
+
+        self._connection = async_call(connect())
+        self._cursor = async_call(self._connection.cursor())
+
+    def tearDown(self):
+        self._cursor.close()
+        self._connection.close()
+        super().tearDown()
+
+    def test_execute(self):
+        """Should emit connection attributes for a manually instrumented connection."""
+        async_call(self._cursor.execute("SELECT 1"))
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "SELECT")
+        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes[DB_SYSTEM], "postgresql")
+        self.assertEqual(span.attributes[DB_NAME], POSTGRES_DB_NAME)
+        self.assertEqual(span.attributes[DB_USER], POSTGRES_USER)
+        self.assertEqual(span.attributes[NET_PEER_NAME], POSTGRES_HOST)
+        self.assertEqual(span.attributes[NET_PEER_PORT], POSTGRES_PORT)
+
+
 class TestFunctionalAiopgCreatePool(TestBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
# Description

Fix aiopg manual instrumentation to read database connection attributes from the underlying psycopg2 connection. Also simplify operation-name resolution by delegating empty arguments to the shared DBAPI helper. No additional dependencies are required.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `uvx tox -e py310-test-instrumentation-aiopg-wrapt2`
- [x] `uvx tox -e py312-test-instrumentation-aiopg-wrapt2`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated