### PR TITLE
fix(psycopg2): avoid IndexError in get_operation_name for comment/whitespace-only statements

### DIFF
--- a/.changelog/4942.fixed
+++ b/.changelog/4942.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-psycopg2`: avoid `IndexError` in `get_operation_name` for comment-only or whitespace-only statements

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -331,8 +331,11 @@ class CursorTracer(dbapi.CursorTracer):
             statement = statement.as_string(cursor)
 
         if isinstance(statement, str):
-            # Strip leading comments so we get the operation name.
-            return self._leading_comment_remover.sub("", statement).split()[0]
+            # Strip leading comments so we get the operation name. A statement that
+            # is truthy but has no tokens left (comment-only or whitespace-only)
+            # must not raise IndexError; return an empty operation name instead.
+            tokens = self._leading_comment_remover.sub("", statement).split()
+            return tokens[0] if tokens else ""
 
         return ""
 

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -130,6 +130,18 @@ class TestPostgresqlIntegration(TestBase):
         self.assertEqual(spans_list[4].name, "query")
         self.assertEqual(spans_list[5].name, "query")
 
+    def test_span_name_comment_or_whitespace_only(self):
+        # Regression: a comment-only or whitespace-only statement is truthy but has
+        # no tokens after leading-comment stripping; get_operation_name must not
+        # raise IndexError.
+        Psycopg2Instrumentor().instrument()
+        cnx = psycopg2.connect(database="test")
+        cursor = cnx.cursor()
+        cursor.execute("/* comment only */")
+        cursor.execute("   ")
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 2)
+
     # pylint: disable=unused-argument
     def test_not_recording(self):
         mock_tracer = mock.Mock()

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/tests/test_psycopg2_integration.py
@@ -141,6 +141,10 @@ class TestPostgresqlIntegration(TestBase):
         cursor.execute("   ")
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 2)
+        # No tokens survive comment/whitespace stripping, so operation_name is
+        # empty and the span name falls back to the db vendor.
+        self.assertEqual(spans_list[0].name, "postgresql")
+        self.assertEqual(spans_list[1].name, "postgresql")
 
     # pylint: disable=unused-argument
     def test_not_recording(self):


### PR DESCRIPTION
Same class as #4934, in the psycopg2 instrumentation's `get_operation_name`: a comment-only / whitespace-only statement is truthy but has no tokens after leading-comment stripping, so `.split()[0]` raises `IndexError`. Guards it like the dbapi base does. Extends the empty-string handling from #2643 to this case.

**Type of change:** Bug fix (non-breaking)

**How Has This Been Tested?** Added `test_span_name_comment_or_whitespace_only` (comment-only + whitespace-only statements no longer raise); existing tests still pass. Verified locally.

**Does This PR Require a Core Repo Change?** No.