### PR TITLE
Clarify error message when there is a `DependencyConflict`

### DIFF
--- a/.changelog/5025.changed
+++ b/.changelog/5025.changed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation`: clarify dependency conflict log messages and promote auto-instrumentation conflict logs to error level

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -1200,7 +1200,7 @@ class TestAutoInstrumentation(TestBaseAutoFastAPI):
 
     @staticmethod
     def _instrumentation_failed_to_load_call(dependency_conflict):
-        return call("Skipping instrumentation %s: %s", "fastapi", dependency_conflict)
+        return call(dependency_conflict.format_message("fastapi"))
 
     @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
     def test_instruments_with_fastapi_installed(self, mock_logger):
@@ -1230,7 +1230,7 @@ class TestAutoInstrumentation(TestBaseAutoFastAPI):
         mock_dep.return_value = dependency_conflict
         _load_instrumentors(mock_distro)
         mock_distro.load_instrumentor.assert_not_called()
-        mock_logger.error.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
+        mock_logger.debug.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
 
     def _create_app(self):
         # instrumentation is handled by the instrument call

--- a/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-fastapi/tests/test_fastapi_instrumentation.py
@@ -1220,7 +1220,7 @@ class TestAutoInstrumentation(TestBaseAutoFastAPI):
         mock_dep.return_value = dependency_conflict
         _load_instrumentors(mock_distro)
         mock_distro.load_instrumentor.assert_not_called()
-        mock_logger.debug.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
+        mock_logger.error.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
 
     @patch("opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts")
     @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
@@ -1230,7 +1230,7 @@ class TestAutoInstrumentation(TestBaseAutoFastAPI):
         mock_dep.return_value = dependency_conflict
         _load_instrumentors(mock_distro)
         mock_distro.load_instrumentor.assert_not_called()
-        mock_logger.debug.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
+        mock_logger.error.assert_has_calls([self._instrumentation_failed_to_load_call(dependency_conflict)])
 
     def _create_app(self):
         # instrumentation is handled by the instrument call

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -88,7 +88,7 @@ def _load_instrumentors(distro):
             entry_point_dist = entry_point_finder.dist_for(entry_point)
             conflict = get_dist_dependency_conflicts(entry_point_dist)
             if conflict:
-                _logger.debug(
+                _logger.error(
                     "Skipping instrumentation %s: %s",
                     entry_point.name,
                     conflict,
@@ -103,7 +103,7 @@ def _load_instrumentors(distro):
             # returning a DependencyConflict. Keeping this error handling in case custom
             # distro and instrumentor behavior raises a DependencyConflictError later.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610
-            _logger.debug(
+            _logger.error(
                 "Skipping instrumentation %s: %s",
                 entry_point.name,
                 exc.conflict,

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -88,11 +88,10 @@ def _load_instrumentors(distro):
             entry_point_dist = entry_point_finder.dist_for(entry_point)
             conflict = get_dist_dependency_conflicts(entry_point_dist)
             if conflict:
-                _logger.error(
-                    "Skipping instrumentation %s: %s",
-                    entry_point.name,
-                    conflict,
-                )
+                if conflict.is_version_conflict:
+                    _logger.error(conflict.format_message(entry_point.name))
+                else:
+                    _logger.debug(conflict.format_message(entry_point.name))
                 continue
 
             # tell instrumentation to not run dep checks again as we already did it above
@@ -103,11 +102,10 @@ def _load_instrumentors(distro):
             # returning a DependencyConflict. Keeping this error handling in case custom
             # distro and instrumentor behavior raises a DependencyConflictError later.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610
-            _logger.error(
-                "Skipping instrumentation %s: %s",
-                entry_point.name,
-                exc.conflict,
-            )
+            if exc.conflict.is_version_conflict:
+                _logger.error(exc.conflict.format_message(entry_point.name))
+            else:
+                _logger.debug(exc.conflict.format_message(entry_point.name))
             continue
         except ModuleNotFoundError as exc:
             # ModuleNotFoundError is raised when the library is not installed

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
@@ -1,11 +1,14 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from functools import cached_property
 from logging import getLogger
 from os import environ
 
 from opentelemetry.instrumentation.dependencies import (
+    DependencyConflict,
     DependencyConflictError,
     get_dist_dependency_conflicts,
 )
@@ -65,6 +68,13 @@ def _load_distro() -> BaseDistro:
     return DefaultDistro()
 
 
+def _log_conflict(entry_point_name: str, conflict: DependencyConflict) -> None:
+    if conflict.is_version_conflict:
+        _logger.error(conflict.format_message(entry_point_name))
+    else:
+        _logger.debug(conflict.format_message(entry_point_name))
+
+
 def _load_instrumentors(distro):
     package_to_exclude = environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, [])
     entry_point_finder = _EntryPointDistFinder()
@@ -88,10 +98,7 @@ def _load_instrumentors(distro):
             entry_point_dist = entry_point_finder.dist_for(entry_point)
             conflict = get_dist_dependency_conflicts(entry_point_dist)
             if conflict:
-                if conflict.is_version_conflict:
-                    _logger.error(conflict.format_message(entry_point.name))
-                else:
-                    _logger.debug(conflict.format_message(entry_point.name))
+                _log_conflict(entry_point.name, conflict)
                 continue
 
             # tell instrumentation to not run dep checks again as we already did it above
@@ -102,10 +109,7 @@ def _load_instrumentors(distro):
             # returning a DependencyConflict. Keeping this error handling in case custom
             # distro and instrumentor behavior raises a DependencyConflictError later.
             # See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3610
-            if exc.conflict.is_version_conflict:
-                _logger.error(exc.conflict.format_message(entry_point.name))
-            else:
-                _logger.debug(exc.conflict.format_message(entry_point.name))
+            _log_conflict(entry_point.name, exc.conflict)
             continue
         except ModuleNotFoundError as exc:
             # ModuleNotFoundError is raised when the library is not installed

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py
@@ -53,6 +53,35 @@ class DependencyConflict:
         self.required_any = required_any
         self.found_any = found_any
 
+    @property
+    def is_version_conflict(self) -> bool:
+        return bool(self.found or self.found_any)
+
+    def format_message(self, instrumentor_name: str) -> str:
+        if self.required:
+            if self.found:
+                return (
+                    f'{instrumentor_name} only instruments "{self.required}", '
+                    f'but currently installed version ("{self.found}") falls outside of that range, '
+                    f"so nothing can be instrumented."
+                )
+            return (
+                f'{instrumentor_name} only instruments "{self.required}", '
+                f"but no installed version was found, so nothing can be instrumented."
+            )
+        if self.required_any:
+            if self.found_any:
+                return (
+                    f'{instrumentor_name} instruments any of "{self.required_any}", '
+                    f'but currently installed version(s) ("{self.found_any}") fall outside of that range, '
+                    f"so nothing can be instrumented."
+                )
+            return (
+                f'{instrumentor_name} requires any of "{self.required_any}", '
+                f"but none are installed, so nothing can be instrumented."
+            )
+        return str(self)
+
     def __str__(self):
         if not self.required and (self.required_any or self.found_any):
             return f'DependencyConflict: requested any of the following: "{self.required_any}" but found: "{self.found_any}"'

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -104,7 +104,11 @@ class BaseInstrumentor(ABC):
                 if raise_exception_on_conflict:
                     raise DependencyConflictError(conflict)
                 # manual instrumentation path: log the conflict as error
-                _LOG.error(conflict)
+                _LOG.error(
+                    "%s - instrumentation %s will not take effect",
+                    conflict,
+                    self.__class__.__name__,
+                )
                 return None
 
         # initialize semantic conventions opt-in if needed

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -104,11 +104,7 @@ class BaseInstrumentor(ABC):
                 if raise_exception_on_conflict:
                     raise DependencyConflictError(conflict)
                 # manual instrumentation path: log the conflict as error
-                _LOG.error(
-                    "%s - instrumentation %s will not take effect",
-                    conflict,
-                    self.__class__.__name__,
-                )
+                _LOG.error(conflict.format_message(self.__class__.__name__))
                 return None
 
         # initialize semantic conventions opt-in if needed

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -160,7 +160,7 @@ class TestLoad(TestCase):
 
     @staticmethod
     def _instrumentation_failed_to_load_call(entry_point, dependency_conflict):
-        return call("Skipping instrumentation %s: %s", entry_point, dependency_conflict)
+        return call(dependency_conflict.format_message(entry_point))
 
     @patch.dict(
         "os.environ",
@@ -252,7 +252,7 @@ class TestLoad(TestCase):
         ep_mock4 = Mock()
         ep_mock4.name = "instr4"  # dependency conflict
 
-        dependency_conflict = DependencyConflict("1.2.3", None)
+        dependency_conflict = DependencyConflict("1.2.3", "1.2.0")
 
         distro_mock = Mock()
 
@@ -289,6 +289,40 @@ class TestLoad(TestCase):
                 ),
             ]
         )
+
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
+    @patch("opentelemetry.instrumentation.auto_instrumentation._load.entry_points")
+    def test_load_instrumentors_dep_not_installed(
+        self, iter_mock, mock_logger, mock_dep
+    ):
+        # Mock opentelemetry_instrumentor entry points
+        ep_mock1 = Mock()
+        ep_mock1.name = "instr1"
+
+        ep_mock2 = Mock()
+        ep_mock2.name = "instr2"
+
+        dependency_conflict = DependencyConflict("1.2.3", None)
+
+        distro_mock = Mock()
+
+        iter_mock.return_value = (ep_mock1, ep_mock2)
+        mock_dep.side_effect = [None, dependency_conflict]
+        _load._load_instrumentors(distro_mock)
+        distro_mock.load_instrumentor.assert_called_once_with(
+            ep_mock1, skip_dep_check=True
+        )
+        mock_logger.debug.assert_has_calls(
+            [
+                call("Instrumented %s", ep_mock1.name),
+                self._instrumentation_failed_to_load_call(
+                    ep_mock2.name,
+                    dependency_conflict,
+                ),
+            ]
+        )
+        mock_logger.error.assert_not_called()
 
     @patch("opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts")
     @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -293,9 +293,7 @@ class TestLoad(TestCase):
     @patch("opentelemetry.instrumentation.auto_instrumentation._load.get_dist_dependency_conflicts")
     @patch("opentelemetry.instrumentation.auto_instrumentation._load._logger")
     @patch("opentelemetry.instrumentation.auto_instrumentation._load.entry_points")
-    def test_load_instrumentors_dep_not_installed(
-        self, iter_mock, mock_logger, mock_dep
-    ):
+    def test_load_instrumentors_dep_not_installed(self, iter_mock, mock_logger, mock_dep):
         # Mock opentelemetry_instrumentor entry points
         ep_mock1 = Mock()
         ep_mock1.name = "instr1"
@@ -310,9 +308,7 @@ class TestLoad(TestCase):
         iter_mock.return_value = (ep_mock1, ep_mock2)
         mock_dep.side_effect = [None, dependency_conflict]
         _load._load_instrumentors(distro_mock)
-        distro_mock.load_instrumentor.assert_called_once_with(
-            ep_mock1, skip_dep_check=True
-        )
+        distro_mock.load_instrumentor.assert_called_once_with(ep_mock1, skip_dep_check=True)
         mock_logger.debug.assert_has_calls(
             [
                 call("Instrumented %s", ep_mock1.name),

--- a/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
+++ b/opentelemetry-instrumentation/tests/auto_instrumentation/test_load.py
@@ -279,6 +279,10 @@ class TestLoad(TestCase):
                     "Instrumentation skipped for library %s",
                     ep_mock3.name,
                 ),
+            ]
+        )
+        mock_logger.error.assert_has_calls(
+            [
                 self._instrumentation_failed_to_load_call(
                     ep_mock4.name,
                     dependency_conflict,

--- a/opentelemetry-instrumentation/tests/test_dependencies.py
+++ b/opentelemetry-instrumentation/tests/test_dependencies.py
@@ -291,7 +291,7 @@ class TestDependencyConflicts(TestBase):
         self.assertTrue(conflict.is_version_conflict)
         self.assertEqual(
             conflict.format_message("Psycopg2Instrumentor"),
-            'Psycopg2Instrumentor instruments any of "[\'psycopg2>=2.7.3.1\', \'psycopg2-binary>=2.7.3.1\']", but currently installed version(s) ("[\'psycopg2 2.6.0\']") fall outside of that range, so nothing can be instrumented.',
+            "Psycopg2Instrumentor instruments any of \"['psycopg2>=2.7.3.1', 'psycopg2-binary>=2.7.3.1']\", but currently installed version(s) (\"['psycopg2 2.6.0']\") fall outside of that range, so nothing can be instrumented.",
         )
 
     def test_dependency_conflict_format_message_required_any_none_installed(self):
@@ -302,5 +302,5 @@ class TestDependencyConflicts(TestBase):
         self.assertFalse(conflict.is_version_conflict)
         self.assertEqual(
             conflict.format_message("KafkaInstrumentor"),
-            'KafkaInstrumentor requires any of "[\'kafka-python>=2.0,<3.0\', \'kafka-python-ng>=2.0,<3.0\']", but none are installed, so nothing can be instrumented.',
+            "KafkaInstrumentor requires any of \"['kafka-python>=2.0,<3.0', 'kafka-python-ng>=2.0,<3.0']\", but none are installed, so nothing can be instrumented.",
         )

--- a/opentelemetry-instrumentation/tests/test_dependencies.py
+++ b/opentelemetry-instrumentation/tests/test_dependencies.py
@@ -266,3 +266,41 @@ class TestDependencyConflicts(TestBase):
             str(conflict),
             '''DependencyConflict: requested any of the following: "['bar~=2.0; extra == "instruments-any"', 'baz~=3.0; extra == "instruments-any"']" but found: "[]"''',
         )
+
+    def test_dependency_conflict_format_message_required_version_mismatch(self):
+        conflict = DependencyConflict("google-genai>=1.32.0,<3", "google-genai 1.31.0")
+        self.assertTrue(conflict.is_version_conflict)
+        self.assertEqual(
+            conflict.format_message("GoogleGenAIInstrumentor"),
+            'GoogleGenAIInstrumentor only instruments "google-genai>=1.32.0,<3", but currently installed version ("google-genai 1.31.0") falls outside of that range, so nothing can be instrumented.',
+        )
+
+    def test_dependency_conflict_format_message_required_not_installed(self):
+        conflict = DependencyConflict("google-genai>=1.32.0,<3", None)
+        self.assertFalse(conflict.is_version_conflict)
+        self.assertEqual(
+            conflict.format_message("GoogleGenAIInstrumentor"),
+            'GoogleGenAIInstrumentor only instruments "google-genai>=1.32.0,<3", but no installed version was found, so nothing can be instrumented.',
+        )
+
+    def test_dependency_conflict_format_message_required_any_version_mismatch(self):
+        conflict = DependencyConflict(
+            required_any=["psycopg2>=2.7.3.1", "psycopg2-binary>=2.7.3.1"],
+            found_any=["psycopg2 2.6.0"],
+        )
+        self.assertTrue(conflict.is_version_conflict)
+        self.assertEqual(
+            conflict.format_message("Psycopg2Instrumentor"),
+            'Psycopg2Instrumentor instruments any of "[\'psycopg2>=2.7.3.1\', \'psycopg2-binary>=2.7.3.1\']", but currently installed version(s) ("[\'psycopg2 2.6.0\']") fall outside of that range, so nothing can be instrumented.',
+        )
+
+    def test_dependency_conflict_format_message_required_any_none_installed(self):
+        conflict = DependencyConflict(
+            required_any=["kafka-python>=2.0,<3.0", "kafka-python-ng>=2.0,<3.0"],
+            found_any=[],
+        )
+        self.assertFalse(conflict.is_version_conflict)
+        self.assertEqual(
+            conflict.format_message("KafkaInstrumentor"),
+            'KafkaInstrumentor requires any of "[\'kafka-python>=2.0,<3.0\', \'kafka-python-ng>=2.0,<3.0\']", but none are installed, so nothing can be instrumented.',
+        )

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -65,7 +65,16 @@ class TestInstrumentor(TestCase):
         mock__check_dependency_conflicts.return_value = conflict
         self.assertIsNone(instrumentor.instrument(raise_exception_on_conflict=False))
         mock_logger.error.assert_any_call(
-            "%s - instrumentation %s will not take effect",
-            conflict,
-            "Instrumentor",
+            'Instrumentor only instruments "missing", but currently installed version ("missing") falls outside of that range, so nothing can be instrumented.'
+        )
+
+    @patch("opentelemetry.instrumentation.instrumentor._LOG")
+    @patch("opentelemetry.instrumentation.instrumentor.BaseInstrumentor._check_dependency_conflicts")
+    def test_instrument_missing_dependency_not_installed_log_error(self, mock__check_dependency_conflicts, mock_logger):
+        instrumentor = self.Instrumentor()
+        conflict = DependencyConflict("missing", None)
+        mock__check_dependency_conflicts.return_value = conflict
+        self.assertIsNone(instrumentor.instrument(raise_exception_on_conflict=False))
+        mock_logger.error.assert_any_call(
+            'Instrumentor only instruments "missing", but no installed version was found, so nothing can be instrumented.'
         )

--- a/opentelemetry-instrumentation/tests/test_instrumentor.py
+++ b/opentelemetry-instrumentation/tests/test_instrumentor.py
@@ -64,4 +64,8 @@ class TestInstrumentor(TestCase):
         conflict = DependencyConflict("missing", "missing")
         mock__check_dependency_conflicts.return_value = conflict
         self.assertIsNone(instrumentor.instrument(raise_exception_on_conflict=False))
-        mock_logger.error.assert_any_call(conflict)
+        mock_logger.error.assert_any_call(
+            "%s - instrumentation %s will not take effect",
+            conflict,
+            "Instrumentor",
+        )


### PR DESCRIPTION
# Description

Updates the log messages that occur when the `instrument` method fails due to `DependencyConflict` to be more clear..

Also raised the severity of the error message that occurs on the auto instrumentation path when the library is installed with an incompatible version

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
