### PR TITLE
fix(structlog): preserve existing processors

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-structlog/src/opentelemetry/instrumentation/structlog/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-structlog/src/opentelemetry/instrumentation/structlog/__init__.py
@@ -345,13 +345,17 @@ class StructlogInstrumentor(BaseInstrumentor):
         config = structlog.get_config()
         current_processors = list(config.get("processors", []))
 
-        # Insert before the last processor, assumed to be the renderer.
-        if current_processors:
-            insert_position = len(current_processors) - 1
-        else:
-            insert_position = 0
+        # Insert before the last processor, assumed to be the renderer, unless
+        # the app has already configured an OTel processor.
+        if not any(
+            isinstance(p, StructlogProcessor) for p in current_processors
+        ):
+            if current_processors:
+                insert_position = len(current_processors) - 1
+            else:
+                insert_position = 0
 
-        current_processors.insert(insert_position, processor)
+            current_processors.insert(insert_position, processor)
 
         # Reconfigure structlog with the new processor chain
         StructlogInstrumentor._original_configure(
@@ -418,11 +422,11 @@ class StructlogInstrumentor(BaseInstrumentor):
         config = structlog.get_config()
         current_processors = list(config.get("processors", []))
 
-        # Remove all StructlogProcessor instances
+        # Remove only the processor added by this instrumentor.
         new_processors = [
             p
             for p in current_processors
-            if not isinstance(p, StructlogProcessor)
+            if p is not StructlogInstrumentor._processor
         ]
         configured_by_app = StructlogInstrumentor._is_configured_by_app
 

--- a/instrumentation/opentelemetry-instrumentation-structlog/src/opentelemetry/instrumentation/structlog/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-structlog/src/opentelemetry/instrumentation/structlog/__init__.py
@@ -317,13 +317,15 @@ class StructlogInstrumentor(BaseInstrumentor):
         config = structlog.get_config()
         current_processors = list(config.get("processors", []))
 
-        # Insert before the last processor, assumed to be the renderer.
-        if current_processors:
-            insert_position = len(current_processors) - 1
-        else:
-            insert_position = 0
+        # Insert before the last processor, assumed to be the renderer, unless
+        # the app has already configured an OTel processor.
+        if not any(isinstance(p, StructlogProcessor) for p in current_processors):
+            if current_processors:
+                insert_position = len(current_processors) - 1
+            else:
+                insert_position = 0
 
-        current_processors.insert(insert_position, processor)
+            current_processors.insert(insert_position, processor)
 
         # Reconfigure structlog with the new processor chain
         StructlogInstrumentor._original_configure(processors=current_processors)
@@ -384,8 +386,8 @@ class StructlogInstrumentor(BaseInstrumentor):
         config = structlog.get_config()
         current_processors = list(config.get("processors", []))
 
-        # Remove all StructlogProcessor instances
-        new_processors = [p for p in current_processors if not isinstance(p, StructlogProcessor)]
+        # Remove only the processor added by this instrumentor.
+        new_processors = [p for p in current_processors if p is not StructlogInstrumentor._processor]
         configured_by_app = StructlogInstrumentor._is_configured_by_app
 
         # Restore the original structlog.configure before reconfiguring so

--- a/instrumentation/opentelemetry-instrumentation-structlog/tests/test_structlog.py
+++ b/instrumentation/opentelemetry-instrumentation-structlog/tests/test_structlog.py
@@ -470,6 +470,48 @@ class TestStructlogInstrumentor(TestBase):
         )
         self.assertTrue(has_otel_processor)
 
