### PR TITLE
botocore: label Bedrock embedding calls as embeddings

### DIFF
--- a/.changelog/5030.fixed
+++ b/.changelog/5030.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-instrumentation-botocore`: label Bedrock embedding calls as `embeddings`

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/bedrock.py
@@ -100,6 +100,18 @@ _GEN_AI_CLIENT_TOKEN_USAGE_BUCKETS = [
 _MODEL_ID_KEY: str = "modelId"
 
 
+def _is_embedding_model(model_id: str) -> bool:
+    """Report whether a Bedrock model id names an embedding model.
+
+    An ``InvokeModel`` request carries nothing that distinguishes an embedding
+    model from a generative one, so the model id is the only signal available.
+    Every embedding family Bedrock offers spells "embed" in its id
+    (``amazon.titan-embed-*``, ``cohere.embed-*``, ``twelvelabs.*-embed-*``),
+    and the check tolerates the region and ARN prefixes an id may carry.
+    """
+    return "embed" in model_id.lower()
+
+
 class _BedrockRuntimeExtension(_AwsSdkExtension):
     """
     This class is an extension for <a
@@ -147,8 +159,10 @@ class _BedrockRuntimeExtension(_AwsSdkExtension):
 
         attributes[GEN_AI_REQUEST_MODEL] = model_id
 
+        if _is_embedding_model(model_id):
+            attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.EMBEDDINGS.value
         # titan in invoke model is a text completion one
-        if "body" in self._call_context.params and "amazon.titan" in model_id:
+        elif "body" in self._call_context.params and "amazon.titan" in model_id:
             attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.TEXT_COMPLETION.value
         else:
             attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.CHAT.value
@@ -164,7 +178,10 @@ class _BedrockRuntimeExtension(_AwsSdkExtension):
         model_id = self._call_context.params.get(_MODEL_ID_KEY)
         if model_id:
             attributes[GEN_AI_REQUEST_MODEL] = model_id
-            attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.CHAT.value
+            if _is_embedding_model(model_id):
+                attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.EMBEDDINGS.value
+            else:
+                attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.CHAT.value
 
             # Converse / ConverseStream
             if inference_config := self._call_context.params.get("inferenceConfig"):
@@ -196,7 +213,12 @@ class _BedrockRuntimeExtension(_AwsSdkExtension):
                 try:
                     request_body = json.loads(body)
 
-                    if "amazon.titan" in model_id:
+                    if _is_embedding_model(model_id):
+                        # An embedding request carries no generation
+                        # configuration to extract, and its operation name is
+                        # already set above.
+                        pass
+                    elif "amazon.titan" in model_id:
                         # titan interface is a text completion one
                         attributes[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.TEXT_COMPLETION.value
                         self._extract_titan_attributes(attributes, request_body)

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_bedrock.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_bedrock.py
@@ -14,12 +14,23 @@ import pytest
 from botocore.eventstream import EventStream, EventStreamError
 from botocore.response import StreamingBody
 
+from opentelemetry.instrumentation.botocore.extensions.bedrock import (
+    _BedrockRuntimeExtension,
+    _is_embedding_model,
+)
 from opentelemetry.instrumentation.botocore.extensions.bedrock_utils import (
     InvokeModelWithResponseStreamWrapper,
     _Choice,
 )
+from opentelemetry.instrumentation.botocore.extensions.types import (
+    _AwsSdkCallContext,
+)
 from opentelemetry.semconv._incubating.attributes.error_attributes import (
     ERROR_TYPE,
+)
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_REQUEST_MODEL,
 )
 from opentelemetry.trace.status import StatusCode
 
@@ -2949,3 +2960,79 @@ def get_anthropic_tool_config():
             },
         }
     ]
+
+
+_EMBEDDING_BODY = {"inputText": "embed me"}
+_COHERE_EMBEDDING_BODY = {"texts": ["embed me"], "input_type": "search_document"}
+
+
+@pytest.mark.parametrize(
+    ("model_id", "body", "expected_operation_name"),
+    [
+        ("cohere.embed-v4:0", _COHERE_EMBEDDING_BODY, "embeddings"),
+        ("cohere.embed-english-v3", _COHERE_EMBEDDING_BODY, "embeddings"),
+        ("amazon.titan-embed-text-v2:0", _EMBEDDING_BODY, "embeddings"),
+        ("amazon.titan-embed-image-v1", _EMBEDDING_BODY, "embeddings"),
+        ("us.amazon.titan-embed-text-v2:0", _EMBEDDING_BODY, "embeddings"),
+        (
+            "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-v4:0",
+            _COHERE_EMBEDDING_BODY,
+            "embeddings",
+        ),
+        # Generative models keep the operation names they had before.
+        (
+            "amazon.titan-text-lite-v1",
+            {"inputText": "hi", "textGenerationConfig": {"temperature": 0.5}},
+            "text_completion",
+        ),
+        (
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 10},
+            "chat",
+        ),
+        ("cohere.command-r-v1:0", {"message": "hi"}, "chat"),
+    ],
+)
+def test_invoke_model_operation_name_by_model(bedrock_runtime_client, model_id, body, expected_operation_name):
+    """InvokeModel labels embedding models as embeddings, on spans and metrics.
+
+    Both extract_attributes and _extract_metrics_attributes assign the
+    operation name independently, so both are asserted: labelling only the
+    span would leave gen_ai.client.operation.duration and
+    gen_ai.client.token.usage reporting a generative operation.
+    """
+    call_context = _AwsSdkCallContext(
+        bedrock_runtime_client,
+        (
+            "InvokeModel",
+            {
+                "modelId": model_id,
+                "body": json.dumps(body),
+            },
+        ),
+    )
+    extension = _BedrockRuntimeExtension(call_context)
+
+    span_attributes = {}
+    extension.extract_attributes(span_attributes)
+    assert span_attributes[GEN_AI_OPERATION_NAME] == expected_operation_name
+    assert span_attributes[GEN_AI_REQUEST_MODEL] == model_id
+
+    metric_attributes = extension._extract_metrics_attributes()
+    assert metric_attributes[GEN_AI_OPERATION_NAME] == expected_operation_name
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("cohere.embed-v4:0", True),
+        ("amazon.titan-embed-text-v2:0", True),
+        ("twelvelabs.marengo-embed-2-7-v1:0", True),
+        ("COHERE.EMBED-V4:0", True),
+        ("amazon.titan-text-lite-v1", False),
+        ("anthropic.claude-3-5-sonnet-20240620-v1:0", False),
+        ("", False),
+    ],
+)
+def test_is_embedding_model(model_id, expected):
+    assert _is_embedding_model(model_id) is expected


### PR DESCRIPTION
Fixes #4996.

## Problem

`extensions/bedrock.py` assigned an LLM operation name to every `InvokeModel` call with no notion of embedding models — `grep -i embed` returned nothing in the file. A Cohere embedding request came out as:

```
gen_ai.request.model   = "cohere.embed-v4:0"
gen_ai.operation.name  = "chat"
```

Titan embedding models fared slightly differently but no better: `amazon.titan-embed-text-v2:0` matches the existing `amazon.titan` branch, so it was reported as `text_completion`. Either way, downstream tools that resolve span kind from `gen_ai.operation.name` classify an embedding call as a generative one.

## Change

Detect embedding models from the model id and assign `GenAiOperationNameValues.EMBEDDINGS`, which is what `opentelemetry-instrumentation-openai-v2` already does for its embedding calls (#3461).

An `InvokeModel` request carries nothing else that separates an embedding model from a generative one — no operation, no distinguishing body key across families — so the model id is the only signal. Every embedding family Bedrock offers spells `embed` in its id (`amazon.titan-embed-*`, `cohere.embed-*`, `twelvelabs.*-embed-*`), and a substring test tolerates the cross-region (`us.`) and ARN prefixes an id can carry.

As the issue notes, the operation name is assigned independently in two places, so both are updated:

- `extract_attributes` — the span attribute, which the span name at the end of the call also derives from.
- `_extract_metrics_attributes` — `gen_ai.client.operation.duration` and `gen_ai.client.token.usage`.

The third site is the `amazon.titan` branch inside the request-body parse, which would otherwise re-label a Titan embedding call as `text_completion`; embedding requests now skip that chain, which has no generation configuration to extract from them anyway.

## Tests

`test_invoke_model_operation_name_by_model` asserts the span attribute and the metric attribute together, over Cohere and Titan embedding ids plus a cross-region prefix and a full model ARN, and pins the existing names for `amazon.titan-text-lite-v1` (`text_completion`), Claude and `cohere.command-r-v1:0` (`chat`) so the generative paths are unchanged. `test_is_embedding_model` covers the id predicate directly, including a mixed-case id and the empty string.

These are constructed from a call context rather than recorded, so they need no cassette: the operation name is decided entirely from the request, before any response.

Verification: `pytest tests/test_botocore_bedrock.py` — 81 passed. `ruff check` and `ruff format --check` (v0.16.1, repo config) clean on the package.

I'll add the `.changelog` fragment for this PR number in a follow-up commit.
