### PR TITLE
feat(bootstrap): detect migrated GenAI instrumentations

### DIFF
--- a/.changelog/4816.added
+++ b/.changelog/4816.added
@@ -1,0 +1,1 @@
+Add migrated GenAI instrumentations to ``opentelemetry-bootstrap`` detection.

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -6,10 +6,6 @@
 
 libraries = [
     {
-        "library": "openai >= 1.26.0",
-        "instrumentation": "opentelemetry-instrumentation-openai-v2",
-    },
-    {
         "library": "google-cloud-aiplatform >= 1.64",
         "instrumentation": "opentelemetry-instrumentation-vertexai>=2.0b0",
     },
@@ -200,6 +196,26 @@ libraries = [
     {
         "library": "urllib3 >= 1.0.0, < 3.0.0",
         "instrumentation": "opentelemetry-instrumentation-urllib3==0.66b0.dev",
+    },
+    {
+        "library": "anthropic >= 0.51.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-anthropic>=1.0b0",
+    },
+    {
+        "library": "google-genai >= 1.32.0, < 3",
+        "instrumentation": "opentelemetry-instrumentation-google-genai>=1.0b1",
+    },
+    {
+        "library": "langchain >= 0.3.21",
+        "instrumentation": "opentelemetry-instrumentation-genai-langchain>=1.0b0",
+    },
+    {
+        "library": "openai >= 1.26.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai>=1.0b0",
+    },
+    {
+        "library": "openai-agents >= 0.3.3",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai-agents>=1.0b0",
     },
 ]
 default_instrumentations = [

--- a/opentelemetry-instrumentation/tests/test_bootstrap.py
+++ b/opentelemetry-instrumentation/tests/test_bootstrap.py
@@ -58,6 +58,33 @@ class TestBootstrap(TestCase):
         self.pip_check_patcher.stop()
         self.pip_install_patcher.stop()
 
+    def test_migrated_genai_instrumentations_are_detected(self):
+        migrated = {
+            "anthropic >= 0.51.0":
+            "opentelemetry-instrumentation-genai-anthropic>=1.0b0",
+            "google-genai >= 1.32.0, < 3":
+            "opentelemetry-instrumentation-google-genai>=1.0b1",
+            "langchain >= 0.3.21":
+            "opentelemetry-instrumentation-genai-langchain>=1.0b0",
+            "openai >= 1.26.0":
+            "opentelemetry-instrumentation-genai-openai>=1.0b0",
+            "openai-agents >= 0.3.3":
+            "opentelemetry-instrumentation-genai-openai-agents>=1.0b0",
+        }
+        generated = {
+            library["library"]: library["instrumentation"]
+            for library in libraries
+        }
+
+        self.assertEqual(
+            {key: generated[key] for key in migrated},
+            migrated,
+        )
+        self.assertNotIn(
+            "opentelemetry-instrumentation-openai-v2",
+            generated.values(),
+        )
+
     @patch("sys.argv", ["bootstrap", "-a", "pipenv"])
     def test_run_unknown_cmd(self):
         with self.assertRaises(SystemExit):

--- a/scripts/generate_instrumentation_bootstrap.py
+++ b/scripts/generate_instrumentation_bootstrap.py
@@ -73,14 +73,45 @@ packages_to_exclude = [
     # development. This filter will get removed once it is further along in its
     # development lifecycle and ready to be included by default.
     "opentelemetry-instrumentation-claude-agent-sdk",
+    # OpenAI instrumentation was migrated to the Python GenAI repository. Keep
+    # the legacy package out of bootstrap requirements so auto-instrumentation
+    # installs the maintained package below instead.
+    "opentelemetry-instrumentation-openai-v2",
 ]
 
 # Static version specifiers for instrumentations that are released independently
 independent_packages = {
-    "opentelemetry-instrumentation-openai-v2": "",
     "opentelemetry-instrumentation-vertexai": ">=2.0b0",
     "opentelemetry-instrumentation-google-genai": "",
 }
+
+# These instrumentations are released from opentelemetry-python-genai rather
+# than this repository, so they cannot be discovered by get_instrumentation_packages.
+# Keep the library requirements aligned with the migrated packages' supported
+# client versions while allowing their independently managed releases to move
+# forward.
+migrated_genai_instrumentations = [
+    {
+        "library": "anthropic >= 0.51.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-anthropic>=1.0b0",
+    },
+    {
+        "library": "google-genai >= 1.32.0, < 3",
+        "instrumentation": "opentelemetry-instrumentation-google-genai>=1.0b1",
+    },
+    {
+        "library": "langchain >= 0.3.21",
+        "instrumentation": "opentelemetry-instrumentation-genai-langchain>=1.0b0",
+    },
+    {
+        "library": "openai >= 1.26.0",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai>=1.0b0",
+    },
+    {
+        "library": "openai-agents >= 0.3.3",
+        "instrumentation": "opentelemetry-instrumentation-genai-openai-agents>=1.0b0",
+    },
+]
 
 
 def main():
@@ -110,6 +141,14 @@ def main():
                     values=[ast.Str(target_pkg), ast.Str(pkg["requirement"])],
                 )
             )
+
+    for pkg in migrated_genai_instrumentations:
+        libraries.elts.append(
+            ast.Dict(
+                keys=[ast.Str("library"), ast.Str("instrumentation")],
+                values=[ast.Str(pkg["library"]), ast.Str(pkg["instrumentation"])],
+            )
+        )
 
     tree = ast.parse(_source_tmpl)
     tree.body[0].value = libraries


### PR DESCRIPTION
## Summary\n\n- add migrated OpenTelemetry GenAI instrumentations to bootstrap detection\n- stop selecting the legacy openai-v2 package now that it has moved to the GenAI repository\n- keep the generated bootstrap source and generator in sync, with regression coverage\n\nCloses #4816\n\n## Validation\n\n- python -m pytest opentelemetry-instrumentation/tests/test_bootstrap.py -q (6 passed)\n- python -m compileall -q scripts/generate_instrumentation_bootstrap.py opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py opentelemetry-instrumentation/tests/test_bootstrap.py\n- git diff --check\n\nuff and hatch are not installed in this environment, so repository-wide formatting and regeneration commands were not available locally.