### PR TITLE
Document HTTP semantic convention opt-in

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -183,6 +183,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-server/src/opentelemetry/instrumentation/aiohttp_server/__init__.py
@@ -139,6 +139,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -209,6 +209,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -283,6 +283,18 @@ We can configure the tags to be appended to the sqlquery log by adding below var
 | ``SQLCOMMENTER_WITH_DB_DRIVER``     | Database driver name used by Django.                      | ``db_driver='django.db.backends.postgresql'``                             |
 +-------------------------------------+-----------------------------------------------------------+---------------------------------------------------------------------------+
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/src/opentelemetry/instrumentation/falcon/__init__.py
@@ -174,6 +174,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/src/opentelemetry/instrumentation/fastapi/__init__.py
@@ -175,6 +175,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -244,6 +244,18 @@ The following sqlcomment key-values can be opted out of through ``commenter_opti
 | ``controller``    | Flask controller/endpoint name.                    | ``controller='home_view'``             |
 +-------------------+----------------------------------------------------+----------------------------------------+
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py
@@ -361,6 +361,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/src/opentelemetry/instrumentation/pyramid/__init__.py
@@ -168,6 +168,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -166,6 +166,18 @@ For example,
 
 will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-starlette/src/opentelemetry/instrumentation/starlette/__init__.py
@@ -167,6 +167,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -147,6 +147,18 @@ Example of the added span attribute,
 Note:
     Environment variable names to capture http headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib/src/opentelemetry/instrumentation/urllib/__init__.py
@@ -160,6 +160,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/__init__.py
@@ -170,6 +170,18 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -211,6 +211,18 @@ In order to prevent unbound cardinality for HTTP methods by default nonstandard 
 To record all of the names set the environment variable  ``OTEL_PYTHON_INSTRUMENTATION_HTTP_CAPTURE_ALL_METHODS``
 to a value that evaluates to true, e.g. ``1``.
 
+Semantic convention opt-in
+**************************
+This instrumentation emits the legacy, experimental HTTP and networking semantic conventions by default. Set
+``OTEL_SEMCONV_STABILITY_OPT_IN`` to one of the following values to change this behavior:
+
+* ``http`` - emit only the stable HTTP and networking semantic conventions.
+* ``http/dup`` - emit both the legacy and stable conventions, allowing for a phased migration.
+
+The environment variable accepts comma-separated values. See the
+`HTTP semantic convention stability migration
+<https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/>`_ for more details.
+
 API
 ---
 """


### PR DESCRIPTION
# Description

Document `OTEL_SEMCONV_STABILITY_OPT_IN` across the HTTP instrumentation package documentation.

The new section explains the legacy default, the `http` and `http/dup` migration options, comma-separated values, and links to the HTTP semantic convention stability migration guide.

Fixes #4202

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e spellcheck`
- [x] Parsed Python syntax and reStructuredText for all 15 changed module docstrings
- [x] `git diff --check`

`tox -e docs` did not reach Sphinx locally because the `mysqlclient` dependency requires `mysql_config`, which is not installed in the local environment.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not applicable for this documentation-only change)
- [ ] Unit tests have been added (not applicable; no runtime code changed)
- [x] Documentation has been updated
