### PR TITLE
fix(django): finish streaming spans on response close

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py
@@ -324,6 +324,8 @@ class _DjangoMiddleware:
         if not _is_asgi_supported and is_asgi_request:
             return response
 
+        is_streaming_response = bool(getattr(response, "streaming", False))
+
         activation = request.META.pop(self._environ_activation_key, None)
         span = request.META.pop(self._environ_span_key, None)
         active_requests_count_attrs = request.META.pop(
@@ -394,43 +396,61 @@ class _DjangoMiddleware:
                 except Exception:  # pylint: disable=broad-exception-caught
                     _logger.exception("Exception raised by response_hook")
 
-        if request_start_time is not None:
-            duration_s = default_timer() - request_start_time
-            if self._duration_histogram_old:
-                duration_attrs_old = _parse_duration_attrs(
-                    duration_attrs, _StabilityMode.DEFAULT
-                )
-                # http.target to be included in old semantic conventions
-                target = duration_attrs.get(HTTP_TARGET)
-                if target:
-                    duration_attrs_old[HTTP_TARGET] = target
-                self._duration_histogram_old.record(
-                    max(round(duration_s * 1000), 0),
-                    duration_attrs_old,
-                )
-            if self._duration_histogram_new:
-                duration_attrs_new = _parse_duration_attrs(
-                    duration_attrs, _StabilityMode.HTTP
-                )
-                self._duration_histogram_new.record(
-                    max(duration_s, 0),
-                    duration_attrs_new,
-                )
-        self._active_request_counter.add(-1, active_requests_count_attrs)
+        def finish_response() -> None:
+            if request_start_time is not None:
+                duration_s = default_timer() - request_start_time
+                if self._duration_histogram_old:
+                    duration_attrs_old = _parse_duration_attrs(
+                        duration_attrs, _StabilityMode.DEFAULT
+                    )
+                    # http.target to be included in old semantic conventions
+                    target = duration_attrs.get(HTTP_TARGET)
+                    if target:
+                        duration_attrs_old[HTTP_TARGET] = target
+                    self._duration_histogram_old.record(
+                        max(round(duration_s * 1000), 0),
+                        duration_attrs_old,
+                    )
+                if self._duration_histogram_new:
+                    duration_attrs_new = _parse_duration_attrs(
+                        duration_attrs, _StabilityMode.HTTP
+                    )
+                    self._duration_histogram_new.record(
+                        max(duration_s, 0),
+                        duration_attrs_new,
+                    )
+            self._active_request_counter.add(-1, active_requests_count_attrs)
 
-        if activation and span:
-            if exception:
-                activation.__exit__(
-                    type(exception),
-                    exception,
-                    getattr(exception, "__traceback__", None),
-                )
-            else:
-                activation.__exit__(None, None, None)
+            if activation and span:
+                if exception:
+                    activation.__exit__(
+                        type(exception),
+                        exception,
+                        getattr(exception, "__traceback__", None),
+                    )
+                else:
+                    activation.__exit__(None, None, None)
 
-        if request.META.get(self._environ_token, None) is not None:
-            detach(request.META.get(self._environ_token))
-            request.META.pop(self._environ_token)
+            if request.META.get(self._environ_token, None) is not None:
+                detach(request.META.get(self._environ_token))
+                request.META.pop(self._environ_token)
+
+        if is_streaming_response:
+            original_close = response.close
+            response_closed = False
+
+            def close_response() -> None:
+                nonlocal response_closed
+                try:
+                    original_close()
+                finally:
+                    if not response_closed:
+                        response_closed = True
+                        finish_response()
+
+            response.close = close_response
+        else:
+            finish_response()
 
         return response
 

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -9,8 +9,8 @@ from timeit import default_timer
 from unittest.mock import Mock, patch
 
 from django import VERSION, conf
-from django.http import HttpRequest, HttpResponse
-from django.test.client import Client
+from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
+from django.test.client import Client, RequestFactory
 from django.test.utils import setup_test_environment, teardown_test_environment
 
 from opentelemetry import trace
@@ -1117,6 +1117,26 @@ class TestMiddlewareSpanActivationTiming(WsgiTestBase):
             for metric in sm.metrics
         )
         self.assertTrue(histogram_found)
+
+    def test_streaming_response_span_ends_when_response_closes(self):
+        """Streaming responses keep the server span open until close()."""
+        request = RequestFactory().get("/traced/")
+        middleware = _DjangoMiddleware(
+            lambda _request: StreamingHttpResponse(iter([b"chunk"]))
+        )
+
+        response = middleware(request)
+
+        self.assertEqual(len(self.memory_exporter.get_finished_spans()), 0)
+
+        response.close()
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertIsNotNone(spans[0].end_time)
+
+        response.close()
+        self.assertEqual(len(self.memory_exporter.get_finished_spans()), 1)
 
     def test_metrics_recorded_with_exception(self):
         """Metrics recorded even when request raises exception."""


### PR DESCRIPTION
## What does this PR do?

Fixes #4681 by keeping Django server spans active for `StreamingHttpResponse` objects until Django invokes the response's guaranteed `close()` lifecycle hook.

The existing response status/header instrumentation and response hook still run in `process_response`; duration metrics, active-request accounting, context detachment, and span finalization are deferred only for streaming responses. The close wrapper is idempotent and finalizes telemetry even when the original close method raises.

## Checklist

- [x] Added regression coverage for deferred span completion and idempotent close handling.
- [x] Ran the Django middleware test suite.
- [x] Ran `git diff --check` and Python compilation.

Test result: `42 passed` for `instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py`.