### PR TITLE
Convert last users of MESSAGGING_MESSAGE_ID and MESSAGGING_SYSTEM from SpanAttributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py
@@ -33,6 +33,7 @@ from opentelemetry.instrumentation.utils import (
     unwrap,
 )
 from opentelemetry.propagators.textmap import CarrierT, Getter, Setter
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import (
     MessagingDestinationKindValues,
     MessagingOperationValues,
@@ -134,7 +135,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
     ) -> None:
         if not span.is_recording():
             return
-        span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sqs")
+        span.set_attribute(messaging_attributes.MESSAGING_SYSTEM, "aws.sqs")
         span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_name)
         span.set_attribute(
             SpanAttributes.MESSAGING_DESTINATION_KIND,
@@ -147,7 +148,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
         if conversation_id:
             span.set_attribute(SpanAttributes.MESSAGING_CONVERSATION_ID, conversation_id)
         if message_id:
-            span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, message_id)
+            span.set_attribute(messaging_attributes.MESSAGING_MESSAGE_ID, message_id)
 
     @staticmethod
     def _safe_end_processing_span(receipt_handle: str) -> None:
@@ -210,7 +211,10 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 message_id = retval.get("MessageId")
                 if message_id:
                     if span.is_recording():
-                        span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, message_id)
+                        span.set_attribute(
+                            messaging_attributes.MESSAGING_MESSAGE_ID,
+                            message_id,
+                        )
                 return retval
 
         wrap_function_wrapper(sqs_class, "send_message", send_wrapper)
@@ -241,7 +245,7 @@ class Boto3SQSInstrumentor(BaseInstrumentor):
                 if message_span:
                     if message_span.is_recording():
                         message_span.set_attribute(
-                            SpanAttributes.MESSAGING_MESSAGE_ID,
+                            messaging_attributes.MESSAGING_MESSAGE_ID,
                             successful_messages.get("MessageId"),
                         )
             for span in ids_to_spans.values():

