### PR TITLE
Add a policy for accepting new instrumentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,30 +368,31 @@ The continuous integration overrides that environment variable with as per the c
 
 ## Policy for accepting new instrumentations
 
-Contributions are very appreciated. Every proposal to add a new instrumentation
-to this repository is considered on its own merits, and the outcome can be
-acceptance or rejection. This section describes how that decision is made and
-why it is made that way.
+Every proposal to add a new instrumentation to this repository is considered on
+its own merits, and the outcome can be acceptance or rejection. This section
+describes how that decision is made and why it is made that way.
 
 ### Why this policy exists
 
-Adding an instrumentation to this repository is not a one time event, it is a
-permanent, recurring cost:
+Consider what happens after an instrumentation is added to this repository:
 
-* It is a growing load on the approvers and maintainers of this repository.
+* Every instrumentation adds load to the approvers and maintainers of this
+  repository, and that load grows with every instrumentation that is added.
 * The approvers and maintainers are usually not experts in the library that a
   given instrumentation instruments.
 * Most of the packages in this repository are released in lockstep, so a single
   instrumentation that nobody can fix holds back or breaks the release of
   everything else.
+* A contributor who is not an approver or a maintainer of this repository
+  frequently proposes a new instrumentation, offers to maintain it, and does
+  maintain it for some time. Later that person stops contributing, for
+  perfectly legitimate reasons. The instrumentation does not stop existing when
+  that happens: the approvers and maintainers of this repository inherit it,
+  including the parts of it that they do not understand.
 
-The situation that motivates this policy happens often. A contributor who is
-not an approver or a maintainer of this repository proposes a new
-instrumentation, offers to maintain it, and does maintain it for some time.
-Later that person stops contributing, for perfectly legitimate reasons. The
-instrumentation does not stop existing when that happens: the approvers and
-maintainers of this repository inherit it, including the parts of it that they
-do not understand.
+Adding an instrumentation to this repository is therefore not a one time event.
+It is a permanent, recurring cost, and it is paid by the approvers and
+maintainers of this repository, not only by whoever adds the instrumentation.
 
 ### The policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,9 +376,10 @@ describes how that decision is made and why it is made that way.
 Once an instrumentation is in this repository it has to be maintained for as
 long as it stays there, and maintaining it takes resources, mostly time. Every
 accepted instrumentation adds to that load and the load only grows, while the
-resources available to absorb it are limited. Maintaining an instrumentation can also take knowledge
-that is not available, since the approvers and maintainers may not be experts
-in the library that a given instrumentation instruments.
+resources available to absorb it are limited. Maintaining an instrumentation
+can also take knowledge that is not available, since the approvers and
+maintainers may not be experts in the library that a given instrumentation
+instruments.
 
 That load falls on the approvers and maintainers of this repository no matter
 who proposes the instrumentation. This scenario can happen: a contributor who

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,11 +403,16 @@ instrumentation to this repository:
 There is no third outcome in which an instrumentation is accepted on the
 condition that the person who proposed it keeps maintaining it. An offer to
 maintain an instrumentation from someone outside the approvers and maintainers
