### PR TITLE
Add semantic-convention conformance test for the Flask instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/test-requirements-3.txt
+++ b/instrumentation/opentelemetry-instrumentation-flask/test-requirements-3.txt
@@ -10,7 +10,10 @@ MarkupSafe==2.1.2
 packaging==24.0
 pluggy==1.6.0
 py-cpuinfo==9.0.0
-pytest==7.4.4
+# The semantic-convention conformance tooling below requires pytest >= 8; this
+# env runs the conformance test case as a normal pytest test, so pytest is
+# bumped here (the older flask envs keep 7.4.4 and simply do not collect it).
+pytest>=8
 tomli==2.0.1
 typing_extensions==4.12.2
 Werkzeug>=3.1.0
@@ -20,3 +23,15 @@ zipp==3.19.2
 -e instrumentation/opentelemetry-instrumentation-wsgi
 -e util/opentelemetry-util-http
 -e instrumentation/opentelemetry-instrumentation-flask
+
+# Semantic-convention conformance tooling, installed from a PINNED commit of the
+# semantic-conventions-conformance repository (it is not published to PyPI). The
+# conformance pytest plugin (from opentelemetry-conformance[pytest]) collects the
+# conformance.yaml in tests/semconv_conformance/ as a normal pytest test, so a
+# semantic-convention violation is an ordinary test failure. The Weaver binary
+# and the pinned registry are provisioned on demand by the test's conftest.
+# Keep the 40-hex commit identical across all four URLs when bumping the pin.
+opentelemetry-conformance[pytest,python] @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/runner
+http-conformance @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/runner
+otel-http-mock-server @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/mock-server
+otel-http-test-client @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/test-client/python

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/README.rst
@@ -1,0 +1,86 @@
+Semantic-convention conformance test (Flask)
+============================================
+
+This directory checks that this repository's own Flask instrumentation emits
+what the OpenTelemetry HTTP semantic conventions require. It runs the same
+conformance machinery as the upstream
+`semantic-conventions-conformance <https://github.com/open-telemetry/semantic-conventions-conformance>`_
+repository, but against the working-tree instrumentation.
+
+It is an ordinary pytest test: it is collected and run by the Flask
+instrumentation's normal test suite, with no special tox environment and no
+special command. Running the Flask tests runs this too, and a
+semantic-convention violation is a normal test failure.
+
+How it works
+------------
+
+- ``server.py`` is the shared HTTP server workload: a Flask app declaring the
+  contract's routes with Flask's own decorators, and nothing else. It is copied
+  from the upstream conformance repo so this instrumentation is measured against
+  the same request contract every language and framework is.
+- ``scenario.py`` turns on exactly one instrumentation (``FlaskInstrumentor``)
+  and serves that app. The instrumentation it imports is this repository's own
+  working-tree package, installed editable by the normal flask test env.
+- ``conformance.yaml`` declares the run: ``runner: http-conformance``, the
+  instrumented and instrumentation library names, the
+  ``OTEL_SEMCONV_STABILITY_OPT_IN=http`` opt-in, and the command that runs the
+  scenario. The ``opentelemetry-conformance`` pytest plugin (registered through
+  its ``pytest11`` entry point when the tooling is installed) collects this
+  ``conformance.yaml`` during normal collection and runs each declared scenario
+  as a pytest test.
+- ``conftest.py`` makes the test self-contained: on the first collection it puts
+  the pinned Weaver binary on ``PATH`` (downloading and caching it if needed)
+  and fetches the pinned semantic-conventions registry into the tooling's cache.
+  If either cannot be obtained (for example offline), it skips the conformance
+  test with a clear reason rather than erroring. Nothing has to be
+  pre-provisioned by hand.
+
+The conformance tooling is not on PyPI, so it is installed from a pinned commit
+of the conformance repository, listed in this package's ``test-requirements-3.txt``
+alongside the other test dependencies (that env's ``pytest`` is bumped to ``>=8``
+because the tooling requires it; the older flask envs keep their pin and simply
+do not collect this test).
+
+Running it
+----------
+
+Just run the flask tests. Locally::
+
+    tox -e py312-test-instrumentation-flask-3
+
+or plain ``pytest`` inside an environment that installed
+``test-requirements-3.txt``::
+
+    pytest instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance
+
+In CI it runs automatically as part of the generated ``test.yml`` matrix for the
+flask-3 environment; no separate workflow.
+
+Adding the next instrumentation
+-------------------------------
+
+This harness is meant to be reused, with the same "normal pytest test" shape. To
+add, for example, ``requests`` (a client instrumentation):
+
+1. Create ``instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/``
+   with a ``scenario.py`` that turns on ``RequestsInstrumentor`` and drives the
+   shared client workload, a ``conformance.yaml`` with
+   ``instrumented_library: requests``,
+   ``instrumentation_library: opentelemetry-instrumentation-requests``, a
+   ``server:`` line running ``http-mock-server --port ${PORT}``, and a
+   ``client`` scenario. Use the Flask files here and the upstream conformance
+   repo's ``requests`` scenario as the templates. A server framework reuses the
+   Flask ``server.py``/``scenario.py`` shape instead.
+2. Copy this directory's ``conftest.py`` into that new directory unchanged (it is
+   generic: it provisions Weaver and the registry for whatever
+   ``conformance.yaml`` is collected beneath it).
+3. Add the four pinned conformance-tooling requirements (identical to the block
+   in this package's ``test-requirements-3.txt``) to one of that instrumentation's
+   normal ``test-requirements*.txt`` files, and bump that file's ``pytest`` to
+   ``>=8``. No new tox environment and no new CI workflow are needed: it runs in
+   that instrumentation's existing test env and the normal ``test.yml`` matrix.
+
+Keep the pinned conformance-repo commit identical across every instrumentation's
+requirements so they are all checked by the same tooling version, and keep the
+Weaver version in ``conftest.py`` in sync with that pin.

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conformance.yaml
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conformance.yaml
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Semantic-convention conformance for this repository's own Flask
+# instrumentation. Collected and run by the conformance pytest plugin
+# (opentelemetry-conformance[pytest]); a semantic-convention violation is a
+# test failure, which is what turns non-compliance into a red CI run.
+#
+# The tooling (opentelemetry-conformance, http-conformance,
+# otel-http-mock-server, otel-http-test-client) is installed from a pinned git
+# ref of the semantic-conventions-conformance repository; see this package's
+# test-requirements-3.txt. The Weaver binary and the pinned registry are
+# provisioned on demand by conftest.py.
+
+runner: http-conformance
+instrumented_library: flask
+instrumentation_library: opentelemetry-instrumentation-flask
+
+env:
+  # Python's HTTP instrumentations still emit the pre-stable attributes by
+  # default, so without this a run measures the old conventions.
+  OTEL_SEMCONV_STABILITY_OPT_IN: http
+
+scenarios:
+  server:
+    # No `uv run --frozen` here, unlike the upstream conformance-repo scenario:
+    # the command runs in the same environment as the flask test suite, which
+    # has this repository's working-tree Flask instrumentation installed
+    # editable, so that in-development instrumentation is the one measured. The
+    # requests are sent from outside the scenario, so a server run holds server
+    # telemetry only; the driver starts this command, chooses the port it binds,
+    # and closes its standard input when it is done.
+    run: otel-http-drive --serve otel-conformance-python scenario.py

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conftest.py
@@ -1,0 +1,195 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Make the conformance test self-contained under plain ``pytest``.
+
+The conformance run shells out to the Weaver binary and checks against a pinned
+semantic-conventions registry. Neither is a Python package, so this conftest
+provisions both on demand the first time the conformance test is collected:
+
+- Weaver: the pinned release is downloaded and cached, and its directory is put
+  on ``PATH`` for this process. If it is already on ``PATH`` at the pinned
+  version, nothing is downloaded.
+- Registry: the pinned semantic-conventions checkout is fetched into the
+  tooling's own cache (the same cache the run uses), so a network failure turns
+  into a clean skip here rather than an error in the middle of the run.
+
+If either genuinely cannot be obtained (for example offline), the conformance
+test is SKIPPED with a clear reason instead of erroring. A developer runs plain
+``pytest`` and it just works; nothing has to be pre-provisioned by hand.
+
+This conftest is deliberately generic: it provisions the tooling for any
+``conformance.yaml`` collected beneath it, so the next instrumentation reuses it
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# The Weaver release the pinned conformance tooling expects. Keep in sync with
+# WEAVER_VERSION in the semantic-conventions-conformance repo the tooling is
+# pinned to (see this package's test-requirements-3.txt).
+_WEAVER_VERSION = "v0.25.1"
+
+# Where the downloaded Weaver binary is cached between runs.
+_WEAVER_CACHE = (
+    Path.home() / ".cache" / "otel-conformance" / "weaver" / _WEAVER_VERSION
+)
+
+# Set by _provision() to a human-readable reason when the conformance test
+# cannot run in this environment; None means it can.
+_skip_reason: str | None = None
+
+
+def _weaver_asset() -> str | None:
+    """The Weaver release asset for this OS/arch, or None if unsupported."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }.get(machine)
+    if arch is None:
+        return None
+    if system == "Linux":
+        return f"weaver-{arch}-unknown-linux-gnu.tar.xz"
+    if system == "Darwin":
+        return f"weaver-{arch}-apple-darwin.tar.xz"
+    return None
+
+
+def _weaver_on_path_version() -> str | None:
+    """The bare version of a ``weaver`` already on PATH, or None."""
+    weaver = shutil.which("weaver")
+    if weaver is None:
+        return None
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [weaver, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    words = completed.stdout.split()
+    return words[-1].lstrip("v") if words else None
+
+
+def _ensure_weaver() -> str | None:
+    """Put the pinned Weaver on PATH, downloading it if needed.
+
+    Returns None on success, or a reason string explaining why it could not be
+    provisioned (used to skip the test).
+    """
+    if _weaver_on_path_version() is not None:
+        # Something usable is already on PATH; let the tooling's own version
+        # check warn if it is not the exact pin.
+        return None
+
+    cached = _WEAVER_CACHE / "weaver"
+    if cached.is_file():
+        os.environ["PATH"] = f"{_WEAVER_CACHE}{os.pathsep}{os.environ['PATH']}"
+        return None
+
+    asset = _weaver_asset()
+    if asset is None:
+        return (
+            f"no Weaver {_WEAVER_VERSION} release asset for this platform "
+            f"({platform.system()} {platform.machine()})"
+        )
+
+    url = (
+        "https://github.com/open-telemetry/weaver/releases/download/"
+        f"{_WEAVER_VERSION}/{asset}"
+    )
+    _WEAVER_CACHE.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / asset
+            with (
+                urllib.request.urlopen(url, timeout=60) as response,  # noqa: S310
+                archive.open("wb") as out,
+            ):
+                shutil.copyfileobj(response, out)
+            with tarfile.open(archive, "r:xz") as tar:
+                member = next(
+                    (m for m in tar.getmembers() if m.name.endswith("/weaver")),
+                    None,
+                )
+                if member is None:
+                    return f"Weaver archive at {url} did not contain a weaver binary"
+                member.name = "weaver"
+                tar.extract(member, _WEAVER_CACHE, filter="data")
+        cached.chmod(cached.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    except (OSError, tarfile.TarError) as error:
+        return f"could not download Weaver {_WEAVER_VERSION} from {url}: {error}"
+
+    os.environ["PATH"] = f"{_WEAVER_CACHE}{os.pathsep}{os.environ['PATH']}"
+    return None
+
+
+def _ensure_registry() -> str | None:
+    """Fetch the pinned semantic-conventions registry into the tooling cache.
+
+    Returns None on success, or a reason string on failure. The HTTP domain
+    package knows which repo and ref to pin, so this reuses its own values and
+    the tooling's own provisioner and cache.
+    """
+    try:
+        from http_conformance import DOMAIN  # noqa: PLC0415
+        from opentelemetry.conformance import provision  # noqa: PLC0415
+    except ImportError as error:
+        return f"conformance tooling is not installed: {error}"
+
+    # The same label the domain itself uses, so the fetch here lands in the very
+    # cache entry the run consumes (rather than fetching the registry twice).
+    label = DOMAIN.repo.rpartition("/")[2]
+    try:
+        provision(DOMAIN.repo, DOMAIN.ref, label=label)
+    except (RuntimeError, OSError) as error:
+        return f"could not fetch the semantic-conventions registry: {error}"
+    return None
+
+
+def _provision() -> None:
+    """Provision Weaver and the registry once, recording any skip reason."""
+    global _skip_reason
+    reason = _ensure_weaver()
+    if reason is not None:
+        _skip_reason = reason
+        return
+    _skip_reason = _ensure_registry()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Runs once per session, before the conformance items execute. Provisioning
+    # here (rather than in a fixture) is what lets the plugin-generated
+    # conformance items — which take no fixtures — still find Weaver on PATH.
+    _provision()
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    # Skip only the conformance items (the ones the conformance plugin makes
+    # from a conformance.yaml), and only when provisioning failed. Ordinary
+    # tests collected nearby are untouched.
+    if _skip_reason is None:
+        return
+    if type(item).__name__ == "ConformanceItem":
+        pytest.skip(_skip_reason)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/conftest.py
@@ -39,7 +39,11 @@ import pytest
 
 # The Weaver release the pinned conformance tooling expects. Keep in sync with
 # WEAVER_VERSION in the semantic-conventions-conformance repo the tooling is
-# pinned to (see this package's test-requirements-3.txt).
+# pinned to (the pin lives in this package's test-requirements).
+#
+# This file is the shared conformance harness: it is intended to be byte-for-byte
+# identical across every instrumentation's tests/semconv_conformance/conftest.py.
+# When changing it, copy the change to the others.
 _WEAVER_VERSION = "v0.25.1"
 
 # Where the downloaded Weaver binary is cached between runs.

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/scenario.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/scenario.py
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serves the shared Flask app with the Flask instrumentation attached.
+
+``otel-conformance-python`` installs the SDK and nothing else, so this is where
+the one instrumentation under test is turned on: explicitly, the way an
+application using library instrumentation does. The instrumentation imported
+here is this repository's own working-tree
+``opentelemetry-instrumentation-flask`` (installed editable by the tox
+environment that runs this scenario), so the conformance run measures the
+in-development instrumentation, not a released pin.
+
+``otel-http-drive`` runs this from its own process and sends the contract at it
+from outside, so nothing loaded here can instrument the sender.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from flask import Flask
+
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from otel_http_test_client import serve
+
+# The shared Flask app is a sibling module. Import it by path so the scenario
+# runs the same whether or not the caller exported a PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from server import create_app  # noqa: E402
+
+
+def instrumented() -> Flask:
+    app = create_app()
+    FlaskInstrumentor().instrument_app(app)
+    return app
+
+
+serve(instrumented)

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/server.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/server.py
@@ -1,0 +1,57 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Flask application the conformance scenario serves.
+
+This is the shared HTTP server workload from the semantic-conventions
+conformance repository, kept identical here so this instrumentation is measured
+against the same request contract every other language and framework is. See
+https://github.com/open-telemetry/semantic-conventions-conformance
+(``scenarios/http/python/flask/scenarios/server.py``).
+
+Nothing here turns instrumentation on, and nothing here may: naming one would
+defeat the sharing. The routes are declared with Flask's own decorators because
+that declaration is what an instrumentation reads ``http.route`` from. Answering
+them goes through the contract's ``respond`` rather than a second copy of the
+statuses and bodies.
+"""
+
+from __future__ import annotations
+
+from flask import Flask, Response, request
+
+from otel_http_test_client import CONTENT_TYPE, respond
+
+
+def create_app() -> Flask:
+    """Build the app, with nothing attached to it.
+
+    A function rather than a module-level app, so the caller decides when it is
+    constructed: an instrumentation that wraps an app has to be installed with
+    the SDK already in place.
+    """
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health() -> Response:
+        return _answer()
+
+    @app.get("/users/<user_id>")
+    def user(user_id: str) -> Response:
+        return _answer()
+
+    @app.post("/items")
+    def items() -> Response:
+        return _answer()
+
+    @app.get("/status/<code>")
+    def status(code: str) -> Response:
+        return _answer()
+
+    return app
+
+
+def _answer() -> Response:
+    body = request.get_data(as_text=True) or None
+    status, payload = respond(request.method, request.path, body)
+    return Response(payload, status=status, content_type=CONTENT_TYPE)


### PR DESCRIPTION
## Description

Adds a semantic-convention conformance test for the Flask instrumentation. It runs as an ordinary `pytest` test in the Flask instrumentation's existing test suite (no separate tox environment or workflow): the test drives the Flask instrumentation over a defined set of HTTP requests and checks that the emitted telemetry conforms to the HTTP semantic conventions. A convention violation is a normal test failure.

The check reuses the tooling from `open-telemetry/semantic-conventions-conformance` (the generic runner, the HTTP domain runner, the mock server, and the HTTP test client) via its pytest plugin, which collects the `conformance.yaml` and turns each scenario into a pytest item. The telemetry is validated with Weaver against a pinned semantic-conventions registry.

This is the first of a planned series: the intent is to add semantic-convention conformance tests to the Python instrumentations where this kind of testing applies, one at a time, with Flask first.

### What it adds

- `instrumentation/opentelemetry-instrumentation-flask/tests/semconv_conformance/`: a shared Flask app, a scenario that enables `FlaskInstrumentor`, a `conformance.yaml`, and a `conftest.py` that provisions the Weaver binary and the pinned registry on demand (and skips with a clear reason if they cannot be obtained, for example offline).
- The four conformance tooling packages added to the Flask instrumentation's `test-requirements-3.txt` (and `pytest>=8`, which the tooling requires). Older Flask test environments do not install the plugin and simply do not collect the file.

### Draft status and open points

This is a draft for discussion. Known points:

- The conformance tooling is not yet published to a package index, so it is currently installed from a pinned Git ref of the conformance repository. This would move to a released dependency once the tooling is published.
- The test currently runs in the newest Flask test environment only.

Feedback on placement and on the overall approach is welcome.
