### PR TITLE
celery: wait for the recorded metric instead of result.ready() in the metrics tests

### DIFF
--- a/.changelog/5016.fixed
+++ b/.changelog/5016.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-celery`: fix flaky metrics tests and restore PyPy test coverage

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_metrics.py
@@ -3,10 +3,7 @@
 
 import threading
 import time
-from platform import python_implementation
 from timeit import default_timer
-
-from pytest import mark
 
 from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.test.test_base import TestBase
@@ -95,7 +92,6 @@ class TestMetrics(TestBase):
             est_value_delta=200,
         )
 
-    @mark.skipif(python_implementation() == "PyPy", reason="Fails randomly in pypy")
     def test_metric_uninstrument(self):
         CeleryInstrumentor().instrument()
 

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_metrics.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_metrics.py
@@ -16,6 +16,21 @@ from .celery_test_tasks import app, task_add
 SCOPE = "opentelemetry.instrumentation.celery"
 
 
+def wait_for(predicate, message, timeout_s=60):
+    """Poll ``predicate`` until it is true, failing the test if it never is."""
+    deadline = time.time() + timeout_s
+    while not predicate():
+        if time.time() > deadline:
+            raise AssertionError(f"timed out after {timeout_s}s waiting for {message}")
+        time.sleep(0.05)
+
+
+def run_task():
+    """Run a task and wait for it to finish."""
+    result = task_add.delay(1, 2)
+    wait_for(result.ready, "the task to finish")
+
+
 class TestMetrics(TestBase):
     def setUp(self):
         super().setUp()
@@ -29,14 +44,26 @@ class TestMetrics(TestBase):
         self._worker.stop()
         self._thread.join()
 
-    def get_metrics(self):
-        result = task_add.delay(1, 2)
+    def recorded_run_count(self):
+        metrics = self.get_sorted_metrics(SCOPE)
+        if not metrics:
+            return 0
+        return sum(point.count for point in metrics[0].data.data_points)
 
-        timeout = time.time() + 60 * 1  # 1 minutes from now
-        while not result.ready():
-            if time.time() > timeout:
-                break
-            time.sleep(0.05)
+    def get_metrics(self, expected_run_count=1):
+        """Run a task and return the metrics once its runtime is recorded.
+
+        Celery stores the task result before it dispatches ``task_postrun``, and
+        the instrumentation records the runtime histogram from its
+        ``task_postrun`` receiver. So an ``AsyncResult`` can be ready while the
+        histogram has not been recorded yet, and waiting on ``result.ready()``
+        alone makes the metric assertions racy.
+        """
+        task_add.delay(1, 2)
+        wait_for(
+            lambda: self.recorded_run_count() >= expected_run_count,
+            f"{expected_run_count} task runs to be recorded",
+        )
         return self.get_sorted_metrics(SCOPE)
 
     def test_basic_metric(self):
@@ -72,13 +99,13 @@ class TestMetrics(TestBase):
     def test_metric_uninstrument(self):
         CeleryInstrumentor().instrument()
 
-        metrics = self.get_metrics()
+        metrics = self.get_metrics(1)
         self.assertEqual(
             metrics[0].data.data_points[0].bucket_counts[1],
             1,
         )
 
-        metrics = self.get_metrics()
+        metrics = self.get_metrics(2)
         self.assertEqual(
             metrics[0].data.data_points[0].bucket_counts[1],
             2,
@@ -86,7 +113,10 @@ class TestMetrics(TestBase):
 
         CeleryInstrumentor().uninstrument()
 
-        metrics = self.get_metrics()
+        # nothing is recorded once uninstrumented, so there is no metric to wait
+        # for here; the task finishing is what makes the assertion meaningful
+        run_task()
+        metrics = self.get_sorted_metrics(SCOPE)
         self.assertEqual(
             metrics[0].data.data_points[0].bucket_counts[1],
             2,


### PR DESCRIPTION
# Description

`test_metrics.py` has the same race that #5015 fixes in `test_tasks.py`. `get_metrics()` waits on `result.ready()` before reading the metrics, but Celery stores the task result before it dispatches `task_postrun`, and `CeleryInstrumentor` records the runtime histogram from its `task_postrun` receiver. So the result can be ready before the histogram has been recorded, and the assertion runs against an empty reader.

`get_metrics()` now waits for the recorded run count instead. It takes the expected count so that the second call in `test_metric_uninstrument`, which asserts the histogram has accumulated two runs, waits for the second run rather than returning on the first. The third call there asserts that nothing is recorded after `uninstrument()`; there is no metric to wait for, so it waits on `result.ready()` to keep the assertion from passing vacuously.

With the race gone, `test_metric_uninstrument`'s `skipif(PyPy, reason="Fails randomly in pypy")` is no longer needed, so it is removed and the test runs on PyPy again.

Test-only change, no instrumentation code touched.

One note: `wait_for` duplicates the helper #5015 adds to `test_tasks.py`. I kept this standalone against `main` so the two can merge independently — different files, no conflict. Happy to rebase onto #5015 and share one helper if you prefer.

Related: #5015.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The window is too narrow to hit reliably on an idle machine, so I widened it with a temporary `conftest.py` that connects a slow `task_postrun` receiver ahead of the instrumentor's. No source touched:

```python
signals.task_postrun.connect(lambda *a, **k: time.sleep(0.5), weak=False)
```

With that loaded, on `main`, `test_basic_metric` fails with `AssertionError: 0 != 1` and `test_metric_uninstrument` with `IndexError: list index out of range`, on both CPython and PyPy. With this change both pass; the failures left in that run are all in `test_tasks.py`, which this PR does not touch.

Unmodified suite, macOS arm64 against `f1b9368aa`:

```
tox -e py312-test-instrumentation-celery   ->  30 passed
tox -e py314-test-instrumentation-celery   ->  30 passed
tox -e pypy3-test-instrumentation-celery   ->  30 passed (29 passed, 1 skipped before)
tox -e lint-instrumentation-celery         ->  10.00/10
ruff check / ruff format --check           ->  clean
```

- [x] Reproduced the race on `main` and confirmed the fix removes it
- [x] Full celery suite green on py3.12, py3.14 and pypy3

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added - existing tests made deterministic
- [ ] Documentation has been updated - not applicable
