### PR TITLE
Add baggage propagation tests for Flask and WSGI instrumentations

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -11,7 +11,7 @@ import flask
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
-from opentelemetry import context, trace
+from opentelemetry import baggage, context, trace
 
 
 class InstrumentationTest:
@@ -20,6 +20,10 @@ class InstrumentationTest:
         if helloid == 500:
             raise ValueError(":-(")
         return "Hello: " + str(helloid)
+
+    @staticmethod
+    def _baggage_endpoint():
+        return dict(baggage.get_all())
 
     @staticmethod
     def _sqlcommenter_endpoint():
@@ -89,6 +93,7 @@ class InstrumentationTest:
 
         # pylint: disable=no-member
         self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        self.app.route("/baggage")(self._baggage_endpoint)
         self.app.route("/sqlcommenter")(self._sqlcommenter_endpoint)
         self.app.route("/multithreaded")(self._multithreaded_endpoint)
         self.app.route("/copy_context")(self._copy_context_endpoint)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/base_test.py
@@ -11,7 +11,7 @@ import flask
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
-from opentelemetry import context, trace
+from opentelemetry import baggage, context, trace
 
 
 class InstrumentationTest:
@@ -20,6 +20,10 @@ class InstrumentationTest:
         if helloid == 500:
             raise ValueError(":-(")
         return "Hello: " + str(helloid)
+
+    @staticmethod
+    def _baggage_endpoint():
+        return dict(baggage.get_all())
 
     @staticmethod
     def _sqlcommenter_endpoint():
@@ -97,6 +101,7 @@ class InstrumentationTest:
 
         # pylint: disable=no-member
         self.app.route("/hello/<int:helloid>")(self._hello_endpoint)
+        self.app.route("/baggage")(self._baggage_endpoint)
         self.app.route("/sqlcommenter")(self._sqlcommenter_endpoint)
         self.app.route("/multithreaded")(self._multithreaded_endpoint)
         self.app.route("/copy_context")(self._copy_context_endpoint)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=too-many-lines
+import json
 from timeit import default_timer
 from unittest.mock import Mock, patch
 
 from flask import Flask, request
 
