### PR TITLE
opentelemetry-instrumentation-kafka-python: migrate to stable/incubating messaging semconv

### DIFF
--- a/.changelog/5014.changed
+++ b/.changelog/5014.changed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-kafka-python`: migrate to stable/incubating messaging semantic conventions

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/__init__.py
@@ -93,6 +93,7 @@ from opentelemetry.instrumentation.kafka.package import _instruments
 from opentelemetry.instrumentation.kafka.utils import _wrap_next, _wrap_send
 from opentelemetry.instrumentation.kafka.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.schemas import Schemas
 
 
 class KafkaInstrumentor(BaseInstrumentor):
@@ -120,7 +121,7 @@ class KafkaInstrumentor(BaseInstrumentor):
             __name__,
             __version__,
             tracer_provider=tracer_provider,
-            schema_url="https://opentelemetry.io/schemas/1.11.0",
+            schema_url=Schemas.V1_27_0.value,
         )
 
         wrap_function_wrapper(kafka.KafkaProducer, "send", _wrap_send(tracer, produce_hook))

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
@@ -1,15 +1,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 from collections.abc import Callable
+from contextlib import suppress
 from logging import getLogger
 
 from kafka.record.abc import ABCRecord
 
 from opentelemetry import context, propagate, trace
 from opentelemetry.propagators import textmap
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
+from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.trace import Tracer
 from opentelemetry.trace.span import Span
 
@@ -22,6 +26,14 @@ class KafkaPropertiesExtractor:
         return instance.config.get("bootstrap_servers")
 
     @staticmethod
+    def extract_client_id(instance):
+        return instance.config.get("client_id")
+
+    @staticmethod
+    def extract_consumer_group(instance):
+        return instance.config.get("group_id")
+
+    @staticmethod
     def _extract_argument(key, position, default_value, args, kwargs):
         if len(args) > position:
             return args[position]
@@ -31,6 +43,11 @@ class KafkaPropertiesExtractor:
     def extract_send_topic(args, kwargs):
         """extract topic from `send` method arguments in KafkaProducer class"""
         return KafkaPropertiesExtractor._extract_argument("topic", 0, "unknown", args, kwargs)
+
+    @staticmethod
+    def extract_send_key(args, kwargs):
+        """extract key from `send` method arguments in KafkaProducer class"""
+        return KafkaPropertiesExtractor._extract_argument("key", 2, None, args, kwargs)
 
     @staticmethod
     def extract_send_headers(args, kwargs):
@@ -50,6 +67,17 @@ class KafkaPropertiesExtractor:
         except (AttributeError, IndexError, TypeError) as exception:
             _LOG.debug("Unable to extract partition: %s", exception)
             return None
+
+
+def _key_to_str(key) -> str | None:
+    if key is None:
+        return None
+
+    if isinstance(key, bytes):
+        with suppress(UnicodeDecodeError):
+            return key.decode()
+
+    return str(key)
 
 
 ProduceHookT = Callable[[Span, list, dict], None] | None
@@ -87,18 +115,103 @@ _kafka_getter = KafkaContextGetter()
 _kafka_setter = KafkaContextSetter()
 
 
-def _enrich_span(
-    span,
-    bootstrap_servers: list[str],
+def _enrich_base_span(
+    span: Span,
+    *,
+    bootstrap_servers,
+    client_id: str | None,
     topic: str,
     partition: int | None,
-):
-    if span.is_recording():
-        span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "kafka")
-        span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
-        if partition is not None:
-            span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)
-        span.set_attribute(SpanAttributes.MESSAGING_URL, json.dumps(bootstrap_servers))
+    key: str | None,
+) -> None:
+    span.set_attribute(
+        messaging_attributes.MESSAGING_SYSTEM,
+        messaging_attributes.MessagingSystemValues.KAFKA.value,
+    )
+    span.set_attribute(server_attributes.SERVER_ADDRESS, json.dumps(bootstrap_servers))
+    if client_id is not None:
+        span.set_attribute(messaging_attributes.MESSAGING_CLIENT_ID, client_id)
+    span.set_attribute(messaging_attributes.MESSAGING_DESTINATION_NAME, topic)
+
+    if partition is not None:
+        span.set_attribute(
+            messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID,
+            str(partition),
+        )
+
+    if key is not None:
+        span.set_attribute(messaging_attributes.MESSAGING_KAFKA_MESSAGE_KEY, key)
+
+
+def _enrich_send_span(
+    span: Span,
+    *,
+    bootstrap_servers,
+    client_id: str | None,
+    topic: str,
+    partition: int | None,
+    key: str | None,
+) -> None:
+    if not span.is_recording():
+        return
+
+    _enrich_base_span(
+        span,
+        bootstrap_servers=bootstrap_servers,
+        client_id=client_id,
+        topic=topic,
+        partition=partition,
+        key=key,
+    )
+
+    span.set_attribute(messaging_attributes.MESSAGING_OPERATION_NAME, "send")
+    span.set_attribute(
+        messaging_attributes.MESSAGING_OPERATION_TYPE,
+        messaging_attributes.MessagingOperationTypeValues.PUBLISH.value,
+    )
+
+
+def _enrich_consume_span(
+    span: Span,
+    *,
+    bootstrap_servers,
+    client_id: str | None,
+    consumer_group: str | None,
+    topic: str,
+    partition: int | None,
+    key: str | None,
+    offset: int,
+) -> None:
+    if not span.is_recording():
+        return
+
+    _enrich_base_span(
+        span,
+        bootstrap_servers=bootstrap_servers,
+        client_id=client_id,
+        topic=topic,
+        partition=partition,
+        key=key,
+    )
+
+    if consumer_group is not None:
+        span.set_attribute(messaging_attributes.MESSAGING_CONSUMER_GROUP_NAME, consumer_group)
+
+    span.set_attribute(messaging_attributes.MESSAGING_OPERATION_NAME, "receive")
+    span.set_attribute(
+        messaging_attributes.MESSAGING_OPERATION_TYPE,
+        messaging_attributes.MessagingOperationTypeValues.RECEIVE.value,
+    )
+
+    span.set_attribute(messaging_attributes.MESSAGING_KAFKA_MESSAGE_OFFSET, offset)
+
+    # https://stackoverflow.com/questions/65935155/identify-and-find-specific-message-in-kafka-topic
+    # A message within Kafka is uniquely defined by its topic name, topic partition and offset.
+    if partition is not None:
+        span.set_attribute(
+            messaging_attributes.MESSAGING_MESSAGE_ID,
+            f"{topic}.{partition}.{offset}",
+        )
 
 
 def _get_span_name(operation: str, topic: str):
@@ -114,6 +227,8 @@ def _wrap_send(tracer: Tracer, produce_hook: ProduceHookT) -> Callable:
 
         topic = KafkaPropertiesExtractor.extract_send_topic(args, kwargs)
         bootstrap_servers = KafkaPropertiesExtractor.extract_bootstrap_servers(instance)
+        client_id = KafkaPropertiesExtractor.extract_client_id(instance)
+        key = _key_to_str(KafkaPropertiesExtractor.extract_send_key(args, kwargs))
         span_name = _get_span_name("send", topic)
         with tracer.start_as_current_span(span_name, kind=trace.SpanKind.PRODUCER) as span:
             propagate.inject(
@@ -129,7 +244,14 @@ def _wrap_send(tracer: Tracer, produce_hook: ProduceHookT) -> Callable:
 
             future = func(*args, **kwargs)
             partition = KafkaPropertiesExtractor.extract_send_partition(future)
-            _enrich_span(span, bootstrap_servers, topic, partition)
+            _enrich_send_span(
+                span,
+                bootstrap_servers=bootstrap_servers,
+                client_id=client_id,
+                topic=topic,
+                partition=partition,
+                key=key,
+            )
             return future
 
     return _traced_send
@@ -141,6 +263,8 @@ def _create_consumer_span(
     record,
     extracted_context,
     bootstrap_servers,
+    client_id,
+    consumer_group,
     args,
     kwargs,
 ):
@@ -152,7 +276,16 @@ def _create_consumer_span(
     ) as span:
         new_context = trace.set_span_in_context(span, extracted_context)
         token = context.attach(new_context)
-        _enrich_span(span, bootstrap_servers, record.topic, record.partition)
+        _enrich_consume_span(
+            span,
+            bootstrap_servers=bootstrap_servers,
+            client_id=client_id,
+            consumer_group=consumer_group,
+            topic=record.topic,
+            partition=record.partition,
+            key=_key_to_str(record.key),
+            offset=record.offset,
+        )
         try:
             if callable(consume_hook):
                 consume_hook(span, record, args, kwargs)
@@ -171,6 +304,8 @@ def _wrap_next(
 
         if record:
             bootstrap_servers = KafkaPropertiesExtractor.extract_bootstrap_servers(instance)
+            client_id = KafkaPropertiesExtractor.extract_client_id(instance)
+            consumer_group = KafkaPropertiesExtractor.extract_consumer_group(instance)
 
             extracted_context = propagate.extract(record.headers, getter=_kafka_getter)
             _create_consumer_span(
@@ -179,6 +314,8 @@ def _wrap_next(
                 record,
                 extracted_context,
                 bootstrap_servers,
+                client_id,
+                consumer_group,
                 args,
                 kwargs,
             )

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/tests/test_utils.py
@@ -4,19 +4,21 @@
 
 from unittest import TestCase, mock
 
+from kafka.consumer.fetcher import ConsumerRecord
 from kafka.producer.future import FutureProduceResult, FutureRecordMetadata
 
 from opentelemetry.instrumentation.kafka.utils import (
     KafkaPropertiesExtractor,
     _create_consumer_span,
-    _enrich_span,
+    _enrich_send_span,
     _get_span_name,
     _kafka_getter,
     _kafka_setter,
     _wrap_next,
     _wrap_send,
 )
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
+from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import SpanKind, StatusCode
 
@@ -29,9 +31,10 @@ class TestUtils(TestCase):
         self.headers = []
         self.kwargs = {"partition": 0, "headers": self.headers}
 
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_client_id")
     @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
     @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition")
-    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_send_span")
     @mock.patch("opentelemetry.trace.set_span_in_context")
     @mock.patch("opentelemetry.propagate.inject")
     def test_wrap_send_with_topic_as_arg(
@@ -41,6 +44,7 @@ class TestUtils(TestCase):
         enrich_span: mock.MagicMock,
         extract_send_partition: mock.MagicMock,
         extract_bootstrap_servers: mock.MagicMock,
+        extract_client_id: mock.MagicMock,
     ) -> None:
         self.wrap_send_helper(
             inject,
@@ -48,11 +52,13 @@ class TestUtils(TestCase):
             enrich_span,
             extract_send_partition,
             extract_bootstrap_servers,
+            extract_client_id,
         )
 
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_client_id")
     @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
     @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_send_partition")
-    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_send_span")
     @mock.patch("opentelemetry.trace.set_span_in_context")
     @mock.patch("opentelemetry.propagate.inject")
     def test_wrap_send_with_topic_as_kwarg(
@@ -62,6 +68,7 @@ class TestUtils(TestCase):
         enrich_span: mock.MagicMock,
         extract_send_partition: mock.MagicMock,
         extract_bootstrap_servers: mock.MagicMock,
+        extract_client_id: mock.MagicMock,
     ) -> None:
         self.args = []
         self.kwargs["topic"] = self.topic_name
@@ -71,8 +78,10 @@ class TestUtils(TestCase):
             enrich_span,
             extract_send_partition,
             extract_bootstrap_servers,
+            extract_client_id,
         )
 
+    # pylint: disable=too-many-locals
     def wrap_send_helper(
         self,
         inject: mock.MagicMock,
@@ -80,6 +89,7 @@ class TestUtils(TestCase):
         enrich_span: mock.MagicMock,
         extract_send_partition: mock.MagicMock,
         extract_bootstrap_servers: mock.MagicMock,
+        extract_client_id: mock.MagicMock,
     ) -> None:
         tracer = mock.MagicMock()
         produce_hook = mock.MagicMock()
@@ -91,6 +101,7 @@ class TestUtils(TestCase):
         retval = wrapped_send(original_send_callback, kafka_producer, self.args, self.kwargs)
 
         extract_bootstrap_servers.assert_called_once_with(kafka_producer)
+        extract_client_id.assert_called_once_with(kafka_producer)
         # The partition is read back from the future returned by send(), not
         # estimated from the call arguments.
         extract_send_partition.assert_called_once_with(original_send_callback.return_value)
@@ -99,9 +110,11 @@ class TestUtils(TestCase):
         span = tracer.start_as_current_span().__enter__.return_value
         enrich_span.assert_called_once_with(
             span,
-            extract_bootstrap_servers.return_value,
-            self.topic_name,
-            extract_send_partition.return_value,
+            bootstrap_servers=extract_bootstrap_servers.return_value,
+            client_id=extract_client_id.return_value,
+            topic=self.topic_name,
+            partition=extract_send_partition.return_value,
+            key=None,
         )
 
         set_span_in_context.assert_called_once_with(span)
@@ -116,8 +129,12 @@ class TestUtils(TestCase):
     @mock.patch("opentelemetry.propagate.extract")
     @mock.patch("opentelemetry.instrumentation.kafka.utils._create_consumer_span")
     @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_bootstrap_servers")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_client_id")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils.KafkaPropertiesExtractor.extract_consumer_group")
     def test_wrap_next(
         self,
+        extract_consumer_group: mock.MagicMock,
+        extract_client_id: mock.MagicMock,
         extract_bootstrap_servers: mock.MagicMock,
         _create_consumer_span: mock.MagicMock,
         extract: mock.MagicMock,
@@ -133,6 +150,12 @@ class TestUtils(TestCase):
         extract_bootstrap_servers.assert_called_once_with(kafka_consumer)
         bootstrap_servers = extract_bootstrap_servers.return_value
 
+        extract_client_id.assert_called_once_with(kafka_consumer)
+        client_id = extract_client_id.return_value
+
+        extract_consumer_group.assert_called_once_with(kafka_consumer)
+        consumer_group = extract_consumer_group.return_value
+
         original_next_callback.assert_called_once_with(*self.args, **self.kwargs)
         self.assertEqual(record, original_next_callback.return_value)
 
@@ -145,13 +168,15 @@ class TestUtils(TestCase):
             record,
             context,
             bootstrap_servers,
+            client_id,
+            consumer_group,
             self.args,
             self.kwargs,
         )
 
     @mock.patch("opentelemetry.trace.set_span_in_context")
     @mock.patch("opentelemetry.context.attach")
-    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_span")
+    @mock.patch("opentelemetry.instrumentation.kafka.utils._enrich_consume_span")
     @mock.patch("opentelemetry.context.detach")
     def test_create_consumer_span(
         self,
@@ -163,6 +188,8 @@ class TestUtils(TestCase):
         tracer = mock.MagicMock()
         consume_hook = mock.MagicMock()
         bootstrap_servers = mock.MagicMock()
+        client_id = mock.MagicMock()
+        consumer_group = mock.MagicMock()
         extracted_context = mock.MagicMock()
         record = mock.MagicMock()
 
@@ -172,6 +199,8 @@ class TestUtils(TestCase):
             record,
             extracted_context,
             bootstrap_servers,
+            client_id,
+            consumer_group,
             self.args,
             self.kwargs,
         )
@@ -187,7 +216,16 @@ class TestUtils(TestCase):
         set_span_in_context.assert_called_once_with(span, extracted_context)
         attach.assert_called_once_with(set_span_in_context.return_value)
 
-        enrich_span.assert_called_once_with(span, bootstrap_servers, record.topic, record.partition)
+        enrich_span.assert_called_once_with(
+            span,
+            bootstrap_servers=bootstrap_servers,
+            client_id=client_id,
+            consumer_group=consumer_group,
+            topic=record.topic,
+            partition=record.partition,
+            key=str(record.key),
+            offset=record.offset,
+        )
         consume_hook.assert_called_once_with(span, record, self.args, self.kwargs)
         detach.assert_called_once_with(attach.return_value)
 
@@ -235,22 +273,36 @@ class TestUtils(TestCase):
 
         self.assertIsNone(partition)
 
-    def test_enrich_span_records_partition_when_present(self):
+    def test_enrich_send_span_records_partition_when_present(self):
         span = mock.MagicMock()
         span.is_recording.return_value = True
 
-        _enrich_span(span, ["localhost:9092"], self.topic_name, 2)
+        _enrich_send_span(
+            span,
+            bootstrap_servers=["localhost:9092"],
+            client_id="client-1",
+            topic=self.topic_name,
+            partition=2,
+            key=None,
+        )
 
-        span.set_attribute.assert_any_call(SpanAttributes.MESSAGING_KAFKA_PARTITION, 2)
+        span.set_attribute.assert_any_call(messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID, "2")
 
-    def test_enrich_span_omits_partition_when_none(self):
+    def test_enrich_send_span_omits_partition_when_none(self):
         span = mock.MagicMock()
         span.is_recording.return_value = True
 
-        _enrich_span(span, ["localhost:9092"], self.topic_name, None)
+        _enrich_send_span(
+            span,
+            bootstrap_servers=["localhost:9092"],
+            client_id="client-1",
+            topic=self.topic_name,
+            partition=None,
+            key=None,
+        )
 
         recorded_attributes = {call.args[0] for call in span.set_attribute.call_args_list}
-        self.assertNotIn(SpanAttributes.MESSAGING_KAFKA_PARTITION, recorded_attributes)
+        self.assertNotIn(messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID, recorded_attributes)
 
 
 @mock.patch(
@@ -268,7 +320,10 @@ class TestWrapSendSpanLifetime(TestBase):
         self.args = [self.topic_name]
         self.kwargs = {"partition": 0, "headers": []}
         self.producer = mock.MagicMock()
-        self.producer.config = {"bootstrap_servers": ["localhost:9092"]}
+        self.producer.config = {
+            "bootstrap_servers": ["localhost:9092"],
+            "client_id": "client-1",
+        }
 
     def test_wrap_send_records_exception_raised_by_send(self, _extract_send_partition: mock.MagicMock) -> None:
         error = ConnectionError("broker unavailable")
@@ -309,3 +364,102 @@ class TestWrapSendSpanLifetime(TestBase):
         self.assertEqual(span.kind, SpanKind.PRODUCER)
         self.assertIs(span.status.status_code, StatusCode.UNSET)
         self.assertEqual(len(span.events), 0)
+
+
+class TestSpanAttributes(TestBase):
+    """Verifies the exact semantic-convention attribute names and value
+    types recorded on produced and consumed spans."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
+
+    def test_send_span_attributes(self) -> None:
+        producer = mock.MagicMock()
+        producer.config = {
+            "bootstrap_servers": ["localhost:9092"],
+            "client_id": "client-1",
+        }
+        future = mock.MagicMock()
+        future._produce_future.topic_partition = ("test_topic", 3)
+        original_send = mock.MagicMock(return_value=future)
+
+        wrapped_send = _wrap_send(self.tracer, None)
+        wrapped_send(
+            original_send,
+            producer,
+            ["test_topic"],
+            {"key": b"key-1", "headers": []},
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "test_topic send")
+        self.assertEqual(span.kind, SpanKind.PRODUCER)
+        self.assertEqual(
+            dict(span.attributes),
+            {
+                messaging_attributes.MESSAGING_SYSTEM: messaging_attributes.MessagingSystemValues.KAFKA.value,
+                server_attributes.SERVER_ADDRESS: '["localhost:9092"]',
+                messaging_attributes.MESSAGING_CLIENT_ID: "client-1",
+                messaging_attributes.MESSAGING_DESTINATION_NAME: "test_topic",
+                messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID: "3",
+                messaging_attributes.MESSAGING_KAFKA_MESSAGE_KEY: "key-1",
+                messaging_attributes.MESSAGING_OPERATION_NAME: "send",
+                messaging_attributes.MESSAGING_OPERATION_TYPE: messaging_attributes.MessagingOperationTypeValues.PUBLISH.value,
+            },
+        )
+
+    def test_receive_span_attributes(self) -> None:
+        consumer = mock.MagicMock()
+        consumer.config = {
+            "bootstrap_servers": ["localhost:9092"],
+            "client_id": "client-1",
+            "group_id": "group-1",
+        }
+        # ConsumerRecord's field set differs across supported kafka-python
+        # versions (e.g. ``leader_epoch`` is not present in 2.0.3), so build
+        # it from whatever fields the installed version actually defines.
+        field_values = {
+            "topic": "test_topic",
+            "partition": 3,
+            "leader_epoch": -1,
+            "offset": 42,
+            "timestamp": -1,
+            "timestamp_type": 0,
+            "key": b"key-1",
+            "value": b"value-1",
+            "headers": [],
+            "checksum": None,
+            "serialized_key_size": -1,
+            "serialized_value_size": -1,
+            "serialized_header_size": -1,
+        }
+        record = ConsumerRecord(**{field: field_values[field] for field in ConsumerRecord._fields})
+        original_next = mock.MagicMock(return_value=record)
+
+        wrapped_next = _wrap_next(self.tracer, None)
+        wrapped_next(original_next, consumer, [], {})
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "test_topic receive")
+        self.assertEqual(span.kind, SpanKind.CONSUMER)
+        self.assertEqual(
+            dict(span.attributes),
+            {
+                messaging_attributes.MESSAGING_SYSTEM: messaging_attributes.MessagingSystemValues.KAFKA.value,
+                server_attributes.SERVER_ADDRESS: '["localhost:9092"]',
+                messaging_attributes.MESSAGING_CLIENT_ID: "client-1",
+                messaging_attributes.MESSAGING_DESTINATION_NAME: "test_topic",
+                messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID: "3",
+                messaging_attributes.MESSAGING_KAFKA_MESSAGE_KEY: "key-1",
+                messaging_attributes.MESSAGING_CONSUMER_GROUP_NAME: "group-1",
+                messaging_attributes.MESSAGING_OPERATION_NAME: "receive",
+                messaging_attributes.MESSAGING_OPERATION_TYPE: messaging_attributes.MessagingOperationTypeValues.RECEIVE.value,
+                messaging_attributes.MESSAGING_KAFKA_MESSAGE_OFFSET: 42,
+                messaging_attributes.MESSAGING_MESSAGE_ID: "test_topic.3.42",
+            },
+        )

--- a/tests/opentelemetry-docker-tests/tests/kafka/test_kafka_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/kafka/test_kafka_functional.py
@@ -9,7 +9,7 @@ from kafka.errors import TopicAlreadyExistsError
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.kafka import KafkaInstrumentor
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.test.test_base import TestBase
 
 KAFKA_HOST = os.getenv("KAFKA_HOST", "localhost")
@@ -60,14 +60,17 @@ class TestFunctionalKafka(TestBase):
         for span, metadata in zip(spans, metadatas):
             self.assertEqual(span.name, f"{KAFKA_TOPIC} send")
             self.assertIs(span.kind, trace_api.SpanKind.PRODUCER)
-            self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "kafka")
             self.assertEqual(
-                span.attributes[SpanAttributes.MESSAGING_DESTINATION],
+                span.attributes[messaging_attributes.MESSAGING_SYSTEM],
+                messaging_attributes.MessagingSystemValues.KAFKA.value,
+            )
+            self.assertEqual(
+                span.attributes[messaging_attributes.MESSAGING_DESTINATION_NAME],
                 KAFKA_TOPIC,
             )
-            partition = span.attributes[SpanAttributes.MESSAGING_KAFKA_PARTITION]
-            self.assertIsInstance(partition, int)
-            self.assertEqual(partition, metadata.partition)
+            partition = span.attributes[messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID]
+            self.assertIsInstance(partition, str)
+            self.assertEqual(partition, str(metadata.partition))
 
     def test_send_with_explicit_partition(self):
         explicit_partition = KAFKA_PARTITION_COUNT - 1
@@ -78,6 +81,6 @@ class TestFunctionalKafka(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
         self.assertEqual(
-            spans[0].attributes[SpanAttributes.MESSAGING_KAFKA_PARTITION],
-            explicit_partition,
+            spans[0].attributes[messaging_attributes.MESSAGING_DESTINATION_PARTITION_ID],
+            str(explicit_partition),
         )


### PR DESCRIPTION
# Description

Migrates `opentelemetry-instrumentation-kafka-python` off the deprecated
`opentelemetry.semconv.trace.SpanAttributes` module onto the current
messaging semantic conventions, matching the pattern already used by
`opentelemetry-instrumentation-aiokafka`.

- `messaging.destination` -> `messaging.destination.name`
- `messaging.url` -> `server.address`
- `messaging.kafka.partition` (int) -> `messaging.destination.partition.id` (string)
- `messaging.system` now uses the `MessagingSystemValues.KAFKA` enum instead of a hardcoded string
- Adds previously-missing attributes: `messaging.operation.name`, `messaging.operation.type`,
  `messaging.client.id`, `messaging.kafka.message.key`, and, on consumer spans,
  `messaging.consumer.group.name`, `messaging.kafka.message.offset`, `messaging.message.id`
- Tracer `schema_url` bumped from `1.11.0` to `Schemas.V1_27_0` to match aiokafka

This is a breaking change to span attribute names/types for anyone relying on the old
attribute names in queries or dashboards.

Fixes #1642

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `tox -e py312-test-instrumentation-kafka-python-latest` and `-oldest` (kafka-python 2.0.3), 16/16 passing
- `tox -e lint-instrumentation-kafka-python` (pylint 10.00/10)
- `pre-commit run ruff --all-files`
- Added `TestSpanAttributes` integration tests asserting exact attribute names and value types for both producer (`send`) and consumer (`receive`) spans

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated