### PR TITLE
opentelemetry-util-http: don't raise on unparsable request targets

### DIFF
--- a/.changelog/4965.fixed
+++ b/.changelog/4965.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-util-http`: stop `_parse_url_query` raising on unparsable urls

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -656,6 +656,20 @@ class TestTornadoInstrumentation(TornadoTest, WsgiTestBase):
 
         self.memory_exporter.clear()
 
+    def test_invalid_request_uri_does_not_break_request(self):
+        # `request.uri` comes straight off the request line and need not be a
+        # parsable URL. Instrumentation must not change the outcome of such a
+        # request; this target matches no route, so the app answers 404. It
+        # previously became a 500 from urlparse raising in _parse_url_query.
+        response = self.fetch("//exa[mple", raise_error=False)
+
+        self.assertEqual(response.code, 404)
+
+        spans = self.memory_exporter.get_finished_spans()
+        server = next(span for span in spans if span.kind is SpanKind.SERVER)
+        self.assertEqual(server.attributes[HTTP_TARGET], "//exa[mple")
+        self.assertEqual(server.attributes[HTTP_STATUS_CODE], 404)
+
 
 class TestTornadoInstrumentationWithXHeaders(TornadoTest):
     def get_httpserver_options(self):  # pylint: disable=no-self-use

--- a/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
+++ b/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py
@@ -254,8 +254,21 @@ def _parse_duration_attrs(req_attrs):
     return duration_attrs
 
 
-def _parse_url_query(url: str):
-    parsed_url = urlparse(url)
+def _parse_url_query(url: str) -> tuple[str, str]:
+    """Split a url into its path and query components.
+
+    Callers may pass request targets that come straight off the request line,
+    so the url need not be parsable. An unparsable one yields empty components
+    rather than raising, since instrumentation must never break the request it
+    is measuring.
+
+    Returns:
+        The path and the query string, either of which may be empty.
+    """
+    try:
+        parsed_url = urlparse(url)
+    except ValueError:  # an unparsable url was passed
+        return "", ""
     path = parsed_url.path
     query_params = parsed_url.query
     return path, query_params

--- a/util/opentelemetry-util-http/tests/test_parse_url_query.py
+++ b/util/opentelemetry-util-http/tests/test_parse_url_query.py
@@ -1,0 +1,35 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from opentelemetry.util.http import _parse_url_query
+
+
+class TestParseUrlQuery(unittest.TestCase):
+    def test_absolute_url(self):
+        self.assertEqual(
+            _parse_url_query("https://example.com/path?color=blue"),
+            ("/path", "color=blue"),
+        )
+
+    def test_request_target(self):
+        self.assertEqual(_parse_url_query("/path?color=blue"), ("/path", "color=blue"))
+
+    def test_no_query(self):
+        self.assertEqual(_parse_url_query("/path"), ("/path", ""))
+
+    def test_empty_url(self):
+        self.assertEqual(_parse_url_query(""), ("", ""))
+
+    def test_unparsable_url_returns_empty_components(self):
+        # urlparse raises "Invalid IPv6 URL" on an unbalanced bracket in what
+        # it takes to be the netloc. Request targets are attacker controlled,
+        # so this must not propagate out of instrumentation.
+        self.assertEqual(_parse_url_query("//exa[mple"), ("", ""))
+
+    def test_unparsable_url_with_query_returns_empty_components(self):
+        self.assertEqual(_parse_url_query("//exa[mple?color=blue"), ("", ""))
+
+    def test_unparsable_absolute_url_returns_empty_components(self):
+        self.assertEqual(_parse_url_query("http://example.com[invalid"), ("", ""))


### PR DESCRIPTION
# Description

`_parse_url_query` in `opentelemetry-util-http` called `urlparse` on request targets that come
straight off the request line. `urlparse` raises `ValueError` ("Invalid IPv6 URL") on targets such
as `//exa[mple`, and because the exception propagated out of instrumentation, tornado turned those
requests into 500s. It now returns empty components instead.

The components are deliberately not recovered by splitting on `?`: `url.query` is optional under the
semantic conventions, and every current caller sources `url.path` from the framework
(`request.path` in tornado, the route template in asgi), so nothing downstream regresses. Preserving
the query for unparsable targets would be a separate change.

Related to #4447, which was closed by #4551 by avoiding `_parse_url_query` in the WSGI
instrumentation; the same root cause remained in the shared helper for the other callers.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New `util/opentelemetry-util-http/tests/test_parse_url_query.py` covers absolute urls,
      request-target-only urls, no query, empty url, and unparsable urls.
- [x] New tornado regression test `test_invalid_request_uri_does_not_break_request` asserts that
      `//exa[mple` still answers 404 with `http.target` and `http.status_code` set. Reverting the
      helper makes it fail with `500 != 404`.
- [x] `uv run tox -e py313-test-util-http` — 66 passed.
- [x] `uv run tox -e py313-test-instrumentation-tornado` — 46 passed. `test_remove_sensitive_params`
      fails locally because `http_server_mock` cannot bind port 5000; it fails the same way without
      this change.
- [x] `uv run pre-commit run ruff --all-files` and `ruff-format` pass.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
