### PR TITLE
feat(resource): add host ID detector

### DIFF
--- a/resource/opentelemetry-resource-detector-host/.changelog/4876.added
+++ b/resource/opentelemetry-resource-detector-host/.changelog/4876.added
@@ -1,0 +1,1 @@
+Add a host resource detector that reads the Linux machine ID into ``host.id``.

--- a/resource/opentelemetry-resource-detector-host/CHANGELOG.md
+++ b/resource/opentelemetry-resource-detector-host/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<!-- changelog start -->

--- a/resource/opentelemetry-resource-detector-host/MANIFEST.in
+++ b/resource/opentelemetry-resource-detector-host/MANIFEST.in
@@ -1,0 +1,1 @@
+include MANIFEST.rst

--- a/resource/opentelemetry-resource-detector-host/MANIFEST.rst
+++ b/resource/opentelemetry-resource-detector-host/MANIFEST.rst
@@ -1,0 +1,8 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst

--- a/resource/opentelemetry-resource-detector-host/README.rst
+++ b/resource/opentelemetry-resource-detector-host/README.rst
@@ -1,0 +1,26 @@
+OpenTelemetry Host Resource Detector
+====================================
+
+This package detects the host identifier from the Linux ``machine-id`` files
+and exposes it as the ``host.id`` resource attribute.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-resource-detector-host
+
+Usage
+-----
+
+::
+
+    from opentelemetry.resource.detector.host import HostIdResourceDetector
+    from opentelemetry.sdk.resources import get_aggregated_resources
+
+    resource = get_aggregated_resources([HostIdResourceDetector()])
+
+The detector checks ``/etc/machine-id`` first, then
+``/var/lib/dbus/machine-id``. If neither file is available, it returns an
+empty resource.

--- a/resource/opentelemetry-resource-detector-host/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-host/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-resource-detector-host"
+dynamic = ["version"]
+description = "Host resource detector for OpenTelemetry"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = ["opentelemetry-sdk ~= 1.21"]
+
+[project.entry-points.opentelemetry_resource_detector]
+host = "opentelemetry.resource.detector.host:HostIdResourceDetector"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/resource/opentelemetry-resource-detector-host"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
+
+[tool.hatch.version]
+path = "src/opentelemetry/resource/detector/host/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src", "/tests", "/README.rst", "/CHANGELOG.md"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]
+
+[tool.towncrier]
+directory = ".changelog"
+filename = "CHANGELOG.md"
+start_string = "<!-- changelog start -->\n"
+template = "../../scripts/changelog_template.j2"
+issue_format = "[#{issue}](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/{issue})"
+wrap = true
+issue_pattern = "^(\\d+)"
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true

--- a/resource/opentelemetry-resource-detector-host/src/opentelemetry/resource/detector/host/__init__.py
+++ b/resource/opentelemetry-resource-detector-host/src/opentelemetry/resource/detector/host/__init__.py
@@ -1,0 +1,48 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from pathlib import Path
+
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+from opentelemetry.semconv.resource import ResourceAttributes
+
+_LOGGER = logging.getLogger(__name__)
+_MACHINE_ID_PATHS = (
+    Path("/etc/machine-id"),
+    Path("/var/lib/dbus/machine-id"),
+)
+
+
+def _get_machine_id(paths=None):
+    """Return the first non-empty machine id available on this host."""
+    paths = _MACHINE_ID_PATHS if paths is None else paths
+    for path in paths:
+        try:
+            machine_id = path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeError) as exception:
+            _LOGGER.debug("Could not read machine id from %s: %s", path, exception)
+            continue
+        if machine_id:
+            return machine_id
+    return None
+
+
+class HostIdResourceDetector(ResourceDetector):
+    """Detect the stable host identifier from the Linux machine-id files."""
+
+    def detect(self) -> Resource:
+        try:
+            machine_id = _get_machine_id()
+            if machine_id:
+                return Resource({ResourceAttributes.HOST_ID: machine_id})
+            return Resource.get_empty()
+        except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.warning(
+                "%s resource detection failed: %s",
+                self.__class__.__name__,
+                exception,
+            )
+            if self.raise_on_error:
+                raise
+            return Resource.get_empty()

--- a/resource/opentelemetry-resource-detector-host/src/opentelemetry/resource/detector/host/version.py
+++ b/resource/opentelemetry-resource-detector-host/src/opentelemetry/resource/detector/host/version.py
@@ -1,0 +1,4 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "0.66b0.dev"

--- a/resource/opentelemetry-resource-detector-host/test-requirements.txt
+++ b/resource/opentelemetry-resource-detector-host/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest==7.4.4
+-e resource/opentelemetry-resource-detector-host