+    def test_instrument_does_not_duplicate_existing_processor(self):
+        """Test instrument() reuses an existing OTel processor."""
+        existing_processor = StructlogProcessor(
+            logger_provider=self.logger_provider
+        )
+        structlog.configure(
+            processors=[
+                existing_processor,
+                structlog.dev.ConsoleRenderer(),
+            ]
+        )
+
+        StructlogInstrumentor().instrument(
+            logger_provider=self.logger_provider
+        )
+
+        processors = structlog.get_config()["processors"]
+        otel_processors = [
+            p for p in processors if isinstance(p, StructlogProcessor)
+        ]
+        self.assertEqual(otel_processors, [existing_processor])
+
+    def test_uninstrument_preserves_existing_processor(self):
+        """Test uninstrument() preserves an app-configured OTel processor."""
+        existing_processor = StructlogProcessor(
+            logger_provider=self.logger_provider
+        )
+        structlog.configure(
+            processors=[
+                existing_processor,
+                structlog.dev.ConsoleRenderer(),
+            ]
+        )
+
+        StructlogInstrumentor().instrument(
+            logger_provider=self.logger_provider
+        )
+        StructlogInstrumentor().uninstrument()
+
+        processors = structlog.get_config()["processors"]
+        self.assertIn(existing_processor, processors)
+
     def test_instrument_without_prior_structlog_configuration_emits_logs(self):
         """Test instrument() emits logs before the app configures structlog."""
         structlog.reset_defaults()

--- a/instrumentation/opentelemetry-instrumentation-structlog/tests/test_structlog.py
+++ b/instrumentation/opentelemetry-instrumentation-structlog/tests/test_structlog.py
@@ -436,6 +436,38 @@ class TestStructlogInstrumentor(TestBase):
         has_otel_processor = any(isinstance(p, StructlogProcessor) for p in new_processors)
         self.assertTrue(has_otel_processor)
 
+    def test_instrument_does_not_duplicate_existing_processor(self):
+        """Test instrument() reuses an existing OTel processor."""
+        existing_processor = StructlogProcessor(logger_provider=self.logger_provider)
+        structlog.configure(
+            processors=[
+                existing_processor,
+                structlog.dev.ConsoleRenderer(),
+            ]
+        )
+
+        StructlogInstrumentor().instrument(logger_provider=self.logger_provider)
+
+        processors = structlog.get_config()["processors"]
+        otel_processors = [p for p in processors if isinstance(p, StructlogProcessor)]
+        self.assertEqual(otel_processors, [existing_processor])
+
+    def test_uninstrument_preserves_existing_processor(self):
+        """Test uninstrument() preserves an app-configured OTel processor."""
+        existing_processor = StructlogProcessor(logger_provider=self.logger_provider)
+        structlog.configure(
+            processors=[
+                existing_processor,
+                structlog.dev.ConsoleRenderer(),
+            ]
+        )
+
+        StructlogInstrumentor().instrument(logger_provider=self.logger_provider)
+        StructlogInstrumentor().uninstrument()
+
+        processors = structlog.get_config()["processors"]
+        self.assertIn(existing_processor, processors)
+
     def test_instrument_without_prior_structlog_configuration_emits_logs(self):
         """Test instrument() emits logs before the app configures structlog."""
         structlog.reset_defaults()


### PR DESCRIPTION
# Description

Preserve an application-configured `StructlogProcessor` when instrumenting and uninstrumenting Structlog.

Previously, instrumentation could add a duplicate processor when one was already configured. Uninstrumentation then removed processors by type, which could remove the application-owned processor as well.

The instrumentor now avoids duplicate insertion and removes only the exact processor instance it created.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Oldest supported Structlog package test environment
- Latest supported Structlog package test environment
- Focused regression tests covering duplicate insertion and ownership during uninstrumentation
- Structlog package lint
- Ruff and Ruff formatting checks
- License-header check

The root `uv sync --frozen --all-packages` command could not complete because the local system lacks the MySQL/MariaDB development libraries required to build `mysqlclient`. This does not affect the Structlog package test environments.

# Does This PR Require a Core Repo Change?

- [ ] Yes
- [x] No

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelog fragment will be added after the PR number is assigned
- [x] Unit tests have been added
- [ ] Documentation has been updated
