### PR TITLE
opentelemetry-instrumentation-tornado: do not unpatch a handler class that only inherits the patched marker

### DIFF
--- a/.changelog/5001.fixed
+++ b/.changelog/5001.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-tornado`: stop `unpatch_handler_class` raising `AttributeError` on a subclass of a patched handler

--- a/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/src/opentelemetry/instrumentation/tornado/__init__.py
@@ -527,7 +527,11 @@ def patch_handler_class(
 
 
 def unpatch_handler_class(cls):
-    if not getattr(cls, _OTEL_PATCHED_KEY, False):
+    # Look at the class' own __dict__ instead of using getattr, which would
+    # also find the marker on a base class. A subclass of a patched class
+    # inherits the marker but owns neither it nor the wrapped methods, so
+    # there is nothing to undo on it.
+    if _OTEL_PATCHED_KEY not in cls.__dict__:
         return
 
     unwrap(cls, "prepare")

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -17,6 +17,7 @@ from opentelemetry.instrumentation.propagators import (
     set_global_response_propagator,
 )
 from opentelemetry.instrumentation.tornado import (
+    _OTEL_PATCHED_KEY,
     TornadoInstrumentor,
     patch_handler_class,
     unpatch_handler_class,
@@ -120,6 +121,26 @@ class TestTornadoInstrumentor(TornadoTest):
         self.assertTrue(patch_handler_class(tracer, {}, AsyncHandler))
         self.assertFalse(patch_handler_class(tracer, {}, AsyncHandler))
         self.assertFalse(patch_handler_class(tracer, {}, AsyncHandler))
+        unpatch_handler_class(AsyncHandler)
+
+    def test_unpatch_subclass_of_patched_class_is_a_noop(self):
+        tracer = trace.get_tracer(__name__)
+        self.assertTrue(patch_handler_class(tracer, {}, AsyncHandler))
+
+        # pylint: disable=abstract-method
+        class SubclassOfAsyncHandler(AsyncHandler):
+            pass
+
+        # The subclass only inherits the patched marker, it does not own it,
+        # so unpatching the subclass must do nothing instead of raising
+        # AttributeError.
+        unpatch_handler_class(SubclassOfAsyncHandler)
+
+        self.assertNotIn(_OTEL_PATCHED_KEY, SubclassOfAsyncHandler.__dict__)
+        # The base class must still be patched and still own the marker.
+        self.assertIn(_OTEL_PATCHED_KEY, AsyncHandler.__dict__)
+        self.assertFalse(patch_handler_class(tracer, {}, AsyncHandler))
+
         unpatch_handler_class(AsyncHandler)
 
 


### PR DESCRIPTION
Fixes #3072

`unpatch_handler_class` decided whether a class was patched using
`getattr(cls, _OTEL_PATCHED_KEY, False)`, which walks the inheritance chain.
When a handler class was patched and a subclass of it was not, that check
returned `True` for the subclass, the function continued, and
`delattr(cls, _OTEL_PATCHED_KEY)` raised `AttributeError`, because the marker
attribute lives on the base class and not on the subclass.

The check now looks at `cls.__dict__` directly, so a class that only inherits
the marker returns early and is left alone.

`patch_handler_class` deliberately keeps using `getattr`. Skipping a subclass
whose base class is already patched is correct there, because the subclass
inherits the wrapped methods and has nothing of its own to patch.

Added a test that subclasses a patched handler, unpatches the subclass, and
asserts that no exception is raised and that the base class stays patched. It
fails with `AttributeError` without the fix.