### PR TITLE
docs: add a couple of httpx2 classes to nitpick exceptions

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -31,6 +31,7 @@ flask~=2.0
 falcon~=2.0
 grpcio~=1.27
 httpx>=0.18.0
+httpx2~=2.0
 kafka-python>=2.0,<3.0
 mysql-connector-python~=8.0
 mysqlclient~=2.1.1

--- a/docs/nitpick-exceptions.ini
+++ b/docs/nitpick-exceptions.ini
@@ -24,8 +24,10 @@ py-class=
     httpx.Client
     httpx.AsyncClient
     httpx.BaseTransport
+    httpx2.BaseTransport
     openai.BaseTransport
     httpx.AsyncBaseTransport
+    httpx2.AsyncBaseTransport
     httpx.SyncByteStream
     httpx.AsyncByteStream
     httpx.Response


### PR DESCRIPTION
# Description

Fixes:

```
sphinx.errors.SphinxWarning:
  /opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-httpx/src/opentelemetry/instrumentation/httpx/__init__.py:
  docstring of opentelemetry.instrumentation.httpx.AsyncOpenTelemetryTransportHttpx2:1:py:class reference target not found: httpx2.AsyncBaseTransport
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
