### PR TITLE
Hide ruff line width change from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Switch to SPDX license headers (#4533)
-# TODO: update with the squash-merge commit SHA after merge
+1f17cc1931389ae2a6b43ac3a45956aa1860588f
+
+# Update line length to 120 (#4933)
+3a96d1cfc6e183e3ccb91bf7505718a2c83a09c8


### PR DESCRIPTION
# Description

Hides #4933 (commit 3a96d1cfc6e183e3ccb91bf7505718a2c83a09c8) from git blame.

Hides #4533 (commit 1f17cc1931389ae2a6b43ac3a45956aa1860588f) which was missed as well.