-from opentelemetry import trace
+from opentelemetry import baggage, trace
 from opentelemetry.instrumentation._semconv import (
     HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     OTEL_SEMCONV_STABILITY_OPT_IN,
@@ -282,6 +283,19 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual(span_list[0].name, "GET /hello/<int:helloid>")
         self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_baggage_extracted_and_active_in_handler(self):
+        resp = self.client.get(
+            "/baggage",
+            headers={"baggage": "key1=value1,key2=value2,key3=1%2F3"},
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(
+            json.loads(resp.data),
+            {"key1": "value1", "key2": "value2", "key3": "1/3"},
+        )
+        # the baggage context is detached once the request has ended
+        self.assertEqual(dict(baggage.get_all()), {})
 
     def test_trace_response(self):
         orig = get_global_response_propagator()

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=too-many-lines
+import json
 from timeit import default_timer
 from unittest.mock import Mock, patch
 
 from flask import Flask, request
 
-from opentelemetry import trace
+from opentelemetry import baggage, trace
 from opentelemetry.instrumentation._semconv import (
     HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
     OTEL_SEMCONV_STABILITY_OPT_IN,
@@ -286,6 +287,19 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         self.assertEqual(span_list[0].name, "GET /hello/<int:helloid>")
         self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    def test_baggage_extracted_and_active_in_handler(self):
+        resp = self.client.get(
+            "/baggage",
+            headers={"baggage": "key1=value1,key2=value2,key3=1%2F3"},
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(
+            json.loads(resp.data),
+            {"key1": "value1", "key2": "value2", "key3": "1/3"},
+        )
+        # the baggage context is detached once the request has ended
+        self.assertEqual(dict(baggage.get_all()), {})
 
     def test_trace_response(self):
         orig = get_global_response_propagator()

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=too-many-lines
-import json
 from timeit import default_timer
 from unittest.mock import Mock, patch
 
@@ -291,7 +290,7 @@ class TestProgrammatic(InstrumentationTest, WsgiTestBase):
         )
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
-            json.loads(resp.data),
+            resp.get_json(),
             {"key1": "value1", "key2": "value2", "key3": "1/3"},
         )
         # the baggage context is detached once the request has ended

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -10,6 +10,7 @@ from unittest import mock
 from urllib.parse import urlsplit
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
+from opentelemetry import baggage
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation._semconv import (
     HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
@@ -196,6 +197,7 @@ _recommended_metrics_attrs_both = {
 SCOPE = "opentelemetry.instrumentation.wsgi"
 
 
+# pylint: disable=too-many-public-methods
 class TestWsgiApplication(WsgiTestBase):
     def setUp(self):
         super().setUp()
@@ -334,6 +336,29 @@ class TestWsgiApplication(WsgiTestBase):
         app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
         response = app(self.environ, self.start_response)
         self.validate_response(response, old_sem_conv=True, new_sem_conv=True)
+
+    def test_baggage_extracted_and_active_in_wrapped_app(self):
+        baggage_in_wrapped_app = {}
+
+        def wsgi_capture_baggage(environ, start_response):
+            baggage_in_wrapped_app.update(baggage.get_all())
+            return simple_wsgi(environ, start_response)
+
+        self.environ["HTTP_BAGGAGE"] = "key1=value1,key2=value2,key3=1%2F3"
+        app = otel_wsgi.OpenTelemetryMiddleware(wsgi_capture_baggage)
+        response = app(self.environ, self.start_response)
+        self.validate_response(response)
+        self.assertEqual(
+            baggage_in_wrapped_app,
+            {"key1": "value1", "key2": "value2", "key3": "1/3"},
+        )
+
+    def test_baggage_detached_after_response_is_consumed(self):
+        self.environ["HTTP_BAGGAGE"] = "key1=value1"
+        app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
+        response = app(self.environ, self.start_response)
+        self.validate_response(response)
+        self.assertEqual(dict(baggage.get_all()), {})
 
     def test_hooks(self):
         hook_headers = (

--- a/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/tests/test_wsgi_middleware.py
@@ -10,6 +10,7 @@ from unittest import mock
 from urllib.parse import urlsplit
 
 import opentelemetry.instrumentation.wsgi as otel_wsgi
+from opentelemetry import baggage
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation._semconv import (
     HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
@@ -192,6 +193,7 @@ _recommended_metrics_attrs_both = {
 SCOPE = "opentelemetry.instrumentation.wsgi"
 
 
+# pylint: disable=too-many-public-methods
 class TestWsgiApplication(WsgiTestBase):
     def setUp(self):
         super().setUp()
@@ -330,6 +332,29 @@ class TestWsgiApplication(WsgiTestBase):
         app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
         response = app(self.environ, self.start_response)
         self.validate_response(response, old_sem_conv=True, new_sem_conv=True)
+
+    def test_baggage_extracted_and_active_in_wrapped_app(self):
+        baggage_in_wrapped_app = {}
+
+        def wsgi_capture_baggage(environ, start_response):
+            baggage_in_wrapped_app.update(baggage.get_all())
+            return simple_wsgi(environ, start_response)
+
+        self.environ["HTTP_BAGGAGE"] = "key1=value1,key2=value2,key3=1%2F3"
+        app = otel_wsgi.OpenTelemetryMiddleware(wsgi_capture_baggage)
+        response = app(self.environ, self.start_response)
+        self.validate_response(response)
+        self.assertEqual(
+            baggage_in_wrapped_app,
+            {"key1": "value1", "key2": "value2", "key3": "1/3"},
+        )
+
+    def test_baggage_detached_after_response_is_consumed(self):
+        self.environ["HTTP_BAGGAGE"] = "key1=value1"
+        app = otel_wsgi.OpenTelemetryMiddleware(simple_wsgi)
+        response = app(self.environ, self.start_response)
+        self.validate_response(response)
+        self.assertEqual(dict(baggage.get_all()), {})
 
     def test_hooks(self):
         hook_headers = (


### PR DESCRIPTION
# Description

The Flask instrumentation and the WSGI `OpenTelemetryMiddleware` extract W3C baggage from
incoming request headers (through the default composite propagator used by
`_start_internal_or_server_span`) and make it active for the duration of the request. This
has worked for a long time, but there was no unit test covering it — neither package
referenced baggage anywhere in its tests.

This PR adds the tests requested in the issue:

- **WSGI** (`test_wsgi_middleware.py`):
  - `test_baggage_extracted_and_active_in_wrapped_app`: baggage entries from the incoming
    `baggage` header (including a percent-encoded value) are available via
    `baggage.get_all()` inside the wrapped WSGI application.
  - `test_baggage_detached_after_response_is_consumed`: the extracted context is detached
    after the response iterable is consumed, so baggage does not leak past the request.
- **Flask** (`base_test.py`, `test_programmatic.py`):
  - `test_baggage_extracted_and_active_in_handler`: baggage from the incoming request
    header is available via `baggage.get_all()` inside the route handler (new `/baggage`
    test route), and the context is detached once the request has ended.

Tests-only change, no functional changes — no changelog fragment (Skip Changelog).
The `# pylint: disable=too-many-public-methods` on `TestWsgiApplication` was needed
because the class was already at the 20-method limit; the same disable is already used on
`TestWsgiAttributes` in the same file.

Fixes #268

## Type of change

- [x] Tests only (no functional change)

# How Has This Been Tested?

- `tox -e py312-test-instrumentation-wsgi` equivalent: full WSGI suite — 54 passed
  (52 baseline + 2 new).
- `tox -e py312-test-instrumentation-flask-3` equivalent: full Flask suite — 61 passed,
  1 skipped (60 baseline + 1 new); also re-run against the oldest tested versions
  (`Flask==2.1.3`, `Werkzeug==2.3.8`, the flask-0 pins) — 61 passed, 1 skipped.
- Negative check: with `OTEL_PROPAGATORS=tracecontext` (baggage propagator removed from
  the composite), both new extraction tests fail — confirming they guard the behavior.
- Lint: `ruff check` / `ruff format --check` (v0.14.1) clean on changed files;
  `pylint --rcfile .pylintrc` (v4.0.5) 10.00/10 on both packages.

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not needed — tests only, requesting `Skip Changelog` label)
- [x] Unit tests have been added
- [ ] Documentation has been updated (not applicable)
