### PR TITLE
feat(bootstrap): detect migrated GenAI instrumentations

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -6,10 +6,6 @@
 
 libraries = [
     {
-        "library": "openai >= 1.26.0",
-        "instrumentation": "opentelemetry-instrumentation-openai-v2",
-    },
-    {
         "library": "google-cloud-aiplatform >= 1.64",
         "instrumentation": "opentelemetry-instrumentation-vertexai>=2.0b0",
     },
@@ -200,6 +196,26 @@ libraries = [
     {
         "library": "urllib3 >= 1.0.0, < 3.0.0",
         "instrumentation": "opentelemetry-instrumentation-urllib3==0.66b0.dev",
+    },
+    {
+        "library": "anthropic >= 0.51.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-anthropic",
+    },
+    {
+        "library": "google-genai >= 1.32.0",
+        "instrumentation": "opentelemetry-instrumentation-google-genai",
+    },
+    {
+        "library": "langchain >= 0.3.21",
+        "instrumentation": "opentelemetry-instrumentation-genai-langchain",
+    },
+    {
+        "library": "openai >= 1.26.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai",
+    },
+    {
+        "library": "openai-agents >= 0.3.3",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai-agents",
     },
 ]
 default_instrumentations = [

--- a/opentelemetry-instrumentation/tests/test_bootstrap.py
+++ b/opentelemetry-instrumentation/tests/test_bootstrap.py
@@ -94,6 +94,24 @@ class TestBootstrap(TestCase):
         )
         self.mock_pip_check.assert_called_once()
 
+    def test_migrated_genai_instrumentations_are_available(self):
+        instrumentation_names = {
+            library["instrumentation"] for library in libraries
+        }
+
+        self.assertTrue(
+            {
+                "opentelemetry-instrumentation-genai-anthropic",
+                "opentelemetry-instrumentation-google-genai",
+                "opentelemetry-instrumentation-genai-langchain",
+                "opentelemetry-instrumentation-genai-openai",
+                "opentelemetry-instrumentation-genai-openai-agents",
+            }.issubset(instrumentation_names)
+        )
+        self.assertNotIn(
+            "opentelemetry-instrumentation-openai-v2", instrumentation_names
+        )
+
     @patch("sys.argv", ["bootstrap", "-a", "install"])
     def test_can_override_available_default_instrumentations(self):
         with patch(

--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -65,6 +65,10 @@ packages_to_exclude = [
     # development. This filter will get removed once it is further along in its
     # development lifecycle and ready to be included by default.
     "opentelemetry-instrumentation-openai-agents-v2",
+    # OpenAI instrumentation was migrated to the opentelemetry-python-genai
+    # repository. Keep the legacy contrib package out of bootstrap results so
+    # environments receive the maintained package name below instead.
+    "opentelemetry-instrumentation-openai-v2",
     # Anthropic instrumentation is currently excluded because it is still in early
     # development. This filter will get removed once it is further along in its
     # development lifecycle and ready to be included by default.
@@ -77,10 +81,36 @@ packages_to_exclude = [
 
 # Static version specifiers for instrumentations that are released independently
 independent_packages = {
-    "opentelemetry-instrumentation-openai-v2": "",
     "opentelemetry-instrumentation-vertexai": ">=2.0b0",
     "opentelemetry-instrumentation-google-genai": "",
 }
+
+# These instrumentations are now released from the opentelemetry-python-genai
+# repository. They are intentionally listed here rather than discovered from
+# the contrib workspace, because bootstrap must continue to offer them after
+# their legacy packages are removed from this repository.
+external_instrumentations = [
+    {
+        "library": "anthropic >= 0.51.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-anthropic",
+    },
+    {
+        "library": "google-genai >= 1.32.0",
+        "instrumentation": "opentelemetry-instrumentation-google-genai",
+    },
+    {
+        "library": "langchain >= 0.3.21",
+        "instrumentation": "opentelemetry-instrumentation-genai-langchain",
+    },
+    {
+        "library": "openai >= 1.26.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai",
+    },
+    {
+        "library": "openai-agents >= 0.3.3",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai-agents",
+    },
+]
 
 
 def main():
@@ -110,6 +140,17 @@ def main():
                     values=[ast.Str(target_pkg), ast.Str(pkg["requirement"])],
                 )
             )
+
+    for external in external_instrumentations:
+        libraries.elts.append(
+            ast.Dict(
+                keys=[ast.Str("library"), ast.Str("instrumentation")],
+                values=[
+                    ast.Str(external["library"]),
+                    ast.Str(external["instrumentation"]),
+                ],
+            )
+        )
 
     tree = ast.parse(_source_tmpl)
     tree.body[0].value = libraries


### PR DESCRIPTION
## Description

Updates `opentelemetry-bootstrap --action=install` to detect the GenAI libraries whose instrumentations now ship from `opentelemetry-python-genai`:

- Anthropic
- Google GenAI
- LangChain
- OpenAI
- OpenAI Agents

The generated bootstrap catalog now uses the maintained `opentelemetry-instrumentation-genai-*` package names and no longer recommends the legacy `opentelemetry-instrumentation-openai-v2` package. The generator keeps these external packages available after the legacy packages are removed from this repository.

Fixes #4816

## Validation

- `PYTHONPATH=opentelemetry-instrumentation/src python -m pytest opentelemetry-instrumentation/tests/test_bootstrap.py -q` ? 6 passed
- Ruff check and format check pass for all changed files
- `git diff --check` passes