### PR TITLE
Deprecate openai-v2 and openai-agents-v2 instrumentations

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -43,9 +43,3 @@ components:
     - DylanRussell
     - keith-decker
     - lmolkova
-
-  instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2:
-    - nagkumar91
-
-  instrumentation-genai/opentelemetry-instrumentation-openai-v2:
-    - lmolkova

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -10,8 +10,6 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-resourcedetector-gcp
         - opentelemetry-sdk-extension-aws
-        - opentelemetry-instrumentation-openai-v2
-        - opentelemetry-instrumentation-openai-agents-v2
         - opentelemetry-instrumentation-vertexai
         - opentelemetry-instrumentation-google-genai
         - opentelemetry-util-genai

--- a/instrumentation-genai/AGENTS.md
+++ b/instrumentation-genai/AGENTS.md
@@ -8,17 +8,20 @@ These rules are additive to the shared instrumentation rules in the repo-root
 
 ## 0. Instrumentations Maintained Elsewhere
 
-GenAI instrumentations no longer live in this repository and are **not** updated here. They
-have moved to the [opentelemetry-python-genai](https://github.com/open-telemetry/opentelemetry-python-genai)
-repository and receive all fixes and updates there:
+Development and releases for these GenAI instrumentations have moved to the
+[opentelemetry-python-genai](https://github.com/open-telemetry/opentelemetry-python-genai)
+repository. Direct new development and fixes there, not here:
 
 - `opentelemetry-instrumentation-genai-anthropic` (anthropic)
 - `opentelemetry-instrumentation-genai-claude-agent-sdk` (claude-agent-sdk)
 - `opentelemetry-instrumentation-genai-langchain` (langchain)
 - `opentelemetry-instrumentation-genai-weaviate-client` (weaviate-client)
+- `opentelemetry-instrumentation-genai-openai` (openai; only security patches in this repo, as `opentelemetry-instrumentation-openai-v2`)
+- `opentelemetry-instrumentation-genai-openai-agents` (openai-agents; only security patches in this repo, as `opentelemetry-instrumentation-openai-agents-v2`)
 
-Do not add, modify, or attempt to fix these instrumentations in this repository. Direct any changes
-to the `opentelemetry-python-genai` repo instead.
+Do not add, modify, or attempt to fix these instrumentations in this repository beyond security
+patches for the packages that still live here. Direct any other changes to the
+`opentelemetry-python-genai` repo instead.
 
 ## 1. Instrumentation Layer Boundary
 

--- a/instrumentation-genai/README.md
+++ b/instrumentation-genai/README.md
@@ -12,7 +12,7 @@
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14 | No | development
 | [opentelemetry-instrumentation-google-genai](./opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0 | No | development
 | [opentelemetry-instrumentation-genai-langchain](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | Yes | development
-| [opentelemetry-instrumentation-openai-agents-v2](./opentelemetry-instrumentation-openai-agents-v2) | openai-agents >= 0.3.3 | No | development
-| [opentelemetry-instrumentation-openai-v2](./opentelemetry-instrumentation-openai-v2) | openai >= 1.26.0 | Yes | development
+| [opentelemetry-instrumentation-genai-openai-agents](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | No | development
+| [opentelemetry-instrumentation-genai-openai](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0 | Yes | development
 | [opentelemetry-instrumentation-vertexai](./opentelemetry-instrumentation-vertexai) | google-cloud-aiplatform >= 1.64 | No | development
 | [opentelemetry-instrumentation-genai-weaviate-client](https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0,<5.0.0 | No | development

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Deprecate `opentelemetry-instrumentation-openai-agents-v2`. Use the
+  `opentelemetry-instrumentation-genai-openai-agents` package instead. This
+  package now only receives security patches. The `opentelemetry-util-genai` 
+  dependency is capped to `< 1.1b0`.
+
 - Align AgentSpanData test stubs and span processor with real OpenAI Agents SDK;
   remove non-existent `operation`, `description`, `agent_id`, and `model` fields.
   ([#4229](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4229))

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - Deprecate `opentelemetry-instrumentation-openai-agents-v2`. Use the
   `opentelemetry-instrumentation-genai-openai-agents` package instead. This
-  package now only receives security patches. The `opentelemetry-util-genai` 
-  dependency is capped to `< 1.1b0`.
+  package now only receives security patches.
 
 - Align AgentSpanData test stubs and span processor with real OpenAI Agents SDK;
   remove non-existent `operation`, `description`, `agent_id`, and `model` fields.

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/README.rst
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/README.rst
@@ -1,11 +1,23 @@
 OpenTelemetry OpenAI Agents Instrumentation
 ===========================================
 
-.. note::
+.. warning::
 
-   This package is being migrated as ``opentelemetry-instrumentation-genai-openai-agents`` to
-   `opentelemetry-python-genai/instrumentation/opentelemetry-instrumentation-genai-openai-agents <https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-openai-agents>`_.
-   Future development will happen there.
+   **This package is deprecated.** Use the
+   `opentelemetry-instrumentation-genai-openai-agents <https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/>`_
+   package instead. ``opentelemetry-instrumentation-openai-agents-v2`` now only
+   receives security patches. Please
+   migrate by replacing it with ``opentelemetry-instrumentation-genai-openai-agents``:
+
+   .. code-block:: console
+
+       pip uninstall opentelemetry-instrumentation-openai-agents-v2
+       pip install opentelemetry-instrumentation-genai-openai-agents
+
+   The replacement package contains **breaking changes** relative to this one.
+   Review the
+   `CHANGELOG <https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/instrumentation/opentelemetry-instrumentation-genai-openai-agents/CHANGELOG.md>`_
+   before upgrading.
 
 |pypi|
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
   "opentelemetry-api >= 1.40",
   "opentelemetry-instrumentation >= 0.61b0",
   "opentelemetry-semantic-conventions >= 0.61b0",
-  "opentelemetry-util-genai >= 0.4b0"
+  "opentelemetry-util-genai > 0.4b0, < 0.6b0",
+  "typing-extensions >= 4.5.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api >= 1.40",
   "opentelemetry-instrumentation >= 0.61b0",
   "opentelemetry-semantic-conventions >= 0.61b0",
-  "opentelemetry-util-genai > 0.4b0, < 0.6b0",
+  "opentelemetry-util-genai >= 0.4b0, < 0.6b0",
   "typing-extensions >= 4.5.0",
 ]
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
@@ -12,6 +12,8 @@ import logging
 import os
 from typing import Any, Collection
 
+from typing_extensions import deprecated
+
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAI,
@@ -40,6 +42,12 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+_DEPRECATION_REASON = (
+    "opentelemetry-instrumentation-openai-agents-v2 is deprecated. Use the "
+    "opentelemetry-instrumentation-genai-openai-agents package instead. This "
+    "package only receives security patches."
+)
 
 _CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 _SYSTEM_OVERRIDE_ENV = "OTEL_INSTRUMENTATION_OPENAI_AGENTS_SYSTEM"
@@ -124,8 +132,14 @@ def _resolve_bool(value: Any, default: bool) -> bool:
     return default
 
 
+@deprecated(_DEPRECATION_REASON)
 class OpenAIAgentsInstrumentor(BaseInstrumentor):
-    """Instrumentation that bridges OpenAI Agents tracing to OpenTelemetry."""
+    """Instrumentation that bridges OpenAI Agents tracing to OpenTelemetry.
+
+    .. deprecated:: 0.2.0
+        Use the ``opentelemetry-instrumentation-genai-openai-agents`` package
+        instead. This package only receives security patches.
+    """
 
     def __init__(self) -> None:
         super().__init__()

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/__init__.py
@@ -43,12 +43,6 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-_DEPRECATION_REASON = (
-    "opentelemetry-instrumentation-openai-agents-v2 is deprecated. Use the "
-    "opentelemetry-instrumentation-genai-openai-agents package instead. This "
-    "package only receives security patches."
-)
-
 _CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 _SYSTEM_OVERRIDE_ENV = "OTEL_INSTRUMENTATION_OPENAI_AGENTS_SYSTEM"
 _CAPTURE_CONTENT_ENV = "OTEL_INSTRUMENTATION_OPENAI_AGENTS_CAPTURE_CONTENT"
@@ -132,7 +126,11 @@ def _resolve_bool(value: Any, default: bool) -> bool:
     return default
 
 
-@deprecated(_DEPRECATION_REASON)
+@deprecated(
+    "opentelemetry-instrumentation-openai-agents-v2 is deprecated. Use the "
+    "opentelemetry-instrumentation-genai-openai-agents package instead. This "
+    "package only receives security patches."
+)
 class OpenAIAgentsInstrumentor(BaseInstrumentor):
     """Instrumentation that bridges OpenAI Agents tracing to OpenTelemetry.
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.latest.txt
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2/tests/requirements.latest.txt
@@ -50,5 +50,5 @@ grpcio>=1.60.0; implementation_name != "pypy"
 grpcio<1.60.0; implementation_name == "pypy"
 
 -e opentelemetry-instrumentation
--e util/opentelemetry-util-genai
 -e instrumentation-genai/opentelemetry-instrumentation-openai-agents-v2
+-e util/opentelemetry-util-genai

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/README.rst
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/README.rst
@@ -1,11 +1,23 @@
 OpenTelemetry OpenAI Instrumentation
 ====================================
 
-.. note::
+.. warning::
 
-   This package is being migrated as ``opentelemetry-instrumentation-genai-openai`` to
-   `opentelemetry-python-genai/instrumentation/opentelemetry-instrumentation-genai-openai <https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-openai>`_.
-   Future development will happen there.
+   **This package is deprecated.** Use the
+   `opentelemetry-instrumentation-genai-openai <https://pypi.org/project/opentelemetry-instrumentation-genai-openai/>`_
+   package instead. ``opentelemetry-instrumentation-openai-v2`` now only
+   receives security patches. Please
+   migrate by replacing it with ``opentelemetry-instrumentation-genai-openai``:
+
+   .. code-block:: console
+
+       pip uninstall opentelemetry-instrumentation-openai-v2
+       pip install opentelemetry-instrumentation-genai-openai
+
+   The replacement package contains **breaking changes** relative to this one.
+   Review the
+   `CHANGELOG <https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/instrumentation/opentelemetry-instrumentation-genai-openai/CHANGELOG.md>`_
+   before upgrading.
 
 |pypi|
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-instrumentation ~= 0.61b0",
   "opentelemetry-semantic-conventions ~= 0.61b0",
   "opentelemetry-util-genai > 0.4b0, < 0.6b0",
+  "typing-extensions >= 4.5.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -67,6 +67,7 @@ API
 from importlib import import_module
 from typing import Collection
 
+from typing_extensions import deprecated
 from wrapt import wrap_function_wrapper
 
 from opentelemetry._logs import get_logger
@@ -96,8 +97,22 @@ from .patch_responses import (
     responses_create,
 )
 
+_DEPRECATION_REASON = (
+    "opentelemetry-instrumentation-openai-v2 is deprecated. Use the "
+    "opentelemetry-instrumentation-genai-openai package instead. This package "
+    "only receives security patches."
+)
 
+
+@deprecated(_DEPRECATION_REASON)
 class OpenAIInstrumentor(BaseInstrumentor):
+    """OpenTelemetry instrumentation for the OpenAI Python client.
+
+    .. deprecated:: 2.5b0
+        Use the ``opentelemetry-instrumentation-genai-openai`` package instead.
+        This package only receives security patches.
+    """
+
     def __init__(self):
         self._meter = None
 

--- a/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation-genai/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -97,14 +97,12 @@ from .patch_responses import (
     responses_create,
 )
 
-_DEPRECATION_REASON = (
+
+@deprecated(
     "opentelemetry-instrumentation-openai-v2 is deprecated. Use the "
     "opentelemetry-instrumentation-genai-openai package instead. This package "
     "only receives security patches."
 )
-
-
-@deprecated(_DEPRECATION_REASON)
 class OpenAIInstrumentor(BaseInstrumentor):
     """OpenTelemetry instrumentation for the OpenAI Python client.
 

--- a/uv.lock
+++ b/uv.lock
@@ -3382,6 +3382,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-genai" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -3396,6 +3397,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 provides-extras = ["instruments"]
 
@@ -3407,6 +3409,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-genai" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -3421,6 +3424,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 provides-extras = ["instruments"]
 


### PR DESCRIPTION
These instrumentations moved to `opentelemetry-instrumentation-genai-openai` and `opentelemetry-instrumentation-genai-openai-agents` in the https://github.com/open-telemetry/opentelemetry-python-genai repository.

- Mark the instrumentor classes as deprecated via `typing_extensions.deprecated` with a docstring note pointing to the new packages
- Add deprecation warnings to the package READMEs (new package name, breaking changes, changelog link)
- Point the instrumentation-genai README table rows to the new packages
