### PR TITLE
opentelemetry-instrumentation-boto3sqs: migrate to current messaging semantic conventions

### DIFF
--- a/.changelog/4920.changed
+++ b/.changelog/4920.changed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-boto3sqs`: migrate to current messaging semantic conventions

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -32,11 +32,16 @@ from opentelemetry.instrumentation.utils import (
     unwrap,
 )
 from opentelemetry.propagators.textmap import CarrierT, Getter, Setter
-from opentelemetry.semconv.trace import (
-    MessagingDestinationKindValues,
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_NAME,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
 )
+from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import Link, Span, SpanKind, Tracer, TracerProvider
 
 from .package import _instruments
@@ -132,31 +137,21 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
     def _enrich_span(
         span: Span,
         queue_name: str,
-        queue_url: str,
-        conversation_id: Optional[str] = None,
-        operation: Optional[MessagingOperationValues] = None,
+        operation_name: str,
+        operation_type: MessagingOperationTypeValues,
         message_id: Optional[str] = None,
     ) -> None:
         if not span.is_recording():
             return
-        span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sqs")
-        span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_name)
         span.set_attribute(
-            SpanAttributes.MESSAGING_DESTINATION_KIND,
-            MessagingDestinationKindValues.QUEUE.value,
+            MESSAGING_SYSTEM, MessagingSystemValues.AWS_SQS.value
         )
-        span.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
+        span.set_attribute(MESSAGING_DESTINATION_NAME, queue_name)
+        span.set_attribute(MESSAGING_OPERATION_NAME, operation_name)
+        span.set_attribute(MESSAGING_OPERATION_TYPE, operation_type.value)
 
-        if operation:
-            span.set_attribute(
-                SpanAttributes.MESSAGING_OPERATION, operation.value
-            )
-        if conversation_id:
-            span.set_attribute(
-                SpanAttributes.MESSAGING_CONVERSATION_ID, conversation_id
-            )
         if message_id:
-            span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, message_id)
+            span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
 
     @staticmethod
     def _safe_end_processing_span(receipt_handle: str) -> None:
@@ -181,7 +176,6 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
     def _create_processing_span(
         self,
         queue_name: str,
-        queue_url: str,
         receipt_handle: str,
         message: Dict[str, Any],
     ) -> None:
@@ -201,9 +195,9 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
             Boto3SQSInstrumentor._enrich_span(
                 span,
                 queue_name,
-                queue_url,
+                "process",
+                MessagingOperationTypeValues.PROCESS,
                 message_id=message_id,
-                operation=MessagingOperationValues.PROCESS,
             )
 
     def _wrap_send_message(self, sqs_class: type) -> None:
@@ -221,16 +215,19 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 kind=SpanKind.PRODUCER,
                 end_on_exit=True,
             ) as span:
-                Boto3SQSInstrumentor._enrich_span(span, queue_name, queue_url)
+                Boto3SQSInstrumentor._enrich_span(
+                    span,
+                    queue_name,
+                    "send",
+                    MessagingOperationTypeValues.PUBLISH,
+                )
                 attributes = kwargs.pop("MessageAttributes", {})
                 propagate.inject(attributes, setter=boto3sqs_setter)
                 retval = wrapped(*args, MessageAttributes=attributes, **kwargs)
                 message_id = retval.get("MessageId")
                 if message_id:
                     if span.is_recording():
-                        span.set_attribute(
-                            SpanAttributes.MESSAGING_MESSAGE_ID, message_id
-                        )
+                        span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
                 return retval
 
         wrap_function_wrapper(sqs_class, "send_message", send_wrapper)
@@ -258,7 +255,10 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 )
                 ids_to_spans[entry_id] = span
                 Boto3SQSInstrumentor._enrich_span(
-                    span, queue_name, queue_url, conversation_id=entry_id
+                    span,
+                    queue_name,
+                    "send",
+                    MessagingOperationTypeValues.PUBLISH,
                 )
                 with trace.use_span(span):
                     if "MessageAttributes" not in entry:
@@ -273,7 +273,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 if message_span:
                     if message_span.is_recording():
                         message_span.set_attribute(
-                            SpanAttributes.MESSAGING_MESSAGE_ID,
+                            MESSAGING_MESSAGE_ID,
                             successful_messages.get("MessageId"),
                         )
             for span in ids_to_spans.values():
@@ -302,8 +302,8 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 Boto3SQSInstrumentor._enrich_span(
                     span,
                     queue_name,
-                    queue_url,
-                    operation=MessagingOperationValues.RECEIVE,
+                    "receive",
+                    MessagingOperationTypeValues.RECEIVE,
                 )
                 retval = wrapped(
                     *args,
@@ -321,7 +321,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                         receipt_handle
                     )
                     self._create_processing_span(
-                        queue_name, queue_url, receipt_handle, message
+                        queue_name, receipt_handle, message
                     )
                 retval["Messages"] = Boto3SQSInstrumentor.ContextableList(
                     messages
@@ -415,7 +415,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
             __name__,
             __version__,
             self._tracer_provider,
-            schema_url="https://opentelemetry.io/schemas/1.11.0",
+            schema_url=Schemas.V1_27_0.value,
         )
         self._wrap_client_creation()
 

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -19,7 +19,8 @@ Usage
 """
 
 import logging
-from typing import Any, Collection, Dict, Generator, List, Mapping, Optional
+from typing import Any, Collection, Dict, Generator, List, Mapping, Optional, Tuple
+from urllib.parse import urlparse
 
 import boto3.session
 import botocore.client
@@ -32,11 +33,18 @@ from opentelemetry.instrumentation.utils import (
     unwrap,
 )
 from opentelemetry.propagators.textmap import CarrierT, Getter, Setter
-from opentelemetry.semconv.trace import (
-    MessagingDestinationKindValues,
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_BATCH_MESSAGE_COUNT,
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_NAME,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
 )
+from opentelemetry.semconv.attributes.server_attributes import SERVER_ADDRESS, SERVER_PORT
+from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import Link, Span, SpanKind, Tracer, TracerProvider
 
 from .package import _instruments
@@ -45,6 +53,8 @@ from .version import __version__
 _logger = logging.getLogger(__name__)
 
 _IS_SQS_INSTRUMENTED_ATTRIBUTE = "_otel_boto3sqs_instrumented"
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
 class Boto3SQSGetter(Getter[CarrierT]):
@@ -127,26 +137,40 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
         span: Span,
         queue_name: str,
         queue_url: str,
-        conversation_id: Optional[str] = None,
-        operation: Optional[MessagingOperationValues] = None,
+        operation_name: str,
+        operation_type: MessagingOperationTypeValues,
         message_id: Optional[str] = None,
     ) -> None:
         if not span.is_recording():
             return
-        span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sqs")
-        span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_name)
-        span.set_attribute(
-            SpanAttributes.MESSAGING_DESTINATION_KIND,
-            MessagingDestinationKindValues.QUEUE.value,
-        )
-        span.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
+        span.set_attribute(MESSAGING_SYSTEM, MessagingSystemValues.AWS_SQS.value)
+        span.set_attribute(MESSAGING_DESTINATION_NAME, queue_name)
+        span.set_attribute(MESSAGING_OPERATION_NAME, operation_name)
+        span.set_attribute(MESSAGING_OPERATION_TYPE, operation_type.value)
 
-        if operation:
-            span.set_attribute(SpanAttributes.MESSAGING_OPERATION, operation.value)
-        if conversation_id:
-            span.set_attribute(SpanAttributes.MESSAGING_CONVERSATION_ID, conversation_id)
+        server_address, server_port = Boto3SQSInstrumentor._extract_server_attributes(queue_url)
+        if server_address:
+            span.set_attribute(SERVER_ADDRESS, server_address)
+            if server_port:
+                span.set_attribute(SERVER_PORT, server_port)
+
         if message_id:
-            span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, message_id)
+            span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
+
+    @staticmethod
+    def _extract_server_attributes(queue_url: str) -> Tuple[Optional[str], Optional[int]]:
+        # A queue URL comes from the caller, so it may not parse: both
+        # `urlparse` itself and reading `port` raise for a malformed one. Let
+        # botocore report a bad URL rather than failing the call from here.
+        try:
+            parsed_url = urlparse(queue_url)
+            hostname = parsed_url.hostname
+            port = parsed_url.port
+        except ValueError:
+            return None, None
+        if port is None:
+            port = _DEFAULT_PORTS.get(parsed_url.scheme)
+        return hostname, port
 
     @staticmethod
     def _safe_end_processing_span(receipt_handle: str) -> None:
@@ -185,8 +209,9 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 span,
                 queue_name,
                 queue_url,
+                "process",
+                MessagingOperationTypeValues.PROCESS,
                 message_id=message_id,
-                operation=MessagingOperationValues.PROCESS,
             )
 
     def _wrap_send_message(self, sqs_class: type) -> None:
@@ -202,14 +227,20 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 kind=SpanKind.PRODUCER,
                 end_on_exit=True,
             ) as span:
-                Boto3SQSInstrumentor._enrich_span(span, queue_name, queue_url)
+                Boto3SQSInstrumentor._enrich_span(
+                    span,
+                    queue_name,
+                    queue_url,
+                    "send",
+                    MessagingOperationTypeValues.PUBLISH,
+                )
                 attributes = kwargs.pop("MessageAttributes", {})
                 propagate.inject(attributes, setter=boto3sqs_setter)
                 retval = wrapped(*args, MessageAttributes=attributes, **kwargs)
                 message_id = retval.get("MessageId")
                 if message_id:
                     if span.is_recording():
-                        span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, message_id)
+                        span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
                 return retval
 
         wrap_function_wrapper(sqs_class, "send_message", send_wrapper)
@@ -228,7 +259,13 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 entry_id = entry["Id"]
                 span = self._tracer.start_span(name=f"{queue_name} send", kind=SpanKind.PRODUCER)
                 ids_to_spans[entry_id] = span
-                Boto3SQSInstrumentor._enrich_span(span, queue_name, queue_url, conversation_id=entry_id)
+                Boto3SQSInstrumentor._enrich_span(
+                    span,
+                    queue_name,
+                    queue_url,
+                    "send",
+                    MessagingOperationTypeValues.PUBLISH,
+                )
                 with trace.use_span(span):
                     if "MessageAttributes" not in entry:
                         entry["MessageAttributes"] = {}
@@ -240,7 +277,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 if message_span:
                     if message_span.is_recording():
                         message_span.set_attribute(
-                            SpanAttributes.MESSAGING_MESSAGE_ID,
+                            MESSAGING_MESSAGE_ID,
                             successful_messages.get("MessageId"),
                         )
             for span in ids_to_spans.values():
@@ -264,7 +301,8 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                     span,
                     queue_name,
                     queue_url,
-                    operation=MessagingOperationValues.RECEIVE,
+                    "receive",
+                    MessagingOperationTypeValues.RECEIVE,
                 )
                 retval = wrapped(
                     *args,
@@ -274,6 +312,10 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 messages = retval.get("Messages", [])
                 if not messages:
                     return retval
+                # A single message is not a batch, and the convention asks for
+                # the count only on spans that describe one.
+                if len(messages) > 1 and span.is_recording():
+                    span.set_attribute(MESSAGING_BATCH_MESSAGE_COUNT, len(messages))
                 for message in messages:
                     receipt_handle = message.get("ReceiptHandle")
                     if not receipt_handle:
@@ -360,7 +402,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
             __name__,
             __version__,
             self._tracer_provider,
-            schema_url="https://opentelemetry.io/schemas/1.11.0",
+            schema_url=Schemas.V1_27_0.value,
         )
         self._wrap_client_creation()
 

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -19,7 +19,16 @@ Usage
 """
 
 import logging
-from typing import Any, Collection, Dict, Generator, List, Mapping, Optional
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
 from urllib.parse import urlparse
 
 import boto3.session
@@ -55,6 +64,8 @@ from .version import __version__
 _logger = logging.getLogger(__name__)
 
 _IS_SQS_INSTRUMENTED_ATTRIBUTE = "_otel_boto3sqs_instrumented"
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
 class Boto3SQSGetter(Getter[CarrierT]):
@@ -156,14 +167,33 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
         span.set_attribute(MESSAGING_OPERATION_NAME, operation_name)
         span.set_attribute(MESSAGING_OPERATION_TYPE, operation_type.value)
 
-        parsed_url = urlparse(queue_url)
-        if parsed_url.hostname:
-            span.set_attribute(SERVER_ADDRESS, parsed_url.hostname)
-            if parsed_url.port:
-                span.set_attribute(SERVER_PORT, parsed_url.port)
+        server_address, server_port = (
+            Boto3SQSInstrumentor._extract_server_attributes(queue_url)
+        )
+        if server_address:
+            span.set_attribute(SERVER_ADDRESS, server_address)
+            if server_port:
+                span.set_attribute(SERVER_PORT, server_port)
 
         if message_id:
             span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
+
+    @staticmethod
+    def _extract_server_attributes(
+        queue_url: str,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        # A queue URL comes from the caller, so it may not parse: both
+        # `urlparse` itself and reading `port` raise for a malformed one. Let
+        # botocore report a bad URL rather than failing the call from here.
+        try:
+            parsed_url = urlparse(queue_url)
+            hostname = parsed_url.hostname
+            port = parsed_url.port
+        except ValueError:
+            return None, None
+        if port is None:
+            port = _DEFAULT_PORTS.get(parsed_url.scheme)
+        return hostname, port
 
     @staticmethod
     def _safe_end_processing_span(receipt_handle: str) -> None:

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -20,6 +20,7 @@ Usage
 
 import logging
 from typing import Any, Collection, Dict, Generator, List, Mapping, Optional
+from urllib.parse import urlparse
 
 import boto3.session
 import botocore.client
@@ -40,6 +41,10 @@ from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
     MESSAGING_SYSTEM,
     MessagingOperationTypeValues,
     MessagingSystemValues,
+)
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace import Link, Span, SpanKind, Tracer, TracerProvider
@@ -137,6 +142,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
     def _enrich_span(
         span: Span,
         queue_name: str,
+        queue_url: str,
         operation_name: str,
         operation_type: MessagingOperationTypeValues,
         message_id: Optional[str] = None,
@@ -149,6 +155,12 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
         span.set_attribute(MESSAGING_DESTINATION_NAME, queue_name)
         span.set_attribute(MESSAGING_OPERATION_NAME, operation_name)
         span.set_attribute(MESSAGING_OPERATION_TYPE, operation_type.value)
+
+        parsed_url = urlparse(queue_url)
+        if parsed_url.hostname:
+            span.set_attribute(SERVER_ADDRESS, parsed_url.hostname)
+            if parsed_url.port:
+                span.set_attribute(SERVER_PORT, parsed_url.port)
 
         if message_id:
             span.set_attribute(MESSAGING_MESSAGE_ID, message_id)
@@ -176,6 +188,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
     def _create_processing_span(
         self,
         queue_name: str,
+        queue_url: str,
         receipt_handle: str,
         message: Dict[str, Any],
     ) -> None:
@@ -195,6 +208,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
             Boto3SQSInstrumentor._enrich_span(
                 span,
                 queue_name,
+                queue_url,
                 "process",
                 MessagingOperationTypeValues.PROCESS,
                 message_id=message_id,
@@ -218,6 +232,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 Boto3SQSInstrumentor._enrich_span(
                     span,
                     queue_name,
+                    queue_url,
                     "send",
                     MessagingOperationTypeValues.PUBLISH,
                 )
@@ -257,6 +272,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 Boto3SQSInstrumentor._enrich_span(
                     span,
                     queue_name,
+                    queue_url,
                     "send",
                     MessagingOperationTypeValues.PUBLISH,
                 )
@@ -302,6 +318,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 Boto3SQSInstrumentor._enrich_span(
                     span,
                     queue_name,
+                    queue_url,
                     "receive",
                     MessagingOperationTypeValues.RECEIVE,
                 )
@@ -321,7 +338,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                         receipt_handle
                     )
                     self._create_processing_span(
-                        queue_name, receipt_handle, message
+                        queue_name, queue_url, receipt_handle, message
                     )
                 retval["Messages"] = Boto3SQSInstrumentor.ContextableList(
                     messages

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -16,10 +16,19 @@ from opentelemetry.instrumentation.boto3sqs import (
     Boto3SQSInstrumentor,
     Boto3SQSSetter,
 )
-from opentelemetry.semconv.trace import (
-    MessagingDestinationKindValues,
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_BATCH_MESSAGE_COUNT,
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_NAME,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
+)
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
 )
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import SpanKind, TraceFlags
@@ -198,12 +207,14 @@ class TestBoto3SQSInstrumentation(TestBase):
             trace_parent.lower(),
         )
 
-    def _default_span_attrs(self):
+    def _default_span_attrs(self, operation_name, operation_type):
         return {
-            SpanAttributes.MESSAGING_SYSTEM: "aws.sqs",
-            SpanAttributes.MESSAGING_DESTINATION: self._queue_name,
-            SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-            SpanAttributes.MESSAGING_URL: self._queue_url,
+            MESSAGING_SYSTEM: MessagingSystemValues.AWS_SQS.value,
+            MESSAGING_DESTINATION_NAME: self._queue_name,
+            MESSAGING_OPERATION_NAME: operation_name,
+            MESSAGING_OPERATION_TYPE: operation_type.value,
+            SERVER_ADDRESS: "sqs.us-east-1.amazonaws.com",
+            SERVER_PORT: 443,
         }
 
     @staticmethod
@@ -257,12 +268,77 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(
             {
-                SpanAttributes.MESSAGING_MESSAGE_ID: message_id,
-                **self._default_span_attrs(),
+                MESSAGING_MESSAGE_ID: message_id,
+                **self._default_span_attrs("send", MessagingOperationTypeValues.PUBLISH),
             },
             span.attributes,
         )
         self._assert_injected_span(message_attrs, span)
+
+    def test_send_message_custom_endpoint_with_port(self):
+        message_id = "123456789"
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": message_id,
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost:4566/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertEqual("localhost", span.attributes[SERVER_ADDRESS])
+        self.assertEqual(4566, span.attributes[SERVER_PORT])
+
+    def test_send_message_custom_endpoint_without_port(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertEqual("localhost", span.attributes[SERVER_ADDRESS])
+        self.assertEqual(80, span.attributes[SERVER_PORT])
+
+    def test_send_message_malformed_port_skips_server_attributes(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost:not-a-port/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertNotIn(SERVER_ADDRESS, span.attributes)
+        self.assertNotIn(SERVER_PORT, span.attributes)
+
+    def test_send_message_unparsable_url_skips_server_attributes(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://[::1/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertNotIn(SERVER_ADDRESS, span.attributes)
+        self.assertNotIn(SERVER_PORT, span.attributes)
 
     def test_send_message_batch(self):
         expected_message_ids = {"1": "msg-1", "2": "msg-2"}
@@ -283,17 +359,16 @@ class TestBoto3SQSInstrumentation(TestBase):
 
         spans = self.get_finished_spans()
         self.assertEqual(2, len(spans))
-        spans_by_entry_id = {span.attributes[SpanAttributes.MESSAGING_CONVERSATION_ID]: span for span in spans}
+        spans_by_message_id = {span.attributes[MESSAGING_MESSAGE_ID]: span for span in spans}
         for entry in entries:
-            entry_id = entry["Id"]
-            span = spans_by_entry_id[entry_id]
+            message_id = expected_message_ids[entry["Id"]]
+            span = spans_by_message_id[message_id]
             self.assertEqual(f"{self._queue_name} send", span.name)
             self.assertEqual(SpanKind.PRODUCER, span.kind)
             self.assertEqual(
                 {
-                    SpanAttributes.MESSAGING_CONVERSATION_ID: entry_id,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: expected_message_ids[entry_id],
-                    **self._default_span_attrs(),
+                    MESSAGING_MESSAGE_ID: message_id,
+                    **self._default_span_attrs("send", MessagingOperationTypeValues.PUBLISH),
                 },
                 span.attributes,
             )
@@ -319,13 +394,10 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(f"{self._queue_name} send", span.name)
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(
-            {
-                SpanAttributes.MESSAGING_CONVERSATION_ID: "1",
-                **self._default_span_attrs(),
-            },
+            self._default_span_attrs("send", MessagingOperationTypeValues.PUBLISH),
             span.attributes,
         )
-        self.assertNotIn(SpanAttributes.MESSAGING_MESSAGE_ID, span.attributes)
+        self.assertNotIn(MESSAGING_MESSAGE_ID, span.attributes)
         self._assert_injected_span(entries[0]["MessageAttributes"], span)
 
     def test_receive_message(self):
@@ -356,11 +428,12 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(SpanKind.CONSUMER, span.kind)
         self.assertEqual(
             {
-                SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.RECEIVE.value,
-                **self._default_span_attrs(),
+                MESSAGING_BATCH_MESSAGE_COUNT: 2,
+                **self._default_span_attrs("receive", MessagingOperationTypeValues.RECEIVE),
             },
             span.attributes,
         )
+        self.assertIsInstance(span.attributes[MESSAGING_BATCH_MESSAGE_COUNT], int)
 
         self.memory_exporter.clear()
 
@@ -378,9 +451,8 @@ class TestBoto3SQSInstrumentation(TestBase):
             # processing span attributes
             self.assertEqual(
                 {
-                    SpanAttributes.MESSAGING_MESSAGE_ID: msg_id,
-                    SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.PROCESS.value,
-                    **self._default_span_attrs(),
+                    MESSAGING_MESSAGE_ID: msg_id,
+                    **self._default_span_attrs("process", MessagingOperationTypeValues.PROCESS),
                 },
                 span.attributes,
             )
@@ -392,6 +464,23 @@ class TestBoto3SQSInstrumentation(TestBase):
             self.assertEqual(attrs["span_id"], link.context.span_id)
 
             self.memory_exporter.clear()
+
+    def test_receive_message_single_message_omits_batch_count(self):
+        mock_response = {"Messages": [self._make_message("1", "hello 1", "01")]}
+
+        with self._mocked_endpoint(mock_response):
+            self._client.receive_message(
+                QueueUrl=self._queue_url,
+                MessageAttributeNames=[],
+            )
+
+        # A receive that returns one message does not describe a batch, so the
+        # count is left off - the attribute set is the plain receive one.
+        span = self._get_only_span()
+        self.assertEqual(
+            self._default_span_attrs("receive", MessagingOperationTypeValues.RECEIVE),
+            span.attributes,
+        )
 
     def test_uninstrument(self):
         mock_response = {

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -225,6 +225,7 @@ class TestBoto3SQSInstrumentation(TestBase):
             MESSAGING_OPERATION_NAME: operation_name,
             MESSAGING_OPERATION_TYPE: operation_type.value,
             SERVER_ADDRESS: "sqs.us-east-1.amazonaws.com",
+            SERVER_PORT: 443,
         }
 
     @staticmethod
@@ -309,6 +310,54 @@ class TestBoto3SQSInstrumentation(TestBase):
         span = self._get_only_span()
         self.assertEqual("localhost", span.attributes[SERVER_ADDRESS])
         self.assertEqual(4566, span.attributes[SERVER_PORT])
+
+    def test_send_message_custom_endpoint_without_port(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertEqual("localhost", span.attributes[SERVER_ADDRESS])
+        self.assertEqual(80, span.attributes[SERVER_PORT])
+
+    def test_send_message_malformed_port_skips_server_attributes(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost:not-a-port/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertNotIn(SERVER_ADDRESS, span.attributes)
+        self.assertNotIn(SERVER_PORT, span.attributes)
+
+    def test_send_message_unparsable_url_skips_server_attributes(self):
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": "123456789",
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://[::1/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertNotIn(SERVER_ADDRESS, span.attributes)
+        self.assertNotIn(SERVER_PORT, span.attributes)
 
     def test_send_message_batch(self):
         expected_message_ids = {"1": "msg-1", "2": "msg-2"}

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -25,6 +25,10 @@ from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
     MessagingOperationTypeValues,
     MessagingSystemValues,
 )
+from opentelemetry.semconv.attributes.server_attributes import (
+    SERVER_ADDRESS,
+    SERVER_PORT,
+)
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import SpanKind, TraceFlags
 from opentelemetry.trace.span import Span, format_span_id, format_trace_id
@@ -220,6 +224,7 @@ class TestBoto3SQSInstrumentation(TestBase):
             MESSAGING_DESTINATION_NAME: self._queue_name,
             MESSAGING_OPERATION_NAME: operation_name,
             MESSAGING_OPERATION_TYPE: operation_type.value,
+            SERVER_ADDRESS: "sqs.us-east-1.amazonaws.com",
         }
 
     @staticmethod
@@ -287,6 +292,23 @@ class TestBoto3SQSInstrumentation(TestBase):
             span.attributes,
         )
         self._assert_injected_span(message_attrs, span)
+
+    def test_send_message_custom_endpoint_with_port(self):
+        message_id = "123456789"
+        mock_response = {
+            "MD5OfMessageBody": "1234",
+            "MessageId": message_id,
+        }
+
+        with self._mocked_endpoint(mock_response):
+            self._client.send_message(
+                QueueUrl=f"http://localhost:4566/123456789012/{self._queue_name}",
+                MessageBody="hello msg",
+            )
+
+        span = self._get_only_span()
+        self.assertEqual("localhost", span.attributes[SERVER_ADDRESS])
+        self.assertEqual(4566, span.attributes[SERVER_PORT])
 
     def test_send_message_batch(self):
         expected_message_ids = {"1": "msg-1", "2": "msg-2"}

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -16,10 +16,14 @@ from opentelemetry.instrumentation.boto3sqs import (
     Boto3SQSInstrumentor,
     Boto3SQSSetter,
 )
-from opentelemetry.semconv.trace import (
-    MessagingDestinationKindValues,
-    MessagingOperationValues,
-    SpanAttributes,
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_DESTINATION_NAME,
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION_NAME,
+    MESSAGING_OPERATION_TYPE,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+    MessagingSystemValues,
 )
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import SpanKind, TraceFlags
@@ -210,12 +214,12 @@ class TestBoto3SQSInstrumentation(TestBase):
             trace_parent.lower(),
         )
 
-    def _default_span_attrs(self):
+    def _default_span_attrs(self, operation_name, operation_type):
         return {
-            SpanAttributes.MESSAGING_SYSTEM: "aws.sqs",
-            SpanAttributes.MESSAGING_DESTINATION: self._queue_name,
-            SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
-            SpanAttributes.MESSAGING_URL: self._queue_url,
+            MESSAGING_SYSTEM: MessagingSystemValues.AWS_SQS.value,
+            MESSAGING_DESTINATION_NAME: self._queue_name,
+            MESSAGING_OPERATION_NAME: operation_name,
+            MESSAGING_OPERATION_TYPE: operation_type.value,
         }
 
     @staticmethod
@@ -275,8 +279,10 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(
             {
-                SpanAttributes.MESSAGING_MESSAGE_ID: message_id,
-                **self._default_span_attrs(),
+                MESSAGING_MESSAGE_ID: message_id,
+                **self._default_span_attrs(
+                    "send", MessagingOperationTypeValues.PUBLISH
+                ),
             },
             span.attributes,
         )
@@ -303,22 +309,20 @@ class TestBoto3SQSInstrumentation(TestBase):
 
         spans = self.get_finished_spans()
         self.assertEqual(2, len(spans))
-        spans_by_entry_id = {
-            span.attributes[SpanAttributes.MESSAGING_CONVERSATION_ID]: span
-            for span in spans
+        spans_by_message_id = {
+            span.attributes[MESSAGING_MESSAGE_ID]: span for span in spans
         }
         for entry in entries:
-            entry_id = entry["Id"]
-            span = spans_by_entry_id[entry_id]
+            message_id = expected_message_ids[entry["Id"]]
+            span = spans_by_message_id[message_id]
             self.assertEqual(f"{self._queue_name} send", span.name)
             self.assertEqual(SpanKind.PRODUCER, span.kind)
             self.assertEqual(
                 {
-                    SpanAttributes.MESSAGING_CONVERSATION_ID: entry_id,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: expected_message_ids[
-                        entry_id
-                    ],
-                    **self._default_span_attrs(),
+                    MESSAGING_MESSAGE_ID: message_id,
+                    **self._default_span_attrs(
+                        "send", MessagingOperationTypeValues.PUBLISH
+                    ),
                 },
                 span.attributes,
             )
@@ -346,13 +350,12 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(f"{self._queue_name} send", span.name)
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(
-            {
-                SpanAttributes.MESSAGING_CONVERSATION_ID: "1",
-                **self._default_span_attrs(),
-            },
+            self._default_span_attrs(
+                "send", MessagingOperationTypeValues.PUBLISH
+            ),
             span.attributes,
         )
-        self.assertNotIn(SpanAttributes.MESSAGING_MESSAGE_ID, span.attributes)
+        self.assertNotIn(MESSAGING_MESSAGE_ID, span.attributes)
         self._assert_injected_span(entries[0]["MessageAttributes"], span)
 
     def test_receive_message(self):
@@ -386,10 +389,9 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(f"{self._queue_name} receive", span.name)
         self.assertEqual(SpanKind.CONSUMER, span.kind)
         self.assertEqual(
-            {
-                SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.RECEIVE.value,
-                **self._default_span_attrs(),
-            },
+            self._default_span_attrs(
+                "receive", MessagingOperationTypeValues.RECEIVE
+            ),
             span.attributes,
         )
 
@@ -411,9 +413,10 @@ class TestBoto3SQSInstrumentation(TestBase):
             # processing span attributes
             self.assertEqual(
                 {
-                    SpanAttributes.MESSAGING_MESSAGE_ID: msg_id,
-                    SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.PROCESS.value,
-                    **self._default_span_attrs(),
+                    MESSAGING_MESSAGE_ID: msg_id,
+                    **self._default_span_attrs(
+                        "process", MessagingOperationTypeValues.PROCESS
+                    ),
                 },
                 span.attributes,
             )


### PR DESCRIPTION
# Description

Migrates the boto3sqs instrumentation off the deprecated `opentelemetry.semconv.trace.SpanAttributes` (schema 1.11.0) onto the current incubating messaging attributes, following the pattern already used by the aiokafka instrumentation:

- `messaging.system`: `aws.sqs` → `aws_sqs` (`MessagingSystemValues.AWS_SQS`)
- `messaging.destination` → `messaging.destination.name`
- `messaging.operation` → `messaging.operation.name` (`send`/`receive`/`process`) + `messaging.operation.type`; send spans now carry operation attributes too
- dropped `messaging.destination_kind` and `messaging.url` (removed from the spec)
- dropped `messaging.conversation_id`, which was being set to the `send_message_batch` entry `Id` (not a conversation/message-group id per spec)
- tracer schema_url: 1.11.0 → `Schemas.V1_27_0` (same as aiokafka)

Span names are intentionally left as `{queue} {operation}` to match the existing aiokafka naming and avoid an extra breaking change; happy to adjust if you'd rather move to `{operation} {queue}` here as well.

Fixes #1639

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — emitted span attribute names/values change

# How Has This Been Tested?

- [x] Updated `tests/test_boto3sqs_instrumentation.py` to assert the new attributes; full suite passes locally (16 passed) with boto3/botocore 1.34.44 (the pinned test versions), plus `ruff check` / `ruff format --check`.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

<!-- oss-radar:idempotency=manual-20260803-131856.w2.open-telemetry_opentelemetry-python-contrib.1639 -->
