### PR TITLE
Add `gcp_resource_detector` back as entry point name

### DIFF
--- a/resource/opentelemetry-resourcedetector-gcp/.changelog/4865.fixed
+++ b/resource/opentelemetry-resourcedetector-gcp/.changelog/4865.fixed
@@ -1,0 +1,1 @@
+Add back `gcp_resource_detector` entry point name for backward compatibility.

--- a/resource/opentelemetry-resourcedetector-gcp/pyproject.toml
+++ b/resource/opentelemetry-resourcedetector-gcp/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 
 [project.entry-points.opentelemetry_resource_detector]
 gcp = "opentelemetry.resourcedetector.gcp_resource_detector:GoogleCloudResourceDetector"
+gcp_resource_detector = "opentelemetry.resourcedetector.gcp_resource_detector:GoogleCloudResourceDetector"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/resource/opentelemetry-resourcedetector-gcp"

--- a/resource/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
+++ b/resource/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
@@ -196,5 +196,6 @@ def test_entry_points():
     assert "gcp" in ep_map
     assert "gcp_resource_detector" in ep_map
     assert ep_map["gcp"].load() is GoogleCloudResourceDetector
-    assert ep_map["gcp_resource_detector"].load() is GoogleCloudResourceDetector
-
+    assert (
+        ep_map["gcp_resource_detector"].load() is GoogleCloudResourceDetector
+    )

--- a/resource/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
+++ b/resource/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import entry_points
 from unittest.mock import Mock
 
 import pytest
@@ -187,3 +188,13 @@ def test_detects_gae_flex(
     )
 
     assert dict(GoogleCloudResourceDetector().detect().attributes) == snapshot
+
+
+def test_entry_points():
+    eps = entry_points(group="opentelemetry_resource_detector")
+    ep_map = {ep.name: ep for ep in eps}
+    assert "gcp" in ep_map
+    assert "gcp_resource_detector" in ep_map
+    assert ep_map["gcp"].load() is GoogleCloudResourceDetector
+    assert ep_map["gcp_resource_detector"].load() is GoogleCloudResourceDetector
+


### PR DESCRIPTION
# Description

Another thing I missed when moving the resource detector over.. [gcp_resource_detector](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/8cba89a602c51d5defafc802eb24be90a9edbc75/opentelemetry-resourcedetector-gcp/setup.cfg#L42-L43) is the current entry point name.. I've left `gcp` too since it matches the style the other resource detectors here are using.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit test

# Does This PR Require a Core Repo Change?

- [x ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
