### PR TITLE
opentelemetry-instrumentation-mysql: support mysql-connector-python 26.7.0 and later

### DIFF
--- a/.changelog/4951.fixed
+++ b/.changelog/4951.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-mysql`: support mysql-connector-python 26.7.0 and later

--- a/.github/workflows/core_contrib_test.yml
+++ b/.github/workflows/core_contrib_test.yml
@@ -1917,6 +1917,36 @@ jobs:
       - name: Run tests
         run: tox -e py310-test-instrumentation-mysql-1 -- -ra
 
+  py310-test-instrumentation-mysql-2:
+    name: instrumentation-mysql-2 
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout contrib repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
+        uses: actions/checkout@v4
+        with:
+          repository: open-telemetry/opentelemetry-python-contrib
+          ref: ${{ env.CONTRIB_REPO_SHA }}
+
+      - name: Checkout core repo @ SHA - ${{ env.CORE_REPO_SHA }}
+        uses: actions/checkout@v4
+        with:
+          repository: open-telemetry/opentelemetry-python
+          ref: ${{ env.CORE_REPO_SHA }}
+          path: opentelemetry-python
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: "x64"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py310-test-instrumentation-mysql-2 -- -ra
+
   py310-test-instrumentation-mysqlclient:
     name: instrumentation-mysqlclient 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6427,6 +6427,25 @@ jobs:
       - name: Run tests
         run: tox -e py310-test-instrumentation-mysql-1 -- -ra
 
+  py310-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 3.10 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py310-test-instrumentation-mysql-2 -- -ra
+
   py311-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.11 Ubuntu
     runs-on: ubuntu-latest
@@ -6464,6 +6483,25 @@ jobs:
 
       - name: Run tests
         run: tox -e py311-test-instrumentation-mysql-1 -- -ra
+
+  py311-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 3.11 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py311-test-instrumentation-mysql-2 -- -ra
 
   py312-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.12 Ubuntu
@@ -6503,6 +6541,25 @@ jobs:
       - name: Run tests
         run: tox -e py312-test-instrumentation-mysql-1 -- -ra
 
+  py312-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 3.12 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py312-test-instrumentation-mysql-2 -- -ra
+
   py313-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.13 Ubuntu
     runs-on: ubuntu-latest
@@ -6540,6 +6597,25 @@ jobs:
 
       - name: Run tests
         run: tox -e py313-test-instrumentation-mysql-1 -- -ra
+
+  py313-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 3.13 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py313-test-instrumentation-mysql-2 -- -ra
 
   py314-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 3.14 Ubuntu
@@ -6579,6 +6655,25 @@ jobs:
       - name: Run tests
         run: tox -e py314-test-instrumentation-mysql-1 -- -ra
 
+  py314-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 3.14 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e py314-test-instrumentation-mysql-2 -- -ra
+
   pypy3-test-instrumentation-mysql-0_ubuntu-latest:
     name: instrumentation-mysql-0 pypy-3.10 Ubuntu
     runs-on: ubuntu-latest
@@ -6616,6 +6711,25 @@ jobs:
 
       - name: Run tests
         run: tox -e pypy3-test-instrumentation-mysql-1 -- -ra
+
+  pypy3-test-instrumentation-mysql-2_ubuntu-latest:
+    name: instrumentation-mysql-2 pypy-3.10 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python pypy-3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "pypy-3.10"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -e pypy3-test-instrumentation-mysql-2 -- -ra
 
   py310-test-instrumentation-mysqlclient_ubuntu-latest:
     name: instrumentation-mysqlclient 3.10 Ubuntu

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -28,7 +28,7 @@
 | [opentelemetry-instrumentation-jinja2](./opentelemetry-instrumentation-jinja2) | jinja2 >= 2.7, < 4.0 | No | development
 | [opentelemetry-instrumentation-kafka-python](./opentelemetry-instrumentation-kafka-python) | kafka-python >= 2.0, < 4.0 | No | development
 | [opentelemetry-instrumentation-logging](./opentelemetry-instrumentation-logging) | logging | No | development
-| [opentelemetry-instrumentation-mysql](./opentelemetry-instrumentation-mysql) | mysql-connector-python >= 8.0, < 10.0 | No | migration
+| [opentelemetry-instrumentation-mysql](./opentelemetry-instrumentation-mysql) | mysql-connector-python >= 8.0 | No | migration
 | [opentelemetry-instrumentation-mysqlclient](./opentelemetry-instrumentation-mysqlclient) | mysqlclient < 3 | No | migration
 | [opentelemetry-instrumentation-pika](./opentelemetry-instrumentation-pika) | pika >= 0.12.0 | No | development
 | [opentelemetry-instrumentation-psycopg](./opentelemetry-instrumentation-psycopg) | psycopg >= 3.1.0 | No | migration

--- a/instrumentation/opentelemetry-instrumentation-mysql/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-mysql/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mysql-connector-python >= 8.0, < 10.0",
+  "mysql-connector-python >= 8.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/package.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/package.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-_instruments = ("mysql-connector-python >= 8.0, < 10.0",)
+# mysql-connector-python switched to a MySQL Server aligned versioning scheme
+# after 9.7.0 (the next release was 26.7.0), so no upper bound is declared here.
+_instruments = ("mysql-connector-python >= 8.0",)
 
 _semconv_status = "migration"

--- a/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-2.txt
+++ b/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-2.txt
@@ -1,0 +1,15 @@
+asgiref==3.8.1
+Deprecated==1.2.14
+iniconfig==2.0.0
+mysql-connector-python==26.7.0
+packaging==24.0
+pluggy==1.6.0
+py-cpuinfo==9.0.0
+pytest==7.4.4
+tomli==2.0.1
+typing_extensions==4.12.2
+wrapt==1.16.0
+zipp==3.19.2
+-e opentelemetry-instrumentation
+-e instrumentation/opentelemetry-instrumentation-dbapi
+-e instrumentation/opentelemetry-instrumentation-mysql

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -38,10 +38,7 @@ libraries = [
         "library": "kafka-python >= 2.0, < 4.0",
         "instrumentation": "opentelemetry-instrumentation-kafka-python==0.66b0.dev",
     },
-    {
-        "library": "mysql-connector-python >= 8.0, < 10.0",
-        "instrumentation": "opentelemetry-instrumentation-mysql==0.66b0.dev",
-    },
+    {"library": "mysql-connector-python >= 8.0", "instrumentation": "opentelemetry-instrumentation-mysql==0.66b0.dev"},
     {"library": "mysqlclient < 3", "instrumentation": "opentelemetry-instrumentation-mysqlclient==0.66b0.dev"},
     {"library": "pika >= 0.12.0", "instrumentation": "opentelemetry-instrumentation-pika==0.66b0.dev"},
     {"library": "psycopg >= 3.1.0", "instrumentation": "opentelemetry-instrumentation-psycopg==0.66b0.dev"},

--- a/tox.ini
+++ b/tox.ini
@@ -215,8 +215,9 @@ envlist =
     ; below mean these dependencies are being used:
     ; 0: mysql-connector-python >=8.0.0,<9.0.0
     ; 1: mysql-connector-python ~=9.0.0
-    py3{10,11,12,13,14}-test-instrumentation-mysql-{0,1}
-    pypy3-test-instrumentation-mysql-{0,1}
+    ; 2: mysql-connector-python >=26.7.0
+    py3{10,11,12,13,14}-test-instrumentation-mysql-{0,1,2}
+    pypy3-test-instrumentation-mysql-{0,1,2}
     lint-instrumentation-mysql
 
     ; opentelemetry-instrumentation-mysqlclient
@@ -610,7 +611,8 @@ deps =
   mysql: {[testenv]test_deps}
   mysql-0: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-0.txt
   mysql-1: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-1.txt
-  lint-instrumentation-mysql: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-1.txt
+  mysql-2: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-2.txt
+  lint-instrumentation-mysql: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysql/test-requirements-2.txt
 
   mysqlclient: {[testenv]test_deps}
   mysqlclient: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-mysqlclient/test-requirements.txt

--- a/uv.lock
+++ b/uv.lock
@@ -3344,7 +3344,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mysql-connector-python", marker = "extra == 'instruments'", specifier = ">=8.0,<10.0" },
+    { name = "mysql-connector-python", marker = "extra == 'instruments'", specifier = ">=8.0" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
     { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-dbapi", editable = "instrumentation/opentelemetry-instrumentation-dbapi" },


### PR DESCRIPTION
# Description

`mysql-connector-python` switched to a MySQL Server aligned versioning scheme after 9.7.0, so its next
release was 26.7.0. That release contains no functional changes, but it falls outside the declared
`mysql-connector-python >= 8.0, < 10.0` bound, so `MySQLInstrumentor().instrument()` logs a
`DependencyConflict` and silently does nothing.

This drops the upper bound instead of raising it, since any fixed cap will break again on the next
version scheme change. `bootstrap_gen.py` and `instrumentation/README.md` were regenerated with
`tox -e generate`, and the CI workflows with `tox -e generate-workflows`.

Fixes #4921

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added a `mysql-2` test environment pinning `mysql-connector-python==26.7.0` and ran
  `tox -e py312-test-instrumentation-mysql-2` (17 passed). With the old `< 10.0` bound restored, 5 of
  those tests fail with `DependencyConflict: requested: "mysql-connector-python >= 8.0, < 10.0" but
  found: "mysql-connector-python 26.7.0"`, so the new environment covers the regression.
- [x] Ran the existing `tox -e py312-test-instrumentation-mysql-0` and
  `tox -e py312-test-instrumentation-mysql-1` environments (17 passed each).
- [x] Ran `pre-commit run ruff --all-files` and `tox -e lint-instrumentation-mysql`.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added — the existing suite now also runs against 26.7.0 via the new `mysql-2` environment
- [x] Documentation has been updated — the generated supported versions table in `instrumentation/README.md`