--- a/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-boto3sqs/tests/test_boto3sqs_instrumentation.py
@@ -16,6 +16,7 @@ from opentelemetry.instrumentation.boto3sqs import (
     Boto3SQSInstrumentor,
     Boto3SQSSetter,
 )
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import (
     MessagingDestinationKindValues,
     MessagingOperationValues,
@@ -200,7 +201,7 @@ class TestBoto3SQSInstrumentation(TestBase):
 
     def _default_span_attrs(self):
         return {
-            SpanAttributes.MESSAGING_SYSTEM: "aws.sqs",
+            messaging_attributes.MESSAGING_SYSTEM: "aws.sqs",
             SpanAttributes.MESSAGING_DESTINATION: self._queue_name,
             SpanAttributes.MESSAGING_DESTINATION_KIND: MessagingDestinationKindValues.QUEUE.value,
             SpanAttributes.MESSAGING_URL: self._queue_url,
@@ -257,7 +258,7 @@ class TestBoto3SQSInstrumentation(TestBase):
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(
             {
-                SpanAttributes.MESSAGING_MESSAGE_ID: message_id,
+                messaging_attributes.MESSAGING_MESSAGE_ID: message_id,
                 **self._default_span_attrs(),
             },
             span.attributes,
@@ -292,7 +293,7 @@ class TestBoto3SQSInstrumentation(TestBase):
             self.assertEqual(
                 {
                     SpanAttributes.MESSAGING_CONVERSATION_ID: entry_id,
-                    SpanAttributes.MESSAGING_MESSAGE_ID: expected_message_ids[entry_id],
+                    messaging_attributes.MESSAGING_MESSAGE_ID: expected_message_ids[entry_id],
                     **self._default_span_attrs(),
                 },
                 span.attributes,
@@ -325,7 +326,7 @@ class TestBoto3SQSInstrumentation(TestBase):
             },
             span.attributes,
         )
-        self.assertNotIn(SpanAttributes.MESSAGING_MESSAGE_ID, span.attributes)
+        self.assertNotIn(messaging_attributes.MESSAGING_MESSAGE_ID, span.attributes)
         self._assert_injected_span(entries[0]["MessageAttributes"], span)
 
     def test_receive_message(self):
@@ -378,7 +379,7 @@ class TestBoto3SQSInstrumentation(TestBase):
             # processing span attributes
             self.assertEqual(
                 {
-                    SpanAttributes.MESSAGING_MESSAGE_ID: msg_id,
+                    messaging_attributes.MESSAGING_MESSAGE_ID: msg_id,
                     SpanAttributes.MESSAGING_OPERATION: MessagingOperationValues.PROCESS.value,
                     **self._default_span_attrs(),
                 },

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sns.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sns.py
@@ -16,6 +16,7 @@ from opentelemetry.instrumentation.botocore.extensions.types import (
     _BotocoreInstrumentorContext,
     _BotoResultT,
 )
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv._incubating.attributes.aws_attributes import (
     AWS_SNS_TOPIC_ARN,
 )
@@ -142,7 +143,7 @@ class _SnsExtension(_AwsSdkExtension):
             call_context.span_kind = self._op.span_kind()
 
     def extract_attributes(self, attributes: _AttributeMapT):
-        attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.sns"
+        attributes[messaging_attributes.MESSAGING_SYSTEM] = "aws.sns"
         topic_arn = self._call_context.params.get("TopicArn")
         if topic_arn:
             attributes[AWS_SNS_TOPIC_ARN] = topic_arn

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/sqs.py
@@ -8,6 +8,7 @@ from opentelemetry.instrumentation.botocore.extensions.types import (
     _BotocoreInstrumentorContext,
     _BotoResultT,
 )
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.span import Span
 
@@ -22,7 +23,7 @@ class _SqsExtension(_AwsSdkExtension):
         if queue_url:
             # TODO: update when semantic conventions exist
             attributes["aws.queue_url"] = queue_url
-            attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.sqs"
+            attributes[messaging_attributes.MESSAGING_SYSTEM] = "aws.sqs"
             attributes[SpanAttributes.MESSAGING_URL] = queue_url
             try:
                 attributes[SpanAttributes.MESSAGING_DESTINATION] = queue_url.split("/")[-1]
@@ -43,17 +44,17 @@ class _SqsExtension(_AwsSdkExtension):
             try:
                 if operation == "SendMessage":
                     span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
+                        messaging_attributes.MESSAGING_MESSAGE_ID,
                         result.get("MessageId"),
                     )
                 elif operation == "SendMessageBatch" and result.get("Successful"):
                     span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
+                        messaging_attributes.MESSAGING_MESSAGE_ID,
                         result["Successful"][0]["MessageId"],
                     )
                 elif operation == "ReceiveMessage" and result.get("Messages"):
                     span.set_attribute(
-                        SpanAttributes.MESSAGING_MESSAGE_ID,
+                        messaging_attributes.MESSAGING_MESSAGE_ID,
                         result["Messages"][0]["MessageId"],
                     )
             except (IndexError, KeyError):

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sns.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sns.py
@@ -10,6 +10,7 @@ from botocore.awsrequest import AWSResponse
 from moto import mock_aws
 
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv._incubating.attributes.aws_attributes import (
     AWS_SNS_TOPIC_ARN,
 )
@@ -66,7 +67,7 @@ class TestSnsExtension(TestBase):
 
         self.assertEqual(SpanKind.PRODUCER, span.kind)
         self.assertEqual(name, span.name)
-        self.assertEqual("aws.sns", span.attributes[SpanAttributes.MESSAGING_SYSTEM])
+        self.assertEqual("aws.sns", span.attributes[messaging_attributes.MESSAGING_SYSTEM])
 
         return span
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_sqs.py
@@ -5,6 +5,7 @@ import botocore.session
 from moto import mock_aws
 
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
 
@@ -33,14 +34,14 @@ class TestSqsExtension(TestBase):
         assert spans
         self.assertEqual(len(spans), 2)
         span = spans[1]
-        self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs")
+        self.assertEqual(span.attributes[messaging_attributes.MESSAGING_SYSTEM], "aws.sqs")
         self.assertEqual(span.attributes[SpanAttributes.MESSAGING_URL], queue_url)
         self.assertEqual(
             span.attributes[SpanAttributes.MESSAGING_DESTINATION],
             "test_queue_name",
         )
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            span.attributes[messaging_attributes.MESSAGING_MESSAGE_ID],
             response["MessageId"],
         )
 
@@ -61,14 +62,14 @@ class TestSqsExtension(TestBase):
         self.assertEqual(len(spans), 2)
         span = spans[1]
         self.assertEqual(span.attributes["rpc.method"], "SendMessageBatch")
-        self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs")
+        self.assertEqual(span.attributes[messaging_attributes.MESSAGING_SYSTEM], "aws.sqs")
         self.assertEqual(span.attributes[SpanAttributes.MESSAGING_URL], queue_url)
         self.assertEqual(
             span.attributes[SpanAttributes.MESSAGING_DESTINATION],
             "test_queue_name",
         )
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            span.attributes[messaging_attributes.MESSAGING_MESSAGE_ID],
             response["Successful"][0]["MessageId"],
         )
 
@@ -84,14 +85,14 @@ class TestSqsExtension(TestBase):
         self.assertEqual(len(spans), 3)
         span = spans[-1]
         self.assertEqual(span.attributes["rpc.method"], "ReceiveMessage")
