### PR TITLE
celery: wait for exported spans instead of result.ready() in tests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -27,6 +27,30 @@ from .celery_test_tasks import (
 )
 
 
+def wait_for(predicate, message, timeout_s=60):
+    """Poll ``predicate`` until it is true, failing the test if it never is."""
+    deadline = time.time() + timeout_s
+    while not predicate():
+        if time.time() > deadline:
+            raise AssertionError(f"timed out after {timeout_s}s waiting for {message}")
+        time.sleep(0.05)
+
+
+def wait_for_spans(exporter, span_count, timeout_s=60):
+    """Wait until ``span_count`` spans have been exported.
+
+    Celery stores the task result before it dispatches ``task_postrun``, and the
+    instrumentation ends the run span from ``task_postrun``. So an ``AsyncResult``
+    can be ready while the run span has not been ended and exported yet, and
+    waiting on ``result.ready()`` alone makes the span assertions racy.
+    """
+    wait_for(
+        lambda: len(exporter.get_finished_spans()) >= span_count,
+        f"{span_count} spans to be exported",
+        timeout_s,
+    )
+
+
 class TestCeleryInstrumentation(TestBase):
     def setUp(self):
         super().setUp()
@@ -45,13 +69,9 @@ class TestCeleryInstrumentation(TestBase):
     def test_task(self):
         CeleryInstrumentor().instrument()
 
-        result = task_add.delay(1, 2)
+        task_add.delay(1, 2)
 
-        timeout = time.time() + 60 * 1  # 1 minutes from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+        wait_for_spans(self.memory_exporter, 2)
 
         spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
         self.assertEqual(len(spans), 2)
@@ -98,11 +118,13 @@ class TestCeleryInstrumentation(TestBase):
 
         result = task_add.delay(1, 2)
 
-        timeout = time.time() + 60 * 1  # 1 minutes from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+        wait_for_spans(self.memory_exporter, 2)
+        # the cache is cleared a few statements after the run span is ended, in
+        # the same task_postrun receiver, so it needs its own wait
+        wait_for(
+            lambda: not instrumentor.task_id_to_start_time,
+            "the task start time cache to be cleared",
+        )
 
         self.assertTrue(result.ready())
         self.assertEqual(result.result, 3)
@@ -111,13 +133,9 @@ class TestCeleryInstrumentation(TestBase):
     def test_task_raises(self):
         CeleryInstrumentor().instrument()
 
-        result = task_raises.delay()
+        task_raises.delay()
 
-        timeout = time.time() + 60 * 1  # 1 minutes from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+        wait_for_spans(self.memory_exporter, 2)
 
         spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
         self.assertEqual(len(spans), 2)
@@ -218,11 +236,7 @@ class TestCeleryInstrumentation(TestBase):
 
         result = task_add.delay(1, 2)
 
-        timeout = time.time() + 60 * 1  # 1 minutes from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+        wait_for_spans(self.memory_exporter, 2)
 
         spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
         self.assertEqual(len(spans), 2)
@@ -235,13 +249,9 @@ class TestCeleryInstrumentation(TestBase):
     def test_task_use_span_links(self):
         CeleryInstrumentor().instrument(use_span_links=True)
 
-        result = task_add.delay(1, 2)
+        task_add.delay(1, 2)
 
-        timeout = time.time() + 60 * 1  # 1 minute from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+        wait_for_spans(self.memory_exporter, 2)
 
         spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
         self.assertEqual(len(spans), 2)
@@ -314,9 +324,8 @@ class TestCelerySignatureTask(TestBase):
         # no-op since already instrumented
         CeleryInstrumentor().instrument()
 
-        res = app.signature("tests.test_tasks.hidden_task", (2,)).apply_async()
-        while not res.ready():
-            time.sleep(0.05)
+        app.signature("tests.test_tasks.hidden_task", (2,)).apply_async()
+        wait_for_spans(self.memory_exporter, 2)
         spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
         self.assertEqual(len(spans), 2)
 

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -231,6 +231,11 @@ class TestCeleryInstrumentation(TestBase):
             "retrieve_context",
             _retrieve_context_wrapper_none_token,
         )
