### PR TITLE
docs: document OTEL_SEMCONV_STABILITY_OPT_IN in database instrumentations

### DIFF
--- a/.changelog/4980.added
+++ b/.changelog/4980.added
@@ -1,0 +1,1 @@
+Document database semantic convention opt-in values in database instrumentation modules.

--- a/instrumentation/opentelemetry-instrumentation-aiopg/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-aiopg
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiopg/src/opentelemetry/instrumentation/aiopg/__init__.py
@@ -66,6 +66,25 @@ Usage
 
     asyncio.run(go())
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/README.rst
@@ -16,6 +16,16 @@ Installation
 
      pip install opentelemetry-instrumentation-asyncpg
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asyncpg/src/opentelemetry/instrumentation/asyncpg/__init__.py
@@ -36,6 +36,25 @@ Run instrumented code:
 
     asyncio.run(main())
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-cassandra/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/README.rst
@@ -17,6 +17,16 @@ Installation
     pip install opentelemetry-instrumentation-cassandra
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry Cassandra Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/cassandra/cassandra.html>`_

--- a/instrumentation/opentelemetry-instrumentation-cassandra/src/opentelemetry/instrumentation/cassandra/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-cassandra/src/opentelemetry/instrumentation/cassandra/__init__.py
@@ -22,6 +22,25 @@ Usage
     session = cluster.connect()
     rows = session.execute("SELECT * FROM test")
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-dbapi/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-dbapi
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -152,6 +152,25 @@ will also be configured by this setting.
     )
 
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-mysql/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-mysql/README.rst
@@ -18,6 +18,16 @@ Installation
     pip install opentelemetry-instrumentation-mysql
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry MySQL Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/mysql/mysql.html>`_

--- a/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysql/src/opentelemetry/instrumentation/mysql/__init__.py
@@ -134,6 +134,25 @@ will also be configured by this setting.
 Warning:
     Capture of sqlcomment in ``db.statement``/``db.query.text`` may have high cardinality without platform normalization. See `Semantic Conventions for database spans <https://opentelemetry.io/docs/specs/semconv/database/database-spans/#generating-a-summary-of-the-query-text>`_ for more information.
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-mysqlclient
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry mysqlclient Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/mysqlclient/mysqlclient.html>`_

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -119,6 +119,25 @@ setting.
 Warning:
     Capture of sqlcomment in ``db.statement``/``db.query.text`` may have high cardinality without platform normalization. See `Semantic Conventions for database spans <https://opentelemetry.io/docs/specs/semconv/database/database-spans/#generating-a-summary-of-the-query-text>`_ for more information.
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-psycopg/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-psycopg
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry Psycopg Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/psycopg/psycopg.html>`_

--- a/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg/src/opentelemetry/instrumentation/psycopg/__init__.py
@@ -133,6 +133,25 @@ will also be configured by this setting.
 Warning:
     Capture of sqlcomment in ``db.statement``/``db.query.text`` may have high cardinality without platform normalization. See `Semantic Conventions for database spans <https://opentelemetry.io/docs/specs/semconv/database/database-spans/#generating-a-summary-of-the-query-text>`_ for more information.
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-psycopg2
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry Psycopg2 Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/psycopg2/psycopg2.html>`_

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/src/opentelemetry/instrumentation/psycopg2/__init__.py
@@ -145,6 +145,25 @@ To capture query parameters in the span attribute `db.statement.parameters`, ena
         capture_parameters=True,
     )
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-pymemcache
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry Pymemcache Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/pymemcache/pymemcache.html>`_

--- a/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-pymongo
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry pymongo Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/pymongo/pymongo.html>`_

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -21,6 +21,25 @@ Usage
     collection = db["MongoDB_Collection"]
     collection.find_one()
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 The `instrument` method accepts the following keyword args:

--- a/instrumentation/opentelemetry-instrumentation-pymssql/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymssql/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-pymssql
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry pymssql Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/pymssql/pymssql.html>`_

