### PR TITLE
feat(aws-lambda): add logger provider support with force flush for Lambda freeze handling

### DIFF
--- a/.changelog/4832.added
+++ b/.changelog/4832.added
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-aws-lambda`: add logger provider support with force flush for Lambda freeze handling

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -110,6 +110,8 @@ from opentelemetry.trace import (
     get_tracer_provider,
 )
 from opentelemetry.trace.status import Status, StatusCode
+from opentelemetry._logs import get_logger_provider, set_logger_provider
+from opentelemetry.sdk._logs import LoggerProvider
 
 logger = logging.getLogger(__name__)
 
@@ -333,6 +335,7 @@ def _instrument(
     event_context_extractor: Callable[[Any], Context],
     tracer_provider: TracerProvider = None,
     meter_provider: MeterProvider = None,
+    logger_provider: LoggerProvider = None,
 ):
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
@@ -437,6 +440,18 @@ def _instrument(
                 "MeterProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
             )
 
+        _logger_provider = logger_provider or get_logger_provider()
+        if hasattr(_logger_provider, "force_flush"):
+            try:
+                # NOTE: `force_flush` before function quit in case of Lambda freeze.
+                _logger_provider.force_flush(flush_timeout)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("LoggerProvider failed to flush logs")
+        else:
+            logger.warning(
+                "LoggerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
+            )
+
         if exception is not None:
             raise exception.with_traceback(exception.__traceback__)
 
@@ -513,6 +528,7 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
             ),
             tracer_provider=kwargs.get("tracer_provider"),
             meter_provider=kwargs.get("meter_provider"),
+            logger_provider=kwargs.get("logger_provider"),
         )
 
     def _uninstrument(self, **kwargs):

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict
 from unittest import mock
 
 from opentelemetry import propagate
+from opentelemetry._logs import NoOpLoggerProvider
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.environment_variables import OTEL_PROPAGATORS
 from opentelemetry.instrumentation.aws_lambda import (
@@ -657,6 +658,15 @@ class TestAwsLambdaInstrumentor(TestAwsLambdaInstrumentorBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans is not None
         self.assertEqual(len(spans), 0)
+
+    def test_no_op_logger_provider(self):
+        logger_provider = NoOpLoggerProvider()
+        AwsLambdaInstrumentor().instrument(logger_provider=logger_provider)
+
+        mock_execute_lambda()
+        spans = self.memory_exporter.get_finished_spans()
+        assert spans is not None
+        self.assertEqual(len(spans), 1)
 
     def test_load_entry_point(self):
         self.assertIs(


### PR DESCRIPTION
# Description
Add support to pass a logger provider (optionally) to allow the log provider to be flushed along with the metrics and traces providers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Does This PR Require a Core Repo Change?

- [x] No.

# How Has This Been Tested?

- [x] `uv run tox`

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
