### PR TITLE
Allow per-package patch releases of the elasticsearch instrumentation

### DIFF
--- a/.changelog/5026.changed
+++ b/.changelog/5026.changed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-elasticsearch`: allow patch releases

--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -10,6 +10,7 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-resourcedetector-gcp
         - opentelemetry-sdk-extension-aws
+        - opentelemetry-instrumentation-elasticsearch
         - opentelemetry-instrumentation-openai-v2
         - opentelemetry-instrumentation-openai-agents-v2
         - opentelemetry-instrumentation-vertexai

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -10,6 +10,7 @@ on:
         - opentelemetry-resource-detector-azure
         - opentelemetry-resourcedetector-gcp
         - opentelemetry-sdk-extension-aws
+        - opentelemetry-instrumentation-elasticsearch
         - opentelemetry-instrumentation-openai-v2
         - opentelemetry-instrumentation-openai-agents-v2
         - opentelemetry-instrumentation-vertexai

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,9 +27,10 @@
 >
 > These libraries are also excluded from the general release.
 >
-> The deprecated GenAI instrumentations listed under [Releasing individual package](#releasing-individual-package)
-> are intentionally absent here: they no longer get major or minor releases from this repository, only
-> patch releases from their existing `package-release/` branches.
+> The deprecated GenAI instrumentations and the dropped elasticsearch instrumentation, listed under
+> [Releasing individual package](#releasing-individual-package), are intentionally absent here: they no
+> longer get major or minor releases from this repository, only patch releases from their existing
+> `package-release/` branches.
 
 Package release preparation is handled by the [`[Package] Prepare release`](./.github/workflows/package-prepare-release.yml) workflow that allows
 to pick a specific package to release. It follows the same versioning strategy and process as the general release.
@@ -95,12 +96,17 @@ The workflow will create a pull request that should be merged in order to procee
 > - opentelemetry-resource-detector-azure
 > - opentelemetry-resourcedetector-gcp
 > - opentelemetry-sdk-extension-aws
+> - opentelemetry-instrumentation-elasticsearch
 > - opentelemetry-instrumentation-openai-v2
 > - opentelemetry-instrumentation-openai-agents-v2
 > - opentelemetry-instrumentation-vertexai
 > - opentelemetry-util-genai
 >
 > These libraries are also excluded from the general patch release.
+>
+> The elasticsearch instrumentation was dropped from `main` by #4759 and is no longer
+> developed here. It is listed only so that its published metadata can still be
+> corrected by a patch release from its `package-release/` branch.
 
 Per-package release is handled by the [`[Package] Release`](./.github/workflows/package-release.yml) workflow that allows
 to pick a specific package to release.


### PR DESCRIPTION
# Description

The elasticsearch instrumentation was dropped from `main` by #4759, so `0.64b0` is its
last published version. That version pins `opentelemetry-instrumentation == 0.64b0` and
`opentelemetry-semantic-conventions == 0.64b0`, and those exact pins break any environment
that still installs the package:

* with nothing else constrained, the resolver silently pulls the whole OpenTelemetry
  install back to `0.64b0`, including instrumentations the user did not intend to downgrade
* with a current instrumentation pinned, for example `opentelemetry-instrumentation-requests==0.65b0`,
  resolution fails outright

Fixing that needs one more patch release, `0.64b1`, that loosens the two pins. This PR only
makes such a release possible. It adds `opentelemetry-instrumentation-elasticsearch` to the
`package` choice input of the `[Package] Prepare patch release` and `[Package] Release`
workflows, and records the arrangement in `RELEASING.md`. No package code changes here.

## Maintainer action needed

I do not have push access to this repository, so I cannot create the release branch myself.
Could a maintainer create

```
package-release/opentelemetry-instrumentation-elasticsearch/v0.64bx
```

from tag `v0.64b0`? The tag is the only possible source, because #4759 deleted the package
from `main`. Once that branch exists I will open the follow-up PR against it with the pin
change, which also has to mirror these two workflow entries onto the branch, since
`workflow_dispatch` reads its input definition from the ref the workflow runs against.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Both failure modes were reproduced with `uv pip compile` against PyPI, and the loosened
pins were confirmed to resolve against the current release before proposing this route.
The workflow files themselves have no test; both were checked to still parse and to list
ten packages.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