--- a/instrumentation/opentelemetry-instrumentation-pymssql/src/opentelemetry/instrumentation/pymssql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymssql/src/opentelemetry/instrumentation/pymssql/__init__.py
@@ -40,6 +40,25 @@ Usage
     cursor.close()
     instrumented_cnx.close()
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 The `instrument` method accepts the following keyword args:

--- a/instrumentation/opentelemetry-instrumentation-pymysql/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-pymysql
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry PyMySQL Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/pymysql/pymysql.html>`_

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -142,6 +142,25 @@ will also be configured by this setting.
 Warning:
     Capture of sqlcomment in ``db.statement``/``db.query.text`` may have high cardinality without platform normalization. See `Semantic Conventions for database spans <https://opentelemetry.io/docs/specs/semconv/database/database-spans/#generating-a-summary-of-the-query-text>`_ for more information.
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-redis/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-redis/README.rst
@@ -15,6 +15,16 @@ Installation
 
     pip install opentelemetry-instrumentation-redis
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/README.rst
@@ -16,6 +16,16 @@ Installation
     pip install opentelemetry-instrumentation-sqlalchemy
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/__init__.py
@@ -118,6 +118,25 @@ will also be configured by this setting.
 Warning:
     Capture of sqlcomment in ``db.statement``/``db.query.text`` may have high cardinality without platform normalization. See `Semantic Conventions for database spans <https://opentelemetry.io/docs/specs/semconv/database/database-spans/#generating-a-summary-of-the-query-text>`_ for more information.
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/README.rst
@@ -14,6 +14,16 @@ Installation
     pip install opentelemetry-instrumentation-sqlite3
 
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 * `OpenTelemetry SQLite3 Instrumentation <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/sqlite3/sqlite3.html>`_

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/src/opentelemetry/instrumentation/sqlite3/__init__.py
@@ -41,6 +41,25 @@ Usage
     cursor.close()
     instrumented_connection.close()
 
++Stable Semantic Conventions
+***************************
+
+This instrumentation supports the database semantic convention migration plan.
+You can control which conventions are emitted by setting the
+``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable to one of these values:
+
+- ``database`` - emit the stable database conventions and stop emitting the
+  old experimental conventions.
+- ``database/dup`` - emit both the old experimental and stable database
+  conventions during a transition period.
+
+The environment variable accepts a comma-separated list of opt-in values. For
+example, ``database,http/dup`` enables stable database conventions and emits
+both old and stable HTTP conventions.
+
+By default, when the environment variable is not set, the old experimental
+database conventions are emitted.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-tortoiseorm/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-tortoiseorm/README.rst
@@ -15,6 +15,16 @@ Installation
 
      pip install opentelemetry-instrumentation-tortoiseorm
 
+Configuration
+-------------
+
+You can configure the semantic conventions emitted by this instrumentation via the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable:
+
+- ``database`` - emit the new, stable db conventions, and stop emitting the old experimental db conventions that the instrumentation emitted previously.
+- ``database/dup`` - emit both the old and the stable db conventions, allowing for a seamless transition.
+
+By default, the old experimental db conventions are emitted.
+
 References
 ----------
 


### PR DESCRIPTION
# Description

Documents the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable in the
READMEs of the 16 database instrumentation packages that support it
(added in release 1.44.0/0.65b0):

- `database` - emit the new, stable db conventions only
- `database/dup` - emit both old and stable db conventions

By default the old experimental db conventions are emitted.

Fixes #4980

## Type of change

- [ ] This change requires a documentation update

# How Has This Been Tested?

- rstcheck and full pre-commit pass on all 16 changed READMEs (ran locally).

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated (docs-only: fragment not required per CONTRIBUTING.md; "Skip Changelog" label added)
- [ ] Unit tests have been added
- [x] Documentation has been updated
