### PR TITLE
fix(aiohttp-client): create the duration histograms once, not per ClientSession

### DIFF
--- a/.changelog/5029.fixed
+++ b/.changelog/5029.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-aiohttp-client`: create the duration histograms once instead of per `ClientSession`

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -233,7 +233,7 @@ from opentelemetry.instrumentation.utils import (
     is_http_instrumentation_enabled,
     unwrap,
 )
-from opentelemetry.metrics import MeterProvider, get_meter
+from opentelemetry.metrics import Histogram, MeterProvider, get_meter
 from opentelemetry.propagate import inject
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv.metrics import (
@@ -321,78 +321,15 @@ def _set_http_status_code_attribute(
     )
 
 
-# pylint: disable=too-many-locals
-# pylint: disable=too-many-statements
-def create_trace_config(
-    url_filter: UrlFilterT = None,
-    request_hook: RequestHookT = None,
-    response_hook: ResponseHookT = None,
-    tracer_provider: TracerProvider | None = None,
-    meter_provider: MeterProvider | None = None,
-    sem_conv_opt_in_mode: _StabilityMode = _StabilityMode.DEFAULT,
-    captured_request_headers: list[str] | None = None,
-    captured_response_headers: list[str] | None = None,
-    sensitive_headers: list[str] | None = None,
-) -> aiohttp.TraceConfig:
-    """Create an aiohttp-compatible trace configuration.
-
-    One span is created for the entire HTTP request, including initial
-    TCP/TLS setup if the connection doesn't exist.
-
-    By default the span name is set to the HTTP request method.
-
-    Example usage:
-
-    .. code:: python
-
-        import aiohttp
-        from opentelemetry.instrumentation.aiohttp_client import create_trace_config
-
-        async with aiohttp.ClientSession(trace_configs=[create_trace_config()]) as session:
-            async with session.get(url) as response:
-                await response.text()
-
-
-    :param url_filter: A callback to process the requested URL prior to adding
-        it as a span attribute. This can be useful to remove sensitive data
-        such as API keys or user personal information.
-
-    :param Callable request_hook: Optional callback that can modify span name and request params.
-    :param Callable response_hook: Optional callback that can modify span name and response params.
-    :param tracer_provider: optional TracerProvider from which to get a Tracer
-    :param meter_provider: optional Meter provider to use
-    :param captured_request_headers: List of HTTP request header regexes to capture as
-        span attributes. Header names matching these patterns will be added as span
-        attributes with the format ``http.request.header.<header_name>``.
-    :param captured_response_headers: List of HTTP response header regexes to capture as
-        span attributes. Header names matching these patterns will be added as span
-        attributes with the format ``http.response.header.<header_name>``.
-    :param sensitive_headers: List of HTTP header regexes whose values should be
-        sanitized (redacted) when captured. Header values matching these patterns
-        will be replaced with ``[REDACTED]``.
-
-    :return: An object suitable for use with :py:class:`aiohttp.ClientSession`.
-    :rtype: :py:class:`aiohttp.TraceConfig`
-    """
-    # `aiohttp.TraceRequestStartParams` resolves to `aiohttp.tracing.TraceRequestStartParams`
-    # which doesn't exist in the aiohttp intersphinx inventory.
-    # Explicitly specify the type for the `request_hook` and `response_hook` param and rtype to work
-    # around this issue.
-
-    schema_url = _get_schema_url(sem_conv_opt_in_mode)
-
-    tracer = get_tracer(
-        __name__,
-        __version__,
-        tracer_provider,
-        schema_url=schema_url,
-    )
-
+def _create_duration_histograms(
+    meter_provider: MeterProvider | None,
+    sem_conv_opt_in_mode: _StabilityMode,
+) -> tuple[Histogram | None, Histogram | None]:
     meter = get_meter(
         __name__,
         __version__,
         meter_provider,
-        schema_url,
+        _get_schema_url(sem_conv_opt_in_mode),
     )
 
     duration_histogram_old = None
@@ -411,6 +348,31 @@ def create_trace_config(
             description="Duration of HTTP client requests.",
             explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW,
         )
+    return duration_histogram_old, duration_histogram_new
+
+
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-statements
+def _create_trace_config(
+    url_filter: UrlFilterT = None,
+    request_hook: RequestHookT = None,
+    response_hook: ResponseHookT = None,
+    tracer_provider: TracerProvider | None = None,
+    sem_conv_opt_in_mode: _StabilityMode = _StabilityMode.DEFAULT,
+    captured_request_headers: list[str] | None = None,
+    captured_response_headers: list[str] | None = None,
+    sensitive_headers: list[str] | None = None,
+    duration_histogram_old: Histogram | None = None,
+    duration_histogram_new: Histogram | None = None,
+) -> aiohttp.TraceConfig:
+    schema_url = _get_schema_url(sem_conv_opt_in_mode)
+
+    tracer = get_tracer(
+        __name__,
+        __version__,
+        tracer_provider,
+        schema_url=schema_url,
+    )
 
     excluded_urls = get_excluded_urls("AIOHTTP_CLIENT")
 
@@ -605,6 +567,76 @@ def create_trace_config(
     return trace_config
 
 
+def create_trace_config(
+    url_filter: UrlFilterT = None,
+    request_hook: RequestHookT = None,
+    response_hook: ResponseHookT = None,
+    tracer_provider: TracerProvider | None = None,
+    meter_provider: MeterProvider | None = None,
+    sem_conv_opt_in_mode: _StabilityMode = _StabilityMode.DEFAULT,
+    captured_request_headers: list[str] | None = None,
+    captured_response_headers: list[str] | None = None,
+    sensitive_headers: list[str] | None = None,
+) -> aiohttp.TraceConfig:
+    """Create an aiohttp-compatible trace configuration.
+
+    One span is created for the entire HTTP request, including initial
+    TCP/TLS setup if the connection doesn't exist.
+
+    By default the span name is set to the HTTP request method.
+
+    Example usage:
+
+    .. code:: python
+
+        import aiohttp
+        from opentelemetry.instrumentation.aiohttp_client import create_trace_config
+
+        async with aiohttp.ClientSession(trace_configs=[create_trace_config()]) as session:
+            async with session.get(url) as response:
+                await response.text()
+
+
+    :param url_filter: A callback to process the requested URL prior to adding
+        it as a span attribute. This can be useful to remove sensitive data
+        such as API keys or user personal information.
+
+    :param Callable request_hook: Optional callback that can modify span name and request params.
+    :param Callable response_hook: Optional callback that can modify span name and response params.
+    :param tracer_provider: optional TracerProvider from which to get a Tracer
+    :param meter_provider: optional Meter provider to use
+    :param captured_request_headers: List of HTTP request header regexes to capture as
+        span attributes. Header names matching these patterns will be added as span
+        attributes with the format ``http.request.header.<header_name>``.
+    :param captured_response_headers: List of HTTP response header regexes to capture as
+        span attributes. Header names matching these patterns will be added as span
+        attributes with the format ``http.response.header.<header_name>``.
+    :param sensitive_headers: List of HTTP header regexes whose values should be
+        sanitized (redacted) when captured. Header values matching these patterns
+        will be replaced with ``[REDACTED]``.
+
+    :return: An object suitable for use with :py:class:`aiohttp.ClientSession`.
+    :rtype: :py:class:`aiohttp.TraceConfig`
+    """
+    # `aiohttp.TraceRequestStartParams` resolves to `aiohttp.tracing.TraceRequestStartParams`
+    # which doesn't exist in the aiohttp intersphinx inventory.
+    # Explicitly specify the type for the `request_hook` and `response_hook` param and rtype to work
+    # around this issue.
+    duration_histogram_old, duration_histogram_new = _create_duration_histograms(meter_provider, sem_conv_opt_in_mode)
+    return _create_trace_config(
+        url_filter=url_filter,
+        request_hook=request_hook,
+        response_hook=response_hook,
+        tracer_provider=tracer_provider,
+        sem_conv_opt_in_mode=sem_conv_opt_in_mode,
+        captured_request_headers=captured_request_headers,
+        captured_response_headers=captured_response_headers,
+        sensitive_headers=sensitive_headers,
+        duration_histogram_old=duration_histogram_old,
+        duration_histogram_new=duration_histogram_new,
+    )
+
+
 def _instrument(
     tracer_provider: TracerProvider | None = None,
     meter_provider: MeterProvider | None = None,
@@ -625,6 +657,11 @@ def _instrument(
 
     trace_configs = trace_configs or ()
 
+    # The instruments are created once here rather than per session: a meter is
+    # retained by its provider for the lifetime of the process, so building one
+    # in instrumented_init would accumulate one per ClientSession.
+    duration_histogram_old, duration_histogram_new = _create_duration_histograms(meter_provider, sem_conv_opt_in_mode)
+
     # pylint:disable=unused-argument
     def instrumented_init(
         wrapped: Callable[..., None],
@@ -635,16 +672,17 @@ def _instrument(
         client_trace_configs = list(kwargs.get("trace_configs") or [])
         client_trace_configs.extend(trace_configs)
 
-        trace_config = create_trace_config(
+        trace_config = _create_trace_config(
             url_filter=url_filter,
             request_hook=request_hook,
             response_hook=response_hook,
             tracer_provider=tracer_provider,
-            meter_provider=meter_provider,
             sem_conv_opt_in_mode=sem_conv_opt_in_mode,
             captured_request_headers=captured_request_headers,
             captured_response_headers=captured_response_headers,
             sensitive_headers=sensitive_headers,
+            duration_histogram_old=duration_histogram_old,
+            duration_histogram_new=duration_histogram_new,
         )
         setattr(trace_config, "_is_instrumented_by_opentelemetry", True)
         client_trace_configs.append(trace_config)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -1509,6 +1509,22 @@ class TestAioHttpClientInstrumentor(TestBase):
         self._assert_spans(0)
         self._assert_metrics(0)
 
+    def test_instrument_creates_one_meter_for_all_sessions(self):
+        AioHttpClientInstrumentor().uninstrument()
+
+        async def open_and_close_sessions(count: int):
+            for _ in range(count):
+                await aiohttp.ClientSession().close()
+
+        with mock.patch(
+            "opentelemetry.instrumentation.aiohttp_client.get_meter",
+            wraps=aiohttp_client.get_meter,
+        ) as patched_get_meter:
+            AioHttpClientInstrumentor().instrument()
+            asyncio.run(open_and_close_sessions(5))
+
+        self.assertEqual(1, patched_get_meter.call_count)
+
 
 class TestLoadingAioHttpInstrumentor(unittest.TestCase):
     def test_loading_instrumentor(self):


### PR DESCRIPTION
# Description

Fixes #4991. `instrumented_init` called `create_trace_config()` for every `aiohttp.ClientSession`; `create_trace_config()` calls `get_meter()` and `create_histogram()`, retaining one meter and histogram per session for the life of the process.

Leak reproduction on `a3881e6` with the default (proxy) meter provider, opening and closing sessions with no requests:

| sessions | retained meters | before fix | after fix |
|---|---|---|---|
| 100 | `_PROXY_METER_PROVIDER._meters` | 100 | 1 |
| 200 | | 200 | 1 |
| 300 | | 300 | 1 |

`_instrument()` now builds histograms once and passes them to private `_create_trace_config()`. Public `create_trace_config()` keeps its signature, docstring and behaviour, so direct callers are unaffected. This matches `requests`, `httpx` and `aiohttp-server`.

Repeated `instrument()`/`uninstrument()` cycles still retain meters: 300 cycles retain 300 meters here and in `opentelemetry-instrumentation-requests`. `get_meter()` now runs per `instrument()` call rather than per session; this is existing repository behaviour.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New regression test `test_instrument_creates_one_meter_for_all_sessions`: fails on `main` with `1 != 5`, passes with the fix.
- [x] `pytest tests/test_aiohttp_client_integration.py`: 40 passed, up from 39; 36 pre-existing local-environment failures before and after (released core 1.39.0/0.60b0 against this tree's 0.66b0.dev pins).
- [x] Verified `http.client.duration count=1` with an SDK `MeterProvider` and `InMemoryMetricReader` through `AioHttpClientInstrumentor` and direct `create_trace_config()`.
- [x] `ruff check` and `ruff format --check` clean on the package.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

AI assistance was used for this change (Claude).