### PR TITLE
opentelemetry-instrumentation-threading: keep the submitted callable's metadata through ThreadPoolExecutor.submit

### DIFF
--- a/.changelog/5011.fixed
+++ b/.changelog/5011.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-threading`: keep submitted callable metadata in `submit`

--- a/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/src/opentelemetry/instrumentation/threading/__init__.py
@@ -26,6 +26,7 @@ run method or the executor's worker thread."
 
 from __future__ import annotations
 
+import functools
 import threading
 from concurrent import futures
 from typing import TYPE_CHECKING, Any, Callable, Collection
@@ -154,6 +155,7 @@ class ThreadingInstrumentor(BaseInstrumentor):
         original_func = args[0]
         otel_context = context.get_current()
 
+        @functools.wraps(original_func)
         def wrapped_func(*func_args: Any, **func_kwargs: Any) -> R:
             token = None
             try:

--- a/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
+++ b/instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py
@@ -3,17 +3,26 @@
 
 from __future__ import annotations
 
+import functools
 import threading
 from concurrent.futures import (
     Future,
     ThreadPoolExecutor,
 )
-from typing import List
+from typing import Callable, List
 from unittest.mock import MagicMock, patch
+
+from wrapt import wrap_function_wrapper
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.test.test_base import TestBase
+
+
+def charge_customer(order_id: int, *, retries: int = 0) -> str:
+    """Charge the customer for the given order."""
+    return f"charged {order_id} after {retries} retries"
 
 
 # pylint: disable=too-many-public-methods
@@ -282,6 +291,77 @@ class TestThreading(TestBase):
         square_span = next(span for span in spans if span.name == "square")
         self.assertIsNotNone(square_span)
         self.assertIs(square_span.parent, root_span.get_span_context())
+
+    def _record_callables_forwarded_to_submit(self) -> List[Callable[..., object]]:
+        """Record the callables this instrumentation forwards to ``submit``.
+
+        ``setUp`` has already instrumented, so the spy is installed while
+        uninstrumented: re-instrumenting then places the instrumentation's own
+        wrapper *outside* it, and the spy sees what the instrumentation passes
+        down rather than what the caller passed in.
+        """
+        seen: List[Callable[..., object]] = []
+
+        def spy(
+            wrapped: Callable[..., object],
+            _instance: ThreadPoolExecutor,
+            args: tuple[Callable[..., object], ...],
+            kwargs: dict[str, object],
+        ) -> object:
+            seen.append(args[0])
+            return wrapped(*args, **kwargs)
+
+        instrumentor = ThreadingInstrumentor()
+        instrumentor.uninstrument()
+        wrap_function_wrapper(ThreadPoolExecutor, "submit", spy)
+        instrumentor.instrument()
+        # cleanups run after tearDown has removed the instrumentation's wrapper,
+        # so only the spy is left to peel off here
+        self.addCleanup(unwrap, ThreadPoolExecutor, "submit")
+
+        return seen
+
+    def test_thread_pool_submit_preserves_callable_identity(self) -> None:
+        seen = self._record_callables_forwarded_to_submit()
+        bound_method = self.print_square
+        partial_charge = functools.partial(charge_customer, 7)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(charge_customer, 1).result()
+            executor.submit(bound_method, 10).result()
+            executor.submit(partial_charge).result()
+
+        self.assertEqual(len(seen), 3)
+        # pylint: disable=unbalanced-tuple-unpacking
+        plain, bound, partial_func = seen
+
+        # a plain function carries every attribute functools.wraps copies
+        self.assertIs(plain.__wrapped__, charge_customer)
+        self.assertEqual(plain.__name__, "charge_customer")
+        self.assertEqual(plain.__doc__, charge_customer.__doc__)
+
+        # a bound method is rebuilt on every attribute access, so compare its
+        # __wrapped__ by equality rather than identity
+        self.assertEqual(bound.__wrapped__, bound_method)
+        self.assertEqual(bound.__name__, "print_square")
+
+        # a partial has no __name__ to copy, but must still be reachable
+        self.assertIs(partial_func.__wrapped__, partial_charge)
+
+    def test_thread_pool_submit_accepts_callables_without_metadata(self) -> None:
+        """``functools.wraps`` must not reject callables that lack ``__name__``."""
+
+        class Doubler:
+            def __call__(self, num: int) -> int:
+                return num * 2
+
+        for label, func, expected in (
+            ("partial", functools.partial(self.print_square), 100),
+            ("callable instance", Doubler(), 20),
+        ):
+            with self.subTest(label):
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    self.assertEqual(executor.submit(func, 10).result(), expected)
 
     def test_threading_run_with_custom_run(self):
         _tracer = self._tracer


### PR DESCRIPTION
# Description

`ThreadingInstrumentor` wraps `ThreadPoolExecutor.submit` and substitutes the caller's callable with a closure that attaches the OTel context. That closure was not `functools.wraps`-ed, so the callable crossing the `submit` boundary carried the wrapper's identity (`__name__ == "wrapped_func"`, no `__doc__`, generic signature, no `__wrapped__`) instead of the user's.

This applies `@functools.wraps(original_func)` to that closure, which is the convention this repository already follows wherever a user-supplied callable is substituted — `asgi` for `send`/`receive`, `wsgi` for `start_response`, `urllib` for `opener_open`, `requests` for `send`, and `google-genai` for tool functions.

This is a consistency fix rather than a fix for an observed failure. On the current `submit` path the loss is masked: `concurrent.futures` stores and calls the callable without reading its identity, and `submit` returns only a `Future`, so no consumer I could name observes it today. It becomes observable for anything positioned to introspect the submitted callable, such as another `submit` wrapper installed inside this one.

`functools.wraps` copies attributes only, so a `wrapped_func` frame still appears in tracebacks and profilers. Callables without `__name__` (`functools.partial`, callable class instances) are unaffected: `functools.update_wrapper` skips missing attributes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Two tests were added to `instrumentation/opentelemetry-instrumentation-threading/tests/test_threading.py`:

- `test_thread_pool_submit_preserves_callable_identity` installs a `submit` wrapper *inside* the instrumentation's own wrapper, so it observes what the instrumentation forwards. It submits a plain function, a bound method and a `functools.partial`, and asserts `__wrapped__` for all three plus `__name__`/`__doc__` where the callable has them. It fails without the change (`'wrapped_func' != 'charge_customer'`).
- `test_thread_pool_submit_accepts_callables_without_metadata` submits a `functools.partial` and a callable class instance, neither of which has `__name__`, and asserts they still run correctly.

Commands run locally:

- `tox -e py312-test-instrumentation-threading` — 16 passed

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
