### PR TITLE
feat(kafka-python): add consumer group attribute

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-kafka-python/.changelog/4877.added
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/.changelog/4877.added
@@ -1,0 +1,1 @@
+Add the ``messaging.consumer.group.name`` attribute to consumer spans.

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
@@ -9,6 +9,7 @@ from kafka.record.abc import ABCRecord
 
 from opentelemetry import context, propagate, trace
 from opentelemetry.propagators import textmap
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Tracer
 from opentelemetry.trace.span import Span
@@ -20,6 +21,13 @@ class KafkaPropertiesExtractor:
     @staticmethod
     def extract_bootstrap_servers(instance):
         return instance.config.get("bootstrap_servers")
+
+    @staticmethod
+    def extract_consumer_group(instance):
+        try:
+            return instance.config.get("group_id")
+        except AttributeError:
+            return None
 
     @staticmethod
     def _extract_argument(key, position, default_value, args, kwargs):
@@ -184,6 +192,7 @@ def _create_consumer_span(
     bootstrap_servers,
     args,
     kwargs,
+    consumer_group=None,
 ):
     span_name = _get_span_name("receive", record.topic)
     with tracer.start_as_current_span(
@@ -194,6 +203,11 @@ def _create_consumer_span(
         new_context = trace.set_span_in_context(span, extracted_context)
         token = context.attach(new_context)
         _enrich_span(span, bootstrap_servers, record.topic, record.partition)
+        if span.is_recording() and consumer_group is not None:
+            span.set_attribute(
+                messaging_attributes.MESSAGING_CONSUMER_GROUP_NAME,
+                consumer_group,
+            )
         try:
             if callable(consume_hook):
                 consume_hook(span, record, args, kwargs)
@@ -214,6 +228,9 @@ def _wrap_next(
             bootstrap_servers = (
                 KafkaPropertiesExtractor.extract_bootstrap_servers(instance)
             )
+            consumer_group = KafkaPropertiesExtractor.extract_consumer_group(
+                instance
+            )
 
             extracted_context = propagate.extract(
                 record.headers, getter=_kafka_getter
@@ -226,6 +243,7 @@ def _wrap_next(
                 bootstrap_servers,
                 args,
                 kwargs,
+                consumer_group,
             )
         return record
 

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
@@ -166,6 +166,7 @@ class TestUtils(TestCase):
             bootstrap_servers,
             self.args,
             self.kwargs,
+            kafka_consumer.config.get.return_value,
         )
 
     @mock.patch("opentelemetry.trace.set_span_in_context")
@@ -193,6 +194,7 @@ class TestUtils(TestCase):
             bootstrap_servers,
             self.args,
             self.kwargs,
+            "consumer-group",
         )
 
         expected_span_name = _get_span_name("receive", record.topic)
@@ -213,6 +215,10 @@ class TestUtils(TestCase):
             span, record, self.args, self.kwargs
         )
         detach.assert_called_once_with(attach.return_value)
+
+        span.set_attribute.assert_called_once_with(
+            "messaging.consumer.group.name", "consumer-group"
+        )
 
     @mock.patch(
         "opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor"
@@ -237,4 +243,16 @@ class TestUtils(TestCase):
                 kafka_properties_extractor, self.args, self.kwargs
             )
             is None
+        )
+
+    def test_extract_consumer_group(self):
+        consumer = mock.Mock()
+        consumer.config = {"group_id": "orders"}
+        self.assertEqual(
+            KafkaPropertiesExtractor.extract_consumer_group(consumer), "orders"
+        )
+
+        consumer_without_config = object()
+        self.assertIsNone(
+            KafkaPropertiesExtractor.extract_consumer_group(consumer_without_config)
         )


### PR DESCRIPTION
## Summary\n- extract group_id from kafka-python consumer configuration\n- emit messaging.consumer.group.name on receive spans\n- add extractor and span-attribute regression coverage\n\nFixes #4593\n\nValidation: python -m py_compile instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py, git diff --check\n\nThe targeted pytest is blocked locally because this environment lacks the repository's OpenTelemetry package dependencies.\n\n