### PR TITLE
Remove CONTRIBUTING guidelines for moved GenAI instrumentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ If you are using AI agents to assist with contributions, please read [AGENTS.md]
     - [How to Receive Comments](#how-to-receive-comments)
     - [How to Get PRs Reviewed](#how-to-get-prs-reviewed)
     - [How to Get PRs Merged](#how-to-get-prs-merged)
+    - [Changelog](#changelog)
     - [Stale PRs](#stale-prs)
   - [Design Choices](#design-choices)
     - [Focus on Capabilities, Not Structure Compliance](#focus-on-capabilities-not-structure-compliance)
@@ -42,8 +43,8 @@ If you are using AI agents to assist with contributions, please read [AGENTS.md]
   - [Guideline for instrumentations](#guideline-for-instrumentations)
     - [Update supported instrumentation package versions](#update-supported-instrumentation-package-versions)
   - [Guideline for GenAI instrumentations](#guideline-for-genai-instrumentations)
-    - [Get Involved](#get-involved)
   - [Expectations from contributors](#expectations-from-contributors)
+    - [Use of AI coding assistants](#use-of-ai-coding-assistants)
     - [Guidelines for native OpenTelemetry instrumentation](#guidelines-for-native-opentelemetry-instrumentation)
   - [Updating supported Python versions](#updating-supported-python-versions)
     - [Bumping the Python baseline](#bumping-the-python-baseline)
@@ -211,8 +212,8 @@ Open a pull request (PR) against the main `opentelemetry-python-contrib` repo.
 A descriptive PR title will help the community better triage and review your changes. Make sure to prefix with the name(s) of the package/subdirectory/domain that your PR updates. Following any of these examples will help:
 
 * "opentelemetry-instrumentation-dbapi: add client operation duration metrics"
-* "GenAI Utils: Add _BaseAgent base class and agent creation lifecycle"
-* "docs(google-genai): document config recording environment variables"
+* "scripts/build.sh: ignore opamp packages"
+* "docs(dbapi): fix pyodbc connect method example "
 
 ### How to Receive Comments
 
@@ -428,15 +429,7 @@ Example PRs: [#2976](https://github.com/open-telemetry/opentelemetry-python-cont
 
 ## Guideline for GenAI instrumentations
 
-Instrumentations that relate to [Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) systems will be placed in the [instrumentation-genai](./instrumentation-genai) folder. This section covers contributions related to those instrumentations. Please note that the [guidelines for instrumentations](#guideline-for-instrumentations) and [expectations from contributors](#expectations-from-contributors) still apply.
-
-### Get Involved
-
-* Reviewing PRs: If you would like to be tagged as reviewer in new PRs related to these instrumentations, please submit a PR to add your GitHub handle to [component_owners.yml](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/component_owners.yml) under the corresponding instrumentation folder(s).
-
-* Approving PRs: If you would like to be able to approve PRs related to these instrumentations, you must join [opentelemetry-python-contrib-approvers](https://github.com/orgs/open-telemetry/teams/opentelemetry-python-contrib-approvers) team. Please ask one of the [Python contrib maintainers](https://github.com/orgs/open-telemetry/teams/opentelemetry-python-contrib-maintainers) to be accepted into the team.
-
-* Tracking and Creating Issues: For tracking issues related to Generative AI, please filter or add the label [gen-ai](https://github.com/open-telemetry/opentelemetry-python-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Agen-ai) when creating or searching issues. If you do not see an issue related to an instrumentation you would like to contribute to, please create a new tracking issue so the community is aware of its progress.
+Instrumentations that relate to [Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) systems should be housed in the dedicated repository [opentelemetry-python-genai](https://github.com/open-telemetry/opentelemetry-python-genai/). Please read [those guidelines](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md).
 
 ## Expectations from contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ If you are using AI agents to assist with contributions, please read [AGENTS.md]
   - [Guideline for instrumentations](#guideline-for-instrumentations)
     - [Update supported instrumentation package versions](#update-supported-instrumentation-package-versions)
   - [Guideline for GenAI instrumentations](#guideline-for-genai-instrumentations)
+  - [Get Involved](#get-involved)
   - [Expectations from contributors](#expectations-from-contributors)
     - [Use of AI coding assistants](#use-of-ai-coding-assistants)
     - [Guidelines for native OpenTelemetry instrumentation](#guidelines-for-native-opentelemetry-instrumentation)
@@ -430,6 +431,14 @@ Example PRs: [#2976](https://github.com/open-telemetry/opentelemetry-python-cont
 ## Guideline for GenAI instrumentations
 
 Instrumentations that relate to [Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) systems should be housed in the dedicated repository [opentelemetry-python-genai](https://github.com/open-telemetry/opentelemetry-python-genai/). Please read [those guidelines](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md).
+
+## Get Involved
+
+* Reviewing PRs: If you would like to be tagged as reviewer in new PRs related to these instrumentations, please submit a PR to add your GitHub handle to [component_owners.yml](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/component_owners.yml) under the corresponding instrumentation folder(s).
+
+* Approving PRs: If you would like to be able to approve PRs related to these instrumentations, you must join [opentelemetry-python-contrib-approvers](https://github.com/orgs/open-telemetry/teams/opentelemetry-python-contrib-approvers) team. Please ask one of the [Python contrib maintainers](https://github.com/orgs/open-telemetry/teams/opentelemetry-python-contrib-maintainers) to be accepted into the team.
+
+* Tracking and Creating Issues: Create or search for issues [here](https://github.com/open-telemetry/opentelemetry-python-contrib/issues). If you do not see an issue related to an instrumentation you would like to contribute to, please create a new tracking issue so the community is aware of its progress.
 
 ## Expectations from contributors
 


### PR DESCRIPTION
# Description

Python GenAI framework instrumentations have been moved to https://github.com/open-telemetry/opentelemetry-python-genai/ and we are deprecating the duplicates that are in this repo: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4918. This `CONTRIBUTING.md` update removes the outdated guidelines and points to the modern repo. IMO [the modern guidelines](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md) are nice and simple, and I don't want to port over what was here. But LMK your thoughts!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Not tested.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [X] Documentation has been updated
