### PR TITLE
Fix invalid wheel metadata in azure resource detector build

### DIFF
--- a/resource/opentelemetry-resource-detector-azure/.changelog/4950.fixed
+++ b/resource/opentelemetry-resource-detector-azure/.changelog/4950.fixed
@@ -1,0 +1,1 @@
+Require hatchling >= 1.27 so built wheels carry valid Metadata-Version 2.4+ for PEP 639 license fields

--- a/resource/opentelemetry-resource-detector-azure/pyproject.toml
+++ b/resource/opentelemetry-resource-detector-azure/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling"]
+# hatchling >= 1.27 is required to emit Metadata-Version 2.4 when the
+# PEP 639 License-Expression/License-File fields are present. Older
+# hatchling versions write Metadata-Version 2.3 together with those fields,
+# producing wheels that packaging validators (e.g. twine check) reject.
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
# Description

The `opentelemetry-resource-detector-azure` 0.1.5 wheel carries `Metadata-Version: 2.3` together with PEP 639 fields (`License-Expression: Apache-2.0`, `License-File: LICENSE`), which packaging validators reject (e.g. `twine check`:

```
InvalidDistribution: Invalid distribution metadata: license-expression introduced in metadata version 2.4, not 2.3
```

Root cause: `[build-system] requires = ["hatchling"]` is unpinned. hatchling 1.24/1.25 emit the PEP 639 fields while writing `Metadata-Version: 2.3`; hatchling >= 1.27 emits them with `Metadata-Version: 2.4+`, which is valid.

Fix: pin `requires = ["hatchling>=1.27"]` in the azure resource detector's `pyproject.toml`. This is localized to this package only.

Fixes #4945

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Reproduced the failure: building with hatchling 1.25 produces `Metadata-Version: 2.3` + `License-Expression` and `twine check` fails with the error above.
- With `requires = ["hatchling>=1.27"]`: `python -m build` produces `Metadata-Version: 2.5` with `License-Expression: Apache-2.0` and `License-File: LICENSE`; `twine check` passes.
- Package unit tests pass (11 passed). No production code was changed.

Note: this repository has no packaging-metadata test harness (release CI only runs `twine upload`, not `twine check`), so verification is via local `python -m build` + `twine check` rather than a new unit test.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