--- a/resource/opentelemetry-resource-detector-host/tests/__init__.py
+++ b/resource/opentelemetry-resource-detector-host/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/resource/opentelemetry-resource-detector-host/tests/test_host.py
+++ b/resource/opentelemetry-resource-detector-host/tests/test_host.py
@@ -1,0 +1,53 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from opentelemetry.resource.detector.host import (
+    HostIdResourceDetector,
+    _get_machine_id,
+)
+from opentelemetry.semconv.resource import ResourceAttributes
+
+
+class HostIdResourceDetectorTest(unittest.TestCase):
+    def test_detects_primary_machine_id_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            primary = Path(directory) / "machine-id"
+            fallback = Path(directory) / "dbus-machine-id"
+            primary.write_text("primary-id\n", encoding="utf-8")
+            fallback.write_text("fallback-id\n", encoding="utf-8")
+
+            with patch(
+                "opentelemetry.resource.detector.host._MACHINE_ID_PATHS",
+                (primary, fallback),
+            ):
+                resource = HostIdResourceDetector().detect()
+
+        self.assertEqual(resource.attributes[ResourceAttributes.HOST_ID], "primary-id")
+
+    def test_falls_back_when_primary_path_is_empty(self):
+        with tempfile.TemporaryDirectory() as directory:
+            primary = Path(directory) / "machine-id"
+            fallback = Path(directory) / "dbus-machine-id"
+            primary.write_text("\n", encoding="utf-8")
+            fallback.write_text("fallback-id\n", encoding="utf-8")
+
+            self.assertEqual(_get_machine_id((primary, fallback)), "fallback-id")
+
+    def test_returns_empty_resource_when_files_are_unavailable(self):
+        missing = Path("this-path-does-not-exist")
+        with patch(
+            "opentelemetry.resource.detector.host._MACHINE_ID_PATHS",
+            (missing,),
+        ):
+            resource = HostIdResourceDetector().detect()
+
+        self.assertNotIn(ResourceAttributes.HOST_ID, resource.attributes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,11 @@ envlist =
     pypy3-test-resource-detector-containerid
     lint-resource-detector-containerid
 
+    ; opentelemetry-resource-detector-host
+    py3{10,11,12,13,14}-test-resource-detector-host
+    pypy3-test-resource-detector-host
+    lint-resource-detector-host
+
     ; opentelemetry-resource-detector-azure
     py3{10,11,12,13,14}-test-resource-detector-azure-{0,1}
     pypy3-test-resource-detector-azure-{0,1}
@@ -760,6 +765,9 @@ deps =
   resource-detector-containerid: {[testenv]test_deps}
   resource-detector-containerid: -r {toxinidir}/resource/opentelemetry-resource-detector-containerid/test-requirements.txt
 
+  resource-detector-host: {[testenv]test_deps}
+  resource-detector-host: -r {toxinidir}/resource/opentelemetry-resource-detector-host/test-requirements.txt
+
   # packages that are released individually should provide a test-requirements.txt with the lowest version of OTel API
   # and SDK supported to test we are honoring it
   resource-detector-azure-0: -r {toxinidir}/resource/opentelemetry-resource-detector-azure/test-requirements-0.txt
@@ -1030,6 +1038,9 @@ commands =
 
   test-resource-detector-containerid: pytest {toxinidir}/resource/opentelemetry-resource-detector-containerid/tests {posargs}
   lint-resource-detector-containerid: sh -c "cd resource && pylint --rcfile ../.pylintrc opentelemetry-resource-detector-containerid"
+
+  test-resource-detector-host: pytest {toxinidir}/resource/opentelemetry-resource-detector-host/tests {posargs}
+  lint-resource-detector-host: sh -c "cd resource && pylint --rcfile ../.pylintrc opentelemetry-resource-detector-host"
 
   test-resource-detector-azure: pytest {toxinidir}/resource/opentelemetry-resource-detector-azure/tests {posargs}
   lint-resource-detector-azure: sh -c "cd resource && pylint --rcfile ../.pylintrc opentelemetry-resource-detector-azure"


### PR DESCRIPTION
## Summary\n- add opentelemetry-resource-detector-host as a standalone resource detector\n- read /etc/machine-id with /var/lib/dbus/machine-id fallback and expose host.id\n- add entry-point, package docs, tox environments, and focused tests\n\nFixes #4830\n\nValidation: python -m py_compile resource/opentelemetry-resource-detector-host/src/opentelemetry/resource/detector/host/__init__.py resource/opentelemetry-resource-detector-host/tests/test_host.py, git diff --check\n\nThe local pytest run is blocked because this environment does not have the OpenTelemetry SDK dependencies installed; the package's tox test environment declares them through the repository test dependencies.\n\n