### PR TITLE
Deprecate gcp resource mapping function

### DIFF
--- a/resource/opentelemetry-resourcedetector-gcp/.changelog/4898.deprecated
+++ b/resource/opentelemetry-resourcedetector-gcp/.changelog/4898.deprecated
@@ -1,0 +1,1 @@
+Deprecate the `get_monitored_resource` function in `opentelemetry-resourcedetector-gcp` as it does not belong in this package.

--- a/resource/opentelemetry-resourcedetector-gcp/pyproject.toml
+++ b/resource/opentelemetry-resourcedetector-gcp/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.30",
   "opentelemetry-sdk ~= 1.30",
   "requests ~= 2.24",
+  "typing-extensions >= 4.5.0",
 ]
 
 [project.entry-points.opentelemetry_resource_detector]

--- a/resource/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
+++ b/resource/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
@@ -5,6 +5,8 @@ import json
 from dataclasses import dataclass
 from typing import Dict, Mapping, Optional, Tuple
 
+from typing_extensions import deprecated
+
 from opentelemetry.resourcedetector.gcp_resource_detector import _constants
 from opentelemetry.resourcedetector.gcp_resource_detector._constants import (
     ResourceAttributes,
@@ -131,6 +133,10 @@ class MonitoredResourceData:
     labels: Mapping[str, str]
 
 
+@deprecated(
+    "get_monitored_resource is deprecated and will be removed in a future release. "
+    "Deprecated since version 1.15.0."
+)
 def get_monitored_resource(
     resource: Resource,
 ) -> Optional[MonitoredResourceData]:

--- a/resource/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
+++ b/resource/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
@@ -12,6 +12,7 @@ from opentelemetry.resourcedetector.gcp_resource_detector._mapping import (
 from opentelemetry.sdk.resources import Attributes, LabelValue, Resource
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "otel_attributes",
     [
@@ -228,6 +229,7 @@ def test_get_monitored_resource(
     assert as_dict == snapshot
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     ("value", "expect"),
     [
@@ -248,3 +250,9 @@ def test_non_string_values(value: LabelValue, expect: str):
 
     value_as_gcm_label = monitored_resource_data.labels["node_id"]
     assert value_as_gcm_label == expect
+
+
+def test_get_monitored_resource_deprecated():
+    resource = Resource({})
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        get_monitored_resource(resource)


### PR DESCRIPTION
# Description

Deprecate the `get_monitored_resource` function in `opentelemetry-resourcedetector-gcp` (`_mapping.py`). This function maps OpenTelemetry Resource attributes to Google Cloud Monitored Resource labels. It was brought over during the initial migration of the GCP resource detector from `opentelemetry-operations-python`, but it does not belong in a resource detector package.

We keep the function with a formal `@deprecated` notice (using `typing_extensions`) because the GCP monitoring exporter in the `opentelemetry-operations-python` repository still depends on this package and expects this mapping to be present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Ran full test matrix using `tox` (`uv run tox -e py312-test-resourcedetector-gcp-1`) across supported Python versions (3.10-3.14, pypy3) and verified all 71 unit tests pass.
- [x] Added unit test `test_get_monitored_resource_deprecated` verifying that calling `get_monitored_resource` raises a `DeprecationWarning`.
- [x] Verified linter and code quality using `uv run tox -e lint-resourcedetector-gcp` (rated 10.00/10).

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
