### PR TITLE
redis: emit db.namespace for database index

### DIFF
--- a/.changelog/4986.fixed
+++ b/.changelog/4986.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-redis`: emit `db.namespace` for Redis database index in stable semconv mode

--- a/instrumentation/opentelemetry-instrumentation-redis/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-redis/README.rst
@@ -15,6 +15,15 @@ Installation
 
     pip install opentelemetry-instrumentation-redis
 
+Semantic Conventions
+--------------------
+
+When the ``OTEL_SEMCONV_STABILITY_OPT_IN`` environment variable is set to
+``database`` or ``database/dup``, the ``db.namespace`` attribute is set to the
+Redis database index (as a string) configured when the connection was
+established. For example, the default Redis database index ``0`` is emitted as
+``db.namespace = "0"``.
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
+++ b/instrumentation/opentelemetry-instrumentation-redis/tests/test_redis.py
@@ -39,6 +39,7 @@ from opentelemetry.semconv._incubating.attributes.net_attributes import (
     NetTransportValues,
 )
 from opentelemetry.semconv.attributes.db_attributes import (
+    DB_NAMESPACE,
     DB_QUERY_TEXT,
     DB_SYSTEM_NAME,
 )
@@ -939,6 +940,10 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertIn(DB_SYSTEM, span.attributes)
         self.assertEqual(span.attributes[DB_SYSTEM], DbSystemValues.REDIS.value)
         self.assertNotIn(DB_SYSTEM_NAME, span.attributes)
+        self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertNotIn(DB_NAMESPACE, span.attributes)
 
     @stability_mode("database")
     def test_pipeline_database_stable_mode(self):
@@ -960,6 +965,10 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertNotIn(DB_SYSTEM, span.attributes)
         self.assertIn(DB_SYSTEM_NAME, span.attributes)
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
+        self.assertNotIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
 
     @stability_mode("database/dup")
     def test_pipeline_database_dup_mode(self):
@@ -984,6 +993,12 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertEqual(span.attributes[DB_SYSTEM], DbSystemValues.REDIS.value)
         self.assertIn(DB_SYSTEM_NAME, span.attributes)
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
+        self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
 
     @stability_mode("")
     def test_db_statement_default_mode(self):
@@ -1058,6 +1073,8 @@ class TestRedisSemconvConfiguration(TestBase):
         span = spans[0]
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertNotIn(DB_NAMESPACE, span.attributes)
 
     @stability_mode("database")
     def test_db_namespace_database_stable_mode(self):
@@ -1072,6 +1089,9 @@ class TestRedisSemconvConfiguration(TestBase):
 
         span = spans[0]
         self.assertNotIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
 
     @stability_mode("database/dup")
     def test_db_namespace_database_dup_mode(self):
@@ -1087,6 +1107,10 @@ class TestRedisSemconvConfiguration(TestBase):
         span = spans[0]
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
 
     @stability_mode("http")
     def test_db_statement_http_stable_mode(self):
@@ -1311,6 +1335,9 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertIn(DB_SYSTEM_NAME, span.attributes)
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
         self.assertNotIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],
@@ -1339,6 +1366,8 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertNotIn(DB_SYSTEM_NAME, span.attributes)
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertNotIn(DB_NAMESPACE, span.attributes)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],
@@ -1369,6 +1398,10 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],
@@ -1403,6 +1436,9 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertIn(DB_SYSTEM_NAME, span.attributes)
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
         self.assertNotIn(DB_REDIS_DATABASE_INDEX, span.attributes)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],
@@ -1438,6 +1474,8 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertNotIn(DB_SYSTEM_NAME, span.attributes)
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertNotIn(DB_NAMESPACE, span.attributes)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],
@@ -1476,6 +1514,10 @@ class TestRedisSemconvConfiguration(TestBase):
         self.assertEqual(span.attributes[DB_SYSTEM_NAME], DbSystemValues.REDIS.value)
         self.assertIn(DB_REDIS_DATABASE_INDEX, span.attributes)
         self.assertEqual(span.attributes[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(span.attributes[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, span.attributes)
+        self.assertEqual(span.attributes[DB_NAMESPACE], "0")
+        self.assertIsInstance(span.attributes[DB_NAMESPACE], str)
         self.assertIn(NET_TRANSPORT, span.attributes)
         self.assertEqual(
             span.attributes[NET_TRANSPORT],

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py
@@ -604,13 +604,14 @@ def _set_db_operation(
 
 def _set_db_redis_database_index(
     result: MutableMapping[str, AttributeValue],
-    database_index: int,
+    database_index: int | None,
     sem_conv_opt_in_mode: _StabilityMode,
 ) -> None:
-    if _report_old(sem_conv_opt_in_mode):
-        if database_index is not None:
+    if database_index is not None:
+        if _report_old(sem_conv_opt_in_mode):
             result[DB_REDIS_DATABASE_INDEX] = int(database_index)
-    # No new attribute - db.redis.database_index was removed with no replacement in semconv 1.38.0
+        if _report_new(sem_conv_opt_in_mode):
+            result[DB_NAMESPACE] = str(database_index)
 
 
 def _set_net_transport(

--- a/opentelemetry-instrumentation/tests/test_semconv.py
+++ b/opentelemetry-instrumentation/tests/test_semconv.py
@@ -575,20 +575,42 @@ class TestOpenTelemetrySemConvStabilityDatabase(TestCase):
         _set_db_redis_database_index(result, 0, sem_conv_opt_in_mode=_StabilityMode.DEFAULT)
         self.assertIn(DB_REDIS_DATABASE_INDEX, result)
         self.assertEqual(result[DB_REDIS_DATABASE_INDEX], 0)
+        self.assertIsInstance(result[DB_REDIS_DATABASE_INDEX], int)
         self.assertNotIn(DB_NAMESPACE, result)
 
     def test_db_redis_database_index_database_stable(self):
         result = {}
         _set_db_redis_database_index(result, 0, sem_conv_opt_in_mode=_StabilityMode.DATABASE)
         self.assertNotIn(DB_REDIS_DATABASE_INDEX, result)
-        self.assertNotIn(DB_NAMESPACE, result)
+        self.assertIn(DB_NAMESPACE, result)
+        self.assertEqual(result[DB_NAMESPACE], "0")
+        self.assertIsInstance(result[DB_NAMESPACE], str)
+
+        result_nonzero = {}
+        _set_db_redis_database_index(result_nonzero, 3, sem_conv_opt_in_mode=_StabilityMode.DATABASE)
+        self.assertNotIn(DB_REDIS_DATABASE_INDEX, result_nonzero)
+        self.assertIn(DB_NAMESPACE, result_nonzero)
+        self.assertEqual(result_nonzero[DB_NAMESPACE], "3")
+        self.assertIsInstance(result_nonzero[DB_NAMESPACE], str)
 
     def test_db_redis_database_index_database_dup(self):
         result = {}
         _set_db_redis_database_index(result, 0, sem_conv_opt_in_mode=_StabilityMode.DATABASE_DUP)
         self.assertIn(DB_REDIS_DATABASE_INDEX, result)
         self.assertEqual(result[DB_REDIS_DATABASE_INDEX], 0)
-        self.assertNotIn(DB_NAMESPACE, result)
+        self.assertIsInstance(result[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, result)
+        self.assertEqual(result[DB_NAMESPACE], "0")
+        self.assertIsInstance(result[DB_NAMESPACE], str)
+
+        result_nonzero = {}
+        _set_db_redis_database_index(result_nonzero, 3, sem_conv_opt_in_mode=_StabilityMode.DATABASE_DUP)
+        self.assertIn(DB_REDIS_DATABASE_INDEX, result_nonzero)
+        self.assertEqual(result_nonzero[DB_REDIS_DATABASE_INDEX], 3)
+        self.assertIsInstance(result_nonzero[DB_REDIS_DATABASE_INDEX], int)
+        self.assertIn(DB_NAMESPACE, result_nonzero)
+        self.assertEqual(result_nonzero[DB_NAMESPACE], "3")
+        self.assertIsInstance(result_nonzero[DB_NAMESPACE], str)
 
     def test_db_redis_database_index_none_value(self):
         result = {}


### PR DESCRIPTION
# Description

Emit `db.namespace` for the Redis database index when stable database semantic conventions are enabled.

In `database/dup` mode, preserve the legacy `db.redis.database_index` integer attribute while also emitting `db.namespace` as a string.

This also adds coverage for sync/async commands and pipelines, including database index `0`, and documents the stable semantic-convention behavior.

Fixes #4986

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `uv run --link-mode copy tox -e py312-test-opentelemetry-instrumentation-wrapt2` — 216 passed, 2 skipped
- [x] `uv run --link-mode copy tox -e py312-test-instrumentation-redis` — 68 passed
- [x] `uv run --link-mode copy tox -e lint-instrumentation-redis`
- [x] `uv run --link-mode copy pre-commit run ruff --all-files`

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated