### PR TITLE
fix(openai-agents): map MCP list-tools spans

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -57,6 +57,14 @@ except ModuleNotFoundError:  # pragma: no cover - test stubs
         tracing_module, "TranscriptionSpanData", Any
     )  # type: ignore[assignment]
 
+try:
+    from agents.tracing.span_data import MCPListToolsSpanData
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - old SDKs
+    MCPListToolsSpanData = globals().get("tracing_module", Any)
+    MCPListToolsSpanData = getattr(
+        MCPListToolsSpanData, "MCPListToolsSpanData", Any
+    )
+
 from opentelemetry.context import attach, detach
 from opentelemetry.metrics import Histogram, get_meter
 from opentelemetry.semconv._incubating.attributes import (
@@ -1548,6 +1556,8 @@ class GenAISemanticProcessor(TracingProcessor):
             return GenAIOperationName.GUARDRAIL
         if _is_instance_of(span_data, HandoffSpanData):
             return GenAIOperationName.HANDOFF
+        if _is_instance_of(span_data, MCPListToolsSpanData):
+            return GenAIOperationName.EXECUTE_TOOL
         return "unknown"
 
     def _extract_genai_attributes(
@@ -1608,6 +1618,27 @@ class GenAISemanticProcessor(TracingProcessor):
             yield from self._get_attributes_from_guardrail_span_data(span_data)
         elif _is_instance_of(span_data, HandoffSpanData):
             yield from self._get_attributes_from_handoff_span_data(span_data)
+        elif _is_instance_of(span_data, MCPListToolsSpanData):
+            yield from self._get_attributes_from_mcp_list_tools_span_data(
+                span_data
+            )
+
+    def _get_attributes_from_mcp_list_tools_span_data(
+        self, span_data: MCPListToolsSpanData
+    ) -> Iterator[tuple[str, AttributeValue]]:
+        """Extract GenAI tool attributes from an MCP tools/list span."""
+        yield GEN_AI_OPERATION_NAME, GenAIOperationName.EXECUTE_TOOL
+
+        if span_data.server:
+            yield GEN_AI_TOOL_NAME, span_data.server
+        yield GEN_AI_TOOL_TYPE, GenAIToolType.EXTENSION
+
+        if (
+            self.include_sensitive_data
+            and self._content_mode.capture_in_span
+            and span_data.result is not None
+        ):
+            yield GEN_AI_TOOL_CALL_RESULT, safe_json_dumps(span_data.result)
 
     def _get_attributes_from_generation_span_data(
         self, span_data: GenerationSpanData, payload: ContentPayload

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/stubs/agents/tracing/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/stubs/agents/tracing/__init__.py
@@ -18,6 +18,7 @@ SPAN_TYPE_AGENT = "agent"
 SPAN_TYPE_FUNCTION = "function"
 SPAN_TYPE_GENERATION = "generation"
 SPAN_TYPE_RESPONSE = "response"
+SPAN_TYPE_MCP_TOOLS = "mcp_tools"
 
 __all__ = [
     "TraceProvider",
@@ -32,6 +33,7 @@ __all__ = [
     "GenerationSpanData",
     "FunctionSpanData",
     "ResponseSpanData",
+    "MCPListToolsSpanData",
 ]
 
 
@@ -78,6 +80,16 @@ class ResponseSpanData:
     @property
     def type(self) -> str:
         return SPAN_TYPE_RESPONSE
+
+
+@dataclass
+class MCPListToolsSpanData:
+    server: str | None = None
+    result: list[str] | None = None
+
+    @property
+    def type(self) -> str:
+        return SPAN_TYPE_MCP_TOOLS
 
 
 class _ProcessorFanout(TracingProcessor):

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -18,6 +18,7 @@ from agents.tracing import (
     AgentSpanData,
     FunctionSpanData,
     GenerationSpanData,
+    MCPListToolsSpanData,
     ResponseSpanData,
 )
 
@@ -175,6 +176,12 @@ def test_operation_and_span_naming(processor_setup):
     function_data = FunctionSpanData()
     assert (
         processor._get_operation_name(function_data)
+        == sp.GenAIOperationName.EXECUTE_TOOL
+    )
+
+    mcp_tools_data = MCPListToolsSpanData(server="calendar")
+    assert (
+        processor._get_operation_name(mcp_tools_data)
         == sp.GenAIOperationName.EXECUTE_TOOL
     )
 
@@ -360,6 +367,25 @@ def test_attribute_builders(processor_setup):
     assert function_attrs[sp.GEN_AI_TOOL_CALL_ARGUMENTS] == {"city": "seattle"}
     assert function_attrs[sp.GEN_AI_TOOL_CALL_RESULT] == {"temperature": 70}
     assert function_attrs[sp.GEN_AI_OUTPUT_TYPE] == sp.GenAIOutputType.JSON
+
+    mcp_attrs = _collect(
+        processor._get_attributes_from_mcp_list_tools_span_data(
+            MCPListToolsSpanData(
+                server="calendar",
+                result=["list_events", "create_event"],
+            )
+        )
+    )
+    assert (
+        mcp_attrs[sp.GEN_AI_OPERATION_NAME]
+        == sp.GenAIOperationName.EXECUTE_TOOL
+    )
+    assert mcp_attrs[sp.GEN_AI_TOOL_NAME] == "calendar"
+    assert mcp_attrs[sp.GEN_AI_TOOL_TYPE] == sp.GenAIToolType.EXTENSION
+    assert json.loads(mcp_attrs[sp.GEN_AI_TOOL_CALL_RESULT]) == [
+        "list_events",
+        "create_event",
+    ]
 
 
 def test_extract_genai_attributes_unknown_type(processor_setup):


### PR DESCRIPTION
## What does this PR do?

Fixes #4197 by recognizing the OpenAI Agents SDK's `MCPListToolsSpanData` instead of emitting an `unknown` operation for `tools/list` spans.

MCP list-tools spans now use the existing GenAI tool semantics: `gen_ai.operation.name=execute_tool`, the MCP server is recorded as `gen_ai.tool.name`, the tool type is `extension`, and the returned tool list is recorded as `gen_ai.tool.call.result` when span content capture is enabled. Older OpenAI Agents SDK versions that do not expose this span-data class remain supported.

## Validation

- Full OpenAI Agents v2 instrumentation test suite: 103 passed.
- Python compilation passed.
- `git diff --check` passed.

Assisted-by: Codex