+        # Unconditional: an assertion or a wait_for_spans timeout below would
+        # otherwise skip the cleanup and leave retrieve_context patched for the
+        # rest of the process, since tearDown only uninstruments and never
+        # unwraps this module-level patch.
+        self.addCleanup(unwrap, utils, "retrieve_context")
 
         CeleryInstrumentor().instrument()
 
@@ -243,8 +248,6 @@ class TestCeleryInstrumentation(TestBase):
 
         # TODO: assert we don't have "TypeError: expected an instance of Token, got None" in logs
         self.assertTrue(result)
-
-        unwrap(utils, "retrieve_context")
 
     def test_task_use_span_links(self):
         CeleryInstrumentor().instrument(use_span_links=True)


### PR DESCRIPTION
# Description

The celery tests wait on `result.ready()` before asserting on spans, but Celery stores the task result before it dispatches `task_postrun`, and `CeleryInstrumentor` ends the run span from its `task_postrun` receiver. So the result can be ready while the run span has not been ended and exported yet, and the assertion runs against an incomplete exporter. That is the `1 != 2` in the issue.

These now wait for the expected number of exported spans instead. `test_task_clears_start_time_cache` also waits for the start-time cache to drain, because that pop happens a few statements after the span is ended in the same receiver. `test_baggage` and `test_uninstrument` keep `result.ready()`, which is the right thing for them to wait on.

Test-only change, no instrumentation code touched.

Two things worth flagging:

- The old loops `break` on timeout and fall through into the assertion, so a genuine hang showed up as a confusing span-count mismatch. These raise with the reason instead.
- `test_metrics.py` waits the same way and has the same race. I left it alone to keep this to one logical change, but it is the same fix if you want it. It already carries a `skipif(PyPy, reason="Fails randomly in pypy")`, which looks like this race showing up there.

Prior analysis of this race in the docker suite is in #4964 by @Pissinatti-py, for #653. Different file and different issue, so no overlap with this change, but they described the cause first and it is worth reading alongside.

Fixes #5009

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ordering measured on macOS arm64 against `f1b9368aa`, showing the result landing before the span ends:

```
   34.304 ms  task_prerun
   35.232 ms  backend.mark_as_failure ENTER
   35.302 ms  task_failure
   35.446 ms  task_postrun          <- run span ends here
   36.029 ms  result.ready() == True
```

```
AT result.ready(): ['apply_async/celery_test_tasks.task_raises']
ONE SECOND LATER : ['apply_async/...', 'run/celery_test_tasks.task_raises']
```

To make it deterministic rather than waiting for a loaded runner, I connected a 0.5s `task_postrun` receiver ahead of the instrumentor's, which widens the real window without touching any source:

```python
from celery import signals
signals.task_postrun.connect(lambda *a, **k: time.sleep(0.5), weak=False)
```

With that loaded, on `main`:

```
8 failed, 22 passed
FAILED test_tasks.py::TestCeleryInstrumentation::test_task
FAILED test_tasks.py::TestCeleryInstrumentation::test_task_clears_start_time_cache
FAILED test_tasks.py::TestCeleryInstrumentation::test_task_not_instrumented_does_not_raise
FAILED test_tasks.py::TestCeleryInstrumentation::test_task_raises
FAILED test_tasks.py::TestCeleryInstrumentation::test_task_use_span_links
FAILED test_tasks.py::TestCelerySignatureTask::test_hidden_task
FAILED test_metrics.py::TestMetrics::test_basic_metric
FAILED test_metrics.py::TestMetrics::test_metric_uninstrument
```

`test_task_raises` fails with `AssertionError: 1 != 2` at `test_tasks.py:123`, the error and line from the CI traceback in the issue.

With this change, same widened window:

```
2 failed, 28 passed
```

The six in `test_tasks.py` are gone. The two remaining are `test_metrics.py`, which this PR does not touch.

Unmodified suite:

```
uvx --from tox --with tox-uv tox -e py312-test-instrumentation-celery   ->  30 passed
uvx --from tox --with tox-uv tox -e lint-instrumentation-celery         ->  10.00/10
ruff check / ruff format --check                                        ->  clean
```

- [x] Reproduced the race on `main` and confirmed the fix removes it
- [x] Full celery suite green on py3.12 and py3.14

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated - test-only, so I believe this needs the `Skip Changelog` label rather than a fragment. Happy to add one if you would rather have it.
- [x] Unit tests have been added - existing tests made deterministic
- [ ] Documentation has been updated - not applicable
