### PR TITLE
opentelemetry-instrumentation-logging: decouple tests from service.name resource attribute

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
+++ b/instrumentation/opentelemetry-instrumentation-logging/tests/test_logging.py
@@ -75,7 +75,7 @@ class TestLoggingInstrumentor(TestBase):
         super().tearDown()
         LoggingInstrumentor().uninstrument()
 
-    def assert_trace_context_injected(self, span_id, trace_id, trace_sampled):
+    def assert_trace_context_injected(self, span_id, trace_id, trace_sampled, resource_attributes):
         with self.caplog.at_level(level=logging.INFO):
             logger = logging.getLogger("test logger")
             logger.info("hello")
@@ -84,7 +84,7 @@ class TestLoggingInstrumentor(TestBase):
             self.assertEqual(record.otelSpanID, span_id)
             self.assertEqual(record.otelTraceID, trace_id)
             self.assertEqual(record.otelTraceSampled, trace_sampled)
-            self.assertEqual(record.otelServiceName, "unknown_service")
+            self.assertEqual(record.otelServiceName, resource_attributes["service.name"])
 
     @mock.patch.dict("os.environ", {"OTEL_PYTHON_LOG_CORRELATION": "true"})
     @mock.patch("logging.basicConfig")
@@ -97,7 +97,7 @@ class TestLoggingInstrumentor(TestBase):
             span_id = format(span_ctx.span_id, "016x")
             trace_id = format(span_ctx.trace_id, "032x")
             trace_sampled = span_ctx.trace_flags.sampled
-            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
+            self.assert_trace_context_injected(span_id, trace_id, trace_sampled, span.resource.attributes)
 
     @mock.patch("logging.basicConfig")
     def test_trace_context_injection_with_log_correlation_instrument_arg(self, basic_config_mock):
@@ -109,7 +109,7 @@ class TestLoggingInstrumentor(TestBase):
             span_id = format(span_ctx.span_id, "016x")
             trace_id = format(span_ctx.trace_id, "032x")
             trace_sampled = span_ctx.trace_flags.sampled
-            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
+            self.assert_trace_context_injected(span_id, trace_id, trace_sampled, span.resource.attributes)
 
     def test_no_trace_context_injection_by_default(self):
         with self.tracer.start_as_current_span("s1"):
@@ -133,21 +133,21 @@ class TestLoggingInstrumentor(TestBase):
             span_id = format(span_ctx.span_id, "016x")
             trace_id = format(span_ctx.trace_id, "032x")
             trace_sampled = span_ctx.trace_flags.sampled
-            self.assert_trace_context_injected(span_id, trace_id, trace_sampled)
+            self.assert_trace_context_injected(span_id, trace_id, trace_sampled, span.resource.attributes)
 
     @mock.patch("logging.basicConfig")
     def test_inject_trace_context_arg_without_span(self, basic_config_mock):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument(inject_trace_context=True)
         basic_config_mock.assert_not_called()
-        self.assert_trace_context_injected("0", "0", False)
+        self.assert_trace_context_injected("0", "0", False, self.tracer.resource.attributes)
 
     @mock.patch("logging.basicConfig")
     def test_trace_context_injection_without_span(self, basic_config_mock):
         LoggingInstrumentor().uninstrument()
         LoggingInstrumentor().instrument(set_logging_format=True)
         basic_config_mock.assert_called_once_with(format=DEFAULT_LOGGING_FORMAT, level=logging.INFO)
-        self.assert_trace_context_injected("0", "0", False)
+        self.assert_trace_context_injected("0", "0", False, self.tracer.resource.attributes)
 
     @mock.patch("logging.basicConfig")
     def test_basic_config_called(self, basic_config_mock):
@@ -225,7 +225,7 @@ class TestLoggingInstrumentor(TestBase):
                 record = self.caplog.records[0]
                 self.assertEqual(record.otelSpanID, span_id)
                 self.assertEqual(record.otelTraceID, trace_id)
-                self.assertEqual(record.otelServiceName, "unknown_service")
+                self.assertEqual(record.otelServiceName, span.resource.attributes["service.name"])
                 self.assertEqual(record.otelTraceSampled, trace_sampled)
                 self.assertEqual(record.custom_user_attribute_from_log_hook, "some-value")
 


### PR DESCRIPTION
# Description

Tests hardcode the service.name value, a PR in core is changing this value and so these tests are failing.

Refs https://github.com/open-telemetry/opentelemetry-python/issues/5544

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
