### PR TITLE
Pass the response message to the aio gRPC client response hook

### DIFF
--- a/.changelog/4938.fixed
+++ b/.changelog/4938.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-grpc`: pass the response message to the aio client response hook, which previously received the gRPC status details string

--- a/.changelog/4938.fixed
+++ b/.changelog/4938.fixed
@@ -1,1 +1,1 @@
-`opentelemetry-instrumentation-grpc`: pass the response message to the aio client response hook, which previously received the gRPC status details string
+`opentelemetry-instrumentation-grpc`: pass the response message to the aio client response hook, which previously received the gRPC status details string; note that the hook is no longer called when the RPC fails

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_aio_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_aio_client.py
@@ -104,8 +104,8 @@ class _BaseAioClientInterceptor(OpenTelemetryClientInterceptor):
             code = await call.code()
             details = await call.details()
 
-            # The response message is what the hook is documented to receive,
-            # and it is what the sync client and the streaming path both pass.
+            # The sync client and the aio streaming path both pass the response
+            # message to the hook; this path passed the status details instead.
             # grpc.aio caches the unary result, so awaiting the call here does
             # not consume it -- the caller's own await still yields it.
             response = None

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_aio_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_aio_client.py
@@ -21,7 +21,7 @@ from opentelemetry.trace.status import Status, StatusCode
 logger = logging.getLogger(__name__)
 
 
-def _unary_done_callback(span, code, details, response_hook):
+def _unary_done_callback(span, code, details, response, response_hook):
     def callback(call):
         try:
             span.set_attribute(
@@ -35,7 +35,8 @@ def _unary_done_callback(span, code, details, response_hook):
                         description=details,
                     )
                 )
-            response_hook(span, details)
+            else:
+                response_hook(span, response)
 
         finally:
             span.end()
@@ -103,7 +104,15 @@ class _BaseAioClientInterceptor(OpenTelemetryClientInterceptor):
             code = await call.code()
             details = await call.details()
 
-            callback = _unary_done_callback(span, code, details, self._call_response_hook)
+            # The response message is what the hook is documented to receive,
+            # and it is what the sync client and the streaming path both pass.
+            # grpc.aio caches the unary result, so awaiting the call here does
+            # not consume it -- the caller's own await still yields it.
+            response = None
+            if code == grpc.StatusCode.OK and self._response_hook:
+                response = await call
+
+            callback = _unary_done_callback(span, code, details, response, self._call_response_hook)
             try:
                 call.add_done_callback(callback)
             except NotImplementedError:

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
@@ -7,7 +7,7 @@ import grpc
 from opentelemetry.instrumentation.grpc import GrpcAioInstrumentorClient
 from opentelemetry.test.test_base import TestBase
 
-from ._aio_client import simple_method
+from ._aio_client import client_streaming_method, simple_method
 from ._server import create_test_server
 from .protobuf import test_server_pb2_grpc  # pylint: disable=no-name-in-module
 
@@ -17,7 +17,7 @@ def request_hook(span, request):
 
 
 def response_hook(span, response):
-    span.set_attribute("response_data", response)
+    span.set_attribute("response_data", response.response_data)
 
 
 def request_hook_with_exception(_span, _request):
@@ -63,7 +63,48 @@ class TestAioClientInterceptorWithHooks(TestBase, IsolatedAsyncioTestCase):
             self.assertEqual(span.attributes["request_data"], "data")
 
             self.assertIn("response_data", span.attributes)
-            self.assertEqual(span.attributes["response_data"], "")
+            self.assertEqual(span.attributes["response_data"], "data")
+        finally:
+            instrumentor.uninstrument()
+
+    async def test_response_hook_stream_unary(self):
+        instrumentor = GrpcAioInstrumentorClient()
+
+        try:
+            instrumentor.instrument(response_hook=response_hook)
+
+            channel = grpc.aio.insecure_channel("localhost:25565")
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            response = await client_streaming_method(stub)
+            assert response.response_data == "data"
+
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+            span = spans[0]
+
+            self.assertIn("response_data", span.attributes)
+            self.assertEqual(span.attributes["response_data"], "data")
+        finally:
+            instrumentor.uninstrument()
+
+    async def test_response_hook_not_called_on_error(self):
+        """There is no response message to hand the hook when the RPC fails."""
+        instrumentor = GrpcAioInstrumentorClient()
+
+        try:
+            instrumentor.instrument(response_hook=response_hook)
+
+            channel = grpc.aio.insecure_channel("localhost:25565")
+            stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
+
+            with self.assertRaises(grpc.RpcError):
+                await simple_method(stub, error=True)
+
+            spans = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(spans), 1)
+
+            self.assertNotIn("response_data", spans[0].attributes)
         finally:
             instrumentor.uninstrument()
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_aio_client_interceptor_hooks.py
@@ -91,9 +91,13 @@ class TestAioClientInterceptorWithHooks(TestBase, IsolatedAsyncioTestCase):
     async def test_response_hook_not_called_on_error(self):
         """There is no response message to hand the hook when the RPC fails."""
         instrumentor = GrpcAioInstrumentorClient()
+        calls = []
+
+        def recording_hook(span, response):
+            calls.append(response)
 
         try:
-            instrumentor.instrument(response_hook=response_hook)
+            instrumentor.instrument(response_hook=recording_hook)
 
             channel = grpc.aio.insecure_channel("localhost:25565")
             stub = test_server_pb2_grpc.GRPCTestServerStub(channel)
@@ -101,10 +105,10 @@ class TestAioClientInterceptorWithHooks(TestBase, IsolatedAsyncioTestCase):
             with self.assertRaises(grpc.RpcError):
                 await simple_method(stub, error=True)
 
-            spans = self.memory_exporter.get_finished_spans()
-            self.assertEqual(len(spans), 1)
+            self.assertEqual(calls, [])
 
-            self.assertNotIn("response_data", spans[0].attributes)
+            # the span still has to be ended on the error path
+            self.assertEqual(len(self.memory_exporter.get_finished_spans()), 1)
         finally:
             instrumentor.uninstrument()
 


### PR DESCRIPTION
Fixes #3490

### Description

The aio client's unary `response_hook` receives the gRPC status **detail string** instead of the response message, so it is `''` on a successful call.

`add_done_callback` cannot take a coroutine, so `_wrap_unary_response` pre-fetches `code` and `details` and passes them into the callback factory. The callback then does `response_hook(span, details)` — `details` was never the response, it just happened to be in scope.

This is an internal inconsistency rather than a design question. Both of the other paths already pass the deserialized message:

- `_client.py:112-113` (sync): `if self._response_hook: self._call_response_hook(span, response)`
- `_aio_client.py` `_wrap_stream_response`: `self._call_response_hook(span, response)`

Only the aio unary path differs. It affects unary-unary and stream-unary.

### Fix

`await call` to get the response before registering the callback. That is free latency-wise — `await call.code()` above it already blocks until the RPC has completed — and `grpc.aio` caches the unary result, so the caller's own `await` still returns the response. The extra await is skipped entirely when no hook is registered.

### Two judgement calls I want to flag rather than have you find

1. **The hook no longer fires on error.** Today it fires with `''` on a non-OK status; now it fires only on OK. That matches the sync client, which never reaches its hook when the call raises, but it *is* a behaviour change for anyone relying on the empty-string call.

   I deliberately did not `await call` on the error path. Doing so raises `AioRpcError` inside the `try`, which the `except grpc.aio.AioRpcError` catches and re-raises from the interceptor rather than from the caller's own `await` — and `add_done_callback` is then never registered, so `span.end()` never runs and the span leaks.

2. The hooks have no docstrings specifying their arguments, so the case for "response message" rests on parity with `_client.py` and `_wrap_stream_response` rather than on documented contract. Happy to be told the aio unary hook was meant to be different.

### Tests

The existing test asserted the bug:

```python
def response_hook(span, response):
    span.set_attribute("response_data", response)
...
    self.assertEqual(span.attributes["response_data"], "")
```

Passing a protobuf message to `set_attribute` is silently dropped, so it could not simply be left alone. The hook now mirrors the sync test's `response.response_data`, and on current `main` that fails with `AttributeError: 'str' object has no attribute 'response_data'`.

Added two cases: stream-unary (same bug, separate call path) and one asserting the hook does not fire on a failed RPC.

`pytest tests/` in the grpc package: 142 passed. There are 10 pre-existing failures in `TestOpenTelemetryServerInterceptorUnix` in my environment (Unix domain sockets on macOS) — I diffed the failing-test sets with and without this change via junit XML and they are identical, so nothing here is a regression. Ruff check and format are clean.

I ran against grpcio 1.75.1 (the pinned test requirement). I did not separately run against the oldest supported grpcio in `test-requirements-0.txt`; `add_done_callback` and awaiting a completed unary call are long-stable, but flagging that I did not verify it.
