### PR TITLE
Fix losing celery spans when worker_max_tasks_per_child recycles the pool child

### DIFF
--- a/.changelog/5003.fixed
+++ b/.changelog/5003.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-celery`: flush tracer and meter providers when a worker process shuts down so spans are not lost when `worker_max_tasks_per_child` recycles the pool child

--- a/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/src/opentelemetry/instrumentation/celery/__init__.py
@@ -75,7 +75,7 @@ from opentelemetry.instrumentation.celery import utils
 from opentelemetry.instrumentation.celery.package import _instruments
 from opentelemetry.instrumentation.celery.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.metrics import get_meter
+from opentelemetry.metrics import get_meter, get_meter_provider
 from opentelemetry.propagate import extract, inject
 from opentelemetry.propagators.textmap import Getter
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
@@ -139,6 +139,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         use_span_links = kwargs.get("use_span_links", False)
 
+        self._tracer_provider = tracer_provider or trace.get_tracer_provider()
         self._tracer = trace.get_tracer(
             __name__,
             __version__,
@@ -148,6 +149,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         self._use_span_links = use_span_links
 
         meter_provider = kwargs.get("meter_provider")
+        self._meter_provider = meter_provider or get_meter_provider()
         meter = get_meter(
             __name__,
             __version__,
@@ -164,6 +166,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         signals.after_task_publish.connect(self._trace_after_publish, weak=False)
         signals.task_failure.connect(self._trace_failure, weak=False)
         signals.task_retry.connect(self._trace_retry, weak=False)
+        signals.worker_process_shutdown.connect(self._flush_providers, weak=False)
 
     def _uninstrument(self, **kwargs):
         signals.task_prerun.disconnect(self._trace_prerun)
@@ -172,6 +175,7 @@ class CeleryInstrumentor(BaseInstrumentor):
         signals.after_task_publish.disconnect(self._trace_after_publish)
         signals.task_failure.disconnect(self._trace_failure)
         signals.task_retry.disconnect(self._trace_retry)
+        signals.worker_process_shutdown.disconnect(self._flush_providers)
         self.task_id_to_start_time = {}
 
     def _trace_prerun(self, *args, **kwargs):
@@ -353,6 +357,15 @@ class CeleryInstrumentor(BaseInstrumentor):
         # Use `str(reason)` instead of `reason.message` in case we get
         # something that isn't an `Exception`
         span.set_attribute(_TASK_RETRY_REASON_KEY, str(reason))
+
+    def _flush_providers(self, *args, **kwargs):
+        # Flush the tracer and meter providers when a worker process is
+        # shutting down. With `worker_max_tasks_per_child`, the pool child
+        # process is terminated as soon as the last task returns, so any spans
+        # or metrics still buffered in the SDK would otherwise be lost.
+        for provider in (self._tracer_provider, self._meter_provider):
+            if provider is not None and hasattr(provider, "force_flush"):
+                provider.force_flush()
 
     def update_task_duration_time(self, task_id):
         cur_time = default_timer()

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -3,12 +3,15 @@
 
 import threading
 import time
+from unittest import mock
 
+from celery import signals as celery_signals
 from wrapt import wrap_function_wrapper
 
-from opentelemetry import baggage, context
+from opentelemetry import baggage, context, trace
 from opentelemetry.instrumentation.celery import CeleryInstrumentor, utils
 from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.metrics import get_meter_provider
 from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_MESSAGE,
     EXCEPTION_STACKTRACE,
@@ -25,6 +28,26 @@ from .celery_test_tasks import (
     task_raises,
     task_returns_baggage,
 )
+
+
+class FakeTracerProvider:
+    def __init__(self):
+        self.force_flush = mock.Mock()
+
+    def get_tracer(  # pylint: disable=no-self-use
+        self, *args, **kwargs
+    ):
+        return trace.get_tracer_provider().get_tracer(*args, **kwargs)
+
+
+class FakeMeterProvider:
+    def __init__(self):
+        self.force_flush = mock.Mock()
+
+    def get_meter(  # pylint: disable=no-self-use
+        self, *args, **kwargs
+    ):
+        return get_meter_provider().get_meter(*args, **kwargs)
 
 
 class TestCeleryInstrumentation(TestBase):
@@ -331,3 +354,35 @@ class TestCelerySignatureTask(TestBase):
         self.assertNotEqual(consumer.parent, producer.context)
         self.assertEqual(consumer.parent.span_id, producer.context.span_id)
         self.assertEqual(consumer.context.trace_id, producer.context.trace_id)
+
+
+class TestCeleryInstrumentationFlush(TestBase):
+    def tearDown(self):
+        super().tearDown()
+        CeleryInstrumentor().uninstrument()
+
+    def test_flush_on_worker_process_shutdown(self):  # pylint: disable=no-self-use
+        tracer_provider = FakeTracerProvider()
+        meter_provider = FakeMeterProvider()
+        CeleryInstrumentor().instrument(
+            tracer_provider=tracer_provider, meter_provider=meter_provider
+        )
+
+        celery_signals.worker_process_shutdown.send(sender=None)
+
+        tracer_provider.force_flush.assert_called_once_with()
+        meter_provider.force_flush.assert_called_once_with()
+
+    def test_no_flush_after_uninstrument(self):  # pylint: disable=no-self-use
+        tracer_provider = FakeTracerProvider()
+        meter_provider = FakeMeterProvider()
+        instrumentor = CeleryInstrumentor()
+        instrumentor.instrument(
+            tracer_provider=tracer_provider, meter_provider=meter_provider
+        )
+        instrumentor.uninstrument()
+
+        celery_signals.worker_process_shutdown.send(sender=None)
+
+        tracer_provider.force_flush.assert_not_called()
+        meter_provider.force_flush.assert_not_called()


### PR DESCRIPTION
# Description

Fixes #4916

With `worker_max_tasks_per_child`, the pool child process is terminated as soon as the last task returns. Spans and metrics still buffered in the SDK (e.g. waiting on `BatchSpanProcessor`'s schedule delay) are never exported — a silent loss of telemetry.

This connects to celery's `worker_process_shutdown` signal (fired inside the dying child before exit) and force-flushes the tracer and meter providers. Providers are stored at instrument time, so providers passed to `CeleryInstrumentor().instrument()` are flushed too; providers without `force_flush` (e.g. NoOp) are skipped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- New tests in `instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py`:
  - `test_flush_on_worker_process_shutdown` — flush fires on the signal
  - `test_no_flush_after_uninstrument` — no flush after `uninstrument()`
- Full celery test suite: 32 passed
- ruff: clean

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated