### PR TITLE
opentelemetry-instrumentation-kafka-python: keep the producer span active while send executes

### DIFF
--- a/.changelog/4931.fixed
+++ b/.changelog/4931.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-kafka-python`: keep the producer span active while the wrapped `send` executes so synchronous failures are recorded on it

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
@@ -171,7 +171,7 @@ def _wrap_send(tracer: Tracer, produce_hook: ProduceHookT) -> Callable:
             except Exception as hook_exception:  # pylint: disable=W0703
                 _LOG.exception(hook_exception)
 
-        return func(*args, **kwargs)
+            return func(*args, **kwargs)
 
     return _traced_send
 

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
@@ -4,6 +4,9 @@
 
 from unittest import TestCase, mock
 
+from kafka.errors import KafkaTimeoutError
+
+from opentelemetry import trace
 from opentelemetry.instrumentation.kafka.utils import (
     KafkaPropertiesExtractor,
     _create_consumer_span,
@@ -13,7 +16,8 @@ from opentelemetry.instrumentation.kafka.utils import (
     _wrap_next,
     _wrap_send,
 )
-from opentelemetry.trace import SpanKind
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind, StatusCode
 
 
 class TestUtils(TestCase):
@@ -237,4 +241,91 @@ class TestUtils(TestCase):
                 kafka_properties_extractor, self.args, self.kwargs
             )
             is None
+        )
+
+
+class TestWrapSendSpanLifetime(TestBase):
+    """The producer span must stay active while the wrapped `send` runs.
+
+    Otherwise a synchronous failure happens after the span has already ended
+    and is never recorded on it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.topic_name = "test_topic"
+        self.args = [self.topic_name]
+        self.kwargs = {"partition": 0, "headers": []}
+        self.tracer = self.tracer_provider.get_tracer(__name__)
+        self.producer = mock.MagicMock()
+
+    @mock.patch(
+        "opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition",
+        return_value=0,
+    )
+    @mock.patch(
+        "opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers",
+        return_value=["localhost:9092"],
+    )
+    def test_send_runs_inside_the_producer_span(
+        self,
+        extract_bootstrap_servers: mock.MagicMock,
+        extract_send_partition: mock.MagicMock,
+    ) -> None:
+        captured_span_context = {}
+
+        def original_send(*args, **kwargs):
+            captured_span_context["value"] = (
+                trace.get_current_span().get_span_context()
+            )
+            return "future"
+
+        wrapped_send = _wrap_send(self.tracer, None)
+        retval = wrapped_send(
+            original_send, self.producer, self.args, self.kwargs
+        )
+
+        self.assertEqual(retval, "future")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            captured_span_context["value"].span_id, spans[0].context.span_id
+        )
+
+    @mock.patch(
+        "opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition",
+        return_value=0,
+    )
+    @mock.patch(
+        "opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers",
+        return_value=["localhost:9092"],
+    )
+    def test_send_exception_is_recorded_and_reraised(
+        self,
+        extract_bootstrap_servers: mock.MagicMock,
+        extract_send_partition: mock.MagicMock,
+    ) -> None:
+        expected_exception = KafkaTimeoutError(
+            "Failed to update metadata after 60.0 secs."
+        )
+        original_send = mock.MagicMock(side_effect=expected_exception)
+
+        wrapped_send = _wrap_send(self.tracer, None)
+        with self.assertRaises(KafkaTimeoutError) as raised:
+            wrapped_send(original_send, self.producer, self.args, self.kwargs)
+
+        self.assertIs(raised.exception, expected_exception)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.kind, SpanKind.PRODUCER)
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
+
+        self.assertEqual(len(span.events), 1)
+        event = span.events[0]
+        self.assertEqual(event.name, "exception")
+        self.assertEqual(
+            event.attributes["exception.type"],
+            "kafka.errors.KafkaTimeoutError",
         )


### PR DESCRIPTION
# Description

`_wrap_send` created the producer span, injected the propagation headers, and then exited the `with` block before calling the wrapped `KafkaProducer.send`. Because `start_as_current_span` ends the span on exit, the instrumented operation ran entirely outside the span it represents: a synchronous failure in `send` was raised after the span had already ended, so the exported span carried `StatusCode.UNSET` and no exception event, and its duration only covered attribute setting and header injection.

This moves `return func(*args, **kwargs)` inside the `with` block so the span stays active while `send` executes. Failures are then recorded by the context manager's default `record_exception` / `set_status_on_exception` behaviour and the original exception is re-raised unmodified. This matches the existing confluent-kafka instrumentation, which already calls the wrapped `produce` inside the span.

Note that `KafkaProducer.send` reports `BrokerResponseError` through the returned future rather than raising, so those failures are still not visible on the span; this change covers the synchronous failure path only.

Part of #4871

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added `TestWrapSendSpanLifetime` in `instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py`, using the real SDK via `TestBase` rather than a mock tracer:

- [x] `test_send_runs_inside_the_producer_span` — captures `trace.get_current_span()` from inside the wrapped call and asserts its `span_id` matches the exported span, confirming the producer span is the active span while `send` runs.
- [x] `test_send_exception_is_recorded_and_reraised` — asserts the original exception object is re-raised, and that the exported span has `SpanKind.PRODUCER`, `StatusCode.ERROR`, and an `exception` event with the expected `exception.type`.

Both new tests fail on `main` and pass with this change. The existing tests in the package are unmodified and continue to pass.