-        self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs")
+        self.assertEqual(span.attributes[messaging_attributes.MESSAGING_SYSTEM], "aws.sqs")
         self.assertEqual(span.attributes[SpanAttributes.MESSAGING_URL], queue_url)
         self.assertEqual(
             span.attributes[SpanAttributes.MESSAGING_DESTINATION],
             "test_queue_name",
         )
         self.assertEqual(
-            span.attributes[SpanAttributes.MESSAGING_MESSAGE_ID],
+            span.attributes[messaging_attributes.MESSAGING_MESSAGE_ID],
             message_result["Messages"][0]["MessageId"],
         )
 
@@ -105,5 +106,5 @@ class TestSqsExtension(TestBase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.attributes["rpc.method"], "SendMessage")
-        self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "aws.sqs")
+        self.assertEqual(span.attributes[messaging_attributes.MESSAGING_SYSTEM], "aws.sqs")
         self.assertEqual(span.attributes[SpanAttributes.MESSAGING_URL], "non-existing")

--- a/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-kafka-python/src/opentelemetry/instrumentation/kafka/utils.py
@@ -9,6 +9,7 @@ from kafka.record.abc import ABCRecord
 
 from opentelemetry import context, propagate, trace
 from opentelemetry.propagators import textmap
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Tracer
 from opentelemetry.trace.span import Span
@@ -94,7 +95,7 @@ def _enrich_span(
     partition: int | None,
 ):
     if span.is_recording():
-        span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "kafka")
+        span.set_attribute(messaging_attributes.MESSAGING_SYSTEM, "kafka")
         span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
         if partition is not None:
             span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)

--- a/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/src/opentelemetry/instrumentation/pika/utils.py
@@ -16,6 +16,7 @@ from wrapt import ObjectProxy
 from opentelemetry import context, propagate, trace
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.propagators.textmap import CarrierT, Getter
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
@@ -167,14 +168,17 @@ def _enrich_span(
     task_destination: str,
     operation: MessagingOperationValues | None = None,
 ) -> None:
-    span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "rabbitmq")
+    span.set_attribute(messaging_attributes.MESSAGING_SYSTEM, "rabbitmq")
     if operation:
         span.set_attribute(SpanAttributes.MESSAGING_OPERATION, operation.value)
     else:
         span.set_attribute(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)
     span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, task_destination)
     if properties.message_id:
-        span.set_attribute(SpanAttributes.MESSAGING_MESSAGE_ID, properties.message_id)
+        span.set_attribute(
+            messaging_attributes.MESSAGING_MESSAGE_ID,
+            properties.message_id,
+        )
     if properties.correlation_id:
         span.set_attribute(SpanAttributes.MESSAGING_CONVERSATION_ID, properties.correlation_id)
     if not channel:

--- a/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pika/tests/test_utils.py
@@ -12,6 +12,7 @@ from pika.channel import Channel
 from pika.spec import Basic, BasicProperties
 
 from opentelemetry.instrumentation.pika import utils
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NET_PEER_NAME,
     NET_PEER_PORT,
@@ -95,10 +96,13 @@ class TestUtils(TestCase):
         span.set_attribute.assert_has_calls(
             any_order=True,
             calls=[
-                mock.call(SpanAttributes.MESSAGING_SYSTEM, "rabbitmq"),
+                mock.call(messaging_attributes.MESSAGING_SYSTEM, "rabbitmq"),
                 mock.call(SpanAttributes.MESSAGING_TEMP_DESTINATION, True),
                 mock.call(SpanAttributes.MESSAGING_DESTINATION, task_destination),
-                mock.call(SpanAttributes.MESSAGING_MESSAGE_ID, properties.message_id),
+                mock.call(
+                    messaging_attributes.MESSAGING_MESSAGE_ID,
+                    properties.message_id,
+                ),
                 mock.call(
                     SpanAttributes.MESSAGING_CONVERSATION_ID,
                     properties.correlation_id,

--- a/tests/opentelemetry-docker-tests/tests/kafka/test_kafka_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/kafka/test_kafka_functional.py
@@ -9,6 +9,7 @@ from kafka.errors import TopicAlreadyExistsError
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.kafka import KafkaInstrumentor
+from opentelemetry.semconv._incubating.attributes import messaging_attributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.test.test_base import TestBase
 
@@ -60,7 +61,10 @@ class TestFunctionalKafka(TestBase):
         for span, metadata in zip(spans, metadatas):
             self.assertEqual(span.name, f"{KAFKA_TOPIC} send")
             self.assertIs(span.kind, trace_api.SpanKind.PRODUCER)
-            self.assertEqual(span.attributes[SpanAttributes.MESSAGING_SYSTEM], "kafka")
+            self.assertEqual(
+                span.attributes[messaging_attributes.MESSAGING_SYSTEM],
+                "kafka",
+            )
             self.assertEqual(
                 span.attributes[SpanAttributes.MESSAGING_DESTINATION],
                 KAFKA_TOPIC,


### PR DESCRIPTION
# Description

Remove more SpanAttributes users so that we can avoid creating semconv helpers for a bunch of attributes that do not have old users of SpanAttributes anymore.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
