### PR TITLE
infra(backport): add backport label to generated PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
   backport:
     permissions:
       contents: write # required for pushing branches
-      pull-requests: write # required for creating pull requests
+      pull-requests: write # required for creating and editing pull requests
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -37,6 +37,7 @@ jobs:
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Create pull request
+        id: create_pr
         env:
           NUMBER: ${{ github.event.inputs.number }}
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
@@ -49,7 +50,15 @@ jobs:
 
           git cherry-pick $commit
           git push origin HEAD:$branch
-          gh pr create --title "[$GITHUB_REF_NAME] $title" \
-                       --body "Clean cherry-pick of #$NUMBER to the \`$GITHUB_REF_NAME\` branch." \
-                       --head $branch \
-                       --base $GITHUB_REF_NAME
+          pr_url=$(gh pr create --title "[$GITHUB_REF_NAME] $title" \
+                                --body "Clean cherry-pick of #$NUMBER to the \`$GITHUB_REF_NAME\` branch." \
+                                --head $branch \
+                                --base $GITHUB_REF_NAME)
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+
+      - name: Add backport label to PR
+        if: steps.create_pr.outputs.pr_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.create_pr.outputs.pr_url }} --add-label "backport"


### PR DESCRIPTION
# Description

Capture the URL of pull requests created by the backport workflow and apply the `backport` label in a guarded follow-up step. This lets lint, test, and miscellaneous workflows select the intended release-branch ref for generated backport PRs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Parsed `.github/workflows/backport.yml` and asserted the PR-output and label-step structure

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not applicable; workflow-only change)
- [ ] Unit tests have been added (not applicable; workflow-only change)
- [ ] Documentation has been updated (not applicable)