-groups is welcome and appreciated, and it is still expected (see
-[expectations from contributors](#expectations-from-contributors)), but it
-cannot be the reason the instrumentation is accepted. This repository has no
-way to enforce such an offer and no remedy once it ends, so a decision that
-depends on it is a decision made on something the repository does not control.
+groups is welcome and appreciated, but it cannot be the reason the
+instrumentation is accepted. This repository has no way to enforce such an
+offer and no remedy once it ends, so a decision that depends on it is a
+decision made on something the repository does not control.
+
+Once an instrumentation has been accepted, the responsibility for maintaining
+it lies with the approvers and maintainers of this repository alone. The person
+who proposed it carries no obligation towards it from that point on, and is
+welcome, but never required, to keep contributing to it and to any other part
+of this repository.
 
 ### What rejection means
 
@@ -542,13 +547,18 @@ Instrumentations that relate to [Generative AI](https://opentelemetry.io/docs/sp
 
 ## Expectations from contributors
 
-OpenTelemetry is an open source community, and as such, greatly encourages contributions from anyone interested in the project. With that being said, there is a certain level of expectation from contributors even after a pull request is merged, specifically pertaining to instrumentations. The OpenTelemetry Python community expects contributors to maintain a level of support and interest in the instrumentations they contribute. This is to ensure that the instrumentation does not become stale and still functions the way the original contributor intended. Some instrumentations also pertain to libraries that the current members of the community are not so familiar with, so it is necessary to rely on the expertise of the original contributing parties.
+OpenTelemetry is an open source community, and as such, greatly encourages contributions from anyone interested in the project.
 
-This expectation is not a substitute for the commitment described in the
+Contributors are welcome to stay involved with the instrumentations they
+contribute and with any other part of this repository, and that involvement is
+valuable. Some instrumentations pertain to libraries that the current members
+of the community are not so familiar with, so the expertise of the original
+contributing parties is appreciated whenever it is available.
+
+Staying involved is not a requirement, though. Once an instrumentation has been
+accepted into this repository, the responsibility for maintaining it lies with
+the approvers and maintainers of this repository alone. See the
 [policy for accepting new instrumentations](#policy-for-accepting-new-instrumentations).
-Continued support from the original contributor is asked for and appreciated,
-but the decision to accept a new instrumentation is never made on the
-assumption that it will be there.
 
 ### Use of AI coding assistants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,12 +409,6 @@ cannot be the reason the instrumentation is accepted. This repository has no
 way to enforce such an offer and no remedy once it ends, so a decision that
 depends on it is a decision made on something the repository does not control.
 
-This also means acceptance is treated as final. There is currently no policy
-for removing an instrumentation from this repository once it has been accepted,
-and writing one is a separate piece of work. Until such a policy exists, "we
-can always drop it later" is not an available answer, so the question has to be
-answered before the instrumentation is accepted, not after.
-
 ### What rejection means
 
 Rejecting an instrumentation `X` that instruments a library `Y` means only that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,12 +383,12 @@ Consider what happens after an instrumentation is added to this repository:
 * Most of the packages in this repository are released in lockstep, so a single
   instrumentation that nobody can fix holds back or breaks the release of
   everything else.
-* A contributor who is not an approver or a maintainer of this repository
-  frequently proposes a new instrumentation, offers to maintain it, and does
-  maintain it for some time. Later that person stops contributing, for
-  perfectly legitimate reasons. The instrumentation does not stop existing when
-  that happens: the approvers and maintainers of this repository inherit it,
-  including the parts of it that they do not understand.
+* This scenario can happen: a contributor who is not an approver or a
+  maintainer of this repository proposes a new instrumentation, offers to
+  maintain it, and does maintain it for some time. Later that person stops
+  contributing, for perfectly legitimate reasons. The instrumentation does not
+  stop existing when that happens, so the approvers and maintainers of this
+  repository inherit it, including the parts of it that they do not understand.
 
 Adding an instrumentation to this repository is therefore not a one time event.
 It is a permanent, recurring cost, and it is paid by the approvers and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,8 +377,8 @@ Consider what happens after an instrumentation is added to this repository:
 
 * Every instrumentation adds load to the approvers and maintainers of this
   repository, and that load grows with every instrumentation that is added.
-* The approvers and maintainers are usually not experts in the library that a
-  given instrumentation instruments.
+* The approvers and maintainers may not be experts in the library that a given
+  instrumentation instruments.
 * This scenario can happen: a contributor who is not an approver or a
   maintainer of this repository proposes a new instrumentation and maintains it
   for some time. Later that person stops contributing, for perfectly legitimate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,14 +373,10 @@ describes how that decision is made and why it is made that way.
 
 ### Why this policy exists
 
-The approvers and maintainers of this repository may not be able to accept
-every instrumentation that is proposed for it.
-
-Accepting an instrumentation is not a one time event. Once an instrumentation
-is in this repository it has to be maintained for as long as it stays there,
-and maintaining it takes resources, mostly time. Every accepted instrumentation
-adds to that load and the load only grows, while the resources available to
-absorb it are limited. Maintaining an instrumentation can also take knowledge
+Once an instrumentation is in this repository it has to be maintained for as
+long as it stays there, and maintaining it takes resources, mostly time. Every
+accepted instrumentation adds to that load and the load only grows, while the
+resources available to absorb it are limited. Maintaining an instrumentation can also take knowledge
 that is not available, since the approvers and maintainers may not be experts
 in the library that a given instrumentation instruments.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,22 +373,28 @@ describes how that decision is made and why it is made that way.
 
 ### Why this policy exists
 
-Consider what happens after an instrumentation is added to this repository:
+The approvers and maintainers of this repository may not be able to accept
+every instrumentation that is proposed for it.
 
-* Every instrumentation adds load to the approvers and maintainers of this
-  repository, and that load grows with every instrumentation that is added.
-* The approvers and maintainers may not be experts in the library that a given
-  instrumentation instruments.
-* This scenario can happen: a contributor who is not an approver or a
-  maintainer of this repository proposes a new instrumentation and maintains it
-  for some time. Later that person stops contributing, for perfectly legitimate
-  reasons. The instrumentation does not stop existing when that happens, so the
-  approvers and maintainers of this repository inherit it, including the parts
-  of it that they do not understand.
+Accepting an instrumentation is not a one time event. Once an instrumentation
+is in this repository it has to be maintained for as long as it stays there,
+and maintaining it takes resources, mostly time. Every accepted instrumentation
+adds to that load and the load only grows, while the resources available to
+absorb it are limited. Maintaining an instrumentation can also take knowledge
+that is not available, since the approvers and maintainers may not be experts
+in the library that a given instrumentation instruments.
 
-Adding an instrumentation to this repository is therefore not a one time event.
-It is a permanent, recurring cost, and it is paid by the approvers and
-maintainers of this repository, not only by whoever adds the instrumentation.
+That load falls on the approvers and maintainers of this repository no matter
+who proposes the instrumentation. This scenario can happen: a contributor who
+is not an approver or a maintainer of this repository proposes a new
+instrumentation and maintains it for some time. Later that person stops
+contributing, for perfectly legitimate reasons. The instrumentation does not
+stop existing when that happens, so the approvers and maintainers of this
+repository inherit it, including the parts of it that they do not understand.
+
+A policy is needed because of that: accepting an instrumentation commits
+resources that this repository may not have, so acceptance cannot be the
+default answer to every proposal.
 
 ### The policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -471,6 +471,7 @@ Python SIG meeting, and the resulting decision is recorded in that issue.
 Below is a checklist of things to be mindful of when implementing a new instrumentation or working on a specific instrumentation. It is one of our goals as a community to keep the implementation specific details of instrumentations as similar across the board as possible for ease of testing and feature parity. It is also good to abstract as much common functionality as possible.
 
 - Find or create a new [Issue](https://github.com/open-telemetry/opentelemetry-python-contrib/issues) describing the tool or framework to instrument and its use cases to support with OpenTelemetry.
+  - For a new instrumentation, do this before writing it, and read the [policy for accepting new instrumentations](#policy-for-accepting-new-instrumentations) first. A new instrumentation is added to this repository only if the approvers and maintainers accept to maintain it themselves.
   - Be familiar with the [expectations from contributors](#expectations-from-contributors) that apply.
   - If you're a tool or framework maintainer, please consider using the OpenTelemetry API directly to support [native instrumentation](#guidelines-for-native-opentelemetry-instrumentation) instead of adding a new community instrumentation library.
 - Follow semantic conventions
@@ -549,6 +550,12 @@ Instrumentations that relate to [Generative AI](https://opentelemetry.io/docs/sp
 ## Expectations from contributors
 
 OpenTelemetry is an open source community, and as such, greatly encourages contributions from anyone interested in the project. With that being said, there is a certain level of expectation from contributors even after a pull request is merged, specifically pertaining to instrumentations. The OpenTelemetry Python community expects contributors to maintain a level of support and interest in the instrumentations they contribute. This is to ensure that the instrumentation does not become stale and still functions the way the original contributor intended. Some instrumentations also pertain to libraries that the current members of the community are not so familiar with, so it is necessary to rely on the expertise of the original contributing parties.
+
+This expectation is not a substitute for the commitment described in the
+[policy for accepting new instrumentations](#policy-for-accepting-new-instrumentations).
+Continued support from the original contributor is asked for and appreciated,
+but the decision to accept a new instrumentation is never made on the
+assumption that it will be there.
 
 ### Use of AI coding assistants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,11 +381,11 @@ Consider what happens after an instrumentation is added to this repository:
 * The approvers and maintainers are usually not experts in the library that a
   given instrumentation instruments.
 * This scenario can happen: a contributor who is not an approver or a
-  maintainer of this repository proposes a new instrumentation, offers to
-  maintain it, and does maintain it for some time. Later that person stops
-  contributing, for perfectly legitimate reasons. The instrumentation does not
-  stop existing when that happens, so the approvers and maintainers of this
-  repository inherit it, including the parts of it that they do not understand.
+  maintainer of this repository proposes a new instrumentation and maintains it
+  for some time. Later that person stops contributing, for perfectly legitimate
+  reasons. The instrumentation does not stop existing when that happens, so the
+  approvers and maintainers of this repository inherit it, including the parts
+  of it that they do not understand.
 
 Adding an instrumentation to this repository is therefore not a one time event.
 It is a permanent, recurring cost, and it is paid by the approvers and
@@ -400,13 +400,11 @@ instrumentation to this repository:
    maintain it themselves, for as long as it is in this repository**.
 2. The approvers and maintainers reject the instrumentation.
 
-There is no third outcome in which an instrumentation is accepted on the
-condition that the person who proposed it keeps maintaining it. An offer to
-maintain an instrumentation from someone outside the approvers and maintainers
-groups is welcome and appreciated, but it cannot be the reason the
-instrumentation is accepted. This repository has no way to enforce such an
-offer and no remedy once it ends, so a decision that depends on it is a
-decision made on something the repository does not control.
+There is no third outcome in which an instrumentation is accepted and somebody
+outside the approvers and maintainers groups is counted on to maintain it. This
+repository cannot enforce such an arrangement and has no remedy when it ends,
+so a decision that depends on it is a decision made on something this
+repository does not control.
 
 Once an instrumentation has been accepted, the responsibility for maintaining
 it lies with the approvers and maintainers of this repository alone. The person

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,9 +368,10 @@ The continuous integration overrides that environment variable with as per the c
 
 ## Policy for accepting new instrumentations
 
-Contributions are very appreciated, but not every proposed instrumentation will
-be accepted into this repository. This section describes how that decision is
-made and why it is made that way.
+Contributions are very appreciated. Every proposal to add a new instrumentation
+to this repository is considered on its own merits, and the outcome can be
+acceptance or rejection. This section describes how that decision is made and
+why it is made that way.
 
 ### Why this policy exists
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,9 +380,6 @@ Consider what happens after an instrumentation is added to this repository:
   repository, and that load grows with every instrumentation that is added.
 * The approvers and maintainers are usually not experts in the library that a
   given instrumentation instruments.
-* Most of the packages in this repository are released in lockstep, so a single
-  instrumentation that nobody can fix holds back or breaks the release of
-  everything else.
 * This scenario can happen: a contributor who is not an approver or a
   maintainer of this repository proposes a new instrumentation, offers to
   maintain it, and does maintain it for some time. Later that person stops

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,6 @@ If you are using AI agents to assist with contributions, please read [AGENTS.md]
     - [Why this policy exists](#why-this-policy-exists)
     - [The policy](#the-policy)
     - [What rejection means](#what-rejection-means)
-    - [What the decision takes into account](#what-the-decision-takes-into-account)
     - [How to propose a new instrumentation](#how-to-propose-a-new-instrumentation)
   - [Guideline for instrumentations](#guideline-for-instrumentations)
     - [Update supported instrumentation package versions](#update-supported-instrumentation-package-versions)
@@ -393,8 +392,9 @@ maintainers of this repository, not only by whoever adds the instrumentation.
 
 ### The policy
 
-There are only two possible outcomes for a proposal to add a new
-instrumentation to this repository:
+The approvers and maintainers of this repository evaluate every proposed
+instrumentation and decide on it. There are only two possible outcomes for that
+decision:
 
 1. The approvers and maintainers accept the instrumentation **and accept to
    maintain it themselves, for as long as it is in this repository**.
@@ -424,33 +424,6 @@ instrumented, and it does not mean that `X` cannot exist:
   it, and it can still be published to PyPI and installed by users.
 * `X` can be proposed again later, for example once the situation that led to
   the rejection has changed.
-
-### What the decision takes into account
-
-Because accepting an instrumentation commits the approvers and maintainers to
-maintaining it themselves, the decision is made deliberately. Among the things
-taken into account are:
-
-* How widely the instrumented library is used, for example its PyPI download
-  numbers. Popularity by itself is not enough to get an instrumentation
-  accepted, but an instrumentation for a personal or rarely used project is
-  unlikely to be accepted.
-* How critical the instrumented library is to the users of this repository.
-* Whether at least one approver or maintainer is willing to be listed as a
-  component owner in [component_owners.yml](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/component_owners.yml)
-  for it and to review changes to it.
-* How closely the proposed instrumentation resembles the instrumentations
-  already in this repository. Consistency across instrumentations is what makes
-  it possible to review and fix one without being an expert in the library it
-  instruments, so "it looks like the other similar instrumentations" counts in
-  favor of a proposal.
-* The quality and the coverage of its tests, including tests against both the
-  minimum and the latest supported versions of the instrumented library. When
-  the approvers and maintainers cannot rely on their own expertise in the
-  instrumented library, they rely on the tests instead.
-
-The absence of native instrumentation in the instrumented library is not by
-itself a reason to reject a proposal.
 
 ### How to propose a new instrumentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ If you are using AI agents to assist with contributions, please read [AGENTS.md]
   - [Running Tests Locally](#running-tests-locally)
     - [Testing against a different Core repo branch/commit](#testing-against-a-different-core-repo-branchcommit)
   - [Style Guide](#style-guide)
+  - [Policy for accepting new instrumentations](#policy-for-accepting-new-instrumentations)
+    - [Why this policy exists](#why-this-policy-exists)
+    - [The policy](#the-policy)
+    - [What rejection means](#what-rejection-means)
+    - [What the decision takes into account](#what-the-decision-takes-into-account)
+    - [How to propose a new instrumentation](#how-to-propose-a-new-instrumentation)
   - [Guideline for instrumentations](#guideline-for-instrumentations)
     - [Update supported instrumentation package versions](#update-supported-instrumentation-package-versions)
   - [Guideline for GenAI instrumentations](#guideline-for-genai-instrumentations)
@@ -359,6 +365,106 @@ The continuous integration overrides that environment variable with as per the c
   as specified with the [napoleon
   extension](http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy)
   extension in [Sphinx](http://www.sphinx-doc.org/en/master/index.html).
+
+## Policy for accepting new instrumentations
+
+Contributions are very appreciated, but not every proposed instrumentation will
+be accepted into this repository. This section describes how that decision is
+made and why it is made that way.
+
+### Why this policy exists
+
+Adding an instrumentation to this repository is not a one time event, it is a
+permanent, recurring cost:
+
+* It is a growing load on the approvers and maintainers of this repository.
+* The approvers and maintainers are usually not experts in the library that a
+  given instrumentation instruments.
+* Most of the packages in this repository are released in lockstep, so a single
+  instrumentation that nobody can fix holds back or breaks the release of
+  everything else.
+
+The situation that motivates this policy happens often. A contributor who is
+not an approver or a maintainer of this repository proposes a new
+instrumentation, offers to maintain it, and does maintain it for some time.
+Later that person stops contributing, for perfectly legitimate reasons. The
+instrumentation does not stop existing when that happens: the approvers and
+maintainers of this repository inherit it, including the parts of it that they
+do not understand.
+
+### The policy
+
+There are only two possible outcomes for a proposal to add a new
+instrumentation to this repository:
+
+1. The approvers and maintainers accept the instrumentation **and accept to
+   maintain it themselves, for as long as it is in this repository**.
+2. The approvers and maintainers reject the instrumentation.
+
+There is no third outcome in which an instrumentation is accepted on the
+condition that the person who proposed it keeps maintaining it. An offer to
+maintain an instrumentation from someone outside the approvers and maintainers
+groups is welcome and appreciated, and it is still expected (see
+[expectations from contributors](#expectations-from-contributors)), but it
+cannot be the reason the instrumentation is accepted. This repository has no
+way to enforce such an offer and no remedy once it ends, so a decision that
+depends on it is a decision made on something the repository does not control.
+
+This also means acceptance is treated as final. There is currently no policy
+for removing an instrumentation from this repository once it has been accepted,
+and writing one is a separate piece of work. Until such a policy exists, "we
+can always drop it later" is not an available answer, so the question has to be
+answered before the instrumentation is accepted, not after.
+
+### What rejection means
+
+Rejecting an instrumentation `X` that instruments a library `Y` means only that
+`X` will not live **in this repository**. It does not mean that `Y` cannot be
+instrumented, and it does not mean that `X` cannot exist:
+
+* `Y` can be instrumented natively, by `Y` itself, which is the preferred
+  option. See [guidelines for native OpenTelemetry instrumentation](#guidelines-for-native-opentelemetry-instrumentation).
+* `X` can live in any other repository, owned by whoever is willing to maintain
+  it, and it can still be published to PyPI and installed by users.
+* `X` can be proposed again later, for example once the situation that led to
+  the rejection has changed.
+
+### What the decision takes into account
+
+Because accepting an instrumentation commits the approvers and maintainers to
+maintaining it themselves, the decision is made deliberately. Among the things
+taken into account are:
+
+* How widely the instrumented library is used, for example its PyPI download
+  numbers. Popularity by itself is not enough to get an instrumentation
+  accepted, but an instrumentation for a personal or rarely used project is
+  unlikely to be accepted.
+* How critical the instrumented library is to the users of this repository.
+* Whether at least one approver or maintainer is willing to be listed as a
+  component owner in [component_owners.yml](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/component_owners.yml)
+  for it and to review changes to it.
+* How closely the proposed instrumentation resembles the instrumentations
+  already in this repository. Consistency across instrumentations is what makes
+  it possible to review and fix one without being an expert in the library it
+  instruments, so "it looks like the other similar instrumentations" counts in
+  favor of a proposal.
+* The quality and the coverage of its tests, including tests against both the
+  minimum and the latest supported versions of the instrumented library. When
+  the approvers and maintainers cannot rely on their own expertise in the
+  instrumented library, they rely on the tests instead.
+
+The absence of native instrumentation in the instrumented library is not by
+itself a reason to reject a proposal.
+
+### How to propose a new instrumentation
+
+Open an [issue](https://github.com/open-telemetry/opentelemetry-python-contrib/issues)
+describing the library to instrument and the use cases to support, **before**
+writing the instrumentation. Proposing first avoids the situation where a
+complete instrumentation is written and then rejected.
+
+The proposal is discussed by the approvers and maintainers, usually in the
+Python SIG meeting, and the resulting decision is recorded in that issue.
 
 ## Guideline for instrumentations
 


### PR DESCRIPTION
# Description

Adds a policy to `CONTRIBUTING.md` describing how the approvers and maintainers of this repository decide whether to accept a new instrumentation, and who maintains it afterwards.

The policy has two possible outcomes for a proposed instrumentation: it is accepted and the approvers and maintainers take on maintaining it themselves, or it is rejected. There is no outcome in which somebody outside those groups is counted on to maintain an accepted instrumentation. The section also states what a rejection does and does not mean, and asks for new instrumentations to be proposed in an issue before they are written.

The section "Expectations from contributors" contradicted this, since it said the community expects contributors to keep maintaining the instrumentations they contribute and that it is necessary to rely on their expertise. It now says that staying involved is welcome and valuable but not required, and that the responsibility lies with the approvers and maintainers alone.

This is the policy discussed in the 2026-09-03 Python SIG meeting. Wording is open to discussion, in particular whether the decision criteria should be written down, which this PR deliberately leaves out.

Fixes #5028

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Documentation only change, no code affected. Checked that every in-page anchor link in `CONTRIBUTING.md` resolves to an existing heading, including the new index entries and cross references.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
