### PR TITLE
docs: fill FastAPI instrumentation setup gaps

### DIFF
--- a/.changelog/3301.changed
+++ b/.changelog/3301.changed
@@ -1,0 +1,3 @@
+`opentelemetry-instrumentation-fastapi`: document automatic setup, standard
+OpenTelemetry environment variables, propagation, WebSocket coverage, and
+logging correlation.

--- a/instrumentation/opentelemetry-instrumentation-fastapi/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/README.rst
@@ -10,7 +10,9 @@ OpenTelemetry FastAPI Instrumentation
 This library provides automatic and manual instrumentation of FastAPI web frameworks,
 instrumenting http requests served by applications utilizing the framework.
 
-auto-instrumentation using the opentelemetry-instrumentation package is also supported.
+Automatic instrumentation using the
+`opentelemetry-instrumentation <https://pypi.org/project/opentelemetry-instrumentation/>`_
+package is also supported.
 
 Installation
 ------------
@@ -18,6 +20,57 @@ Installation
 ::
 
     pip install opentelemetry-instrumentation-fastapi
+
+For the ``opentelemetry-instrument`` launcher, install the distro and an OTLP
+exporter as well:
+
+::
+
+    pip install opentelemetry-distro opentelemetry-exporter-otlp
+    opentelemetry-bootstrap -a install
+    opentelemetry-instrument uvicorn myapp:app
+
+Manual instrumentation is available when the application creates its own
+FastAPI instance:
+
+.. code-block:: python
+
+    import fastapi
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+    app = fastapi.FastAPI()
+    FastAPIInstrumentor.instrument_app(app)
+
+Configuration and propagation
+-----------------------------
+
+The launcher and SDK read the standard OpenTelemetry environment variables.
+For example, these configure the service name and OTLP destination without
+application-specific setup:
+
+::
+
+    OTEL_SERVICE_NAME=my-fastapi-service
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+    OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+
+Incoming HTTP trace context is extracted by the ASGI middleware, so normal
+FastAPI requests propagate context automatically. WebSocket routes are also
+instrumented as ASGI connections (including the handshake); the integration
+creates a server span for the route rather than one span per WebSocket
+message.
+
+Logging is a separate signal. FastAPI instrumentation does not turn log
+records into span events. To correlate application logs with request spans,
+install and enable the
+`logging instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html>`_:
+
+::
+
+    pip install opentelemetry-instrumentation-logging
+
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    LoggingInstrumentor().instrument(set_logging_format=True)
 
 References
 ----------


### PR DESCRIPTION
Closes #3301

## Summary
- document `opentelemetry-instrument` setup and link the launcher package
- describe standard environment variables and automatic HTTP propagation
- clarify WebSocket route coverage and the distinction between request spans and message-level events
- document logging correlation as a separate signal with a concrete setup example
- add a changelog fragment

## Validation
- `git diff --check`
- reviewed the FastAPI ASGI middleware and existing WebSocket integration tests to keep the documentation aligned with implementation
- the package test suite cannot collect in this Windows checkout because the editable instrumentation package is not installed (`ModuleNotFoundError`)
- RST parser tooling is unavailable (`docutils` is not installed)