### PR TITLE
fix(openai-agents): map MCP tool discovery spans

### DIFF
--- a/.changelog/4197.fixed
+++ b/.changelog/4197.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-openai-agents-v2`: Map MCP tool discovery to a `tools/list` client span

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api >= 1.40",
   "opentelemetry-instrumentation >= 0.61b0",
   "opentelemetry-semantic-conventions >= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0"
+  "opentelemetry-util-genai > 0.4b0, < 0.6b0"
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
@@ -18,6 +18,8 @@ from opentelemetry.semconv._incubating.attributes import (
 )
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import get_tracer
+from opentelemetry.util.genai.completion_hook import load_completion_hook
+from opentelemetry.util.genai.handler import TelemetryHandler
 
 from .package import _instruments
 from .span_processor import (
@@ -136,6 +138,13 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):
             return
 
         tracer_provider = kwargs.get("tracer_provider")
+        telemetry_handler = TelemetryHandler(
+            tracer_provider=tracer_provider,
+            meter_provider=kwargs.get("meter_provider"),
+            logger_provider=kwargs.get("logger_provider"),
+            completion_hook=kwargs.get("completion_hook")
+            or load_completion_hook(),
+        )
         tracer = get_tracer(
             __name__,
             "",
@@ -169,6 +178,7 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):
 
         processor = GenAISemanticProcessor(
             tracer=tracer,
+            telemetry_handler=telemetry_handler,
             system_name=system,
             include_sensitive_data=content_mode
             != ContentCaptureMode.NO_CONTENT,

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -1562,7 +1562,7 @@ class GenAISemanticProcessor(TracingProcessor):
             )
             otel_span.end()
 
-        for invocation in self._mcp_invocations.values():
+        for invocation in reversed(self._mcp_invocations.values()):
             invocation.fail(RuntimeError("Application shutdown"))
 
         for trace_id, root_span in list(self._root_spans.items()):
@@ -2247,7 +2247,7 @@ class GenAISemanticProcessor(TracingProcessor):
             )
             if invocation_trace_id == trace_id
         ]
-        for span_id in mcp_spans_to_remove:
+        for span_id in reversed(mcp_spans_to_remove):
             if invocation := self._mcp_invocations.pop(span_id, None):
                 invocation.fail(
                     RuntimeError("Trace ended before span completion")

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import MCPInvocation
+from opentelemetry.util.genai.types import Error
 from opentelemetry.util.genai.utils import gen_ai_json_dumps
 
 try:
@@ -1438,10 +1439,19 @@ class GenAISemanticProcessor(TracingProcessor):
         if invocation := self._mcp_invocations.pop(span.span_id, None):
             if error := getattr(span, "error", None):
                 invocation.fail(
-                    RuntimeError(
-                        error.get("message", "MCP operation failed")
-                        if isinstance(error, dict)
-                        else str(error)
+                    Error(
+                        message=(
+                            error.get("message", "MCP operation failed")
+                            if isinstance(error, dict)
+                            else str(error)
+                        ),
+                        type=(
+                            error.get("type")
+                            or error.get("name")
+                            or "MCPError"
+                            if isinstance(error, dict)
+                            else type(error).__qualname__
+                        ),
                     )
                 )
             else:

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -531,6 +531,7 @@ class GenAISemanticProcessor(TracingProcessor):
         self._root_spans: dict[str, OtelSpan] = {}
         self._otel_spans: dict[str, OtelSpan] = {}
         self._mcp_invocations: dict[str, MCPInvocation] = {}
+        self._mcp_invocation_trace_ids: dict[str, str] = {}
         self._tokens: dict[str, object] = {}
         self._span_parents: dict[str, Optional[str]] = {}
         self._agent_content: dict[str, Dict[str, list[Any]]] = {}
@@ -1344,11 +1345,11 @@ class GenAISemanticProcessor(TracingProcessor):
 
     def on_trace_end(self, trace: Trace) -> None:
         """End root span when trace ends."""
+        self._cleanup_spans_for_trace(trace.trace_id)
         if root_span := self._root_spans.pop(trace.trace_id, None):
             if root_span.is_recording():
                 root_span.set_status(Status(StatusCode.OK))
             root_span.end()
-        self._cleanup_spans_for_trace(trace.trace_id)
 
     def on_span_start(self, span: Span[Any]) -> None:
         """Start child span for agent span."""
@@ -1375,11 +1376,11 @@ class GenAISemanticProcessor(TracingProcessor):
         context = set_span_in_context(parent_span) if parent_span else None
         if _is_instance_of(span.span_data, MCPListToolsSpanData):
             self._mcp_invocations[span.span_id] = (
-                self._telemetry_handler.start_mcp(
-                    MCP_METHOD_TOOLS_LIST,
+                self._telemetry_handler.start_mcp_tools_list(
                     parent_context=context,
                 )
             )
+            self._mcp_invocation_trace_ids[span.span_id] = span.trace_id
             return
 
         # Get operation details for span naming
@@ -1437,6 +1438,7 @@ class GenAISemanticProcessor(TracingProcessor):
     def on_span_end(self, span: Span[Any]) -> None:
         """Finalize span with attributes, events, and metrics."""
         if invocation := self._mcp_invocations.pop(span.span_id, None):
+            self._mcp_invocation_trace_ids.pop(span.span_id, None)
             if error := getattr(span, "error", None):
                 invocation.fail(
                     Error(
@@ -1571,6 +1573,7 @@ class GenAISemanticProcessor(TracingProcessor):
 
         self._otel_spans.clear()
         self._mcp_invocations.clear()
+        self._mcp_invocation_trace_ids.clear()
         self._root_spans.clear()
         self._tokens.clear()
         self._span_parents.clear()
@@ -2237,6 +2240,21 @@ class GenAISemanticProcessor(TracingProcessor):
 
     def _cleanup_spans_for_trace(self, trace_id: str) -> None:
         """Clean up spans for a trace to prevent memory leaks."""
+        mcp_spans_to_remove = [
+            span_id
+            for span_id, invocation_trace_id in (
+                self._mcp_invocation_trace_ids.items()
+            )
+            if invocation_trace_id == trace_id
+        ]
+        for span_id in mcp_spans_to_remove:
+            if invocation := self._mcp_invocations.pop(span_id, None):
+                invocation.fail(
+                    RuntimeError("Trace ended before span completion")
+                )
+            self._mcp_invocation_trace_ids.pop(span_id, None)
+            self._span_parents.pop(span_id, None)
+
         spans_to_remove = [
             span_id
             for span_id in self._otel_spans.keys()

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -37,22 +37,25 @@ try:
         GenerationSpanData,
         GuardrailSpanData,
         HandoffSpanData,
-        MCPListToolsSpanData,
         ResponseSpanData,
         SpeechSpanData,
         TranscriptionSpanData,
+    )
+
+    tracing_span_data_module = importlib.import_module(
+        "agents.tracing.span_data"
     )
 except ModuleNotFoundError:  # pragma: no cover - test stubs
     tracing_module = importlib.import_module("agents.tracing")
     Span = getattr(tracing_module, "Span")
     Trace = getattr(tracing_module, "Trace")
     TracingProcessor = getattr(tracing_module, "TracingProcessor")
+    tracing_span_data_module = tracing_module
     AgentSpanData = getattr(tracing_module, "AgentSpanData", Any)  # type: ignore[assignment]
     FunctionSpanData = getattr(tracing_module, "FunctionSpanData", Any)  # type: ignore[assignment]
     GenerationSpanData = getattr(tracing_module, "GenerationSpanData", Any)  # type: ignore[assignment]
     GuardrailSpanData = getattr(tracing_module, "GuardrailSpanData", Any)  # type: ignore[assignment]
     HandoffSpanData = getattr(tracing_module, "HandoffSpanData", Any)  # type: ignore[assignment]
-    MCPListToolsSpanData = getattr(tracing_module, "MCPListToolsSpanData", Any)  # type: ignore[assignment]
     ResponseSpanData = getattr(tracing_module, "ResponseSpanData", Any)  # type: ignore[assignment]
     SpeechSpanData = getattr(tracing_module, "SpeechSpanData", Any)  # type: ignore[assignment]
     TranscriptionSpanData = getattr(
@@ -63,6 +66,9 @@ from opentelemetry.context import attach, detach
 from opentelemetry.metrics import Histogram, get_meter
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    mcp_attributes as MCPAttributes,
 )
 from opentelemetry.semconv._incubating.attributes import (
     server_attributes as ServerAttributes,
@@ -76,6 +82,10 @@ from opentelemetry.trace import (
     set_span_in_context,
 )
 from opentelemetry.util.types import AttributeValue
+
+MCPListToolsSpanData: type[Any] = getattr(
+    tracing_span_data_module, "MCPListToolsSpanData", type(None)
+)
 
 # Import all semantic convention constants
 # ---- GenAI semantic convention helpers (embedded from constants.py) ----
@@ -246,8 +256,8 @@ GEN_AI_HANDOFF_FROM_AGENT = "gen_ai.handoff.from_agent"
 GEN_AI_HANDOFF_TO_AGENT = "gen_ai.handoff.to_agent"
 GEN_AI_EMBEDDINGS_DIMENSION_COUNT = "gen_ai.embeddings.dimension.count"
 GEN_AI_TOKEN_TYPE = _attr("GEN_AI_TOKEN_TYPE", "gen_ai.token.type")
-MCP_METHOD_NAME = "mcp.method.name"
-MCP_METHOD_TOOLS_LIST = "tools/list"
+MCP_METHOD_NAME = MCPAttributes.MCP_METHOD_NAME
+MCP_METHOD_TOOLS_LIST = MCPAttributes.McpMethodNameValues.TOOLS_LIST.value
 
 # ---- Normalization utilities (embedded from utils.py) ----
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -27,6 +27,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Sequence
 from urllib.parse import urlparse
 
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.invocation import MCPInvocation
 from opentelemetry.util.genai.utils import gen_ai_json_dumps
 
 try:
@@ -447,6 +449,7 @@ class GenAISemanticProcessor(TracingProcessor):
     def __init__(
         self,
         tracer: Optional[Tracer] = None,
+        telemetry_handler: TelemetryHandler | None = None,
         system_name: str = "openai",
         include_sensitive_data: bool = True,
         content_mode: ContentCaptureMode = ContentCaptureMode.SPAN_AND_EVENT,
@@ -478,6 +481,7 @@ class GenAISemanticProcessor(TracingProcessor):
             server_port: Server port (can be overridden by env var or base_url)
         """
         self._tracer = tracer
+        self._telemetry_handler = telemetry_handler or TelemetryHandler()
         self.system_name = normalize_provider(system_name) or system_name
         self._content_mode = content_mode
         self.include_sensitive_data = include_sensitive_data and (
@@ -525,6 +529,7 @@ class GenAISemanticProcessor(TracingProcessor):
         # Span tracking
         self._root_spans: dict[str, OtelSpan] = {}
         self._otel_spans: dict[str, OtelSpan] = {}
+        self._mcp_invocations: dict[str, MCPInvocation] = {}
         self._tokens: dict[str, object] = {}
         self._span_parents: dict[str, Optional[str]] = {}
         self._agent_content: dict[str, Dict[str, list[Any]]] = {}
@@ -1367,6 +1372,14 @@ class GenAISemanticProcessor(TracingProcessor):
             else self._root_spans.get(span.trace_id)
         )
         context = set_span_in_context(parent_span) if parent_span else None
+        if _is_instance_of(span.span_data, MCPListToolsSpanData):
+            self._mcp_invocations[span.span_id] = (
+                self._telemetry_handler.start_mcp(
+                    MCP_METHOD_TOOLS_LIST,
+                    parent_context=context,
+                )
+            )
+            return
 
         # Get operation details for span naming
         operation_name = self._get_operation_name(span.span_data)
@@ -1391,32 +1404,25 @@ class GenAISemanticProcessor(TracingProcessor):
         # Generate spec-compliant span name
         span_name = get_span_name(operation_name, model, agent_name, tool_name)
 
-        is_mcp_list_tools = _is_instance_of(
-            span.span_data, MCPListToolsSpanData
-        )
-        if is_mcp_list_tools:
-            attributes = {MCP_METHOD_NAME: MCP_METHOD_TOOLS_LIST}
-        else:
-            attributes = {
-                GEN_AI_PROVIDER_NAME: self.system_name,
-                GEN_AI_SYSTEM_KEY: self.system_name,
-                GEN_AI_OPERATION_NAME: operation_name,
-            }
+        attributes = {
+            GEN_AI_PROVIDER_NAME: self.system_name,
+            GEN_AI_SYSTEM_KEY: self.system_name,
+            GEN_AI_OPERATION_NAME: operation_name,
+        }
         # Legacy emission removed
 
-        if not is_mcp_list_tools:
-            agent_name_override = self.agent_name or self._agent_name_default
-            agent_id_override = self.agent_id or self._agent_id_default
-            agent_desc_override = (
-                self.agent_description or self._agent_description_default
-            )
-            if agent_name_override:
-                attributes[GEN_AI_AGENT_NAME] = agent_name_override
-            if agent_id_override:
-                attributes[GEN_AI_AGENT_ID] = agent_id_override
-            if agent_desc_override:
-                attributes[GEN_AI_AGENT_DESCRIPTION] = agent_desc_override
-            attributes.update(self._get_server_attributes())
+        agent_name_override = self.agent_name or self._agent_name_default
+        agent_id_override = self.agent_id or self._agent_id_default
+        agent_desc_override = (
+            self.agent_description or self._agent_description_default
+        )
+        if agent_name_override:
+            attributes[GEN_AI_AGENT_NAME] = agent_name_override
+        if agent_id_override:
+            attributes[GEN_AI_AGENT_ID] = agent_id_override
+        if agent_desc_override:
+            attributes[GEN_AI_AGENT_DESCRIPTION] = agent_desc_override
+        attributes.update(self._get_server_attributes())
 
         otel_span = self._tracer.start_span(
             name=span_name,
@@ -1429,6 +1435,20 @@ class GenAISemanticProcessor(TracingProcessor):
 
     def on_span_end(self, span: Span[Any]) -> None:
         """Finalize span with attributes, events, and metrics."""
+        if invocation := self._mcp_invocations.pop(span.span_id, None):
+            if error := getattr(span, "error", None):
+                invocation.fail(
+                    RuntimeError(
+                        error.get("message", "MCP operation failed")
+                        if isinstance(error, dict)
+                        else str(error)
+                    )
+                )
+            else:
+                invocation.stop()
+            self._span_parents.pop(span.span_id, None)
+            return
+
         if token := self._tokens.pop(span.span_id, None):
             detach(token)
 
@@ -1530,6 +1550,9 @@ class GenAISemanticProcessor(TracingProcessor):
             )
             otel_span.end()
 
+        for invocation in self._mcp_invocations.values():
+            invocation.fail(RuntimeError("Application shutdown"))
+
         for trace_id, root_span in list(self._root_spans.items()):
             root_span.set_status(
                 Status(StatusCode.ERROR, "Application shutdown")
@@ -1537,6 +1560,7 @@ class GenAISemanticProcessor(TracingProcessor):
             root_span.end()
 
         self._otel_spans.clear()
+        self._mcp_invocations.clear()
         self._root_spans.clear()
         self._tokens.clear()
         self._span_parents.clear()
@@ -1586,10 +1610,6 @@ class GenAISemanticProcessor(TracingProcessor):
     ) -> Iterator[tuple[str, AttributeValue]]:
         """Yield (attr, value) pairs for GenAI semantic conventions."""
         span_data = span.span_data
-
-        if _is_instance_of(span_data, MCPListToolsSpanData):
-            yield MCP_METHOD_NAME, MCP_METHOD_TOOLS_LIST
-            return
 
         # Base attributes
         yield GEN_AI_PROVIDER_NAME, self.system_name

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -37,6 +37,7 @@ try:
         GenerationSpanData,
         GuardrailSpanData,
         HandoffSpanData,
+        MCPListToolsSpanData,
         ResponseSpanData,
         SpeechSpanData,
         TranscriptionSpanData,
@@ -51,6 +52,7 @@ except ModuleNotFoundError:  # pragma: no cover - test stubs
     GenerationSpanData = getattr(tracing_module, "GenerationSpanData", Any)  # type: ignore[assignment]
     GuardrailSpanData = getattr(tracing_module, "GuardrailSpanData", Any)  # type: ignore[assignment]
     HandoffSpanData = getattr(tracing_module, "HandoffSpanData", Any)  # type: ignore[assignment]
+    MCPListToolsSpanData = getattr(tracing_module, "MCPListToolsSpanData", Any)  # type: ignore[assignment]
     ResponseSpanData = getattr(tracing_module, "ResponseSpanData", Any)  # type: ignore[assignment]
     SpeechSpanData = getattr(tracing_module, "SpeechSpanData", Any)  # type: ignore[assignment]
     TranscriptionSpanData = getattr(
@@ -244,6 +246,8 @@ GEN_AI_HANDOFF_FROM_AGENT = "gen_ai.handoff.from_agent"
 GEN_AI_HANDOFF_TO_AGENT = "gen_ai.handoff.to_agent"
 GEN_AI_EMBEDDINGS_DIMENSION_COUNT = "gen_ai.embeddings.dimension.count"
 GEN_AI_TOKEN_TYPE = _attr("GEN_AI_TOKEN_TYPE", "gen_ai.token.type")
+MCP_METHOD_NAME = "mcp.method.name"
+MCP_METHOD_TOOLS_LIST = "tools/list"
 
 # ---- Normalization utilities (embedded from utils.py) ----
 
@@ -556,6 +560,10 @@ class GenAISemanticProcessor(TracingProcessor):
         self, span: Span[Any], attributes: dict[str, AttributeValue]
     ) -> None:
         """Record metrics for the span."""
+        if _is_instance_of(
+            getattr(span, "span_data", None), MCPListToolsSpanData
+        ):
+            return
         if not self._metrics_enabled or (
             self._duration_histogram is None
             and self._token_usage_histogram is None
@@ -1272,6 +1280,8 @@ class GenAISemanticProcessor(TracingProcessor):
 
     def _get_span_kind(self, span_data: Any) -> SpanKind:
         """Determine appropriate span kind based on span data type."""
+        if _is_instance_of(span_data, MCPListToolsSpanData):
+            return SpanKind.CLIENT
         if _is_instance_of(span_data, FunctionSpanData):
             return SpanKind.INTERNAL  # Tool execution is internal
         if _is_instance_of(
@@ -1371,26 +1381,32 @@ class GenAISemanticProcessor(TracingProcessor):
         # Generate spec-compliant span name
         span_name = get_span_name(operation_name, model, agent_name, tool_name)
 
-        attributes = {
-            GEN_AI_PROVIDER_NAME: self.system_name,
-            GEN_AI_SYSTEM_KEY: self.system_name,
-            GEN_AI_OPERATION_NAME: operation_name,
-        }
+        is_mcp_list_tools = _is_instance_of(
+            span.span_data, MCPListToolsSpanData
+        )
+        if is_mcp_list_tools:
+            attributes = {MCP_METHOD_NAME: MCP_METHOD_TOOLS_LIST}
+        else:
+            attributes = {
+                GEN_AI_PROVIDER_NAME: self.system_name,
+                GEN_AI_SYSTEM_KEY: self.system_name,
+                GEN_AI_OPERATION_NAME: operation_name,
+            }
         # Legacy emission removed
 
-        # Add configured agent and server attributes
-        agent_name_override = self.agent_name or self._agent_name_default
-        agent_id_override = self.agent_id or self._agent_id_default
-        agent_desc_override = (
-            self.agent_description or self._agent_description_default
-        )
-        if agent_name_override:
-            attributes[GEN_AI_AGENT_NAME] = agent_name_override
-        if agent_id_override:
-            attributes[GEN_AI_AGENT_ID] = agent_id_override
-        if agent_desc_override:
-            attributes[GEN_AI_AGENT_DESCRIPTION] = agent_desc_override
-        attributes.update(self._get_server_attributes())
+        if not is_mcp_list_tools:
+            agent_name_override = self.agent_name or self._agent_name_default
+            agent_id_override = self.agent_id or self._agent_id_default
+            agent_desc_override = (
+                self.agent_description or self._agent_description_default
+            )
+            if agent_name_override:
+                attributes[GEN_AI_AGENT_NAME] = agent_name_override
+            if agent_id_override:
+                attributes[GEN_AI_AGENT_ID] = agent_id_override
+            if agent_desc_override:
+                attributes[GEN_AI_AGENT_DESCRIPTION] = agent_desc_override
+            attributes.update(self._get_server_attributes())
 
         otel_span = self._tracer.start_span(
             name=span_name,
@@ -1522,6 +1538,8 @@ class GenAISemanticProcessor(TracingProcessor):
 
     def _get_operation_name(self, span_data: Any) -> str:
         """Determine operation name from span data type."""
+        if _is_instance_of(span_data, MCPListToolsSpanData):
+            return MCP_METHOD_TOOLS_LIST
         if _is_instance_of(span_data, GenerationSpanData):
             # Check if it's embeddings
             if hasattr(span_data, "embedding_dimension"):
@@ -1558,6 +1576,10 @@ class GenAISemanticProcessor(TracingProcessor):
     ) -> Iterator[tuple[str, AttributeValue]]:
         """Yield (attr, value) pairs for GenAI semantic conventions."""
         span_data = span.span_data
+
+        if _is_instance_of(span_data, MCPListToolsSpanData):
+            yield MCP_METHOD_NAME, MCP_METHOD_TOOLS_LIST
+            return
 
         # Base attributes
         yield GEN_AI_PROVIDER_NAME, self.system_name

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.oldest.txt
@@ -29,8 +29,8 @@ opentelemetry-exporter-otlp-proto-http~=1.30
 opentelemetry-api==1.40  # when updating, also update in pyproject.toml
 opentelemetry-sdk==1.40  # when updating, also update in pyproject.toml
 opentelemetry-semantic-conventions==0.61b0  # when updating, also update in pyproject.toml
-opentelemetry-util-genai==0.4b.0  # when updating, also update in pyproject.toml
 grpcio>=1.60.0; implementation_name != "pypy"
 grpcio<1.60.0; implementation_name == "pypy"
 
+-e util/opentelemetry-util-genai
 -e instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/stubs/agents/tracing/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/stubs/agents/tracing/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "AgentSpanData",
     "GenerationSpanData",
     "FunctionSpanData",
+    "MCPListToolsSpanData",
     "ResponseSpanData",
 ]
 
@@ -78,6 +79,16 @@ class ResponseSpanData:
     @property
     def type(self) -> str:
         return SPAN_TYPE_RESPONSE
+
+
+@dataclass
+class MCPListToolsSpanData:
+    server: str | None = None
+    result: list[str] | None = None
+
+    @property
+    def type(self) -> str:
+        return "mcp_tools"
 
 
 class _ProcessorFanout(TracingProcessor):

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -426,6 +426,32 @@ def test_mcp_list_tools_span_uses_mcp_semantic_conventions(processor_setup):
     assert sp.GEN_AI_TOOL_NAME not in finished.attributes
 
 
+def test_mcp_list_tools_span_preserves_reported_error_type(processor_setup):
+    processor, exporter = processor_setup
+    trace = FakeTrace(name="workflow", trace_id="trace-mcp-error")
+    processor.on_trace_start(trace)
+
+    mcp_span = FakeSpan(
+        trace_id=trace.trace_id,
+        span_id="mcp-list-tools-error",
+        span_data=MCPListToolsSpanData(server="Time"),
+        started_at="2025-01-01T00:00:00Z",
+        ended_at="2025-01-01T00:00:01Z",
+        error={"type": "timeout", "message": "server timed out"},
+    )
+    processor.on_span_start(mcp_span)
+    processor.on_span_end(mcp_span)
+    processor.on_trace_end(trace)
+
+    finished = next(
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == sp.MCP_METHOD_TOOLS_LIST
+    )
+    assert finished.attributes["error.type"] == "timeout"
+    assert finished.status.description == "server timed out"
+
+
 def test_span_status_helper():
     status = sp._get_span_status(
         SimpleNamespace(error={"message": "boom", "data": "bad"})

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -106,7 +106,11 @@ def processor_setup():
     exporter = InMemorySpanExporter()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     tracer = provider.get_tracer(__name__)
-    processor = sp.GenAISemanticProcessor(tracer=tracer, system_name="openai")
+    processor = sp.GenAISemanticProcessor(
+        tracer=tracer,
+        telemetry_handler=sp.TelemetryHandler(tracer_provider=provider),
+        system_name="openai",
+    )
     yield processor, exporter
     processor.shutdown()
     exporter.clear()

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.semconv._incubating.attributes import (
     server_attributes as _server_attributes,
 )
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, get_current_span
 from opentelemetry.trace.status import StatusCode
 
 
@@ -476,6 +476,39 @@ def test_mcp_list_tools_span_ends_when_trace_finishes_early(processor_setup):
     assert mcp_span.span_id not in processor._mcp_invocations
     assert mcp_span.span_id not in processor._mcp_invocation_trace_ids
     assert mcp_span.span_id not in processor._span_parents
+
+
+@pytest.mark.parametrize("finish_with_shutdown", [False, True])
+def test_nested_mcp_spans_cleanup_in_lifo_order(
+    processor_setup, finish_with_shutdown
+):
+    processor, _ = processor_setup
+    trace = FakeTrace(name="workflow", trace_id="trace-mcp-nested")
+    processor.on_trace_start(trace)
+    original_current_span = get_current_span()
+
+    parent = FakeSpan(
+        trace_id=trace.trace_id,
+        span_id="mcp-parent",
+        span_data=MCPListToolsSpanData(server="Parent"),
+        started_at="2025-01-01T00:00:00Z",
+    )
+    child = FakeSpan(
+        trace_id=trace.trace_id,
+        span_id="mcp-child",
+        parent_id=parent.span_id,
+        span_data=MCPListToolsSpanData(server="Child"),
+        started_at="2025-01-01T00:00:01Z",
+    )
+    processor.on_span_start(parent)
+    processor.on_span_start(child)
+
+    if finish_with_shutdown:
+        processor.shutdown()
+    else:
+        processor.on_trace_end(trace)
+
+    assert get_current_span() is original_current_span
 
 
 def test_span_status_helper():

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -452,6 +452,32 @@ def test_mcp_list_tools_span_preserves_reported_error_type(processor_setup):
     assert finished.status.description == "server timed out"
 
 
+def test_mcp_list_tools_span_ends_when_trace_finishes_early(processor_setup):
+    processor, exporter = processor_setup
+    trace = FakeTrace(name="workflow", trace_id="trace-mcp-incomplete")
+    processor.on_trace_start(trace)
+
+    mcp_span = FakeSpan(
+        trace_id=trace.trace_id,
+        span_id="mcp-list-tools-incomplete",
+        span_data=MCPListToolsSpanData(server="Time"),
+        started_at="2025-01-01T00:00:00Z",
+    )
+    processor.on_span_start(mcp_span)
+    processor.on_trace_end(trace)
+
+    finished = next(
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == sp.MCP_METHOD_TOOLS_LIST
+    )
+    assert finished.status.status_code is StatusCode.ERROR
+    assert finished.status.description == "Trace ended before span completion"
+    assert mcp_span.span_id not in processor._mcp_invocations
+    assert mcp_span.span_id not in processor._mcp_invocation_trace_ids
+    assert mcp_span.span_id not in processor._span_parents
+
+
 def test_span_status_helper():
     status = sp._get_span_status(
         SimpleNamespace(error={"message": "boom", "data": "bad"})

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/test_z_span_processor_unit.py
@@ -18,6 +18,7 @@ from agents.tracing import (
     AgentSpanData,
     FunctionSpanData,
     GenerationSpanData,
+    MCPListToolsSpanData,
     ResponseSpanData,
 )
 
@@ -178,6 +179,14 @@ def test_operation_and_span_naming(processor_setup):
         == sp.GenAIOperationName.EXECUTE_TOOL
     )
 
+    mcp_list_tools = MCPListToolsSpanData(
+        server="Time", result=["get_current_time"]
+    )
+    assert (
+        processor._get_operation_name(mcp_list_tools)
+        == sp.MCP_METHOD_TOOLS_LIST
+    )
+
     response_data = ResponseSpanData()
     assert (
         processor._get_operation_name(response_data)
@@ -192,6 +201,7 @@ def test_operation_and_span_naming(processor_setup):
 
     assert processor._get_span_kind(GenerationSpanData()) is SpanKind.CLIENT
     assert processor._get_span_kind(FunctionSpanData()) is SpanKind.INTERNAL
+    assert processor._get_span_kind(mcp_list_tools) is SpanKind.CLIENT
 
     assert (
         sp.get_span_name(sp.GenAIOperationName.CHAT, model="gpt-4o")
@@ -380,6 +390,36 @@ def test_extract_genai_attributes_unknown_type(processor_setup):
     assert attrs[sp.GEN_AI_PROVIDER_NAME] == "openai"
     assert attrs[sp.GEN_AI_SYSTEM_KEY] == "openai"
     assert sp.GEN_AI_OPERATION_NAME not in attrs
+
+
+def test_mcp_list_tools_span_uses_mcp_semantic_conventions(processor_setup):
+    processor, exporter = processor_setup
+    trace = FakeTrace(name="workflow", trace_id="trace-mcp")
+    processor.on_trace_start(trace)
+
+    mcp_span = FakeSpan(
+        trace_id=trace.trace_id,
+        span_id="mcp-list-tools",
+        span_data=MCPListToolsSpanData(
+            server="Time", result=["get_current_time"]
+        ),
+        started_at="2025-01-01T00:00:00Z",
+        ended_at="2025-01-01T00:00:01Z",
+    )
+    processor.on_span_start(mcp_span)
+    processor.on_span_end(mcp_span)
+    processor.on_trace_end(trace)
+
+    finished = next(
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == sp.MCP_METHOD_TOOLS_LIST
+    )
+    assert finished.kind is SpanKind.CLIENT
+    assert finished.attributes[sp.MCP_METHOD_NAME] == sp.MCP_METHOD_TOOLS_LIST
+    assert sp.GEN_AI_PROVIDER_NAME not in finished.attributes
+    assert sp.GEN_AI_OPERATION_NAME not in finished.attributes
+    assert sp.GEN_AI_TOOL_NAME not in finished.attributes
 
 
 def test_span_status_helper():

--- a/util/opentelemetry-util-genai/.changelog/4197.added
+++ b/util/opentelemetry-util-genai/.changelog/4197.added
@@ -1,0 +1,1 @@
+Add MCP client invocation support and a `tools/list` telemetry factory.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -85,7 +85,12 @@ class GenAIInvocation(ABC):
         self._context_token: ContextToken | None = None
         self._monotonic_start_s: float | None = None
 
-    def _start(self, attributes: dict[str, Any] | None = None) -> None:
+    def _start(
+        self,
+        attributes: dict[str, Any] | None = None,
+        *,
+        context: Context | None = None,
+    ) -> None:
         """Start the invocation span and attach it to the current context.
 
         Args:
@@ -95,6 +100,7 @@ class GenAIInvocation(ABC):
             name=self._span_name,
             kind=self._span_kind,
             attributes=attributes,
+            context=context,
         )
         self._span_context = set_span_in_context(self.span)
         self._monotonic_start_s = timeit.default_timer()

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -116,7 +116,11 @@ class GenAIInvocation(ABC):
 
     def _apply_error_attributes(self, error: Error) -> None:
         """Apply error status and error.type attribute to the span, events, and metrics."""
-        error_type = error.type.__qualname__
+        error_type = (
+            error.type
+            if isinstance(error.type, str)
+            else error.type.__qualname__
+        )
         self.span.set_status(Status(StatusCode.ERROR, error.message))
         self.attributes[error_attributes.ERROR_TYPE] = error_type
         self.metric_attributes[error_attributes.ERROR_TYPE] = error_type

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_mcp_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_mcp_invocation.py
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from opentelemetry._logs import Logger
+from opentelemetry.context import Context
+from opentelemetry.semconv._incubating.attributes import (
+    mcp_attributes as MCP,
+)
+from opentelemetry.trace import SpanKind, Tracer
+from opentelemetry.util.genai._invocation import Error, GenAIInvocation
+from opentelemetry.util.genai.completion_hook import CompletionHook
+from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
+
+
+class MCPInvocation(GenAIInvocation):
+    """Represents a Model Context Protocol request or notification."""
+
+    def __init__(
+        self,
+        tracer: Tracer,
+        metrics_recorder: InvocationMetricsRecorder,
+        logger: Logger,
+        completion_hook: CompletionHook,
+        method_name: str,
+        *,
+        protocol_version: str | None = None,
+        session_id: str | None = None,
+        resource_uri: str | None = None,
+        parent_context: Context | None = None,
+    ) -> None:
+        super().__init__(
+            tracer,
+            metrics_recorder,
+            logger,
+            completion_hook,
+            operation_name=method_name,
+            span_name=method_name,
+            span_kind=SpanKind.CLIENT,
+        )
+        self.method_name = method_name
+        self.protocol_version = protocol_version
+        self.session_id = session_id
+        self.resource_uri = resource_uri
+        self._start(
+            self._get_attributes(),
+            context=parent_context,
+        )
+
+    def _get_attributes(self) -> dict[str, Any]:
+        optional_attrs = (
+            (MCP.MCP_PROTOCOL_VERSION, self.protocol_version),
+            (MCP.MCP_SESSION_ID, self.session_id),
+            (MCP.MCP_RESOURCE_URI, self.resource_uri),
+        )
+        return {
+            MCP.MCP_METHOD_NAME: self.method_name,
+            **{
+                key: value
+                for key, value in optional_attrs
+                if value is not None
+            },
+        }
+
+    def _apply_finish(self, error: Error | None = None) -> None:
+        if error is not None:
+            self._apply_error_attributes(error)
+        attributes = self._get_attributes()
+        attributes.update(self.attributes)
+        self.span.set_attributes(attributes)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_mcp_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_mcp_invocation.py
@@ -17,7 +17,14 @@ from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
 
 
 class MCPInvocation(GenAIInvocation):
-    """Represents a Model Context Protocol request or notification."""
+    """Represent an MCP client operation.
+
+    Follows the `MCP client semantic conventions
+    <https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/mcp.md#client>`_.
+    ``mcp.method.name`` is always set. ``mcp.protocol.version`` is set only
+    when ``protocol_version`` is provided, and ``mcp.session.id`` is set only
+    when ``session_id`` is provided.
+    """
 
     def __init__(
         self,
@@ -29,7 +36,6 @@ class MCPInvocation(GenAIInvocation):
         *,
         protocol_version: str | None = None,
         session_id: str | None = None,
-        resource_uri: str | None = None,
         parent_context: Context | None = None,
     ) -> None:
         super().__init__(
@@ -44,7 +50,6 @@ class MCPInvocation(GenAIInvocation):
         self.method_name = method_name
         self.protocol_version = protocol_version
         self.session_id = session_id
-        self.resource_uri = resource_uri
         self._start(
             self._get_attributes(),
             context=parent_context,
@@ -54,7 +59,6 @@ class MCPInvocation(GenAIInvocation):
         optional_attrs = (
             (MCP.MCP_PROTOCOL_VERSION, self.protocol_version),
             (MCP.MCP_SESSION_ID, self.session_id),
-            (MCP.MCP_RESOURCE_URI, self.resource_uri),
         )
         return {
             MCP.MCP_METHOD_NAME: self.method_name,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -234,7 +234,6 @@ class TelemetryHandler:
         *,
         protocol_version: str | None = None,
         session_id: str | None = None,
-        resource_uri: str | None = None,
         parent_context: Context | None = None,
     ) -> MCPInvocation:
         """Create and start an MCP tools/list client invocation."""
@@ -246,7 +245,6 @@ class TelemetryHandler:
             MCP.McpMethodNameValues.TOOLS_LIST.value,
             protocol_version=protocol_version,
             session_id=session_id,
-            resource_uri=resource_uri,
             parent_context=parent_context,
         )
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -44,6 +44,7 @@ from opentelemetry._logs import (
     LoggerProvider,
     get_logger,
 )
+from opentelemetry.context import Context
 from opentelemetry.metrics import MeterProvider, get_meter
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import (
@@ -64,6 +65,7 @@ from opentelemetry.util.genai.environment_variables import (
 from opentelemetry.util.genai.invocation import (
     EmbeddingInvocation,
     InferenceInvocation,
+    MCPInvocation,
     ToolInvocation,
     WorkflowInvocation,
 )
@@ -222,6 +224,28 @@ class TelemetryHandler:
             tool_call_id=tool_call_id,
             tool_type=tool_type,
             tool_description=tool_description,
+        )
+
+    def start_mcp(
+        self,
+        method_name: str,
+        *,
+        protocol_version: str | None = None,
+        session_id: str | None = None,
+        resource_uri: str | None = None,
+        parent_context: Context | None = None,
+    ) -> MCPInvocation:
+        """Create and start an MCP request or notification invocation."""
+        return MCPInvocation(
+            self._tracer,
+            self._metrics_recorder,
+            self._logger,
+            self._completion_hook,
+            method_name,
+            protocol_version=protocol_version,
+            session_id=session_id,
+            resource_uri=resource_uri,
+            parent_context=parent_context,
         )
 
     def start_workflow(

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -46,6 +46,9 @@ from opentelemetry._logs import (
 )
 from opentelemetry.context import Context
 from opentelemetry.metrics import MeterProvider, get_meter
+from opentelemetry.semconv._incubating.attributes import (
+    mcp_attributes as MCP,
+)
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import (
     SpanKind,
@@ -226,22 +229,21 @@ class TelemetryHandler:
             tool_description=tool_description,
         )
 
-    def start_mcp(
+    def start_mcp_tools_list(
         self,
-        method_name: str,
         *,
         protocol_version: str | None = None,
         session_id: str | None = None,
         resource_uri: str | None = None,
         parent_context: Context | None = None,
     ) -> MCPInvocation:
-        """Create and start an MCP request or notification invocation."""
+        """Create and start an MCP tools/list client invocation."""
         return MCPInvocation(
             self._tracer,
             self._metrics_recorder,
             self._logger,
             self._completion_hook,
-            method_name,
+            MCP.McpMethodNameValues.TOOLS_LIST.value,
             protocol_version=protocol_version,
             session_id=session_id,
             resource_uri=resource_uri,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/invocation.py
@@ -23,6 +23,7 @@ from opentelemetry.util.genai._invocation import (
     Error,
     GenAIInvocation,
 )
+from opentelemetry.util.genai._mcp_invocation import MCPInvocation
 from opentelemetry.util.genai._tool_invocation import ToolInvocation
 from opentelemetry.util.genai._workflow_invocation import WorkflowInvocation
 
@@ -32,6 +33,7 @@ __all__ = [
     "Error",
     "GenAIInvocation",
     "InferenceInvocation",
+    "MCPInvocation",
     "EmbeddingInvocation",
     "ToolInvocation",
     "WorkflowInvocation",

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
@@ -227,7 +227,7 @@ class OutputMessage:
 @dataclass
 class Error:
     message: str
-    type: Type[BaseException]
+    type: Type[BaseException] | str
 
 
 def __getattr__(name: str) -> object:

--- a/util/opentelemetry-util-genai/tests/test_handler_mcp.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_mcp.py
@@ -15,6 +15,7 @@ from opentelemetry.util.genai.invocation import (
     GenAIInvocation,
     MCPInvocation,
 )
+from opentelemetry.util.genai.types import Error
 
 
 def test_mcp_invocation_uses_mcp_semantic_conventions() -> None:
@@ -42,3 +43,19 @@ def test_mcp_invocation_uses_mcp_semantic_conventions() -> None:
         MCP.MCP_PROTOCOL_VERSION: "2025-06-18",
         MCP.MCP_SESSION_ID: "session-1",
     }
+
+
+def test_mcp_invocation_preserves_reported_error_type() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    handler = TelemetryHandler(tracer_provider=provider)
+
+    invocation = handler.start_mcp(MCP.McpMethodNameValues.TOOLS_LIST.value)
+    invocation.fail(Error(message="server timed out", type="timeout"))
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes["error.type"] == "timeout"
+    assert span.status.description == "server timed out"

--- a/util/opentelemetry-util-genai/tests/test_handler_mcp.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_mcp.py
@@ -24,8 +24,7 @@ def test_mcp_invocation_uses_mcp_semantic_conventions() -> None:
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     handler = TelemetryHandler(tracer_provider=provider)
 
-    invocation = handler.start_mcp(
-        MCP.McpMethodNameValues.TOOLS_LIST.value,
+    invocation = handler.start_mcp_tools_list(
         protocol_version="2025-06-18",
         session_id="session-1",
     )
@@ -51,7 +50,7 @@ def test_mcp_invocation_preserves_reported_error_type() -> None:
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     handler = TelemetryHandler(tracer_provider=provider)
 
-    invocation = handler.start_mcp(MCP.McpMethodNameValues.TOOLS_LIST.value)
+    invocation = handler.start_mcp_tools_list()
     invocation.fail(Error(message="server timed out", type="timeout"))
 
     spans = exporter.get_finished_spans()

--- a/util/opentelemetry-util-genai/tests/test_handler_mcp.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_mcp.py
@@ -1,0 +1,44 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    mcp_attributes as MCP,
+)
+from opentelemetry.trace import SpanKind
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.invocation import (
+    GenAIInvocation,
+    MCPInvocation,
+)
+
+
+def test_mcp_invocation_uses_mcp_semantic_conventions() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    handler = TelemetryHandler(tracer_provider=provider)
+
+    invocation = handler.start_mcp(
+        MCP.McpMethodNameValues.TOOLS_LIST.value,
+        protocol_version="2025-06-18",
+        session_id="session-1",
+    )
+    assert isinstance(invocation, MCPInvocation)
+    assert isinstance(invocation, GenAIInvocation)
+    invocation.stop()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == MCP.McpMethodNameValues.TOOLS_LIST.value
+    assert span.kind is SpanKind.CLIENT
+    assert span.attributes == {
+        MCP.MCP_METHOD_NAME: MCP.McpMethodNameValues.TOOLS_LIST.value,
+        MCP.MCP_PROTOCOL_VERSION: "2025-06-18",
+        MCP.MCP_SESSION_ID: "session-1",
+    }


### PR DESCRIPTION
# Description

Map OpenAI Agents SDK MCP tool discovery spans to the MCP semantic conventions instead of exporting them as unknown GenAI operations. `MCPListToolsSpanData` now produces a `tools/list` client span through the shared `TelemetryHandler`/`MCPInvocation` lifecycle with `mcp.method.name=tools/list`, without inventing GenAI operation, provider, tool, or server attributes that do not describe discovery.

Fixes #4197

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `python -m pytest -q` for the instrumentation plus focused MCP utility coverage (105 passed)
- [x] `ruff check` on the changed Python files
- [x] `ruff format --check` on the changed Python files
- [x] Full `opentelemetry-util-genai` test suite (232 passed)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated


