### PR TITLE
Add semantic-convention conformance test for the requests instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-requests/test-requirements.txt
@@ -8,7 +8,10 @@ iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
 py-cpuinfo==9.0.0
-pytest==7.4.4
+# The semantic-convention conformance tooling below requires pytest >= 8; the
+# requests test suite runs the conformance test case as a normal pytest test,
+# so pytest is bumped here.
+pytest>=8
 requests==2.33.1
 tomli==2.0.1
 typing_extensions==4.12.2
@@ -18,3 +21,16 @@ zipp==3.19.2
 -e opentelemetry-instrumentation
 -e util/opentelemetry-util-http
 -e instrumentation/opentelemetry-instrumentation-requests
+
+# Semantic-convention conformance tooling, installed from a PINNED commit of the
+# semantic-conventions-conformance repository (it is not published to PyPI). The
+# conformance pytest plugin (from opentelemetry-conformance[pytest]) collects the
+# conformance.yaml in tests/semconv_conformance/ as a normal pytest test, so a
+# semantic-convention violation is an ordinary test failure. The Weaver binary
+# and the pinned registry are provisioned on demand by the test's conftest.
+# Keep the 40-hex commit identical with the other instrumentations' conformance
+# requirements so they are all checked by the same tooling version.
+opentelemetry-conformance[pytest,python] @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/runner
+http-conformance @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/runner
+otel-http-mock-server @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/mock-server
+otel-http-test-client @ git+https://github.com/open-telemetry/semantic-conventions-conformance.git@f4b190bce26af05a6e9cf697a1fb3f87708fa916#subdirectory=tools/http/test-client/python

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/README.rst
@@ -1,0 +1,76 @@
+Semantic-convention conformance test (requests)
+===============================================
+
+This directory checks that this repository's own ``requests`` instrumentation
+emits what the OpenTelemetry HTTP semantic conventions require. It runs the same
+conformance machinery as the upstream
+`semantic-conventions-conformance <https://github.com/open-telemetry/semantic-conventions-conformance>`_
+repository, but against the working-tree instrumentation.
+
+It is an ordinary pytest test: it is collected and run by the requests
+instrumentation's normal test suite, with no special tox environment and no
+special command. Running the requests tests runs this too, and a
+semantic-convention violation is a normal test failure.
+
+Client vs server
+----------------
+
+``requests`` is an HTTP *client*, so this scenario differs from the Flask one
+(which is a server):
+
+- ``conformance.yaml`` declares a ``server:`` that runs the shared mock HTTP
+  server (``http-mock-server``). The runner starts it, chooses its port, and
+  publishes its base URL to the scenario as ``MOCK_SERVER_URL``.
+- ``client.py`` is the shared client workload: it drives the contract's request
+  sequence at that mock server, using this library's own ``requests.Session``.
+  It turns on no instrumentation.
+- ``scenario.py`` turns on exactly one instrumentation
+  (``RequestsInstrumentor``) and runs the workload. The instrumentation it
+  imports is this repository's own working-tree package.
+- There is no ``otel-http-drive --serve`` wrapper here (that is for a server
+  scenario, where the driver sends requests at the framework under test from
+  outside its process). A client scenario is itself the sender.
+
+Everything else is the same as the Flask conformance test.
+
+Shared harness
+--------------
+
+``conftest.py`` is the shared conformance harness: it puts the pinned Weaver
+binary on ``PATH`` (downloading and caching it if needed) and fetches the pinned
+semantic-conventions registry on demand, and skips the conformance test with a
+clear reason if either cannot be obtained (for example offline). It is
+byte-for-byte identical to the ``conftest.py`` under every other
+instrumentation's ``tests/semconv_conformance/``. When changing it, copy the
+change to the others.
+
+The conformance tooling is not on PyPI, so it is installed from a pinned commit
+of the conformance repository, listed in this package's ``test-requirements.txt``
+alongside the other test dependencies (``pytest`` is bumped to ``>=8`` because
+the tooling requires it).
+
+Running it
+----------
+
+Just run the requests tests. Locally::
+
+    tox -e py312-test-instrumentation-requests
+
+or plain ``pytest`` inside an environment that installed
+``test-requirements.txt``::
+
+    pytest instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance
+
+In CI it runs automatically as part of the generated ``test.yml`` matrix for the
+requests environment; no separate workflow.
+
+Adding the next instrumentation
+-------------------------------
+
+Copy this directory's ``conftest.py`` unchanged, add a ``scenario.py`` +
+``conformance.yaml`` (server-shaped like Flask or client-shaped like this one),
+add the four pinned conformance-tooling requirements and ``pytest>=8`` to that
+instrumentation's existing ``test-requirements``. No new tox environment and no
+new CI workflow are needed. Keep the pinned conformance-repo commit identical
+across every instrumentation, and keep the Weaver version in ``conftest.py`` in
+sync with that pin.

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/client.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/client.py
@@ -1,0 +1,54 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The requests workload the conformance scenario sends.
+
+This is the shared HTTP client workload from the semantic-conventions
+conformance repository, kept identical here so this instrumentation is measured
+against the same request contract every other language and framework is. See
+https://github.com/open-telemetry/semantic-conventions-conformance
+(``scenarios/http/python/requests/scenarios/client.py``).
+
+Nothing here turns instrumentation on, and nothing here may: naming one would
+defeat the sharing. Only the send is this library's; the sequence, the answers,
+and the checking are the contract's, so a client is measured against exactly
+what a server scenario would have answered.
+"""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+from otel_http_test_client import CONTENT_TYPE, USER_AGENT, drive
+
+
+def run() -> None:
+    """Send the contract at the mock server the runner started."""
+    base_url = os.environ.get("MOCK_SERVER_URL")
+    if not base_url:
+        raise RuntimeError(
+            "MOCK_SERVER_URL is not set — the runner publishes it for the "
+            "server the package declares"
+        )
+
+    # One session for the whole sequence, so the requests share a connection
+    # the way an application's would.
+    with requests.Session() as session:
+
+        def send(method: str, url: str, body: str | None) -> tuple[int, str]:
+            headers = {"User-Agent": USER_AGENT}
+            if body is not None:
+                headers["Content-Type"] = CONTENT_TYPE
+            # A 4xx or 5xx is what the contract asked for, so it comes back as a
+            # status: requests raises for one only when told to.
+            response = session.request(
+                method,
+                url,
+                data=None if body is None else body.encode("utf-8"),
+                headers=headers,
+            )
+            return response.status_code, response.text
+
+        drive(base_url, send)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/conformance.yaml
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/conformance.yaml
@@ -1,0 +1,40 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Semantic-convention conformance for this repository's own requests
+# instrumentation. Collected and run by the conformance pytest plugin
+# (opentelemetry-conformance[pytest]); a semantic-convention violation is a
+# test failure, which is what turns non-compliance into a red CI run.
+#
+# requests is an HTTP client, so unlike the Flask (server) scenario this
+# declares a mock server for the client to call: the runner starts
+# http-mock-server, publishes its address as MOCK_SERVER_URL, and the client
+# scenario drives the shared workload at it.
+#
+# The tooling (opentelemetry-conformance, http-conformance,
+# otel-http-mock-server, otel-http-test-client) is installed from a pinned git
+# ref of the semantic-conventions-conformance repository; see this package's
+# test-requirements.txt. The Weaver binary and the pinned registry are
+# provisioned on demand by conftest.py.
+
+runner: http-conformance
+instrumented_library: requests
+instrumentation_library: opentelemetry-instrumentation-requests
+
+env:
+  # Python's HTTP instrumentations still emit the pre-stable attributes by
+  # default, so without this a run measures the old conventions.
+  OTEL_SEMCONV_STABILITY_OPT_IN: http
+
+server:
+  # The runner substitutes ${PORT} and publishes the base URL as
+  # MOCK_SERVER_URL for the client scenario.
+  run: http-mock-server --port ${PORT}
+
+scenarios:
+  client:
+    # No `uv run --frozen` here, unlike the upstream conformance-repo scenario:
+    # the command runs in the same environment as the requests test suite, which
+    # has this repository's working-tree requests instrumentation installed
+    # editable, so that in-development instrumentation is the one measured.
+    run: otel-conformance-python scenario.py

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/conftest.py
@@ -1,0 +1,199 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Make the conformance test self-contained under plain ``pytest``.
+
+The conformance run shells out to the Weaver binary and checks against a pinned
+semantic-conventions registry. Neither is a Python package, so this conftest
+provisions both on demand the first time the conformance test is collected:
+
+- Weaver: the pinned release is downloaded and cached, and its directory is put
+  on ``PATH`` for this process. If it is already on ``PATH`` at the pinned
+  version, nothing is downloaded.
+- Registry: the pinned semantic-conventions checkout is fetched into the
+  tooling's own cache (the same cache the run uses), so a network failure turns
+  into a clean skip here rather than an error in the middle of the run.
+
+If either genuinely cannot be obtained (for example offline), the conformance
+test is SKIPPED with a clear reason instead of erroring. A developer runs plain
+``pytest`` and it just works; nothing has to be pre-provisioned by hand.
+
+This conftest is deliberately generic: it provisions the tooling for any
+``conformance.yaml`` collected beneath it, so the next instrumentation reuses it
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# The Weaver release the pinned conformance tooling expects. Keep in sync with
+# WEAVER_VERSION in the semantic-conventions-conformance repo the tooling is
+# pinned to (the pin lives in this package's test-requirements).
+#
+# This file is the shared conformance harness: it is intended to be byte-for-byte
+# identical across every instrumentation's tests/semconv_conformance/conftest.py.
+# When changing it, copy the change to the others.
+_WEAVER_VERSION = "v0.25.1"
+
+# Where the downloaded Weaver binary is cached between runs.
+_WEAVER_CACHE = (
+    Path.home() / ".cache" / "otel-conformance" / "weaver" / _WEAVER_VERSION
+)
+
+# Set by _provision() to a human-readable reason when the conformance test
+# cannot run in this environment; None means it can.
+_skip_reason: str | None = None
+
+
+def _weaver_asset() -> str | None:
+    """The Weaver release asset for this OS/arch, or None if unsupported."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }.get(machine)
+    if arch is None:
+        return None
+    if system == "Linux":
+        return f"weaver-{arch}-unknown-linux-gnu.tar.xz"
+    if system == "Darwin":
+        return f"weaver-{arch}-apple-darwin.tar.xz"
+    return None
+
+
+def _weaver_on_path_version() -> str | None:
+    """The bare version of a ``weaver`` already on PATH, or None."""
+    weaver = shutil.which("weaver")
+    if weaver is None:
+        return None
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [weaver, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    words = completed.stdout.split()
+    return words[-1].lstrip("v") if words else None
+
+
+def _ensure_weaver() -> str | None:
+    """Put the pinned Weaver on PATH, downloading it if needed.
+
+    Returns None on success, or a reason string explaining why it could not be
+    provisioned (used to skip the test).
+    """
+    if _weaver_on_path_version() is not None:
+        # Something usable is already on PATH; let the tooling's own version
+        # check warn if it is not the exact pin.
+        return None
+
+    cached = _WEAVER_CACHE / "weaver"
+    if cached.is_file():
+        os.environ["PATH"] = f"{_WEAVER_CACHE}{os.pathsep}{os.environ['PATH']}"
+        return None
+
+    asset = _weaver_asset()
+    if asset is None:
+        return (
+            f"no Weaver {_WEAVER_VERSION} release asset for this platform "
+            f"({platform.system()} {platform.machine()})"
+        )
+
+    url = (
+        "https://github.com/open-telemetry/weaver/releases/download/"
+        f"{_WEAVER_VERSION}/{asset}"
+    )
+    _WEAVER_CACHE.mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / asset
+            with (
+                urllib.request.urlopen(url, timeout=60) as response,  # noqa: S310
+                archive.open("wb") as out,
+            ):
+                shutil.copyfileobj(response, out)
+            with tarfile.open(archive, "r:xz") as tar:
+                member = next(
+                    (m for m in tar.getmembers() if m.name.endswith("/weaver")),
+                    None,
+                )
+                if member is None:
+                    return f"Weaver archive at {url} did not contain a weaver binary"
+                member.name = "weaver"
+                tar.extract(member, _WEAVER_CACHE, filter="data")
+        cached.chmod(cached.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    except (OSError, tarfile.TarError) as error:
+        return f"could not download Weaver {_WEAVER_VERSION} from {url}: {error}"
+
+    os.environ["PATH"] = f"{_WEAVER_CACHE}{os.pathsep}{os.environ['PATH']}"
+    return None
+
+
+def _ensure_registry() -> str | None:
+    """Fetch the pinned semantic-conventions registry into the tooling cache.
+
+    Returns None on success, or a reason string on failure. The HTTP domain
+    package knows which repo and ref to pin, so this reuses its own values and
+    the tooling's own provisioner and cache.
+    """
+    try:
+        from http_conformance import DOMAIN  # noqa: PLC0415
+        from opentelemetry.conformance import provision  # noqa: PLC0415
+    except ImportError as error:
+        return f"conformance tooling is not installed: {error}"
+
+    # The same label the domain itself uses, so the fetch here lands in the very
+    # cache entry the run consumes (rather than fetching the registry twice).
+    label = DOMAIN.repo.rpartition("/")[2]
+    try:
+        provision(DOMAIN.repo, DOMAIN.ref, label=label)
+    except (RuntimeError, OSError) as error:
+        return f"could not fetch the semantic-conventions registry: {error}"
+    return None
+
+
+def _provision() -> None:
+    """Provision Weaver and the registry once, recording any skip reason."""
+    global _skip_reason
+    reason = _ensure_weaver()
+    if reason is not None:
+        _skip_reason = reason
+        return
+    _skip_reason = _ensure_registry()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Runs once per session, before the conformance items execute. Provisioning
+    # here (rather than in a fixture) is what lets the plugin-generated
+    # conformance items — which take no fixtures — still find Weaver on PATH.
+    _provision()
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    # Skip only the conformance items (the ones the conformance plugin makes
+    # from a conformance.yaml), and only when provisioning failed. Ordinary
+    # tests collected nearby are untouched.
+    if _skip_reason is None:
+        return
+    if type(item).__name__ == "ConformanceItem":
+        pytest.skip(_skip_reason)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/scenario.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/scenario.py
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sends the shared requests workload with the requests instrumentation on.
+
+``otel-conformance-python`` installs the SDK and nothing else, so this is where
+the one instrumentation under test is turned on: explicitly, the way an
+application using library instrumentation does. The instrumentation imported
+here is this repository's own working-tree
+``opentelemetry-instrumentation-requests`` (installed editable by the test env
+that runs this scenario), so the conformance run measures the in-development
+instrumentation, not a released pin.
+
+Unlike the Flask server scenario, this is a client: the runner starts the mock
+HTTP server (declared under ``server:`` in conformance.yaml) and publishes its
+address as ``MOCK_SERVER_URL``; the workload drives ``requests`` at it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+# The shared client workload is a sibling module. Import it by path so the
+# scenario runs the same whether or not the caller exported a PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from client import run  # noqa: E402
+
+RequestsInstrumentor().instrument()
+run()


### PR DESCRIPTION
## Description

Adds a semantic-convention conformance test for the `requests` instrumentation, the HTTP-client counterpart of the Flask (server) conformance test in #4966. It runs as an ordinary `pytest` test in the `requests` instrumentation's existing test suite (no separate tox environment or workflow): the test drives the `requests` instrumentation over a defined set of HTTP requests against a mock server and checks that the emitted telemetry conforms to the HTTP semantic conventions. A convention violation is a normal test failure.

The check reuses the tooling from `open-telemetry/semantic-conventions-conformance` (the generic runner, the HTTP domain runner, the mock server, and the HTTP test client) via its pytest plugin, which collects the `conformance.yaml` and turns each scenario into a pytest item. The telemetry is validated with Weaver against a pinned semantic-conventions registry.

This is the second instrumentation in a planned series (Flask was first, in #4966): the intent is to add semantic-convention conformance tests to the Python instrumentations where this kind of testing applies, one at a time.

### Shared harness / code reuse

The Weaver-and-registry provisioning `conftest.py` is a shared harness kept byte-for-byte identical across instrumentations (the same file as in #4966). Only the per-instrumentation parts differ: the scenario (which turns on `RequestsInstrumentor`), the `conformance.yaml` (client shape: it starts the HTTP mock server and runs a client scenario), the client workload, and the pinned tooling lines added to this package's `test-requirements.txt`.

### What it adds

- `instrumentation/opentelemetry-instrumentation-requests/tests/semconv_conformance/`: a client workload that drives the shared request contract with a `requests.Session`, a scenario that enables `RequestsInstrumentor`, a `conformance.yaml` (client scenario plus a `server:` block that runs the mock server), and the shared `conftest.py`.
- The four conformance tooling packages added to the `requests` instrumentation's `test-requirements.txt` (and `pytest>=8`, which the tooling requires).

### Draft status and open points

This is a draft for discussion. Known points, same as #4966:

- The conformance tooling is not yet published to a package index, so it is currently installed from a pinned Git ref of the conformance repository. This would move to a released dependency once the tooling is published.
- The long-term way to remove the duplicated `conftest.py` is to move the provisioning upstream into the conformance tooling itself.

Feedback on the approach is welcome.
